### PR TITLE
Cuda Fortran (CUF) backend implementation including tests

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,6 +5,7 @@
 - O. Marsden (ECMWF)
 - A. Nawab (ECMWF)
 - B. Reuter (ECMWF)
+- M. Staneker (ECMWF)
 
 If you have contributed to this project, please add your name in the above
 alphabetical list.

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -39,6 +39,7 @@ Currently, Loki has backends to generate Fortran, C, Python, and Maxeler MaxJ
 .. autosummary::
 
    loki.backend.fgen.fgen
+   loki.backend.cufgen.cufgen
    loki.backend.cgen.cgen
    loki.backend.pygen.pygen
    loki.backend.dacegen.dacegen

--- a/loki/backend/__init__.py
+++ b/loki/backend/__init__.py
@@ -10,3 +10,4 @@ from loki.backend.cgen import * # noqa
 from loki.backend.maxgen import * # noqa
 from loki.backend.pygen import * # noqa
 from loki.backend.dacegen import * # noqa
+from loki.backend.cufgen import * # noqa

--- a/loki/backend/cufgen.py
+++ b/loki/backend/cufgen.py
@@ -1,0 +1,60 @@
+from loki.backend.fgen import FortranCodegen
+
+__all__ = ['cufgen', 'CudaFortranCodegen']
+
+
+class CudaFortranCodegen(FortranCodegen):
+    """
+    Tree visitor that extends `FortranCodegen` with Cuda Fortran (CUF) language variations.
+    """
+
+    def __init__(self, depth=0, indent='  ', linewidth=90, conservative=True):
+        super().__init__(depth=depth, indent=indent, linewidth=linewidth, conservative=conservative)
+
+    def visit_CallStatement(self, o, **kwargs):
+        """
+        Format call statement as
+          CALL(<chevron>) <name>(<args>)
+          with the chevron as launch configuration for device offloading,
+          resulting in something like
+          call kernel<<<grid,block[,bytes][,streamid]>>>(arg1,arg2,...)
+        """
+        pragma = self.visit(o.pragma, **kwargs)
+        name = self.visit(o.name, **kwargs)
+        args = self.visit_all(o.arguments, **kwargs)
+        if o.chevron is not None:
+            chevron = f"<<<{','.join([str(elem) for elem in o.chevron])}>>>"
+        else:
+            chevron = ""
+        call = self.format_line('CALL ', name, chevron, '(', self.join_items(args), ')')
+        return self.join_lines(pragma, call)
+
+    def visit_SymbolAttributes(self, o, **kwargs):
+        """
+        Format declaration attributes as
+          <typename>[(<spec>)] [, <attributes>]
+        """
+        attr_str = super().visit_SymbolAttributes(o, **kwargs)
+        attributes = []
+
+        attr_dic = {
+            "device": "DEVICE",
+            "managed": "MANAGED",
+            "constant": "CONSTANT",
+            "shared": "SHARED",
+            "pinned": "PINNED",
+            "texture": "TEXTURE"
+                    }
+
+        for key, value in attr_dic.items():
+            if getattr(o, key):
+                attributes += [value]
+
+        return self.join_items([attr_str] + attributes)
+
+
+def cufgen(ir, depth=0, conservative=False, linewidth=132):
+    """
+    Generate standardized Fortran code from one or many IR objects/trees.
+    """
+    return CudaFortranCodegen(depth=depth, linewidth=linewidth, conservative=conservative).visit(ir)

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -573,6 +573,13 @@ class MetaSymbol(StrCompareMixin, pmbl.AlgebraicLeaf):
         """
         return self.symbol.type
 
+    @type.setter
+    def type(self, _type):
+        """
+        Update the :any:`SymbolAttributes` declared for this symbol
+        """
+        self.symbol.type = _type
+
     @property
     def variables(self):
         """

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -770,13 +770,16 @@ class CallStatement(LeafNode):
     not_active : bool, optional
         Flag to indicate that this call has explicitly been marked as inactive for
         the purpose of processing call trees (Default: `None`)
+    chevron : tuple of :any:`pymbolic.primitives.Expression`
+        Launch configuration for CUDA Fortran Kernels.
+        See [CUDA Fortran programming guide](https://docs.nvidia.com/hpc-sdk/compilers/cuda-fortran-prog-guide/).
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
 
     _traversable = ['name', 'arguments', 'kwarguments']
 
-    def __init__(self, name, arguments, kwarguments=None, pragma=None, not_active=None, **kwargs):
+    def __init__(self, name, arguments, kwarguments=None, pragma=None, not_active=None, chevron=None, **kwargs):
         super().__init__(**kwargs)
 
         assert isinstance(name, Expression)
@@ -785,6 +788,8 @@ class CallStatement(LeafNode):
             is_iterable(kwarguments) and all(isinstance(a, tuple) and len(a) == 2 and
                                              isinstance(a[1], Expression) for a in kwarguments)
         )
+        assert chevron is None or (
+                is_iterable(chevron) and all(isinstance(a, Expression) for a in chevron) and 2 <= len(chevron) <= 4)
 
         self.name = name
         self.arguments = as_tuple(arguments)
@@ -792,6 +797,7 @@ class CallStatement(LeafNode):
         self.kwarguments = as_tuple(kwarguments) if kwarguments else ()
         self.not_active = not_active
         self.pragma = pragma
+        self.chevron = chevron
 
     def __repr__(self):
         return f'Call:: {self.name}'

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -565,10 +565,13 @@ class ProgramUnit(Scope):
         """
         return self._source
 
-    def to_fortran(self, conservative=False):
+    def to_fortran(self, conservative=False, cuf=False):
         """
         Convert this unit to Fortran source representation
         """
+        if cuf:
+            from loki.backend.cufgen import cufgen # pylint: disable=import-outside-toplevel
+            return cufgen(self, conservative=conservative)
         from loki.backend.fgen import fgen  # pylint: disable=import-outside-toplevel
         return fgen(self, conservative=conservative)
 

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from codetiming import Timer
 
 from loki.backend.fgen import fgen
+from loki.backend.cufgen import cufgen
 from loki.frontend import (
     OMNI, OFP, FP, REGEX, sanitize_input, Source, read_file, preprocess_cpp,
     parse_omni_source, parse_ofp_source, parse_fparser_source,
@@ -398,7 +399,9 @@ class Sourcefile:
     def source(self):
         return self._source
 
-    def to_fortran(self, conservative=False):
+    def to_fortran(self, conservative=False, cuf=False):
+        if cuf:
+            return cufgen(self, conservative=conservative)
         return fgen(self, conservative=conservative)
 
     @property
@@ -498,7 +501,7 @@ class Sourcefile:
         # TODO: Should type-check for an `Operation` object here
         op.apply(self, **kwargs)
 
-    def write(self, path=None, source=None, conservative=False):
+    def write(self, path=None, source=None, conservative=False, cuf=False):
         """
         Write content as Fortran source code to file
 
@@ -511,9 +514,11 @@ class Sourcefile:
         conservative : bool, optional
             Enable conservative output in the backend, aiming to be as much string-identical
             as possible (default: False)
+        cuf: bool, optional
+            To use either Cuda Fortran or Fortran backend
         """
         path = self.path if path is None else Path(path)
-        source = self.to_fortran(conservative) if source is None else source
+        source = self.to_fortran(conservative, cuf) if source is None else source
         self.to_file(source=source, path=path)
 
     @classmethod

--- a/tests/test_cufgen.py
+++ b/tests/test_cufgen.py
@@ -1,0 +1,117 @@
+import pytest
+
+from conftest import available_frontends
+from loki import Module, FindNodes, Transformer
+from loki import ir
+from loki.expression import symbols as sym
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_cufgen(frontend):
+    """
+    A simple test routine to test the Cuda Fortran (CUF) backend
+    """
+
+    fcode = """
+module transformation_module_cufgen
+  implicit none
+  integer, parameter :: len = 10
+contains
+
+  subroutine driver(a, b, c)
+    integer, intent(inout) :: a
+    integer, intent(inout) :: b(len)
+    integer, intent(inout) :: c(a, len)
+    integer :: var_device
+    integer :: var_managed
+    integer :: var_constant
+    integer :: var_shared
+    integer :: var_pinned
+    integer :: var_texture
+    call kernel(a, b)    
+  end subroutine driver
+
+  subroutine kernel(a, b)
+    integer, intent(inout) :: a
+    integer, intent(inout) :: b(len)
+    real :: x(a) 
+    real :: k2_tmp(a, a)
+    call device1(x, k2_tmp) 
+  end subroutine kernel
+
+  subroutine device(x, y)
+    real, intent(inout) :: x(len)
+    real, intent(inout) :: y(len, len)
+  end subroutine device
+
+end module transformation_module_cufgen
+"""
+
+    module = Module.from_source(fcode, frontend=frontend)
+
+    driver = None
+    kernels = []
+    device_subroutines = []
+    for routine in module.routines:
+        if "driver" in routine.name:
+            driver = routine
+        elif "kernel" in routine.name:
+            kernels.append(routine)
+        elif "device" in routine.name:
+            device_subroutines.append(routine)
+
+    assert driver
+    assert module.to_fortran(cuf=True) == module.to_fortran()
+
+    decl_map = {}
+    for decl in FindNodes(ir.VariableDeclaration).visit(driver.spec):
+        if "device" in decl.symbols[0].name:
+            decl_map[decl] = decl.clone(symbols=(decl.symbols[0].clone(type=decl.symbols[0].type.clone(device=True)),))
+        if "managed" in decl.symbols[0].name:
+            decl_map[decl] = decl.clone(symbols=(decl.symbols[0].clone(type=decl.symbols[0].type.clone(managed=True)),))
+        if "constant" in decl.symbols[0].name:
+            decl_map[decl] = decl.clone(
+                symbols=(decl.symbols[0].clone(type=decl.symbols[0].type.clone(constant=True)),))
+        if "shared" in decl.symbols[0].name:
+            decl_map[decl] = decl.clone(symbols=(decl.symbols[0].clone(type=decl.symbols[0].type.clone(shared=True)),))
+        if "pinned" in decl.symbols[0].name:
+            decl_map[decl] = decl.clone(symbols=(decl.symbols[0].clone(type=decl.symbols[0].type.clone(pinned=True)),))
+        if "texture" in decl.symbols[0].name:
+            decl_map[decl] = decl.clone(symbols=(decl.symbols[0].clone(type=decl.symbols[0].type.clone(texture=True)),))
+    driver.spec = Transformer(decl_map).visit(driver.spec)
+
+    call_map = {}
+    for call in FindNodes(ir.CallStatement).visit(driver.body):
+        if "kernel" in str(call.name):
+            with pytest.raises(Exception):
+                _ = call.clone(chevron=(sym.IntLiteral(1), sym.IntLiteral(1), sym.IntLiteral(1), sym.IntLiteral(1),
+                                        sym.IntLiteral(1)))
+            with pytest.raises(Exception):
+                _ = call.clone(chevron=(1, 1))
+            with pytest.raises(Exception):
+                _ = call.clone(chevron=2)
+
+            call_map[call] = call.clone(chevron=(sym.IntLiteral(1), sym.IntLiteral(1),
+                                                 sym.IntLiteral(1), sym.IntLiteral(1)))
+
+    driver.body = Transformer(call_map).visit(driver.body)
+
+    for kernel in kernels:
+        kernel.prefix = ("ATTRIBUTES(GLOBAL)",)
+
+    for device_subroutine in device_subroutines:
+        device_subroutine.prefix = ("ATTRIBUTES(DEVICE)",)
+
+    cuf_str = module.to_fortran(cuf=True)
+
+    assert "INTEGER, DEVICE" in cuf_str
+    assert "INTEGER, MANAGED" in cuf_str
+    assert "INTEGER, CONSTANT" in cuf_str
+    assert "INTEGER, SHARED" in cuf_str
+    assert "INTEGER, PINNED" in cuf_str
+    assert "INTEGER, TEXTURE" in cuf_str
+
+    assert "<<<" in cuf_str and ">>>" in cuf_str
+
+    assert "ATTRIBUTES(GLOBAL) SUBROUTINE kernel" in cuf_str
+    assert "ATTRIBUTES(DEVICE) SUBROUTINE device" in cuf_str


### PR DESCRIPTION
## CUDA Fortran

### CUDA Fortran Kernels

* the thread index for each dimension starts at one
* kernel invocation: `kernel<<<grid size, thread block size>>>`
	* `call kernel<<<grid,block[,bytes][,streamid]>>>(arg1,arg2,...)`
	* e.g. using the `dim3` derived type: `type(dim3) =:: blocks, threads`
		* `blocks = dim3(n/256, n/16, 1)`, `threads = dim3(16, 16, 1)`  
* device subprograms are not allowed to have the `SAVE` attribute or with data initialization

| subroutine/function qualifier | description |
| ----------------------------- | ----------- |
| `attributes(host)` | to be executed on the host |
| `attributes(global)` | to be executed on the device, called using a kernel call | 
| `attributes(device)` | to be executed on the device, called from a subprogram with `global` or `device` attribute | 
| `attributes(host,device)` | either `host` or `device` | 
| `attributes(grid_global)` | like `global`, but threads within the grid group are guaranteed to be co-resident on the devic, allowing a grid synchronization (on cc70 hardware and greater) | 


* predefind variables (`cudafor`) in device subprograms

| variable | description |
| -------- | ----------- |
| `threadidx`, `threadidx%x` and/or `threadidx%z` | thread index within its thread block (for one or two dimensional thread blocks) |
| `blockdim` | dimension of the thread block, same value for all thread blocks in the same grid |
| `blockidx`, `blockidx%x` and/or `blockidx%z`| block index within the grid |
| `griddim` | dimension of the grid |
| `warpssize` | constant integer, threads are executed in groups of `warpsize` (currently 32) |


```fortran
! Kernel definition
attributes(global) subroutine ksaxpy( n, a, x, y )
    real, dimension(*) :: x,y
    real, value :: a
    integer, value :: n, i
    i = (blockidx%x-1) * blockdim%x + threadidx%x
    if( i <= n ) y(i) = a * x(i) + y(i)
end subroutine

! Host subroutine
subroutine solve( n, a, x, y )
    real, device, dimension(*) :: x, y
    real :: a
    integer :: n
    ! call the kernel
    call ksaxpy<<<n/64, 64>>>( n, a, x, y )
end subroutine
```

#### Kernel Loop directive

* automatic kernel generation and invocation from a region of host code containing one or more tightly nested loops
	* `!$cuf kernel do[(n)] <<< grid, block  [optional stream] >>>`
	* or `!$cuf kernel do[(n)] <<< grid, block, 0, streamid >>>`
	* or `!$cuf kernel do[(n)] <<< grid, block, stream=streamid >>>` 
* scalar reduction operation, such as summing the values in a vector or matrix, are handled by the compiler, e.g. generation of the final reduction kernel, inserting synchronization into the kernel as appropriate

e.g. (grid shape is computed by the compiler)

```fortran
!$cuf kernel do(2) <<< (*,*), (32,4) >>>
do j = 1, m
  do i = 1, n
    a(i,j) = b(i,j) + c(i,j)
  end do
end do
```

e.g. (automatic) reduction

```fortran
rsum = 0.0
!$cuf kernel do <<< *, * >>>
do i = 1, n
    rsum = rsum + x(i)* y(i)
end do
```

e.g. explicit reduction

* allowed reductions
	* Fortran integer type: `+`, `*`, `max`, `min`, `iand`, `ior`, and `ieor` 
	* Fortran real type: `+`, `*`, `max`, `min`
	* Fortran complex type: `+` 
	* Fortran logical type: `.and.`, `.or.`

```fortran
value = 0.0
!$cuf kernel do <<< *, * >>> reduce(+:value)
do i = 1, n
    a(i) = real(int(a(i) * 100.0 - 50.0),kind=4)
    if (a(i) .ge. 0.0) then
        value = value + a(i)
    else
        value = value + a(i) + 50.0
    end if
end do
```

* the directive specifying `n` must be followed by at least that many tightly-nested `DO` loops
* tighly-nested `DO` loops must have invariant loop limits
* the invariant loop limits cannot be a value from an array expression, unless those arrays have the managed attribute
* no `GOTO` or `EXIT` statements within or between any loops that have been mapped onto the grid and block configuration values
	*  body of the loops may contain assignment statements, IF statements, loops, and GOTO statements
* only CUDA Fortran data types allowed 
* device-specific intrinsics such as the syncthreads and other warp or block-level cooperating, syncing, or barrier functions should be avoided except in very limited situations
* subroutine and function calls to attributes(device) subprograms are allowed if they are in the same module as the code containing the directive
* implicit loops and F90 array syntax are not allowed within the directive loops


### Variable Qualifiers

* by default all variables are alllocated in the host main memory

| qualifier | description |
| --------- | ----------- |
| `attributes(device)` | allocated in the device global memory | 
| `attributes(managed)` | may be used in both host and device code |
| `attributes(constant)` | device constant variable, allocated in the device constant memory (modifiable by the host but not by the device) |
| `attributes(shared)` | may not be data initialized, allocated in the device shared memory for a thread block, a write in one thread only guaranteed to be visible by another thread in the thread block after `SYNCTHREADS()` |
| `attributes(pinned)` | a pinned variable must be an allocatable array, when allocated it will be allocated in host pagelocked memory allowing for faster copies |
| `attributes(texture)` | a texture variable must be an F90 pointer (real or integer), read-only |

* members of derived type may not have the device attribute unless they are allocatable
* device variables
	* device variables and arrays may be passed as actual argumnts to host and device subprograms
		* subprogram interface must be explicit and the matching dummy argument must also have the device attribute
	* device variables and arrays declareed in a host subprogram cannot have the `save` attribute unless they are allocatable 
* shared variables
	* shared data may not have the `pointer`, `target` or `allocatable` attributes
	* members of derived type may not have the shared attribute
	* `real, shared :: x(*)` is allowed but memory for this assumed-siye shared memory needs to be defined by the kernel invocation
* dummy arguments (like in Fortran) are passed by default by reference, therefor the actual argument must be stored in device global memory
	* scalar arguments can be passed by value adding the `value` argument 
	
### F90 pointers

* (recently added support for) F90 pointers that point to device data
	* limited to pointer declared at module scope
	* accessed through module assocation, or can be passed in to global subroutines
	* `associated()` function is also supported in device code  

```fortran
module devptr
! currently, pointer declarations must be in a module
  real, device, pointer, dimension(:) :: mod_dev_ptr
  real, device, pointer, dimension(:) :: arg_dev_ptr
  real, device, target,  dimension(4) :: mod_dev_arr
  real, device, dimension(4) :: mod_res_arr
contains
  attributes(global) subroutine test(arg_ptr)
    real, device, pointer, dimension(:) :: arg_ptr
    ! copy 4 elements from one of two spots
    if (associated(arg_ptr)) then
      mod_res_arr = arg_ptr
    else
      mod_res_arr = mod_dev_ptr
    end if
  end subroutine test
end module devptr
```

## Compilation

* CUDA Fortran is enabled in compilation specifying `-cuda` or renaming the file to have a `.cuf` or `.CUF` extension
* target architecture e.g. `-Mcuda=cc35`
* specifying emulation mode: `-Mcuda=emu`
* target CUDA toolkit version e.g. `-Mcuda=cuda5.0`
* `-Mcuda=fastmath` enables faster intrinsics
* `-Mcuda-nofma` disables fused multiply-add
* `-Mcuda=maxregcount:<n>` limits registr usage per thread
* `-Mcuda=ptxinfo` prints memory usage per kernel
* `-Mcuda=rdc` (relocatable device code) allows to call device functions between modules

### Conditional compilation

* pre-processing is enabled by either the `-Mpreprocess` option or by using capital letters in the filename extension
	* then `_CUDA` macro is defined


e.g. 

```fortran
program p
!@cuf use cudafor
real a(1000)
!@cuf attributes(managed) :: a
real b(1000)
!@cuf real, device :: b_dev(1000)
b = 2.0
!@cuf b_dev = b
!@cuf associate(b=>b_dev)
!$cuf kernel do(1) <<<*,*>>>
do i = 1, 1000
    a(i) = real(i) * b(i)
end do
!@cuf end associate
#ifdef _CUDA
print *,"GPU sum passed? ",sum(a).eq.1000*1001
#else
print *,"CPU sum passed? ",sum(a).eq.1000*1001
#endif
end program
``` 


## Device memory

* dynamically allocated in host buprograms using the `allocate` statement, if it does not have the `save` attribute, it will be automatically deallocated when the subprogram returns
	* also applicable to scalars

```fortran
real, allocatable, device :: b(:)
allocate(b(5024),stat=istat)
...
if(allocated(b)) deallocate(b)
```

* automatic and local arrays, having the lifetime of the subprogram (as usual)

```fortran
subroutine vfunc(a,c,n)
    real, device :: adev(n)
    real, device :: atmp(4)
    ...
end subroutine vfunc   ! adev and atmp are deallocated
```

* allocating device memory using runtime routines (C-like behaviour)

```fortran
real, allocatable, device :: v(:)
istat = cudaMalloc(v, 100)
...
istat = cudaFree(v)
```

* using `NV_CUDAFOR_DEVICE_IS_MANAGED=1` all device data allocation will be managed meory instead of device memory (potentially without coding changes)


### Memory transfer 

* copy H2D (and vice-versa) is possible through simple assigment statements in the host program (using CUDA stream zero)
	* unless `cudaforSetDefaultStream` was used to associate one or more device and managed variables to a particular stream 
* an assignment with device variables on both sides copies the ata between two device variables or arrays
* elemental transfers are supported (but perform poorly)
* array slices are also supported, whereas the performance is dependent on the size of the slice, the amount of contiguous data in the slices and the implementation

further following expressions are legal:

```fortran
a = adev
adev = a
b = a + adev
c = x * adev + b
```

## Synchronization

* `syncthreads` - barrier synchronization for all threads in a single thread block
* `syncthreads_count` - additionally evaluates the integer argument `int_value` for all threads of the block and returns the number of threads for which `int_value` evaluates to non-zero
* `syncthreads_and(int_value)` - additionally evaluates the integer argument `int_value` for all threads of the block and returns non-zero if and only if `int_value` evaluates to non-zero for all of them
* `synthreads_or(int_value)` - additionally evaluates the integer argument `int_value` for all threads of the block and returns non-zero if and only if `int_value` evaluates to non-zero for any of them
* `syncwarp` - cause all executing threads within a warp, and specified in the mask argument, to reach a barrier
* `threadfence` - all global and ahared memory accesses by the calling thread prior to `threadfence()` are visible to:
	* all the threads in the thread block for shared memory accesses
	* all the threads in the device for global memory accesses 
* `threadfence_block` - visible to all the threads in the thread block 
* `threadfence_system` 


* warp-vote operations:
	* `allthreads`: `if( allthreads(a(i)<0.0) ) allneg = .true.`
	* `anythread`: `if( anythread(a(i)<0.0) ) allneg = .true.`
	* `ballot(int_value)`: evaluates the argument `int_value` for all threads of the warp and returns an integer whose Nth bit is set if and only if `int_value` evaluates to non-zero for the Nth thread of the warp
	* `activemask` - returns a 32-bit integer mask of all the curently active threads
	* ...

## Device intrinsics

* Fortran intrinsics allowed in device subprograms
	* `abs`, `aimag`, `aint`, `anint`, `ceiling`, `cmplx`, `conjg`, `dim`, `floor`, `int`, `logical`, `max`, `min`, `mod`, `modulo`, `nint`, `real`, `sign`	* ...
* CUF additions by NVIDIA:
	* ...


## Runtime APIs

* device management:
	* `cudaChooseDevice`
	* `cudaDeviceGetAttribute`
	* `cudaDeviceGetCacheConfig`
	* `cudaDeviceGetLimit`
	* `cudaSetDevice`
	* ...  
