### PR TITLE
Github actions workflow for documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,96 @@
+name: documentation
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push events
+  push:
+    branches: [ 'main' ]
+    tags-ignore: [ '**' ]
+
+  # Triggers the workflow on pull request events
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  clean:
+    name: Clean-up branch documentation
+
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # false: try to complete all jobs
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install sites-toolkit -i https://get.ecmwf.int/repository/pypi-all/simple
+
+    - name: Clean-up documentation on sites
+      env:
+        SITES_TOKEN: ${{ secrets.SITES_TOKEN }}
+      working-directory: ./docs
+      run: |
+        ./sites-manager.py --space=docs --name=loki --token "$SITES_TOKEN" delete ${{ github.ref_name }} || true
+
+  build:
+    name: Build and upload documentation
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # false: try to complete all jobs
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install pandoc
+      run: |
+        sudo apt-get update || true
+        sudo apt-get install -y pandoc
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install sites-toolkit -i https://get.ecmwf.int/repository/pypi-all/simple
+        pip install .[docs]
+
+    - name: Build documentation
+      working-directory: ./docs
+      run: |
+        make html
+
+    - name: Upload documentation to sites
+      env:
+        SITES_TOKEN: ${{ secrets.SITES_TOKEN }}
+      working-directory: ./docs
+      run: |
+        ./sites-manager.py --space=docs --name=loki --token "$SITES_TOKEN" upload build/html ${{ github.ref_name }} || true
+
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Documentation for this branch can be viewed at https://sites.ecmwf.int/docs/loki/${{ github.ref_name }}'
+          })


### PR DESCRIPTION
Remaining CI item was auto-generating and uploading documentation. Not entirely sure this workflow does what it is supposed to do, but it generates documentation for pull request branches and should hopefully do the same for main after merging - and ideally clean-up the pr documentation files.

As a courtesy, the action even prints the link to the generated documentation in the PR ;-)