### PR TITLE
Transformation: parametrise

### DIFF
--- a/docs/source/transform.rst
+++ b/docs/source/transform.rst
@@ -89,6 +89,7 @@ to grow in the future:
    loki.transform.transform_hoist_variables.HoistVariablesTransformation
    loki.transform.transform_hoist_variables.HoistTemporaryArraysAnalysis
    loki.transform.transform_hoist_variables.HoistTemporaryArraysTransformationAllocatable
+   loki.transform.transform_parametrise.ParametriseTransformation
 
 Further transformations are defined for specific use-cases but may prove
 useful in a wider context. These are defined in :mod:`transformations`:

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -189,7 +189,6 @@ class OMNI2IR(GenericVisitor):
         """
         Universal default for XML element types
         """
-        # from IPython import embed; embed()
         warning('No specific handler for node type %s', o.__class__.name)
         children = tuple(self.visit(c, **kwargs) for c in o)
         children = tuple(c for c in children if c is not None)

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -189,6 +189,7 @@ class OMNI2IR(GenericVisitor):
         """
         Universal default for XML element types
         """
+        # from IPython import embed; embed()
         warning('No specific handler for node type %s', o.__class__.name)
         children = tuple(self.visit(c, **kwargs) for c in o)
         children = tuple(c for c in children if c is not None)
@@ -1362,6 +1363,10 @@ class OMNI2IR(GenericVisitor):
     def visit_gotoStatement(self, o, **kwargs):
         label = int(o.attrib['label_name'])
         return ir.Intrinsic(text=f'go to {label: d}', source=kwargs['source'])
+
+    def visit_FstopStatement(self, o, **kwargs):
+        code = o.attrib['code']
+        return ir.Intrinsic(text=f'stop {code!s}', source=kwargs['source'])
 
     def visit_statementLabel(self, o, **kwargs):
         return ir.Comment('__STATEMENT_LABEL__', label=o.attrib['label_name'], source=kwargs['source'])

--- a/loki/transform/__init__.py
+++ b/loki/transform/__init__.py
@@ -18,3 +18,4 @@ from loki.transform.fortran_max_transform import * # noqa
 from loki.transform.fortran_python_transform import * # noqa
 from loki.transform.build_system_transform import * # noqa
 from loki.transform.transform_hoist_variables import * # noqa
+from loki.transform.transform_parametrise import * # noqa

--- a/loki/transform/transform_parametrise.py
+++ b/loki/transform/transform_parametrise.py
@@ -1,0 +1,229 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Parametrise variables.
+
+E.g., parametrise
+
+.. code-block:: fortran
+
+    subroutine driver(a, b)
+        integer, intent(in) :: a
+        integer, intent(in) :: b
+        call kernel(a, b)
+    end subroutine driver
+
+    subroutine kernel(a, b)
+        integer, intent(in) :: a
+        integer, intent(in) :: b
+        real :: array(a)
+        ...
+    end subroutine kernel
+
+using the transformation
+
+.. code-block:: python
+
+    dic2p = {'a': 10}
+    scheduler.process(transformation=ParametriseTransformation(dic2p=dic2p))
+
+to
+
+.. code-block:: fortran
+
+    subroutine driver(parametrised_a, b)
+        integer, parameter :: a = 10
+        integer, intent(in) :: parametrised_a
+        integer, intent(in) :: b
+        IF (parametrised_a /= 10) THEN
+            PRINT *, "Variable a parametrised to value 10, but subroutine driver received another value."
+            STOP 1
+        END IF
+        call kernel(b)
+    end subroutine driver
+
+    subroutine kernel(b)
+        integer, parameter :: a = 10
+        integer, intent(in) :: b
+        real :: array(a)
+        ...
+    end subroutine kernel
+"""
+from loki.expression import symbols as sym
+from loki import ir, FindNodes, FindVariables, as_tuple, Transformer, SubstituteExpressions, FindLiterals, is_iterable
+from loki.transform.transformation import Transformation
+from loki.transform.transform_inline import inline_constant_parameters
+
+
+__all__ = ['ParametriseTransformation']
+
+
+class ParametriseTransformation(Transformation):
+    """
+
+    Parameters
+    ----------
+    dic2p: dict
+        Dictionary of variable names and corresponding values to be parametrised.
+    disable: tuple
+        Tuple of subroutines not to be processed.
+    replace_by_value: bool
+        Replace variables entirely by value (default: `False`)
+    entry_points: None or tuple
+        Subroutine names to be used as entry points for parametrisation. Default `None` uses driver(s) as
+        entry points.
+    abort_callback:
+        Callback routine used for error on sanity check.
+        Available arguments via ``kwargs``:
+
+        * ``msg`` - predefined error message
+        * ``routine`` - the routine executing the sanity check
+        * ``var`` - the variable getting checked
+        * ``value`` - the value the variable should have (according to :attr:`dic2p`)
+    key : str
+        Access identifier/key for the ``item.user_data`` dictionary. Only necessary to provide if several of
+        these transformations are carried out in succession.
+    """
+
+    _key = "ParametriseTransformation"
+
+    def __init__(self, dic2p, disable=(), replace_by_value=False, entry_points=None, abort_callback=None, key=None):
+        self.dic2p = dic2p
+        self.disable = disable
+        self.replace_by_value = replace_by_value
+        self.entry_points = entry_points
+        if self.entry_points is not None:
+            assert is_iterable(entry_points)
+        self.abort_callback = abort_callback
+        if key is not None:
+            self._key = key
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Transformation applied to :any:`Subroutine` item.
+
+        Parametrises all variables as defined by :attr:`dic2p` either to be a parameter or by replacing the
+        variable with the value itself.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The subroutine to be transformed.
+        **kwargs : optional
+            Keyword arguments for the transformation.
+        """
+
+        item = kwargs.get('item', None)
+        role = kwargs.get('role', None)
+
+        if item and not item.local_name == routine.name.lower():
+            return
+
+        successors = kwargs.get('successors', None)
+        successor_map = {successor.routine.name: successor for successor in successors}
+
+        # decide whether subroutine is an entry point or not
+        process_entry_point = False
+        if self.entry_points is None:
+            if role is not None and role == "driver":
+                dic2p = self.dic2p
+                process_entry_point = True
+            else:
+                if self._key in item.user_data:
+                    dic2p = item.user_data[self._key]
+                else:
+                    dic2p = {}
+        else:
+            if routine.name in self.entry_points:
+                dic2p = self.dic2p
+                process_entry_point = True
+            else:
+                if self._key in item.user_data:
+                    dic2p = item.user_data[self._key]
+                else:
+                    dic2p = {}
+
+        vars2p = [key for key in dic2p]
+
+        # proceed if dictionary with mapping of variables to parametrised is not empty
+        if dic2p:
+            if process_entry_point:
+                # rename arguments that are parametrised (to allow for sanity checks)
+                arguments = []
+                for arg in routine.arguments:
+                    if arg.name not in vars2p:
+                        arguments.append(arg)
+                    else:
+                        arguments.append(arg.clone(name=f'parametrised_{arg.name}'))
+                routine.arguments = arguments
+                # introduce sanity check
+                for key, value in reversed(dic2p.items()):
+                    if f'parametrised_{key}' in routine.variable_map:
+                        error_msg = f"Variable {key} parametrised to value {value}, but subroutine {routine.name} " \
+                                    f"received another value"
+                        condition = sym.Comparison(routine.variable_map[f'parametrised_{key}'], '!=',
+                                                   sym.IntLiteral(value))
+                        comment = ir.Comment(f"! Stop execution: {error_msg}")
+                        parametrised_var = routine.variable_map[f'parametrised_{key}']
+                        if self.abort_callback is None:
+                            abort = (ir.Intrinsic(text=f'PRINT *, "{error_msg}: ", {parametrised_var.name}'),
+                                     ir.Intrinsic(text="STOP 1"))
+                        else:
+                            kwargs = {"msg": error_msg, "routine": routine.name, "var": parametrised_var,
+                                      "value": value}
+                            abort = self.abort_callback(**kwargs)
+                        body = (comment,) + abort
+                        conditional = ir.Conditional(condition=condition,
+                                                     body=body, else_body=None)
+                        routine.body.prepend(conditional)
+                        routine.body.prepend(ir.Comment(f"! Sanity check for parametrised variable: {key}"))
+            else:
+                routine.arguments = [arg for arg in routine.arguments if arg.name not in vars2p]
+
+            # remove variables to be parametrised from all call statements
+            call_map = {}
+            for call in FindNodes(ir.CallStatement).visit(routine.body):
+                if call.name not in self.disable:
+                    successor_map[call.name].user_data[self._key] = {}
+                    arg_map = dict(call.arg_iter())
+                    arg_map_reversed = {v: k for k, v in arg_map.items()}
+                    indices = [call.arguments.index(var2p) for var2p in vars2p if var2p in call.arguments]
+                    for index in indices:
+                        successor_map[call.name].user_data[self._key][arg_map_reversed[call.arguments[index]]] = \
+                            dic2p[call.arguments[index].name]
+                    arguments = [arg for i, arg in enumerate(call.arguments) if arg not in vars2p]
+                    call_map[call] = call.clone(arguments=arguments)
+            routine.body = Transformer(call_map).visit(routine.body)
+
+            # remove declarations
+            declarations = FindNodes(ir.VariableDeclaration).visit(routine.spec)
+            parameter_declarations = []
+            decl_map = {}
+            for decl in declarations:
+                symbols = []
+                for smbl in decl.symbols:
+                    if smbl in vars2p:
+                        parameter_declarations.append(decl.clone(symbols=(smbl.clone(
+                            type=decl.symbols[0].type.clone(parameter=True, intent=None,
+                                                            initial=sym.IntLiteral(
+                                                                dic2p[smbl.name]))),)))
+                    else:
+                        symbols.append(smbl.clone())
+
+                    if symbols:
+                        decl_map[decl] = decl.clone(symbols=as_tuple(symbols))
+                    else:
+                        decl_map[decl] = None
+            routine.spec = Transformer(decl_map).visit(routine.spec)
+
+            declarations = FindNodes(ir.VariableDeclaration).visit(routine.spec)
+            for parameter_declaration in parameter_declarations:
+                routine.spec.insert(routine.spec.body.index(declarations[0]), parameter_declaration)
+
+            if self.replace_by_value:
+                inline_constant_parameters(routine=routine, external_only=False)

--- a/loki/transform/transform_parametrise.py
+++ b/loki/transform/transform_parametrise.py
@@ -152,9 +152,12 @@ class ParametriseTransformation(Transformation):
 
     _key = "ParametriseTransformation"
 
-    def __init__(self, dic2p, disable=(), replace_by_value=False, entry_points=None, abort_callback=None, key=None):
+    def __init__(self, dic2p, disable=None, replace_by_value=False, entry_points=None, abort_callback=None, key=None):
         self.dic2p = dic2p
-        self.disable = [_.upper() for _ in disable]
+        if disable is None:
+            self.disable = ()
+        else:
+            self.disable = [_.upper() for _ in disable]
         self.replace_by_value = replace_by_value
         if entry_points is not None:
             self.entry_points = [_.upper() for _ in entry_points]

--- a/tests/sources/projParametrise/parametrise.f90
+++ b/tests/sources/projParametrise/parametrise.f90
@@ -10,9 +10,7 @@ contains
 
     subroutine driver(a, b, c, d)
         integer, intent(inout) :: a, b, d(b)
-        ! integer, intent(in) :: b
         integer, intent(inout) :: c(a, b)
-        ! integer, intent(inout) :: d(b)
         real :: x, y
         call kernel1(a, b, c)
         call kernel2(a, b, d)
@@ -26,20 +24,6 @@ contains
         real :: x(a)
         call kernel1(a, b, c)
     end subroutine another_driver
-
-!    subroutine kernel1(a, b, c)
-!        integer, intent(in) :: a
-!        integer, intent(in) :: b
-!        integer, intent(inout) :: c(a, b)
-!        integer :: d(b)
-!        integer :: local_a
-!        real :: x(a)
-!        integer :: y(a, b)
-!        real :: k1_tmp(a, b)
-!        y = 11
-!        c = y
-!        call device2(a, b, d, x)
-!    end subroutine kernel1
 
     subroutine kernel1(a, b, c)
         integer, intent(in) :: a
@@ -62,16 +46,6 @@ contains
         real :: k2_tmp(a_new, a_new)
         call device1(a_new, b, d, x, k2_tmp)
     end subroutine kernel2
-
-!    subroutine kernel2(a, b, d)
-!        integer, intent(in) :: a
-!        integer, intent(in) :: b
-!        integer, intent(inout) :: d(b)
-!        real :: x(a)
-!        real :: y, z
-!        real :: k2_tmp(a, a)
-!        call device1(a, b, d, x, k2_tmp)
-!    end subroutine kernel2
 
     subroutine device1(a, b, d, x, y)
         integer, intent(in) :: a

--- a/tests/sources/projParametrise/parametrise.f90
+++ b/tests/sources/projParametrise/parametrise.f90
@@ -1,0 +1,99 @@
+module parametrise
+    implicit none
+contains
+
+    subroutine stop_execution(msg)
+        character(200), INTENT(IN) :: msg
+        PRINT *, msg
+        stop 1
+    end subroutine stop_execution
+
+    subroutine driver(a, b, c, d)
+        integer, intent(inout) :: a, b, d(b)
+        ! integer, intent(in) :: b
+        integer, intent(inout) :: c(a, b)
+        ! integer, intent(inout) :: d(b)
+        real :: x, y
+        call kernel1(a, b, c)
+        call kernel2(a, b, d)
+        call kernel1(a, b, c)
+    end subroutine driver
+
+    subroutine another_driver(a, b, c)
+        integer, intent(in) :: a
+        integer, intent(in) :: b
+        integer, intent(inout) :: c(a, b)
+        real :: x(a)
+        call kernel1(a, b, c)
+    end subroutine another_driver
+
+!    subroutine kernel1(a, b, c)
+!        integer, intent(in) :: a
+!        integer, intent(in) :: b
+!        integer, intent(inout) :: c(a, b)
+!        integer :: d(b)
+!        integer :: local_a
+!        real :: x(a)
+!        integer :: y(a, b)
+!        real :: k1_tmp(a, b)
+!        y = 11
+!        c = y
+!        call device2(a, b, d, x)
+!    end subroutine kernel1
+
+    subroutine kernel1(a, b, c)
+        integer, intent(in) :: a
+        integer, intent(in) :: b
+        integer, intent(inout) :: c(a, b)
+        integer :: local_a
+        real :: x(a)
+        integer :: y(a, b)
+        real :: k1_tmp(a, b)
+        y = 11
+        c = y
+    end subroutine kernel1
+
+    subroutine kernel2(a_new, b, d)
+        integer, intent(in) :: a_new
+        integer, intent(in) :: b
+        integer, intent(inout) :: d(b)
+        real :: x(a_new)
+        real :: y, z
+        real :: k2_tmp(a_new, a_new)
+        call device1(a_new, b, d, x, k2_tmp)
+    end subroutine kernel2
+
+!    subroutine kernel2(a, b, d)
+!        integer, intent(in) :: a
+!        integer, intent(in) :: b
+!        integer, intent(inout) :: d(b)
+!        real :: x(a)
+!        real :: y, z
+!        real :: k2_tmp(a, a)
+!        call device1(a, b, d, x, k2_tmp)
+!    end subroutine kernel2
+
+    subroutine device1(a, b, d, x, y)
+        integer, intent(in) :: a
+        integer, intent(in) :: b
+        integer, intent(inout) :: d(b)
+        real, intent(inout) :: x(a)
+        real, intent(inout) :: y(a, a)
+        real :: z
+        integer :: d1_tmp
+        call device2(a, b, d, x)
+        call device2(a, b, d, x)
+    end subroutine device1
+
+    subroutine device2(a, b, d, x)
+        integer, intent(in) :: a
+        integer, intent(in) :: b
+        integer, intent(inout) :: d(b)
+        real, intent(inout) :: x(a)
+        integer z(b)
+        integer :: d2_tmp(b)
+        z = 42
+        d = z
+    end subroutine device2
+
+end module parametrise

--- a/tests/test_transform_parametrise.py
+++ b/tests/test_transform_parametrise.py
@@ -1,0 +1,482 @@
+"""
+A selection of tests for the generic hoist functionality.
+"""
+from pathlib import Path
+import pytest
+import numpy as np
+
+from conftest import jit_compile_lib, available_frontends, jit_compile, clean_test
+from loki import Builder, Module, Subroutine, FindNodes, Import, FindVariables
+from loki.expression import symbols as sym
+from loki import ir, as_tuple, is_iterable, fgen
+from loki.transform import inline_elemental_functions, inline_constant_parameters, replace_selected_kind
+from loki import Scheduler, OMNI
+from loki.transform import ParametriseTransformation
+import loki.expression.symbols as sym
+
+write_transformation_output = True
+
+OMNI_fail = 'OMNI cannot deal with "stop 1", as type object "xml.etree.ElementTree.Element" has no attribute "name"'
+
+@pytest.fixture(scope='module', name='here')
+def fixture_here():
+    return Path(__file__).parent
+
+
+@pytest.fixture(name='config')
+def fixture_config():
+    """
+    Default configuration dict with basic options.
+    """
+    return {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True,
+        },
+        'routine': [
+            {
+                'name': 'driver',
+                'role': 'driver',
+                'expand': True,
+            },
+            {
+                'name': 'another_driver',
+                'role': 'driver',
+                'expand': True,
+            },
+        ]
+    }
+
+
+def compile_and_test(scheduler, here, a=5, b=1, test_name=""):
+    """
+    Compile the source code and call the driver function in order to test the results for correctness.
+    """
+    for item in scheduler.items:
+        if "driver" in item.name:
+            suffix = '.F90'
+            if test_name != "":
+                item.source.path = Path(f"{item.source.path.stem}_{test_name}")
+            module = jit_compile(item.source, filepath=item.source.path.with_suffix(suffix).name, objname=None)
+            c = np.zeros((a, b), dtype=np.int32, order='F')
+            d = np.zeros((b,), dtype=np.int32, order='F')
+            module.Parametrise.driver(a, b, c, d)
+            assert (c == 11).all()
+            assert (d == 42).all()
+            clean_test(filepath=here.parent / item.source.path.with_suffix(suffix).name)
+
+
+def check_arguments_and_parameter(scheduler, subroutine_arguments, call_arguments, parameter_variables):
+    """
+    Check the subroutine and call arguments of each subroutine.
+    """
+    for item in scheduler.items:
+        routine_parameters = [var for var in item.routine.variables if var.type.parameter]
+        if "driver" in item.name and "another" not in item.name:
+            assert routine_parameters == parameter_variables["driver"]
+            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["driver"]
+            for call in FindNodes(ir.CallStatement).visit(item.routine.body):
+                if "kernel1" in call.name:
+                    assert call.arguments == call_arguments["kernel1"]
+                elif "kernel2" in call.name:
+                    assert call.arguments == call_arguments["kernel2"]
+        elif "another_driver" in item.name:
+            assert routine_parameters == parameter_variables["another_driver"]
+            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["another_driver"]
+            for call in FindNodes(ir.CallStatement).visit(item.routine.body):
+                if "kernel1" in call.name:
+                    assert call.arguments == call_arguments["kernel1"]
+        elif "kernel1" in item.name:
+            assert routine_parameters == parameter_variables["kernel1"]
+            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["kernel1"]
+        elif "kernel2" in item.name:
+            assert routine_parameters == parameter_variables["kernel2"]
+            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["kernel2"]
+            for call in FindNodes(ir.CallStatement).visit(item.routine.body):
+                if "device1" in call.name:
+                    assert call.arguments == call_arguments["device1"]
+                elif "device2" in call.name:
+                    assert call.arguments == call_arguments["device2"]
+        elif "device1" in item.name:
+            assert routine_parameters == parameter_variables["device1"]
+            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["device1"]
+            for call in FindNodes(ir.CallStatement).visit(item.routine.body):
+                if "device2" in call.name:
+                    assert call.arguments == call_arguments["device2"]
+        elif "device2" in item.name:
+            assert routine_parameters == parameter_variables["device2"]
+            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["device2"]
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+def test_source(here, frontend, config):
+    """
+    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    """
+
+    proj = here/'sources/projParametrise'
+
+    dic2p = {'a': 12, 'b': 11}
+    a = dic2p['a']
+    b = dic2p['b']
+
+    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
+
+    # check generated source code
+    subroutine_arguments = {
+        "driver": ['a', 'b', 'c', 'd'],
+        "another_driver": ['a', 'b', 'c'],
+        "kernel1": ['a', 'b', 'c'],
+        "kernel2": ['a_new', 'b', 'd'],
+        "device1": ['a', 'b', 'd', 'x', 'y'],
+        "device2": ['a', 'b', 'd', 'x'],
+    }
+
+    call_arguments = {
+        "kernel1": ('a', 'b', 'c'),
+        "kernel2": ('a', 'b', 'd'),
+        "device1": ('a_new', 'b', 'd', 'x', 'k2_tmp'),
+        "device2": ('a', 'b', 'd', 'x')
+    }
+
+    parameter_variables = {
+        "driver": [],
+        "another_driver": [],
+        "kernel1": [],
+        "kernel2": [],
+        "device1": [],
+        "device2": [],
+    }
+
+    check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
+                                  call_arguments=call_arguments, parameter_variables=parameter_variables)
+
+    compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name="original_source")
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+def test_parametrise(here, frontend, config):
+    """
+    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    """
+
+    proj = here/'sources/projParametrise'
+
+    dic2p = {'a': 12, 'b': 11}
+    a = dic2p['a']
+    b = dic2p['b']
+
+    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
+
+    transformation = ParametriseTransformation(dic2p=dic2p)
+    scheduler.process(transformation=transformation)
+
+    suffix = f'.parametrised.F90'
+    for item in scheduler.items:
+        if write_transformation_output:
+            sourcefile = item.source
+            sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
+
+    subroutine_arguments = {
+        "driver": ['parametrised_a', 'parametrised_b', 'c', 'd'],
+        "another_driver": ['parametrised_a', 'parametrised_b', 'c'],
+        "kernel1": ['c'],
+        "kernel2": ['d'],
+        "device1": ['d', 'x', 'y'],
+        "device2": ['d', 'x'],
+    }
+
+    call_arguments = {
+        "kernel1": ('c',),
+        "kernel2": ('d',),
+        "device1": ('d', 'x', 'k2_tmp'),
+        "device2": ('d', 'x')
+    }
+
+    parameter_variables = {
+        "driver": ['a', 'b'],
+        "another_driver": ['a', 'b'],
+        "kernel1": ['a', 'b'],
+        "kernel2": ['a_new', 'b'],
+        "device1": ['a', 'b'],
+        "device2": ['a', 'b'],
+    }
+
+    check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
+                                  call_arguments=call_arguments, parameter_variables=parameter_variables)
+
+    compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name="parametrised")
+
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+def test_parametrise_replace(here, frontend, config):
+    """
+    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    """
+
+    proj = here/'sources/projParametrise'
+
+    dic2p = {'a': 12, 'b': 11}
+    a = dic2p['a']
+    b = dic2p['b']
+
+    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
+
+    transformation = ParametriseTransformation(dic2p=dic2p, replace_by_value=True)
+    scheduler.process(transformation=transformation)
+
+    suffix = f'.replaced.F90'
+    for item in scheduler.items:
+        if write_transformation_output:
+            sourcefile = item.source
+            sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
+
+    subroutine_arguments = {
+        "driver": ['parametrised_a', 'parametrised_b', 'c', 'd'],
+        "another_driver": ['parametrised_a', 'parametrised_b', 'c'],
+        "kernel1": ['c'],
+        "kernel2": ['d'],
+        "device1": ['d', 'x', 'y'],
+        "device2": ['d', 'x'],
+    }
+
+    call_arguments = {
+        "kernel1": ('c',),
+        "kernel2": ('d',),
+        "device1": ('d', 'x', 'k2_tmp'),
+        "device2": ('d', 'x')
+    }
+
+    parameter_variables = {
+        "driver": [],
+        "another_driver": [],
+        "kernel1": [],
+        "kernel2": [],
+        "device1": [],
+        "device2": [],
+    }
+
+    check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
+                                  call_arguments=call_arguments, parameter_variables=parameter_variables)
+
+    for item in scheduler.items:
+        routine_spec_str = fgen(item.routine.spec)
+        if "driver" in item.name and "another" not in item.name:
+            assert f'c({a}, {b})' in routine_spec_str
+            assert f'd({b})' in routine_spec_str
+        elif "another_driver" in item.name:
+            assert f'c({a}, {b})' in routine_spec_str
+            assert f'x({a})' in routine_spec_str
+        elif "kernel1" in item.name:
+            assert f'c({a}, {b})' in routine_spec_str
+            assert f'x({a})' in routine_spec_str
+            assert f'y({a}, {b})' in routine_spec_str
+            assert f'k1_tmp({a}, {b})' in routine_spec_str
+        elif "kernel2" in item.name:
+            assert f'd({b})' in routine_spec_str
+            assert f'x({a})' in routine_spec_str
+            assert f'k2_tmp({a}, {a})' in routine_spec_str
+        elif "device1" in item.name:
+            assert f'd({b})' in routine_spec_str
+            assert f'x({a})' in routine_spec_str
+            assert f'y({a}, {a})' in routine_spec_str
+        elif "device2" in item.name:
+            assert f'd({b})' in routine_spec_str
+            assert f'x({a})' in routine_spec_str
+            assert f'z({b})' in routine_spec_str
+            assert f'd2_tmp({b})' in routine_spec_str
+
+    compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name="replaced")
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+def test_parametrise_callback(here, frontend, config):
+    """
+    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    """
+
+    proj = here/'sources/projParametrise'
+
+    dic2p = {'a': 12, 'b': 11}
+    a = dic2p['a']
+    b = dic2p['b']
+
+    subroutine_arguments = {
+        "driver": ['parametrised_a', 'parametrised_b', 'c', 'd'],
+        "another_driver": ['parametrised_a', 'parametrised_b', 'c'],
+        "kernel1": ['c'],
+        "kernel2": ['d'],
+        "device1": ['d', 'x', 'y'],
+        "device2": ['d', 'x'],
+    }
+
+    call_arguments = {
+        "kernel1": ('c',),
+        "kernel2": ('d',),
+        "device1": ('d', 'x', 'k2_tmp'),
+        "device2": ('d', 'x')
+    }
+
+    parameter_variables = {
+        "driver": ['a', 'b'],
+        "another_driver": ['a', 'b'],
+        "kernel1": ['a', 'b'],
+        "kernel2": ['a_new', 'b'],
+        "device1": ['a', 'b'],
+        "device2": ['a', 'b'],
+    }
+
+    def error_stop(**kwargs):
+        msg = kwargs.get("msg")
+        return ir.Intrinsic(text=f'error stop "{msg}"'),
+
+    def stop_execution(**kwargs):
+        msg = kwargs.get("msg")
+        return ir.CallStatement(name=sym.Variable(name="stop_execution"), arguments=(sym.StringLiteral(f'{msg}'),)),
+
+    abort_callbacks = (error_stop, stop_execution)
+
+    for i, abort_callback in enumerate(abort_callbacks):
+        scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
+        transformation = ParametriseTransformation(dic2p=dic2p, abort_callback=abort_callback,
+                                                   disable=(abort_callback.__name__,))
+        scheduler.process(transformation=transformation)
+
+        suffix = f'.parametrised_callback_{i+1}.F90'
+        for item in scheduler.items:
+            if write_transformation_output:
+                sourcefile = item.source
+                sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
+
+        check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
+                                      call_arguments=call_arguments, parameter_variables=parameter_variables)
+
+        compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name=f"callback_{i+1}")
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+def test_parametrise_callback_wrong_input(here, frontend, config):
+    """
+    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    """
+
+    proj = here/'sources/projParametrise'
+
+    dic2p = {'a': 12, 'b': 11}
+    a = dic2p['a']
+    b = dic2p['b']
+
+    def only_warn(**kwargs):
+        msg = kwargs.get("msg")
+        return ir.Intrinsic(text=f'print *, "This is just a warning: {msg}"'),
+
+    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
+    transformation = ParametriseTransformation(dic2p=dic2p, abort_callback=only_warn)
+    scheduler.process(transformation=transformation)
+
+    suffix = f'.parametrised_callback_wrong_input.F90'
+    for item in scheduler.items:
+        if write_transformation_output:
+            sourcefile = item.source
+            sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
+
+    subroutine_arguments = {
+        "driver": ['parametrised_a', 'parametrised_b', 'c', 'd'],
+        "another_driver": ['parametrised_a', 'parametrised_b', 'c'],
+        "kernel1": ['c'],
+        "kernel2": ['d'],
+        "device1": ['d', 'x', 'y'],
+        "device2": ['d', 'x'],
+    }
+
+    call_arguments = {
+        "kernel1": ('c',),
+        "kernel2": ('d',),
+        "device1": ('d', 'x', 'k2_tmp'),
+        "device2": ('d', 'x')
+    }
+
+    parameter_variables = {
+        "driver": ['a', 'b'],
+        "another_driver": ['a', 'b'],
+        "kernel1": ['a', 'b'],
+        "kernel2": ['a_new', 'b'],
+        "device1": ['a', 'b'],
+        "device2": ['a', 'b'],
+    }
+
+    check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
+                                  call_arguments=call_arguments, parameter_variables=parameter_variables)
+
+    test_name = "parametrised_callback_wrong_input"
+    a = a + 1
+    b = b + 1
+    for item in scheduler.items:
+        if "driver" in item.name:
+            suffix = '.F90'
+            if test_name != "":
+                item.source.path = Path(f"{item.source.path.stem}_{test_name}")
+            module = jit_compile(item.source, filepath=item.source.path.with_suffix(suffix).name, objname=None)
+            c = np.zeros((a, b), dtype=np.int32, order='F')
+            d = np.zeros((b,), dtype=np.int32, order='F')
+            module.Parametrise.driver(a, b, c, d)
+            assert not (c == 11).all()
+            assert not (d == 42).all()
+            clean_test(filepath=here.parent / item.source.path.with_suffix(suffix).name)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+def test_parametrise_entry_points(here, frontend, config):
+    """
+    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    """
+
+    proj = here/'sources/projParametrise'
+
+    dic2p = {'a': 12, 'b': 11}
+    a = dic2p['a']
+    b = dic2p['b']
+
+    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
+
+    transformation = ParametriseTransformation(dic2p=dic2p, entry_points=("kernel1", "kernel2"))
+    scheduler.process(transformation=transformation)
+
+    suffix = f'.parametrised_entry_points.F90'
+    for item in scheduler.items:
+        if write_transformation_output:
+            sourcefile = item.source
+            sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
+
+    subroutine_arguments = {
+        "driver": ['a', 'b', 'c', 'd'],
+        "another_driver": ['a', 'b', 'c'],
+        "kernel1": ['parametrised_a', 'parametrised_b', 'c'],
+        "kernel2": ['a_new', 'parametrised_b', 'd'],
+        "device1": ['a', 'd', 'x', 'y'],
+        "device2": ['a', 'd', 'x'],
+    }
+
+    call_arguments = {
+        "kernel1": ('a', 'b', 'c'),
+        "kernel2": ('a', 'b', 'd'),
+        "device1": ('a_new', 'd', 'x', 'k2_tmp'),
+        "device2": ('a', 'd', 'x')
+    }
+
+    parameter_variables = {
+        "driver": [],
+        "another_driver": [],
+        "kernel1": ['a', 'b'],
+        "kernel2": ['b'],
+        "device1": ['b'],
+        "device2": ['b'],
+    }
+
+    check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
+                                  call_arguments=call_arguments, parameter_variables=parameter_variables)
+
+    compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name="parametrised_entry_points")

--- a/tests/test_transform_parametrise.py
+++ b/tests/test_transform_parametrise.py
@@ -1,22 +1,15 @@
 """
-A selection of tests for the generic hoist functionality.
+A selection of tests for the parametrisation functionality.
 """
 from pathlib import Path
 import pytest
 import numpy as np
 
-from conftest import jit_compile_lib, available_frontends, jit_compile, clean_test
-from loki import Builder, Module, Subroutine, FindNodes, Import, FindVariables
-from loki.expression import symbols as sym
-from loki import ir, as_tuple, is_iterable, fgen
-from loki.transform import inline_elemental_functions, inline_constant_parameters, replace_selected_kind
-from loki import Scheduler, OMNI
+from conftest import available_frontends, jit_compile, clean_test
+from loki import ir, fgen, Scheduler, FindNodes, OMNI
 from loki.transform import ParametriseTransformation
 import loki.expression.symbols as sym
 
-write_transformation_output = True
-
-OMNI_fail = 'OMNI cannot deal with "stop 1", as type object "xml.etree.ElementTree.Element" has no attribute "name"'
 
 @pytest.fixture(scope='module', name='here')
 def fixture_here():
@@ -70,50 +63,54 @@ def compile_and_test(scheduler, here, a=5, b=1, test_name=""):
 
 def check_arguments_and_parameter(scheduler, subroutine_arguments, call_arguments, parameter_variables):
     """
-    Check the subroutine and call arguments of each subroutine.
+    Check the parameters, subroutine and call arguments of each subroutine.
     """
-    for item in scheduler.items:
-        routine_parameters = [var for var in item.routine.variables if var.type.parameter]
-        if "driver" in item.name and "another" not in item.name:
-            assert routine_parameters == parameter_variables["driver"]
-            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["driver"]
-            for call in FindNodes(ir.CallStatement).visit(item.routine.body):
-                if "kernel1" in call.name:
-                    assert call.arguments == call_arguments["kernel1"]
-                elif "kernel2" in call.name:
-                    assert call.arguments == call_arguments["kernel2"]
-        elif "another_driver" in item.name:
-            assert routine_parameters == parameter_variables["another_driver"]
-            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["another_driver"]
-            for call in FindNodes(ir.CallStatement).visit(item.routine.body):
-                if "kernel1" in call.name:
-                    assert call.arguments == call_arguments["kernel1"]
-        elif "kernel1" in item.name:
-            assert routine_parameters == parameter_variables["kernel1"]
-            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["kernel1"]
-        elif "kernel2" in item.name:
-            assert routine_parameters == parameter_variables["kernel2"]
-            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["kernel2"]
-            for call in FindNodes(ir.CallStatement).visit(item.routine.body):
-                if "device1" in call.name:
-                    assert call.arguments == call_arguments["device1"]
-                elif "device2" in call.name:
-                    assert call.arguments == call_arguments["device2"]
-        elif "device1" in item.name:
-            assert routine_parameters == parameter_variables["device1"]
-            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["device1"]
-            for call in FindNodes(ir.CallStatement).visit(item.routine.body):
-                if "device2" in call.name:
-                    assert call.arguments == call_arguments["device2"]
-        elif "device2" in item.name:
-            assert routine_parameters == parameter_variables["device2"]
-            assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["device2"]
+    item = scheduler.item_map['parametrise#driver']
+    routine_parameters = [var for var in item.routine.variables if var.type.parameter]
+    assert routine_parameters == parameter_variables["driver"]
+    assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["driver"]
+    for call in FindNodes(ir.CallStatement).visit(item.routine.body):
+        if "kernel1" in call.name:
+            assert call.arguments == call_arguments["kernel1"]
+        elif "kernel2" in call.name:
+            assert call.arguments == call_arguments["kernel2"]
+    item = scheduler.item_map['parametrise#another_driver']
+    routine_parameters = [var for var in item.routine.variables if var.type.parameter]
+    assert routine_parameters == parameter_variables["another_driver"]
+    assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["another_driver"]
+    for call in FindNodes(ir.CallStatement).visit(item.routine.body):
+        if "kernel1" in call.name:
+            assert call.arguments == call_arguments["kernel1"]
+    item = scheduler.item_map['parametrise#kernel1']
+    routine_parameters = [var for var in item.routine.variables if var.type.parameter]
+    assert routine_parameters == parameter_variables["kernel1"]
+    assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["kernel1"]
+    item = scheduler.item_map['parametrise#kernel2']
+    routine_parameters = [var for var in item.routine.variables if var.type.parameter]
+    assert routine_parameters == parameter_variables["kernel2"]
+    assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["kernel2"]
+    for call in FindNodes(ir.CallStatement).visit(item.routine.body):
+        if "device1" in call.name:
+            assert call.arguments == call_arguments["device1"]
+        elif "device2" in call.name:
+            assert call.arguments == call_arguments["device2"]
+    item = scheduler.item_map['parametrise#device1']
+    routine_parameters = [var for var in item.routine.variables if var.type.parameter]
+    assert routine_parameters == parameter_variables["device1"]
+    assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["device1"]
+    for call in FindNodes(ir.CallStatement).visit(item.routine.body):
+        if "device2" in call.name:
+            assert call.arguments == call_arguments["device2"]
+    item = scheduler.item_map['parametrise#device2']
+    routine_parameters = [var for var in item.routine.variables if var.type.parameter]
+    assert routine_parameters == parameter_variables["device2"]
+    assert [arg.name for arg in item.routine.arguments] == subroutine_arguments["device2"]
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_source(here, frontend, config):
     """
-    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    Test the actual source code without any transformations applied.
     """
 
     proj = here/'sources/projParametrise'
@@ -156,10 +153,10 @@ def test_source(here, frontend, config):
     compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name="original_source")
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_parametrise(here, frontend, config):
     """
-    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    Basic testing of parametrisation functionality.
     """
 
     proj = here/'sources/projParametrise'
@@ -172,12 +169,6 @@ def test_parametrise(here, frontend, config):
 
     transformation = ParametriseTransformation(dic2p=dic2p)
     scheduler.process(transformation=transformation)
-
-    suffix = f'.parametrised.F90'
-    for item in scheduler.items:
-        if write_transformation_output:
-            sourcefile = item.source
-            sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
 
     subroutine_arguments = {
         "driver": ['parametrised_a', 'parametrised_b', 'c', 'd'],
@@ -210,11 +201,10 @@ def test_parametrise(here, frontend, config):
     compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name="parametrised")
 
 
-
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_parametrise_replace(here, frontend, config):
     """
-    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    Basic testing of parametrisation functionality including replacing of the variables with the actual values.
     """
 
     proj = here/'sources/projParametrise'
@@ -227,12 +217,6 @@ def test_parametrise_replace(here, frontend, config):
 
     transformation = ParametriseTransformation(dic2p=dic2p, replace_by_value=True)
     scheduler.process(transformation=transformation)
-
-    suffix = f'.replaced.F90'
-    for item in scheduler.items:
-        if write_transformation_output:
-            sourcefile = item.source
-            sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
 
     subroutine_arguments = {
         "driver": ['parametrised_a', 'parametrised_b', 'c', 'd'],
@@ -262,40 +246,64 @@ def test_parametrise_replace(here, frontend, config):
     check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
                                   call_arguments=call_arguments, parameter_variables=parameter_variables)
 
-    for item in scheduler.items:
-        routine_spec_str = fgen(item.routine.spec)
-        if "driver" in item.name and "another" not in item.name:
-            assert f'c({a}, {b})' in routine_spec_str
-            assert f'd({b})' in routine_spec_str
-        elif "another_driver" in item.name:
-            assert f'c({a}, {b})' in routine_spec_str
-            assert f'x({a})' in routine_spec_str
-        elif "kernel1" in item.name:
-            assert f'c({a}, {b})' in routine_spec_str
-            assert f'x({a})' in routine_spec_str
-            assert f'y({a}, {b})' in routine_spec_str
-            assert f'k1_tmp({a}, {b})' in routine_spec_str
-        elif "kernel2" in item.name:
-            assert f'd({b})' in routine_spec_str
-            assert f'x({a})' in routine_spec_str
-            assert f'k2_tmp({a}, {a})' in routine_spec_str
-        elif "device1" in item.name:
-            assert f'd({b})' in routine_spec_str
-            assert f'x({a})' in routine_spec_str
-            assert f'y({a}, {a})' in routine_spec_str
-        elif "device2" in item.name:
-            assert f'd({b})' in routine_spec_str
-            assert f'x({a})' in routine_spec_str
-            assert f'z({b})' in routine_spec_str
-            assert f'd2_tmp({b})' in routine_spec_str
+    if frontend == OMNI:
+        routine_spec_str = fgen(scheduler.item_map['parametrise#driver'].routine.spec)
+        assert f'c(1:{a}, 1:{b})' in routine_spec_str
+        assert f'd(1:{b})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#another_driver'].routine.spec)
+        assert f'c(1:{a}, 1:{b})' in routine_spec_str
+        assert f'x(1:{a})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#kernel1'].routine.spec)
+        assert f'c(1:{a}, 1:{b})' in routine_spec_str
+        assert f'x(1:{a})' in routine_spec_str
+        assert f'y(1:{a}, 1:{b})' in routine_spec_str
+        assert f'k1_tmp(1:{a}, 1:{b})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#kernel2'].routine.spec)
+        assert f'd(1:{b})' in routine_spec_str
+        assert f'x(1:{a})' in routine_spec_str
+        assert f'k2_tmp(1:{a}, 1:{a})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#device1'].routine.spec)
+        assert f'd(1:{b})' in routine_spec_str
+        assert f'x(1:{a})' in routine_spec_str
+        assert f'y(1:{a}, 1:{a})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#device2'].routine.spec)
+        assert f'd(1:{b})' in routine_spec_str
+        assert f'x(1:{a})' in routine_spec_str
+        assert f'z(1:{b})' in routine_spec_str
+        assert f'd2_tmp(1:{b})' in routine_spec_str
+    else:
+        routine_spec_str = fgen(scheduler.item_map['parametrise#driver'].routine.spec)
+        assert f'c({a}, {b})' in routine_spec_str
+        assert f'd({b})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#another_driver'].routine.spec)
+        assert f'c({a}, {b})' in routine_spec_str
+        assert f'x({a})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#kernel1'].routine.spec)
+        assert f'c({a}, {b})' in routine_spec_str
+        assert f'x({a})' in routine_spec_str
+        assert f'y({a}, {b})' in routine_spec_str
+        assert f'k1_tmp({a}, {b})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#kernel2'].routine.spec)
+        assert f'd({b})' in routine_spec_str
+        assert f'x({a})' in routine_spec_str
+        assert f'k2_tmp({a}, {a})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#device1'].routine.spec)
+        assert f'd({b})' in routine_spec_str
+        assert f'x({a})' in routine_spec_str
+        assert f'y({a}, {a})' in routine_spec_str
+        routine_spec_str = fgen(scheduler.item_map['parametrise#device2'].routine.spec)
+        assert f'd({b})' in routine_spec_str
+        assert f'x({a})' in routine_spec_str
+        assert f'z({b})' in routine_spec_str
+        assert f'd2_tmp({b})' in routine_spec_str
 
     compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name="replaced")
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_parametrise_callback(here, frontend, config):
     """
-    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    Testing of the parametrisation functionality with modified callbacks for failed sanity checks.
     """
 
     proj = here/'sources/projParametrise'
@@ -331,25 +339,22 @@ def test_parametrise_callback(here, frontend, config):
 
     def error_stop(**kwargs):
         msg = kwargs.get("msg")
-        return ir.Intrinsic(text=f'error stop "{msg}"'),
+        abort = (ir.Intrinsic(text=f'error stop "{msg}"'),)
+        return abort
 
     def stop_execution(**kwargs):
         msg = kwargs.get("msg")
-        return ir.CallStatement(name=sym.Variable(name="stop_execution"), arguments=(sym.StringLiteral(f'{msg}'),)),
+        abort = (ir.CallStatement(name=sym.Variable(name="stop_execution"), arguments=(sym.StringLiteral(f'{msg}'),)),)
+        return abort
 
     abort_callbacks = (error_stop, stop_execution)
 
     for i, abort_callback in enumerate(abort_callbacks):
-        scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
+        scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'],
+                              frontend=frontend)
         transformation = ParametriseTransformation(dic2p=dic2p, abort_callback=abort_callback,
                                                    disable=(abort_callback.__name__,))
         scheduler.process(transformation=transformation)
-
-        suffix = f'.parametrised_callback_{i+1}.F90'
-        for item in scheduler.items:
-            if write_transformation_output:
-                sourcefile = item.source
-                sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
 
         check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
                                       call_arguments=call_arguments, parameter_variables=parameter_variables)
@@ -357,10 +362,11 @@ def test_parametrise_callback(here, frontend, config):
         compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name=f"callback_{i+1}")
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+@pytest.mark.parametrize('frontend', available_frontends())  # xfail=[(OMNI, OMNI_fail)]
 def test_parametrise_callback_wrong_input(here, frontend, config):
     """
-    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    Testing of the parametrisation functionality with modified callback for failed sanity checks including test of
+    a failed sanity check.
     """
 
     proj = here/'sources/projParametrise'
@@ -371,17 +377,12 @@ def test_parametrise_callback_wrong_input(here, frontend, config):
 
     def only_warn(**kwargs):
         msg = kwargs.get("msg")
-        return ir.Intrinsic(text=f'print *, "This is just a warning: {msg}"'),
+        abort = (ir.Intrinsic(text=f'print *, "This is just a warning: {msg}"'),)
+        return abort
 
     scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
     transformation = ParametriseTransformation(dic2p=dic2p, abort_callback=only_warn)
     scheduler.process(transformation=transformation)
-
-    suffix = f'.parametrised_callback_wrong_input.F90'
-    for item in scheduler.items:
-        if write_transformation_output:
-            sourcefile = item.source
-            sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
 
     subroutine_arguments = {
         "driver": ['parametrised_a', 'parametrised_b', 'c', 'd'],
@@ -428,10 +429,10 @@ def test_parametrise_callback_wrong_input(here, frontend, config):
             clean_test(filepath=here.parent / item.source.path.with_suffix(suffix).name)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, OMNI_fail)]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_parametrise_entry_points(here, frontend, config):
     """
-    Basic testing of the non-modified Hoist functionality, thus hoisting all (non-parameter) local variables.
+    Testing of parametrisation functionality with defined entry points/functions, thus not being the default (driver).
     """
 
     proj = here/'sources/projParametrise'
@@ -444,12 +445,6 @@ def test_parametrise_entry_points(here, frontend, config):
 
     transformation = ParametriseTransformation(dic2p=dic2p, entry_points=("kernel1", "kernel2"))
     scheduler.process(transformation=transformation)
-
-    suffix = f'.parametrised_entry_points.F90'
-    for item in scheduler.items:
-        if write_transformation_output:
-            sourcefile = item.source
-            sourcefile.write(path=sourcefile.path.with_suffix(suffix).name)
 
     subroutine_arguments = {
         "driver": ['a', 'b', 'c', 'd'],

--- a/tests/test_transform_parametrise.py
+++ b/tests/test_transform_parametrise.py
@@ -108,7 +108,7 @@ def check_arguments_and_parameter(scheduler, subroutine_arguments, call_argument
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_source(here, frontend, config):
+def test_parametrise_source(here, frontend, config):
     """
     Test the actual source code without any transformations applied.
     """
@@ -154,7 +154,7 @@ def test_source(here, frontend, config):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_parametrise(here, frontend, config):
+def test_parametrise_simple(here, frontend, config):
     """
     Basic testing of parametrisation functionality.
     """
@@ -202,7 +202,7 @@ def test_parametrise(here, frontend, config):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_parametrise_replace(here, frontend, config):
+def test_parametrise_simple_replace_by_value(here, frontend, config):
     """
     Basic testing of parametrisation functionality including replacing of the variables with the actual values.
     """
@@ -301,7 +301,7 @@ def test_parametrise_replace(here, frontend, config):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_parametrise_callback(here, frontend, config):
+def test_parametrise_modified_callback(here, frontend, config):
     """
     Testing of the parametrisation functionality with modified callbacks for failed sanity checks.
     """
@@ -362,8 +362,8 @@ def test_parametrise_callback(here, frontend, config):
         compile_and_test(scheduler=scheduler, here=here, a=a, b=b, test_name=f"callback_{i+1}")
 
 
-@pytest.mark.parametrize('frontend', available_frontends())  # xfail=[(OMNI, OMNI_fail)]
-def test_parametrise_callback_wrong_input(here, frontend, config):
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_parametrise_modified_callback_wrong_input(here, frontend, config):
     """
     Testing of the parametrisation functionality with modified callback for failed sanity checks including test of
     a failed sanity check.
@@ -430,7 +430,7 @@ def test_parametrise_callback_wrong_input(here, frontend, config):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_parametrise_entry_points(here, frontend, config):
+def test_parametrise_non_driver_entry_points(here, frontend, config):
     """
     Testing of parametrisation functionality with defined entry points/functions, thus not being the default (driver).
     """


### PR DESCRIPTION
**Probably best explained using an example** (same code used for the unit tests):

<details>
<summary>Source code/Starting point</summary>

```fortran
module parametrise
    implicit none
contains

    subroutine stop_execution(msg)
        character(200), INTENT(IN) :: msg
        PRINT *, msg
        stop 1
    end subroutine stop_execution

    subroutine driver(a, b, c, d)
        integer, intent(inout) :: a, b, d(b)
        integer, intent(inout) :: c(a, b)
        real :: x, y
        call kernel1(a, b, c)
        call kernel2(a, b, d)
        call kernel1(a, b, c)
    end subroutine driver

    subroutine another_driver(a, b, c)
        integer, intent(in) :: a
        integer, intent(in) :: b
        integer, intent(inout) :: c(a, b)
        real :: x(a)
        call kernel1(a, b, c)
    end subroutine another_driver

    subroutine kernel1(a, b, c)
        integer, intent(in) :: a
        integer, intent(in) :: b
        integer, intent(inout) :: c(a, b)
        integer :: local_a
        real :: x(a)
        integer :: y(a, b)
        real :: k1_tmp(a, b)
        y = 11
        c = y
    end subroutine kernel1

    subroutine kernel2(a_new, b, d)
        integer, intent(in) :: a_new
        integer, intent(in) :: b
        integer, intent(inout) :: d(b)
        real :: x(a_new)
        real :: y, z
        real :: k2_tmp(a_new, a_new)
        call device1(a_new, b, d, x, k2_tmp)
    end subroutine kernel2

    subroutine device1(a, b, d, x, y)
        integer, intent(in) :: a
        integer, intent(in) :: b
        integer, intent(inout) :: d(b)
        real, intent(inout) :: x(a)
        real, intent(inout) :: y(a, a)
        real :: z
        integer :: d1_tmp
        call device2(a, b, d, x)
        call device2(a, b, d, x)
    end subroutine device1

    subroutine device2(a, b, d, x)
        integer, intent(in) :: a
        integer, intent(in) :: b
        integer, intent(inout) :: d(b)
        real, intent(inout) :: x(a)
        integer z(b)
        integer :: d2_tmp(b)
        z = 42
        d = z
    end subroutine device2

end module parametrise
```

</details>

________

can be transformed via 

```py
dic2p = {'a': 12, 'b': 11}
scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
transformation = ParametriseTransformation(dic2p=dic2p)
scheduler.process(transformation=transformation)
```

to:

<details>
<summary>`a` and `b` parametrised</summary>

```fortran
MODULE parametrise
  IMPLICIT NONE
  CONTAINS
  
  SUBROUTINE stop_execution (msg)
    CHARACTER(LEN=200), INTENT(IN) :: msg
    PRINT *, msg
    STOP 1
  END SUBROUTINE stop_execution
  
  SUBROUTINE driver (parametrised_a, parametrised_b, c, d)
    INTEGER, PARAMETER :: a = 12
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(INOUT) :: d(b)
    INTEGER, INTENT(INOUT) :: c(a, b)
    REAL :: x, y
    INTEGER, INTENT(INOUT) :: parametrised_a
    INTEGER, INTENT(INOUT) :: parametrised_b
    ! Sanity check for parametrised variable: a
    IF (parametrised_a /= 12) THEN
      ! Stop execution: Variable a parametrised to value 12, but subroutine driver received another value
      PRINT *, "Variable a parametrised to value 12, but subroutine driver received another value: ", parametrised_a
      STOP 1
    END IF
    ! Sanity check for parametrised variable: b
    IF (parametrised_b /= 11) THEN
      ! Stop execution: Variable b parametrised to value 11, but subroutine driver received another value
      PRINT *, "Variable b parametrised to value 11, but subroutine driver received another value: ", parametrised_b
      STOP 1
    END IF
    CALL kernel1(c)
    CALL kernel2(d)
    CALL kernel1(c)
  END SUBROUTINE driver
  
  SUBROUTINE another_driver (parametrised_a, parametrised_b, c)
    INTEGER, PARAMETER :: a = 12
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(INOUT) :: c(a, b)
    REAL :: x(a)
    INTEGER, INTENT(IN) :: parametrised_a
    INTEGER, INTENT(IN) :: parametrised_b
    ! Sanity check for parametrised variable: a
    IF (parametrised_a /= 12) THEN
      ! Stop execution: Variable a parametrised to value 12, but subroutine another_driver received another value
      PRINT *, "Variable a parametrised to value 12, but subroutine another_driver received another value: ", parametrised_a
      STOP 1
    END IF
    ! Sanity check for parametrised variable: b
    IF (parametrised_b /= 11) THEN
      ! Stop execution: Variable b parametrised to value 11, but subroutine another_driver received another value
      PRINT *, "Variable b parametrised to value 11, but subroutine another_driver received another value: ", parametrised_b
      STOP 1
    END IF
    CALL kernel1(c)
  END SUBROUTINE another_driver
  
  SUBROUTINE kernel1 (c)
    INTEGER, PARAMETER :: a = 12
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(INOUT) :: c(a, b)
    INTEGER :: local_a
    REAL :: x(a)
    INTEGER :: y(a, b)
    REAL :: k1_tmp(a, b)
    y = 11
    c = y
  END SUBROUTINE kernel1
  
  SUBROUTINE kernel2 (d)
    INTEGER, PARAMETER :: a_new = 12
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(INOUT) :: d(b)
    REAL :: x(a_new)
    REAL :: y, z
    REAL :: k2_tmp(a_new, a_new)
    CALL device1(d, x, k2_tmp)
  END SUBROUTINE kernel2
  
  SUBROUTINE device1 (d, x, y)
    INTEGER, PARAMETER :: a = 12
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(INOUT) :: d(b)
    REAL, INTENT(INOUT) :: x(a)
    REAL, INTENT(INOUT) :: y(a, a)
    REAL :: z
    INTEGER :: d1_tmp
    CALL device2(d, x)
    CALL device2(d, x)
  END SUBROUTINE device1
  
  SUBROUTINE device2 (d, x)
    INTEGER, PARAMETER :: a = 12
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(INOUT) :: d(b)
    REAL, INTENT(INOUT) :: x(a)
    INTEGER :: z(b)
    INTEGER :: d2_tmp(b)
    z = 42
    d = z
  END SUBROUTINE device2
  
END MODULE parametrise
```

</details>

* this assumes the entry points to be the *driver*s
* uses the default abort mechanism

_______

**or** can be transformed via 

```py
dic2p = {'a': 12, 'b': 11}
scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
transformation = ParametriseTransformation(dic2p=dic2p, replace_by_value=True)
scheduler.process(transformation=transformation)
```

to:

<details>
<summary>`a` and `b` replaced by value</summary>

```fortran
MODULE parametrise
  IMPLICIT NONE
  CONTAINS
  
  SUBROUTINE stop_execution (msg)
    CHARACTER(LEN=200), INTENT(IN) :: msg
    PRINT *, msg
    STOP 1
  END SUBROUTINE stop_execution
  
  SUBROUTINE driver (parametrised_a, parametrised_b, c, d)
    INTEGER, INTENT(INOUT) :: d(11)
    INTEGER, INTENT(INOUT) :: c(12, 11)
    REAL :: x, y
    INTEGER, INTENT(INOUT) :: parametrised_a
    INTEGER, INTENT(INOUT) :: parametrised_b
    ! Sanity check for parametrised variable: a
    IF (parametrised_a /= 12) THEN
      ! Stop execution: Variable a parametrised to value 12, but subroutine driver received another value
      PRINT *, "Variable a parametrised to value 12, but subroutine driver received another value: ", parametrised_a
      STOP 1
    END IF
    ! Sanity check for parametrised variable: b
    IF (parametrised_b /= 11) THEN
      ! Stop execution: Variable b parametrised to value 11, but subroutine driver received another value
      PRINT *, "Variable b parametrised to value 11, but subroutine driver received another value: ", parametrised_b
      STOP 1
    END IF
    CALL kernel1(c)
    CALL kernel2(d)
    CALL kernel1(c)
  END SUBROUTINE driver
  
  SUBROUTINE another_driver (parametrised_a, parametrised_b, c)
    INTEGER, INTENT(INOUT) :: c(12, 11)
    REAL :: x(12)
    INTEGER, INTENT(IN) :: parametrised_a
    INTEGER, INTENT(IN) :: parametrised_b
    ! Sanity check for parametrised variable: a
    IF (parametrised_a /= 12) THEN
      ! Stop execution: Variable a parametrised to value 12, but subroutine another_driver received another value
      PRINT *, "Variable a parametrised to value 12, but subroutine another_driver received another value: ", parametrised_a
      STOP 1
    END IF
    ! Sanity check for parametrised variable: b
    IF (parametrised_b /= 11) THEN
      ! Stop execution: Variable b parametrised to value 11, but subroutine another_driver received another value
      PRINT *, "Variable b parametrised to value 11, but subroutine another_driver received another value: ", parametrised_b
      STOP 1
    END IF
    CALL kernel1(c)
  END SUBROUTINE another_driver
  
  SUBROUTINE kernel1 (c)
    INTEGER, INTENT(INOUT) :: c(12, 11)
    INTEGER :: local_a
    REAL :: x(12)
    INTEGER :: y(12, 11)
    REAL :: k1_tmp(12, 11)
    y = 11
    c = y
  END SUBROUTINE kernel1
  
  SUBROUTINE kernel2 (d)
    INTEGER, INTENT(INOUT) :: d(11)
    REAL :: x(12)
    REAL :: y, z
    REAL :: k2_tmp(12, 12)
    CALL device1(d, x, k2_tmp)
  END SUBROUTINE kernel2
  
  SUBROUTINE device1 (d, x, y)
    INTEGER, INTENT(INOUT) :: d(11)
    REAL, INTENT(INOUT) :: x(12)
    REAL, INTENT(INOUT) :: y(12, 12)
    REAL :: z
    INTEGER :: d1_tmp
    CALL device2(d, x)
    CALL device2(d, x)
  END SUBROUTINE device1
  
  SUBROUTINE device2 (d, x)
    INTEGER, INTENT(INOUT) :: d(11)
    REAL, INTENT(INOUT) :: x(12)
    INTEGER :: z(11)
    INTEGER :: d2_tmp(11)
    z = 42
    d = z
  END SUBROUTINE device2
  
END MODULE parametrise
```

</details>

__________

**or** can be transformed via 

```py
dic2p = {'a': 12, 'b': 11}
scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
transformation = ParametriseTransformation(dic2p=dic2p, entry_points=("kernel1", "kernel2"))
scheduler.process(transformation=transformation)
```

to:

<details>
<summary>`a` and `b` parametrised, different entry points</summary>

```fortran
MODULE parametrise
  IMPLICIT NONE
  CONTAINS
  
  SUBROUTINE stop_execution (msg)
    CHARACTER(LEN=200), INTENT(IN) :: msg
    PRINT *, msg
    STOP 1
  END SUBROUTINE stop_execution
  
  SUBROUTINE driver (a, b, c, d)
    INTEGER, INTENT(INOUT) :: a, b, d(b)
    INTEGER, INTENT(INOUT) :: c(a, b)
    REAL :: x, y
    CALL kernel1(a, b, c)
    CALL kernel2(a, b, d)
    CALL kernel1(a, b, c)
  END SUBROUTINE driver
  
  SUBROUTINE another_driver (a, b, c)
    INTEGER, INTENT(IN) :: a
    INTEGER, INTENT(IN) :: b
    INTEGER, INTENT(INOUT) :: c(a, b)
    REAL :: x(a)
    CALL kernel1(a, b, c)
  END SUBROUTINE another_driver
  
  SUBROUTINE kernel1 (parametrised_a, parametrised_b, c)
    INTEGER, PARAMETER :: a = 12
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(INOUT) :: c(a, b)
    INTEGER :: local_a
    REAL :: x(a)
    INTEGER :: y(a, b)
    REAL :: k1_tmp(a, b)
    INTEGER, INTENT(IN) :: parametrised_a
    INTEGER, INTENT(IN) :: parametrised_b
    ! Sanity check for parametrised variable: a
    IF (parametrised_a /= 12) THEN
      ! Stop execution: Variable a parametrised to value 12, but subroutine kernel1 received another value
      PRINT *, "Variable a parametrised to value 12, but subroutine kernel1 received another value: ", parametrised_a
      STOP 1
    END IF
    ! Sanity check for parametrised variable: b
    IF (parametrised_b /= 11) THEN
      ! Stop execution: Variable b parametrised to value 11, but subroutine kernel1 received another value
      PRINT *, "Variable b parametrised to value 11, but subroutine kernel1 received another value: ", parametrised_b
      STOP 1
    END IF
    y = 11
    c = y
  END SUBROUTINE kernel1
  
  SUBROUTINE kernel2 (a_new, parametrised_b, d)
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(IN) :: a_new
    INTEGER, INTENT(INOUT) :: d(b)
    REAL :: x(a_new)
    REAL :: y, z
    REAL :: k2_tmp(a_new, a_new)
    INTEGER, INTENT(IN) :: parametrised_b
    ! Sanity check for parametrised variable: b
    IF (parametrised_b /= 11) THEN
      ! Stop execution: Variable b parametrised to value 11, but subroutine kernel2 received another value
      PRINT *, "Variable b parametrised to value 11, but subroutine kernel2 received another value: ", parametrised_b
      STOP 1
    END IF
    CALL device1(a_new, d, x, k2_tmp)
  END SUBROUTINE kernel2
  
  SUBROUTINE device1 (a, d, x, y)
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(IN) :: a
    INTEGER, INTENT(INOUT) :: d(b)
    REAL, INTENT(INOUT) :: x(a)
    REAL, INTENT(INOUT) :: y(a, a)
    REAL :: z
    INTEGER :: d1_tmp
    CALL device2(a, d, x)
    CALL device2(a, d, x)
  END SUBROUTINE device1
  
  SUBROUTINE device2 (a, d, x)
    INTEGER, PARAMETER :: b = 11
    INTEGER, INTENT(IN) :: a
    INTEGER, INTENT(INOUT) :: d(b)
    REAL, INTENT(INOUT) :: x(a)
    INTEGER :: z(b)
    INTEGER :: d2_tmp(b)
    z = 42
    d = z
  END SUBROUTINE device2
  
END MODULE parametrise
```

</details>

* this assumes the entry points to be the the specified subroutines

