### PR TITLE
Implied-do support and error for `PROGRAM`

### DIFF
--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -73,7 +73,10 @@ class FCodeMapper(LokiStringifyMapper):
             enclosing_prec, PREC_COMPARISON)
 
     def map_literal_list(self, expr, enclosing_prec, *args, **kwargs):
-        return '(/' + ','.join(str(c) for c in expr.elements) + '/)'
+        values = ','.join(self.rec(c, PREC_NONE, *args, **kwargs) for c in expr.elements)
+        if expr.dtype is not None:
+            return f'(/ {fgen(expr.dtype)} :: {values} /)'
+        return f'(/ {values} /)'
 
     def map_foreign(self, expr, *args, **kwargs):
         try:

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -191,7 +191,7 @@ class LokiStringifyMapper(StringifyMapper):
         return ' // '.join(self.rec(c, enclosing_prec, *args, **kwargs) for c in expr.children)
 
     def map_literal_list(self, expr, enclosing_prec, *args, **kwargs):
-        values = ','.join(self.rec(c, PREC_NONE, *args, **kwargs) for c in expr.elements)
+        values = ', '.join(self.rec(c, PREC_NONE, *args, **kwargs) for c in expr.elements)
         if expr.dtype is not None:
             return f'[ {str(expr.dtype)} :: {values} ]'
         return f'[ {values} ]'

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1129,7 +1129,8 @@ class IntrinsicLiteral(ExprMetadataMixin, StrCompareMixin, _Literal):
     Any literal not represented by a dedicated class.
 
     Its value is stored as string and returned unaltered.
-    This is currently used for complex and BOZ constants.
+    This is currently used for complex and BOZ constants and to retain
+    array constructor expressions with type spec or implied-do.
 
     Parameters
     ----------

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1213,8 +1213,6 @@ class LiteralList(ExprMetadataMixin, pmbl.AlgebraicLeaf):
 
     def __getinitargs__(self):
         return (self.elements, self.dtype)
-        elements = ','.join(repr(c) for c in self.elements)
-        return (f'[{elements}]',)
 
 
 class InlineDo(ExprMetadataMixin, pmbl.AlgebraicLeaf):

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -30,7 +30,7 @@ __all__ = [
     'MetaSymbol', 'Scalar', 'Array', 'Variable',
     # Non-typed leaf nodes
     'FloatLiteral', 'IntLiteral', 'LogicLiteral', 'StringLiteral',
-    'IntrinsicLiteral', 'Literal', 'LiteralList',
+    'IntrinsicLiteral', 'Literal', 'LiteralList', 'InlineDo',
     # Internal nodes
     'Sum', 'Product', 'Quotient', 'Power', 'Comparison', 'LogicalAnd', 'LogicalOr',
     'LogicalNot', 'InlineCall', 'Cast', 'Range', 'LoopRange', 'RangeIndex', 'ArraySubscript',
@@ -1204,15 +1204,34 @@ class LiteralList(ExprMetadataMixin, pmbl.AlgebraicLeaf):
     A list of constant literals, e.g., as used in Array Initialization Lists.
     """
 
-    def __init__(self, values, **kwargs):
+    def __init__(self, values, dtype=None, **kwargs):
         self.elements = values
+        self.dtype = dtype
         super().__init__(**kwargs)
 
     mapper_method = intern('map_literal_list')
 
     def __getinitargs__(self):
+        return (self.elements, self.dtype)
         elements = ','.join(repr(c) for c in self.elements)
         return (f'[{elements}]',)
+
+
+class InlineDo(ExprMetadataMixin, pmbl.AlgebraicLeaf):
+    """
+    An inlined do, e.g., implied-do as used in array constructors
+    """
+
+    def __init__(self, values, variable, bounds, **kwargs):
+        self.values = values
+        self.variable = variable
+        self.bounds = bounds
+        super().__init__(**kwargs)
+
+    mapper_method = intern('map_inline_do')
+
+    def __getinitargs__(self):
+        return (self.values, self.variable, self.bounds)
 
 
 class Sum(ExprMetadataMixin, StrCompareMixin, pmbl.Sum):

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1620,6 +1620,15 @@ class FParser2IR(GenericVisitor):
     # Subroutine and Function definitions
     #
 
+    def visit_Main_Program(self, o, **kwargs):
+        """
+        The entire block that comprises a ``PROGRAM`` definition
+
+        Loki does currently not have support for ``PROGRAM`` blocks, and this
+        will raise a :any:`NotImplementedError`
+        """
+        self.warn_or_fail('No support for PROGRAM')
+
     def visit_Subroutine_Subprogram(self, o, **kwargs):
         """
         The entire block that comprises a ``SUBROUTINE`` definition, i.e.

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -988,7 +988,11 @@ class FParser2IR(GenericVisitor):
         """
         if o.children[0] is not None:
             # TODO: implement Type_Spec support
-            return self.visit_Base(o, **kwargs)
+            source = kwargs.get('source')
+            if source:
+                source = source.clone_with_string(o.string)
+            values = as_tuple(sym.IntrinsicLiteral(o.string))
+            return sym.LiteralList(values=values, source=source)
         return self.visit(o.children[1], **kwargs)
 
     def visit_Ac_Value_List(self, o, **kwargs):
@@ -1005,10 +1009,15 @@ class FParser2IR(GenericVisitor):
         """
         An implied-do for array constructors
         """
-        # TODO: implement implied-do
-        return self.visit_Base(o, **kwargs)
+        values = as_tuple(sym.IntrinsicLiteral(o.string))
+        return sym.LiteralList(values=values)
 
-    visit_Ac_Implied_Do_Control = visit_Ac_Implied_Do
+    def visit_Ac_Spec(self, o, **kwargs):
+        """
+        An ac-spec in an array constructor (i.e. with type definition)
+        """
+        values = as_tuple(sym.IntrinsicLiteral(o.string))
+        return sym.LiteralList(values=values)
 
     #
     # DATA statements

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1638,7 +1638,7 @@ class OFP2IR(GenericVisitor):
     def visit_array_constructor_values(self, o, **kwargs):
         values = [self.visit(v, **kwargs) for v in o.findall('value')]
         values = [v for v in values if v is not None]  # Filter empy values
-        return sym.LiteralList(values=values, source=kwargs['source'])
+        return sym.LiteralList(values=as_tuple(values), source=kwargs['source'])
 
     def visit_operation(self, o, **kwargs):
         """

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1283,6 +1283,9 @@ class OFP2IR(GenericVisitor):
         )
         return module
 
+    def visit_program(self, o, **kwargs):
+        self.warn_or_fail('No support for PROGRAM')
+
     def visit_association(self, o, **kwargs):
         return sym.Variable(name=o.attrib['associate-name'])
 

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -316,6 +316,9 @@ class OMNI2IR(GenericVisitor):
 
         # Return type and dummy args
         ftype = self.type_map[o.find('name').attrib['type']]
+        if ftype.attrib.get('is_program') == 'true':
+            self.warn_or_fail('No support for PROGRAM')
+            return None
         proc_type = self.visit(ftype, scope=scope, symbol_map=symbol_map)
         is_function = ftype.attrib['return_type'] != 'Fvoid'
         args = tuple(a.text for a in ftype.findall('params/name'))
@@ -350,6 +353,8 @@ class OMNI2IR(GenericVisitor):
 
         # Instantiate the object
         routine = self._create_Subroutine_object(o, kwargs['scope'], kwargs['symbol_map'])
+        if routine is None:
+            return None
         kwargs['scope'] = routine
 
         # Parse the spec

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -304,7 +304,7 @@ end subroutine logical_array
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OFP, 'Not implemented'), (OMNI, 'Not implemented')]
+    xfail=[(OFP, 'Not implemented')]
 ))
 def test_array_constructor(here, frontend):
     """

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -311,7 +311,7 @@ def test_array_constructor(here, frontend):
     Test various array constructor formats
     """
     fcode = """
-subroutine array_constructor(dim, zarr1, zarr2, narr1, narr2, narr3, narr4)
+subroutine array_constructor(dim, zarr1, zarr2, narr1, narr2, narr3, narr4, narr5)
     implicit none
     integer, intent(in) :: dim
     real(8), intent(inout) :: zarr1(dim+1)
@@ -320,6 +320,7 @@ subroutine array_constructor(dim, zarr1, zarr2, narr1, narr2, narr3, narr4)
     integer, intent(inout) :: narr2(10)
     integer, intent(inout) :: narr3(3)
     integer, intent(inout) :: narr4(2,2)
+    integer, intent(inout) :: narr5(10)
     integer :: i
 
     zarr1 = [ 3.6, (3.6 / I, I = 1, dim) ]
@@ -328,6 +329,7 @@ subroutine array_constructor(dim, zarr1, zarr2, narr1, narr2, narr3, narr4)
     narr3 = [integer :: 1, 2., 3d0]    ! A default integer array
     zarr2 = [real(8) :: 1, 2, 3._8]  ! A real(8) array
     narr4 = RESHAPE([1,2,3,4], shape=[2,2])
+    narr5 = (/(I, I=30, 48, 2)/)
 end subroutine array_constructor
     """.strip()
 
@@ -342,7 +344,8 @@ end subroutine array_constructor
     narr2 = np.zeros(10, dtype=np.int32)
     narr3 = np.zeros(3, dtype=np.int32)
     narr4 = np.zeros((2, 2), dtype=np.int32, order='F')
-    function(dim, zarr1, zarr2, narr1, narr2, narr3, narr4)
+    narr5 = np.zeros(10, dtype=np.int32)
+    function(dim, zarr1, zarr2, narr1, narr2, narr3, narr4, narr5)
 
     assert np.isclose(zarr1, ([3.6] + [3.6/(i+1) for i in range(dim)])).all()
     assert np.isclose(zarr2, [1., 2., 3.]).all()
@@ -350,6 +353,7 @@ end subroutine array_constructor
     assert (narr2 == range(1, -9, -1)).all()
     assert (narr3 == [1, 2, 3]).all()
     assert (narr4 == np.array([[1, 3], [2, 4]], order='F')).all()
+    assert (narr5 == range(30, 49, 2)).all()
 
     clean_test(filepath)
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -303,6 +303,57 @@ end subroutine logical_array
     clean_test(filepath)
 
 
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OFP, 'Not implemented'), (OMNI, 'Not implemented')]
+))
+def test_array_constructor(here, frontend):
+    """
+    Test various array constructor formats
+    """
+    fcode = """
+subroutine array_constructor(dim, zarr1, zarr2, narr1, narr2, narr3, narr4)
+    implicit none
+    integer, intent(in) :: dim
+    real(8), intent(inout) :: zarr1(dim+1)
+    real(8), intent(inout) :: zarr2(3)
+    integer, intent(inout) :: narr1(dim)
+    integer, intent(inout) :: narr2(10)
+    integer, intent(inout) :: narr3(3)
+    integer, intent(inout) :: narr4(2,2)
+    integer :: i
+
+    zarr1 = [ 3.6, (3.6 / I, I = 1, dim) ]
+    narr1 = (/ (I, I = 1, DIM) /)
+    narr2 = (/1, 0, (I, I = -1, -6, -1), -7, -8 /)
+    narr3 = [integer :: 1, 2., 3d0]    ! A default integer array
+    zarr2 = [real(8) :: 1, 2, 3._8]  ! A real(8) array
+    narr4 = RESHAPE([1,2,3,4], shape=[2,2])
+end subroutine array_constructor
+    """.strip()
+
+    filepath = here/f'array_constructor_{frontend}.f90'
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    function = jit_compile(routine, filepath=filepath, objname='array_constructor')
+
+    dim = 13
+    zarr1 = np.zeros(dim+1, dtype=np.float64)
+    zarr2 = np.zeros(3, dtype=np.float64)
+    narr1 = np.zeros(dim, dtype=np.int32)
+    narr2 = np.zeros(10, dtype=np.int32)
+    narr3 = np.zeros(3, dtype=np.int32)
+    narr4 = np.zeros((2, 2), dtype=np.int32, order='F')
+    function(dim, zarr1, zarr2, narr1, narr2, narr3, narr4)
+
+    assert np.isclose(zarr1, ([3.6] + [3.6/(i+1) for i in range(dim)])).all()
+    assert np.isclose(zarr2, [1., 2., 3.]).all()
+    assert (narr1 == range(1, dim+1)).all()
+    assert (narr2 == range(1, -9, -1)).all()
+    assert (narr3 == [1, 2, 3]).all()
+    assert (narr4 == np.array([[1, 3], [2, 4]], order='F')).all()
+
+    clean_test(filepath)
+
+
 @pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Precedence not honoured')]))
 def test_parenthesis(frontend):
     """


### PR DESCRIPTION
This expands the support for array constructors, in particular `implied-do` format and with type-spec. They had not been handled gracefully before. Implemented for OMNI and fparser, OFP seemed too silly.

Piggy-backed is more sane handling of `PROGRAM` blocks - i.e., printing an error and bailing out. Behaviour was different between frontends before, some treating them as subroutines and others skipping over them. It shouldn't be terribly hard to add an implementation of `ProgramUnit` for that but until we do, we should gracefully fail or ignore that node rather than have some scrambled-together half-representation (since this has confused users before).