### PR TITLE
Numpy<1.24 due to f90wrap incompatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ license_file = LICENSE
 [options]
 packages = find:
 install_requires =
-    numpy  # essential for tests, loop transformations and other dependencies
+    numpy<1.24  # essential for tests, loop transformations and other dependencies
     pymbolic>=2022.1  # essential for expression tree
     PyYAML  # essential for loki-lint
     pcpp  # essential for preprocessing


### PR DESCRIPTION
See https://github.com/jameskermode/f90wrap/issues/175

NumPy 1.24 ships with "new f2py features and fixes": https://numpy.org/doc/stable/release/1.24.0-notes.html

This requirement can be relaxed once f90wrap has caught up.