### PR TITLE
IR: Use frozen dataclasses to enforce immutablity - Part 1

### DIFF
--- a/example/02_working_with_the_ir.ipynb
+++ b/example/02_working_with_the_ir.ipynb
@@ -130,7 +130,7 @@
    "source": [
     "outer_loop, inner_loop = loops\n",
     "new_inner_loop = outer_loop.clone(body=inner_loop.body)\n",
-    "loop_map = {outer_loop: inner_loop.clone(body=new_inner_loop)}\n",
+    "loop_map = {outer_loop: inner_loop.clone(body=(new_inner_loop,))}\n",
     "loop_map"
    ]
   },

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -86,12 +86,12 @@ class DataflowAnalysisAttacher(Transformer):
     def visit_Node(self, o, **kwargs):
         # Live symbols are determined on InternalNode handler levels and
         # get passed down to all child nodes
-        setattr(o, '_live_symbols', kwargs.get('live_symbols', set()))
+        o._update(_live_symbols=kwargs.get('live_symbols', set()))
 
         # Symbols defined or used by this node are determined by their individual
         # handler routines and passed on to visitNode from there
-        setattr(o, '_defines_symbols', kwargs.get('defines_symbols', set()))
-        setattr(o, '_uses_symbols', kwargs.get('uses_symbols', set()))
+        o._update(_defines_symbols=kwargs.get('defines_symbols', set()))
+        o._update(_uses_symbols=kwargs.get('uses_symbols', set()))
         return o
 
     # Internal nodes
@@ -251,9 +251,7 @@ class DataflowAnalysisDetacher(Transformer):
         super().__init__(inplace=True, **kwargs)
 
     def visit_Node(self, o, **kwargs):
-        for attr in ('_live_symbols', '_defines_symbols', '_uses_symbols'):
-            if hasattr(o, attr):
-                delattr(o, attr)
+        o._update(_live_symbols=None, _defines_symbols=None, _uses_symbols=None)
         return super().visit_Node(o, **kwargs)
 
 

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -152,7 +152,7 @@ class DataflowAnalysisAttacher(Transformer):
         uses = self._symbols_from_expr(as_tuple(eset)) | self._symbols_from_expr(as_tuple(vset))
         body, defines, uses = self._visit_body(o.bodies, live=live, uses=uses, **kwargs)
         else_body, else_defines, uses = self._visit_body(o.else_body, live=live, uses=uses, **kwargs)
-        body = [as_tuple(b,) for b in body]
+        body = tuple(as_tuple(b,) for b in body)
         o._update(bodies=body, else_body=else_body)
         defines = defines | else_defines
         return self.visit_Node(o, live_symbols=live, defines_symbols=defines, uses_symbols=uses, **kwargs)
@@ -161,7 +161,7 @@ class DataflowAnalysisAttacher(Transformer):
         live = kwargs.pop('live_symbols', set())
         conditions = self._symbols_from_expr(o.conditions)
         body, defines, uses = self._visit_body(o.bodies, live=live, uses=conditions, **kwargs)
-        body = [as_tuple(b,) for b in body]
+        body = tuple(as_tuple(b,) for b in body)
         default, default_defs, uses = self._visit_body(o.default, live=live, uses=uses, **kwargs)
         o._update(bodies=body, default=default)
         return self.visit_Node(o, live_symbols=live, defines_symbols=defines|default_defs, uses_symbols=uses, **kwargs)

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2112,7 +2112,8 @@ class FParser2IR(GenericVisitor):
             labels += [self.get_label(conditional)]
 
         # Build IR nodes backwards using else-if branch as else body
-        node = ir.Conditional(condition=conditions[-1], body=bodies[-1], else_body=as_tuple(else_body),
+        body = as_tuple(flatten(bodies[-1]))
+        node = ir.Conditional(condition=conditions[-1], body=body, else_body=as_tuple(else_body),
                               inline=False, has_elseif=False, label=labels[-1], source=sources[-1])
         for idx in reversed(range(len(conditions)-1)):
             node = ir.Conditional(condition=conditions[idx], body=bodies[idx], else_body=as_tuple(node),

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -241,17 +241,17 @@ class OFP2IR(GenericVisitor):
     def visit_if(self, o, **kwargs):
         # process all conditions and bodies
         conditions = [self.visit(h, **kwargs) for h in o.findall('header')]
-        bodies = [as_tuple(self.visit(b, **kwargs)) for b in o.findall('body')]
+        bodies = [flatten(as_tuple(self.visit(b, **kwargs))) for b in o.findall('body')]
         ncond = len(conditions)
         if len(bodies) > ncond:
             else_body = bodies[-1]
             bodies = bodies[:-1]
         else:
-            else_body = None
+            else_body = ()
         assert ncond == len(bodies)
         # shortcut for inline conditionals
         if o.find('if-then-stmt') is None:
-            assert ncond == 1 and else_body is None
+            assert ncond == 1 and else_body is ()
             return ir.Conditional(condition=conditions[0], body=bodies[0], else_body=(),
                                   inline=True, has_elseif=False, label=kwargs['label'],
                                   source=kwargs['source'])
@@ -1398,7 +1398,7 @@ class OFP2IR(GenericVisitor):
             )
         else:
             # No ONLY list
-            symbols = None
+            symbols = ()
             # Rename list
             rename_list = dict(self.visit(s, **kwargs) for s in o.findall('rename/rename'))
             if module is not None:

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -251,7 +251,7 @@ class OFP2IR(GenericVisitor):
         assert ncond == len(bodies)
         # shortcut for inline conditionals
         if o.find('if-then-stmt') is None:
-            assert ncond == 1 and else_body is ()
+            assert ncond == 1 and else_body == ()
             return ir.Conditional(condition=conditions[0], body=bodies[0], else_body=(),
                                   inline=True, has_elseif=False, label=kwargs['label'],
                                   source=kwargs['source'])

--- a/loki/frontend/preprocessing.py
+++ b/loki/frontend/preprocessing.py
@@ -133,7 +133,7 @@ def reinsert_contiguous(ir, pp_info):
     """
     if pp_info:
         for decl in FindNodes(VariableDeclaration).visit(ir):
-            if decl._source.lines[0] in pp_info:
+            if decl.source.lines[0] in pp_info:
                 for var in decl.symbols:
                     var.scope.symbol_attrs[var.name] = var.scope.symbol_attrs[var.name].clone(contiguous=True)
     return ir
@@ -146,9 +146,9 @@ def reinsert_convert_endian(ir, pp_info):
     """
     if pp_info:
         for intr in FindNodes(Intrinsic).visit(ir):
-            match = pp_info.get(intr._source.lines[0], [None])[0]
+            match = pp_info.get(intr.source.lines[0], [None])[0]
             if match is not None:
-                source = intr._source
+                source = intr.source
                 assert source is not None
                 text = match['ws'] + match['pre'] + match['convert'] + match['post']
                 if match['post'].rstrip().endswith('&'):
@@ -165,9 +165,9 @@ def reinsert_open_newunit(ir, pp_info):
     """
     if pp_info:
         for intr in FindNodes(Intrinsic).visit(ir):
-            match = pp_info.get(intr._source.lines[0], [None])[0]
+            match = pp_info.get(intr.source.lines[0], [None])[0]
             if match is not None:
-                source = intr._source
+                source = intr.source
                 assert source is not None
                 text = match['ws'] + match['open'] + match['args1'] + (match['delim'] or '')
                 text += match['newunit_key'] + match['newunit_val'] + match['args2']

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -622,7 +622,9 @@ class ProcedureStatementPattern(Pattern):
             sym.Variable(name=s, type=SymbolAttributes(ProcedureType(name=s)), scope=scope)
             for s in procedures
         ]
-        return ir.ProcedureDeclaration(symbols=symbols, module=is_module, source=reader.source_from_current_line)
+        return ir.ProcedureDeclaration(
+            symbols=symbols, module=is_module, source=reader.source_from_current_line()
+        )
 
 
 class TypedefPattern(Pattern):
@@ -746,7 +748,7 @@ class ProcedureBindingPattern(Pattern):
                 initial = sym.Variable(name=s[1], type=type_, scope=scope.parent)
                 symbols += [sym.Variable(name=s[0], type=type_.clone(initial=initial), scope=scope)]
 
-        return ir.ProcedureDeclaration(symbols=symbols, source=reader.source_from_current_line)
+        return ir.ProcedureDeclaration(symbols=symbols, source=reader.source_from_current_line())
 
 
 class GenericBindingPattern(Pattern):

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -63,8 +63,8 @@ def inline_comments(ir):
         # Comment is in-line and can be merged
         # Note, we need to re-create the statement node
         # so that Transformers don't throw away the changes.
-        if pair[0]._source and pair[1]._source:
-            if pair[1]._source.lines[0] == pair[0]._source.lines[1]:
+        if pair[0].source and pair[1].source:
+            if pair[1].source.lines[0] == pair[0].source.lines[1]:
                 mapper[pair[0]] = pair[0]._rebuild(comment=pair[1])
                 mapper[pair[1]] = None  # Mark for deletion
     return NestedTransformer(mapper, invalidate_source=False).visit(ir)
@@ -79,7 +79,7 @@ def cluster_comments(ir):
     for comments in comment_groups:
         # Build a CommentBlock and map it to first comment
         # and map remaining comments to None for removal
-        if all(c._source is not None for c in comments):
+        if all(c.source is not None for c in comments):
             if all(c.source.string is not None for c in comments):
                 string = '\n'.join(c.source.string for c in comments)
             else:

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -1424,10 +1424,10 @@ class MultiConditional(LeafNode):
         super().__init__(**kwargs)
 
         assert isinstance(expr, Expression)
-        assert is_iterable(values) and all(isinstance(v, tuple) and all(isinstance(c, Expression) for c in v)
+        assert isinstance(values, tuple) and all(isinstance(v, tuple) and all(isinstance(c, Expression) for c in v)
                                            for v in values)
-        assert is_iterable(bodies) and all(isinstance(b, tuple) for b in bodies)
-        assert is_iterable(else_body)
+        assert isinstance(bodies, tuple) and all(isinstance(b, tuple) for b in bodies)
+        assert isinstance(else_body, tuple)
 
         self.expr = expr
         self.values = as_tuple(values)

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -329,6 +329,14 @@ class Section(InternalNode, _SectionBase):
 
     _argnames = InternalNode._argnames
 
+    def __post_init__(self):
+        super().__post_init__()
+        assert self.body is None or isinstance(self.body, tuple)
+
+        # Ensure we have no nested tuples in the body
+        if not all(not isinstance(n, tuple) for n in as_tuple(self.body)):
+            self._update(body=as_tuple(flatten(self.body)))
+
     def append(self, node):
         """
         Append the given node(s) to the section's body.

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -501,7 +501,7 @@ class Loop(InternalNode, _LoopBase):
 class _WhileLoopBase():
     """ Type definitions for :any:`WhileLoop` node type. """
 
-    condition: Expression
+    condition: Union[Expression, None]
     body: Tuple[Node, ...]
     pragma: Node = None
     pragma_post: Node = None
@@ -1191,7 +1191,7 @@ class PreprocessorDirective(LeafNode, _PreprocessorDirectiveBase):
 class _ImportBase():
     """ Type definitions for :any:`Import` node type. """
 
-    module: str
+    module: Union[str, None]
     symbols: Tuple[Expression, ...] = ()
     nature: str = None
     c_import: bool = False

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -80,8 +80,8 @@ class Node:
 
     def __init__(self, source=None, label=None):
         super().__init__()
-        self._source = source
-        self._label = label
+        self.source = source
+        self.label = label
 
     @property
     def _canonical(self):
@@ -169,21 +169,6 @@ class Node:
         Arguments used to construct the Node that cannot be traversed.
         """
         return {k: v for k, v in self.args.items() if k not in self._traversable}
-
-    @property
-    def source(self):
-        """
-        The :py:class:`loki.frontend.source.Source` object with information
-        about the original source for that Node.
-        """
-        return self._source
-
-    @property
-    def label(self):
-        """
-        Return the statement label of this node.
-        """
-        return self._label
 
     def __repr__(self):
         raise NotImplementedError

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -12,7 +12,7 @@ Control flow node classes for
 """
 
 from collections import OrderedDict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from itertools import chain
 from typing import Any, Tuple, Union
@@ -53,7 +53,7 @@ dataclass_strict = partial(dataclass_validated, config=config)
 
 # Abstract base classes
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Node:
     """
     Base class for all node types in Loki's internal representation.
@@ -245,7 +245,7 @@ class Node:
         return self.__dict__['_uses_symbols']
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class InternalNode(Node):
     """
     Internal representation of a control flow node that has a traversable
@@ -271,7 +271,7 @@ class InternalNode(Node):
         raise NotImplementedError
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class LeafNode(Node):
     """
     Internal representation of a control flow node without a `body`.
@@ -313,7 +313,7 @@ class ScopedNode(Scope):
 # Intermediate node types
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _SectionBase():
     """ Type definitions for :any:`Section` node type. """
 
@@ -321,7 +321,7 @@ class _SectionBase():
     body: Tuple[Any, ...] = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Section(InternalNode, _SectionBase):
     """
     Internal representation of a single code region.
@@ -428,7 +428,7 @@ class Associate(ScopedNode, Section):
         return 'Associate::'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _LoopBase():
     """ Type definitions for :any:`Loop` node type. """
 
@@ -442,7 +442,7 @@ class _LoopBase():
     has_end_do: bool = True
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Loop(InternalNode, _LoopBase):
     """
     Internal representation of a loop with induction variable and range.
@@ -497,7 +497,7 @@ class Loop(InternalNode, _LoopBase):
         return f'Loop::{label} {control}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _WhileLoopBase():
     """ Type definitions for :any:`WhileLoop` node type. """
 
@@ -510,7 +510,7 @@ class _WhileLoopBase():
     has_end_do: bool = True
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class WhileLoop(InternalNode, _WhileLoopBase):
     """
     Internal representation of a while loop in source code.
@@ -563,7 +563,7 @@ class WhileLoop(InternalNode, _WhileLoopBase):
         return f'WhileLoop::{label} {control}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _ConditionalBase():
     """ Type definitions for :any:`Conditional` node type. """
 
@@ -575,7 +575,7 @@ class _ConditionalBase():
     name: str = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Conditional(InternalNode, _ConditionalBase):
     """
     Internal representation of a conditional branching construct.
@@ -626,7 +626,7 @@ class Conditional(InternalNode, _ConditionalBase):
         return 'Conditional::'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _PragmaRegionBase():
     """ Type definitions for :any:`PragmaRegion` node type. """
 
@@ -635,7 +635,7 @@ class _PragmaRegionBase():
     pragma_post: Node = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class PragmaRegion(InternalNode, _PragmaRegionBase):
     """
     Internal representation of a block of code defined by two matching pragmas.
@@ -676,7 +676,7 @@ class PragmaRegion(InternalNode, _PragmaRegionBase):
         return 'PragmaRegion::'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _InterfaceBase():
     """ Type definitions for :any:`Interface` node type. """
 
@@ -685,7 +685,7 @@ class _InterfaceBase():
     spec: Union[Expression, str] = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Interface(InternalNode, _InterfaceBase):
     """
     Internal representation of a Fortran interface block.
@@ -734,7 +734,7 @@ class Interface(InternalNode, _InterfaceBase):
 
 # Leaf node types
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _AssignmentBase():
     """ Type definitions for :any:`Assignment` node type. """
 
@@ -744,7 +744,7 @@ class _AssignmentBase():
     comment: Node = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Assignment(LeafNode, _AssignmentBase):
     """
     Internal representation of a variable assignment.
@@ -777,7 +777,7 @@ class Assignment(LeafNode, _AssignmentBase):
         return f'Assignment:: {str(self.lhs)} = {str(self.rhs)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _ConditionalAssignmentBase():
     """ Type definitions for :any:`ConditionalAssignment` node type. """
 
@@ -787,7 +787,7 @@ class _ConditionalAssignmentBase():
     else_rhs: Expression = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class ConditionalAssignment(LeafNode, _ConditionalAssignmentBase):
     """
     Internal representation of an inline conditional assignment using a
@@ -823,7 +823,7 @@ class ConditionalAssignment(LeafNode, _ConditionalAssignmentBase):
         return f'CondAssign:: {self.lhs} = {self.condition} ? {self.rhs} : {self.else_rhs}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _CallStatementBase():
     """ Type definitions for :any:`CallStatement` node type. """
 
@@ -835,7 +835,7 @@ class _CallStatementBase():
     chevron: Tuple[Expression, ...] = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class CallStatement(LeafNode, _CallStatementBase):
     """
     Internal representation of a subroutine call.
@@ -941,7 +941,7 @@ class CallStatement(LeafNode, _CallStatementBase):
         return chain(args, kwargs)
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _AllocationBase():
     """ Type definitions for :any:`Allocation` node type. """
 
@@ -950,7 +950,7 @@ class _AllocationBase():
     status_var: Expression = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Allocation(LeafNode, _AllocationBase):
     """
     Internal representation of a variable allocation.
@@ -982,7 +982,7 @@ class Allocation(LeafNode, _AllocationBase):
         return f'Allocation:: {", ".join(str(var) for var in self.variables)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _DeallocationBase():
     """ Type definitions for :any:`Deallocation` node type. """
 
@@ -990,7 +990,7 @@ class _DeallocationBase():
     status_var: Expression = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Deallocation(LeafNode, _DeallocationBase):
     """
     Internal representation of a variable deallocation.
@@ -1018,14 +1018,14 @@ class Deallocation(LeafNode, _DeallocationBase):
         return f'Deallocation:: {", ".join(str(var) for var in self.variables)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _NullifyBase():
     """ Type definitions for :any:`Nullify` node type. """
 
     variables: Tuple[Expression, ...]
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Nullify(LeafNode, _NullifyBase):
     """
     Internal representation of a pointer nullification.
@@ -1049,14 +1049,14 @@ class Nullify(LeafNode, _NullifyBase):
         return f'Nullify:: {", ".join(str(var) for var in self.variables)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _CommentBase():
     """ Type definitions for :any:`Comment` node type. """
 
     text: str
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Comment(LeafNode, _CommentBase):
     """
     Internal representation of a single comment.
@@ -1079,14 +1079,14 @@ class Comment(LeafNode, _CommentBase):
         return f'Comment:: {truncate_string(self.text)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _CommentBlockBase():
     """ Type definitions for :any:`CommentBlock` node type. """
 
     comments: Tuple[Node, ...]
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class CommentBlock(LeafNode, _CommentBlockBase):
     """
     Internal representation of a block comment that is formed from
@@ -1116,7 +1116,7 @@ class CommentBlock(LeafNode, _CommentBlockBase):
         return f'CommentBlock:: {truncate_string(self.text)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _PragmaBase():
     """ Type definitions for :any:`Pragma` node type. """
 
@@ -1124,7 +1124,7 @@ class _PragmaBase():
     content: str = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Pragma(LeafNode, _PragmaBase):
     """
     Internal representation of a pragma.
@@ -1152,14 +1152,14 @@ class Pragma(LeafNode, _PragmaBase):
         return f'Pragma:: {self.keyword} {truncate_string(self.content)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _PreprocessorDirectiveBase():
     """ Type definitions for :any:`PreprocessorDirective` node type. """
 
     text: str = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class PreprocessorDirective(LeafNode, _PreprocessorDirectiveBase):
     """
     Internal representation of a preprocessor directive.
@@ -1181,7 +1181,7 @@ class PreprocessorDirective(LeafNode, _PreprocessorDirectiveBase):
         return f'PreprocessorDirective:: {truncate_string(self.text)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _ImportBase():
     """ Type definitions for :any:`Import` node type. """
 
@@ -1194,7 +1194,7 @@ class _ImportBase():
     rename_list: Tuple[Any, ...] = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Import(LeafNode, _ImportBase):
     """
     Internal representation of an import.
@@ -1249,7 +1249,7 @@ class Import(LeafNode, _ImportBase):
         return f'{_c}Import:: {self.module} => {self.symbols}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _VariableDeclarationBase():
     """ Type definitions for :any:`VariableDeclaration` node type. """
 
@@ -1259,7 +1259,7 @@ class _VariableDeclarationBase():
     pragma: Node = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class VariableDeclaration(LeafNode, _VariableDeclarationBase):
     """
     Internal representation of a variable declaration.
@@ -1304,7 +1304,7 @@ class VariableDeclaration(LeafNode, _VariableDeclarationBase):
         return f'VariableDeclaration:: {symbols}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _ProcedureDeclarationBase():
     """ Type definitions for :any:`ProcedureDeclaration` node type. """
 
@@ -1318,7 +1318,7 @@ class _ProcedureDeclarationBase():
     pragma: Tuple[Node, ...] = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class ProcedureDeclaration(LeafNode, _ProcedureDeclarationBase):
     """
     Internal representation of a procedure declaration.
@@ -1371,7 +1371,7 @@ class ProcedureDeclaration(LeafNode, _ProcedureDeclarationBase):
         return f'ProcedureDeclaration:: {symbols}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _DataDeclarationBase():
     """ Type definitions for :any:`DataDeclaration` node type. """
 
@@ -1381,7 +1381,7 @@ class _DataDeclarationBase():
     values: Tuple[Expression, ...]
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class DataDeclaration(LeafNode, _DataDeclarationBase):
     """
     Internal representation of a ``DATA`` declaration for explicit array
@@ -1411,7 +1411,7 @@ class DataDeclaration(LeafNode, _DataDeclarationBase):
         return f'DataDeclaration:: {str(self.variable)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _StatementFunctionBase():
     """ Type definitions for :any:`StatementFunction` node type. """
 
@@ -1421,7 +1421,7 @@ class _StatementFunctionBase():
     return_type: SymbolAttributes
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class StatementFunction(LeafNode, _StatementFunctionBase):
     """
     Internal representation of Fortran statement function statements
@@ -1606,7 +1606,7 @@ class TypeDef(ScopedNode, LeafNode):
         self.rescope_symbols()
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _MultiConditionalBase():
     """ Type definitions for :any:`MultiConditional` node type. """
 
@@ -1617,7 +1617,7 @@ class _MultiConditionalBase():
     name: str = None
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class MultiConditional(LeafNode, _MultiConditionalBase):
     """
     Internal representation of a multi-value conditional (eg. ``SELECT``).
@@ -1658,7 +1658,7 @@ class MultiConditional(LeafNode, _MultiConditionalBase):
         return f'MultiConditional::{label} {str(self.expr)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _MaskedStatementBase():
     """ Type definitions for :any:`MaskedStatement` node type. """
 
@@ -1668,7 +1668,7 @@ class _MaskedStatementBase():
     inline: bool = False
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class MaskedStatement(LeafNode, _MaskedStatementBase):
     """
     Internal representation of a masked array assignment (``WHERE`` clause).
@@ -1715,7 +1715,7 @@ class _IntrinsicBase():
     text: str
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Intrinsic(LeafNode, _IntrinsicBase):
     """
     Catch-all generic node for corner-cases.
@@ -1744,14 +1744,14 @@ class Intrinsic(LeafNode, _IntrinsicBase):
         return f'Intrinsic:: {truncate_string(self.text)}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _EnumerationBase():
     """ Type definitions for :any:`Enumeration` node type. """
 
     symbols: Tuple[Expression, ...]
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class Enumeration(LeafNode, _EnumerationBase):
     """
     Internal representation of an ``ENUM``
@@ -1780,14 +1780,14 @@ class Enumeration(LeafNode, _EnumerationBase):
         return f'Enumeration:: {symbols}'
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class _RawSourceBase():
     """ Type definitions for :any:`RawSource` node type. """
 
     text: str
 
 
-@dataclass(frozen=True)
+@dataclass_strict(frozen=True)
 class RawSource(LeafNode, _RawSourceBase):
     """
     Generic node for unparsed source code sections

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -13,10 +13,13 @@ Control flow node classes for
 
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from functools import partial
 from itertools import chain
 from typing import Any, Tuple, Union
 
 from pymbolic.primitives import Expression
+
+from pydantic.dataclasses import dataclass as dataclass_validated
 
 from loki.scope import Scope
 from loki.tools import flatten, as_tuple, is_iterable, truncate_string, CaseInsensitiveDict
@@ -39,6 +42,14 @@ __all__ = [
     'Intrinsic', 'Enumeration', 'RawSource'
 ]
 
+# Configuration for validation mechanism via pydantic
+config = {
+    'validate_assignment': True,
+    'arbitrary_types_allowed': True,
+}
+
+# Using this decorator, we can force strict validation
+dataclass_strict = partial(dataclass_validated, config=config)
 
 # Abstract base classes
 

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -294,13 +294,18 @@ class ScopedNode(Scope):
 
 
 @dataclass(frozen=True)
-class Section(InternalNode):
-    """
-    Internal representation of a single code region.
-    """
+class _SectionBase():
+    """ Type definitions for :any:`Section` node type. """
 
     # Sections may contain Module / Subroutine objects
     body: Tuple[Any, ...] = None
+
+
+@dataclass(frozen=True)
+class Section(InternalNode, _SectionBase):
+    """
+    Internal representation of a single code region.
+    """
 
     _argnames = InternalNode._argnames
 
@@ -404,7 +409,21 @@ class Associate(ScopedNode, Section):
 
 
 @dataclass(frozen=True)
-class Loop(InternalNode):
+class _LoopBase():
+    """ Type definitions for :any:`Loop` node type. """
+
+    variable: Expression
+    bounds: Expression
+    body: Tuple[Node, ...]
+    pragma: Tuple[Node, ...] = None
+    pragma_post: Tuple[Node, ...] = None
+    loop_label: Any = None
+    name: str = None
+    has_end_do: bool = True
+
+
+@dataclass(frozen=True)
+class Loop(InternalNode, _LoopBase):
     """
     Internal representation of a loop with induction variable and range.
 
@@ -439,15 +458,6 @@ class Loop(InternalNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    variable: Expression = None
-    bounds: Expression = None
-    body: Tuple[Node, ...] = None
-    pragma: Tuple[Node, ...] = None
-    pragma_post: Tuple[Node, ...] = None
-    loop_label: Any = None
-    name: str = None
-    has_end_do: bool = True
-
     _argnames = InternalNode._argnames + (
         'variable', 'bounds', 'body', 'pragma', 'pragma_post',
         'loop_label', 'name', 'has_end_do'
@@ -467,7 +477,20 @@ class Loop(InternalNode):
 
 
 @dataclass(frozen=True)
-class WhileLoop(InternalNode):
+class _WhileLoopBase():
+    """ Type definitions for :any:`WhileLoop` node type. """
+
+    condition: Expression
+    body: Tuple[Node, ...]
+    pragma: Node = None
+    pragma_post: Node = None
+    loop_label: Any = None
+    name: str = None
+    has_end_do: bool = True
+
+
+@dataclass(frozen=True)
+class WhileLoop(InternalNode, _WhileLoopBase):
     """
     Internal representation of a while loop in source code.
 
@@ -504,14 +527,6 @@ class WhileLoop(InternalNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    condition: Expression = None
-    body: Tuple[Node, ...] = None
-    pragma: Node = None
-    pragma_post: Node = None
-    loop_label: Any = None
-    name: str = None
-    has_end_do: bool = True
-
     _argnames = InternalNode._argnames + (
         'condition', 'body', 'pragma', 'pragma_post', 'loop_label',
         'name', 'has_end_do'
@@ -528,7 +543,19 @@ class WhileLoop(InternalNode):
 
 
 @dataclass(frozen=True)
-class Conditional(InternalNode):
+class _ConditionalBase():
+    """ Type definitions for :any:`Conditional` node type. """
+
+    condition: Expression
+    body: Tuple[Node, ...]
+    else_body: Tuple[Node, ...] = None
+    inline: bool = False
+    has_elseif: bool = False
+    name: str = None
+
+
+@dataclass(frozen=True)
+class Conditional(InternalNode, _ConditionalBase):
     """
     Internal representation of a conditional branching construct.
 
@@ -555,13 +582,6 @@ class Conditional(InternalNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    condition: Expression = None
-    body: Tuple[Node, ...] = None
-    else_body: Tuple[Node, ...] = None
-    inline: bool = False
-    has_elseif: bool = False
-    name: str = None
-
     _argnames = InternalNode._argnames + (
         'condition', 'body', 'else_body', 'inline', 'has_elseif', 'name'
     )
@@ -585,7 +605,16 @@ class Conditional(InternalNode):
 
 
 @dataclass(frozen=True)
-class PragmaRegion(InternalNode):
+class _PragmaRegionBase():
+    """ Type definitions for :any:`PragmaRegion` node type. """
+
+    body: Tuple[Node, ...]
+    pragma: Node = None
+    pragma_post: Node = None
+
+
+@dataclass(frozen=True)
+class PragmaRegion(InternalNode, _PragmaRegionBase):
     """
     Internal representation of a block of code defined by two matching pragmas.
 
@@ -607,10 +636,6 @@ class PragmaRegion(InternalNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    body: Tuple[Node, ...] = None
-    pragma: Node = None
-    pragma_post: Node = None
-
     _argnames = InternalNode._argnames + ('body', 'pragma', 'pragma_post')
 
     _traversable = ['body']
@@ -630,7 +655,16 @@ class PragmaRegion(InternalNode):
 
 
 @dataclass(frozen=True)
-class Interface(InternalNode):
+class _InterfaceBase():
+    """ Type definitions for :any:`Interface` node type. """
+
+    body: Tuple[Any, ...]
+    abstract: bool = False
+    spec: Union[Expression, str] = None
+
+
+@dataclass(frozen=True)
+class Interface(InternalNode, _InterfaceBase):
     """
     Internal representation of a Fortran interface block.
 
@@ -646,10 +680,6 @@ class Interface(InternalNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    body: Tuple[Any, ...] = None
-    abstract: bool = False
-    spec: Union[Expression, str] = None
 
     _argnames = InternalNode._argnames + ('body', 'abstract', 'spec')
 
@@ -682,7 +712,17 @@ class Interface(InternalNode):
 # Leaf node types
 
 @dataclass(frozen=True)
-class Assignment(LeafNode):
+class _AssignmentBase():
+    """ Type definitions for :any:`Assignment` node type. """
+
+    lhs: Expression
+    rhs: Expression
+    ptr: bool = False
+    comment: Node = None
+
+
+@dataclass(frozen=True)
+class Assignment(LeafNode, _AssignmentBase):
     """
     Internal representation of a variable assignment.
 
@@ -701,11 +741,6 @@ class Assignment(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    lhs: Expression = None
-    rhs: Expression = None
-    ptr: bool = False
-    comment: Node = None
-
     _argnames = LeafNode._argnames + ('lhs', 'rhs', 'ptr', 'comment')
 
     _traversable = ['lhs', 'rhs']
@@ -719,7 +754,17 @@ class Assignment(LeafNode):
 
 
 @dataclass(frozen=True)
-class ConditionalAssignment(LeafNode):
+class _ConditionalAssignmentBase():
+    """ Type definitions for :any:`ConditionalAssignment` node type. """
+
+    lhs: Expression = None
+    condition: Expression = None
+    rhs: Expression = None
+    else_rhs: Expression = None
+
+
+@dataclass(frozen=True)
+class ConditionalAssignment(LeafNode, _ConditionalAssignmentBase):
     """
     Internal representation of an inline conditional assignment using a
     ternary operator.
@@ -746,11 +791,6 @@ class ConditionalAssignment(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    lhs: Expression = None
-    condition: Expression = None
-    rhs: Expression = None
-    else_rhs: Expression = None
-
     _argnames = LeafNode._argnames + ('condition', 'lhs', 'rhs', 'else_rhs')
 
     _traversable = ['condition', 'lhs', 'rhs', 'else_rhs']
@@ -760,7 +800,19 @@ class ConditionalAssignment(LeafNode):
 
 
 @dataclass(frozen=True)
-class CallStatement(LeafNode):
+class _CallStatementBase():
+    """ Type definitions for :any:`CallStatement` node type. """
+
+    name: Expression
+    arguments: Tuple[Expression, ...] = None
+    kwarguments: Tuple[Any, ...] = None
+    pragma: Tuple[Node, ...] = None
+    not_active: bool = None
+    chevron: Tuple[Expression, ...] = None
+
+
+@dataclass(frozen=True)
+class CallStatement(LeafNode, _CallStatementBase):
     """
     Internal representation of a subroutine call.
 
@@ -786,13 +838,6 @@ class CallStatement(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    name: Expression = None
-    arguments: Tuple[Expression, ...] = None
-    kwarguments: Tuple[Any, ...] = None
-    pragma: Tuple[Node, ...] = None
-    not_active: bool = None
-    chevron: Tuple[Expression, ...] = None
 
     _argnames = LeafNode._argnames + (
         'name', 'arguments', 'kwarguments', 'pragma', 'not_active', 'chevron'
@@ -872,7 +917,16 @@ class CallStatement(LeafNode):
 
 
 @dataclass(frozen=True)
-class Allocation(LeafNode):
+class _AllocationBase():
+    """ Type definitions for :any:`Allocation` node type. """
+
+    variables: Tuple[Expression, ...]
+    data_source: Expression = None
+    status_var: Expression = None
+
+
+@dataclass(frozen=True)
+class Allocation(LeafNode, _AllocationBase):
     """
     Internal representation of a variable allocation.
 
@@ -887,10 +941,6 @@ class Allocation(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    variables: Tuple[Expression, ...] = None
-    data_source: Expression = None
-    status_var: Expression = None
 
     _argnames = LeafNode._argnames + ('variables', 'data_source', 'status_var')
 
@@ -907,7 +957,15 @@ class Allocation(LeafNode):
 
 
 @dataclass(frozen=True)
-class Deallocation(LeafNode):
+class _DeallocationBase():
+    """ Type definitions for :any:`Deallocation` node type. """
+
+    variables: Tuple[Expression, ...]
+    status_var: Expression = None
+
+
+@dataclass(frozen=True)
+class Deallocation(LeafNode, _DeallocationBase):
     """
     Internal representation of a variable deallocation.
 
@@ -920,10 +978,6 @@ class Deallocation(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    variables: Tuple[Expression, ...] = None
-    status_var: Expression = None
-
     _argnames = LeafNode._argnames + ('variables', 'status_var')
 
     _traversable = ['variables', 'status_var']
@@ -936,8 +990,16 @@ class Deallocation(LeafNode):
     def __repr__(self):
         return f'Deallocation:: {", ".join(str(var) for var in self.variables)}'
 
+
 @dataclass(frozen=True)
-class Nullify(LeafNode):
+class _NullifyBase():
+    """ Type definitions for :any:`Nullify` node type. """
+
+    variables: Tuple[Expression, ...]
+
+
+@dataclass(frozen=True)
+class Nullify(LeafNode, _NullifyBase):
     """
     Internal representation of a pointer nullification.
 
@@ -948,8 +1010,6 @@ class Nullify(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    variables: Tuple[Expression, ...] = None
 
     _traversable = ['variables']
 
@@ -962,7 +1022,14 @@ class Nullify(LeafNode):
 
 
 @dataclass(frozen=True)
-class Comment(LeafNode):
+class _CommentBase():
+    """ Type definitions for :any:`Comment` node type. """
+
+    text: str
+
+
+@dataclass(frozen=True)
+class Comment(LeafNode, _CommentBase):
     """
     Internal representation of a single comment.
 
@@ -975,8 +1042,6 @@ class Comment(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    text: str = None
-
     _argnames = LeafNode._argnames + ('text', )
 
     def __post_init__(self):
@@ -987,7 +1052,14 @@ class Comment(LeafNode):
 
 
 @dataclass(frozen=True)
-class CommentBlock(LeafNode):
+class _CommentBlockBase():
+    """ Type definitions for :any:`CommentBlock` node type. """
+
+    comments: Tuple[Node, ...]
+
+
+@dataclass(frozen=True)
+class CommentBlock(LeafNode, _CommentBlockBase):
     """
     Internal representation of a block comment that is formed from
     multiple single-line comments.
@@ -999,8 +1071,6 @@ class CommentBlock(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    comments: Tuple[Node, ...] = None
 
     _argnames = LeafNode._argnames + ('comments', )
 
@@ -1018,7 +1088,15 @@ class CommentBlock(LeafNode):
 
 
 @dataclass(frozen=True)
-class Pragma(LeafNode):
+class _PragmaBase():
+    """ Type definitions for :any:`Pragma` node type. """
+
+    keyword: str
+    content: str = None
+
+
+@dataclass(frozen=True)
+class Pragma(LeafNode, _PragmaBase):
     """
     Internal representation of a pragma.
 
@@ -1035,9 +1113,6 @@ class Pragma(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    keyword: str = None
-    content: str = None
-
     _argnames = LeafNode._argnames + ('keyword', 'content')
 
     def __post_init__(self):
@@ -1048,7 +1123,14 @@ class Pragma(LeafNode):
 
 
 @dataclass(frozen=True)
-class PreprocessorDirective(LeafNode):
+class _PreprocessorDirectiveBase():
+    """ Type definitions for :any:`PreprocessorDirective` node type. """
+
+    text: str = None
+
+
+@dataclass(frozen=True)
+class PreprocessorDirective(LeafNode, _PreprocessorDirectiveBase):
     """
     Internal representation of a preprocessor directive.
 
@@ -1063,8 +1145,6 @@ class PreprocessorDirective(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    text: str = None
-
     _argnames = LeafNode._argnames + ('text', )
 
     def __repr__(self):
@@ -1072,7 +1152,20 @@ class PreprocessorDirective(LeafNode):
 
 
 @dataclass(frozen=True)
-class Import(LeafNode):
+class _ImportBase():
+    """ Type definitions for :any:`Import` node type. """
+
+    module: str
+    symbols: Tuple[Expression, ...] = ()
+    nature: str = None
+    c_import: bool = False
+    f_include: bool = False
+    f_import: bool = False
+    rename_list: Tuple[Any, ...] = None
+
+
+@dataclass(frozen=True)
+class Import(LeafNode, _ImportBase):
     """
     Internal representation of an import.
 
@@ -1096,14 +1189,6 @@ class Import(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    module: str = None
-    symbols: Tuple[Expression, ...] = ()
-    nature: str = None
-    c_import: bool = False
-    f_include: bool = False
-    f_import: bool = False
-    rename_list: Tuple[Any, ...] = None
 
     _argnames = LeafNode._argnames + (
         'module', 'symbols', 'nature', 'c_import', 'f_include',
@@ -1134,7 +1219,17 @@ class Import(LeafNode):
 
 
 @dataclass(frozen=True)
-class VariableDeclaration(LeafNode):
+class _VariableDeclarationBase():
+    """ Type definitions for :any:`VariableDeclaration` node type. """
+
+    symbols: Tuple[Expression, ...]
+    dimensions: Tuple[Expression, ...] = None
+    comment: Node = None
+    pragma: Node = None
+
+
+@dataclass(frozen=True)
+class VariableDeclaration(LeafNode, _VariableDeclarationBase):
     """
     Internal representation of a variable declaration.
 
@@ -1157,11 +1252,6 @@ class VariableDeclaration(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    symbols: Tuple[Expression, ...] = None
-    dimensions: Tuple[Expression, ...] = None
-    comment: Node = None
-    pragma: Node = None
-
     _argnames = LeafNode._argnames + (
         'symbols', 'dimensions', 'comment', 'pragma'
     )
@@ -1183,7 +1273,21 @@ class VariableDeclaration(LeafNode):
 
 
 @dataclass(frozen=True)
-class ProcedureDeclaration(LeafNode):
+class _ProcedureDeclarationBase():
+    """ Type definitions for :any:`ProcedureDeclaration` node type. """
+
+    symbols: Tuple[Expression, ...]
+    interface: Union[Expression, DataType] = None
+    external: bool = False
+    module: bool = False
+    generic: bool = False
+    final: bool = False
+    comment: Node = None
+    pragma: Tuple[Node, ...] = None
+
+
+@dataclass(frozen=True)
+class ProcedureDeclaration(LeafNode, _ProcedureDeclarationBase):
     """
     Internal representation of a procedure declaration.
 
@@ -1215,15 +1319,6 @@ class ProcedureDeclaration(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    symbols: Tuple[Expression, ...] = None
-    interface: Union[Expression, DataType] = None
-    external: bool = False
-    module: bool = False
-    generic: bool = False
-    final: bool = False
-    comment: Node = None
-    pragma: Tuple[Node, ...] = None
-
     _argnames = LeafNode._argnames + (
         'symbols', 'interface', 'external', 'module', 'generic',
         'final', 'comment', 'pragma'
@@ -1244,7 +1339,17 @@ class ProcedureDeclaration(LeafNode):
 
 
 @dataclass(frozen=True)
-class DataDeclaration(LeafNode):
+class _DataDeclarationBase():
+    """ Type definitions for :any:`DataDeclaration` node type. """
+
+    # TODO: This should only allow Expression instances but needs frontend changes
+    # TODO: Support complex statements (LOKI-23)
+    variable: Any
+    values: Tuple[Expression, ...]
+
+
+@dataclass(frozen=True)
+class DataDeclaration(LeafNode, _DataDeclarationBase):
     """
     Internal representation of a ``DATA`` declaration for explicit array
     value lists.
@@ -1258,11 +1363,6 @@ class DataDeclaration(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    # TODO: This should only allow Expression instances but needs frontend changes
-    # TODO: Support complex statements (LOKI-23)
-    variable: Any = None
-    values: Tuple[Expression, ...] = None
 
     _argnames = LeafNode._argnames + ('variable', 'values')
 
@@ -1278,7 +1378,17 @@ class DataDeclaration(LeafNode):
 
 
 @dataclass(frozen=True)
-class StatementFunction(LeafNode):
+class _StatementFunctionBase():
+    """ Type definitions for :any:`StatementFunction` node type. """
+
+    variable: Expression
+    arguments: Tuple[Expression, ...]
+    rhs: Expression
+    return_type: SymbolAttributes
+
+
+@dataclass(frozen=True)
+class StatementFunction(LeafNode, _StatementFunctionBase):
     """
     Internal representation of Fortran statement function statements
 
@@ -1293,11 +1403,6 @@ class StatementFunction(LeafNode):
     return_type : :any:`SymbolAttributes`
         The return type of the statement function
     """
-
-    variable: Expression = None
-    arguments: Tuple[Expression, ...] = None
-    rhs: Expression = None
-    return_type: SymbolAttributes = None
 
     _argnames = LeafNode._argnames + (
         'variable', 'arguments', 'rhs', 'return_type'
@@ -1467,7 +1572,18 @@ class TypeDef(ScopedNode, LeafNode):
 
 
 @dataclass(frozen=True)
-class MultiConditional(LeafNode):
+class _MultiConditionalBase():
+    """ Type definitions for :any:`MultiConditional` node type. """
+
+    expr: Expression
+    values: Tuple[Any, ...]
+    bodies: Tuple[Any, ...]
+    else_body: Tuple[Node, ...]
+    name: str = None
+
+
+@dataclass(frozen=True)
+class MultiConditional(LeafNode, _MultiConditionalBase):
     """
     Internal representation of a multi-value conditional (eg. ``SELECT``).
 
@@ -1486,12 +1602,6 @@ class MultiConditional(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    expr: Expression = None
-    values: Tuple[Any, ...] = None
-    bodies: Tuple[Any, ...] = None
-    else_body: Tuple[Node, ...] = None
-    name: str = None
 
     _argnames = LeafNode._argnames + (
         'expr', 'values', 'bodies', 'else_body', 'name'
@@ -1513,7 +1623,17 @@ class MultiConditional(LeafNode):
 
 
 @dataclass(frozen=True)
-class MaskedStatement(LeafNode):
+class _MaskedStatementBase():
+    """ Type definitions for :any:`MaskedStatement` node type. """
+
+    conditions: Tuple[Expression, ...]
+    bodies: Tuple[Tuple[Node, ...], ...]
+    default: Tuple[Node, ...] = None
+    inline: bool = False
+
+
+@dataclass(frozen=True)
+class MaskedStatement(LeafNode, _MaskedStatementBase):
     """
     Internal representation of a masked array assignment (``WHERE`` clause).
 
@@ -1531,11 +1651,6 @@ class MaskedStatement(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    conditions: Tuple[Expression, ...] = None
-    bodies: Tuple[Tuple[Node, ...], ...] = None
-    default: Tuple[Node, ...] = None
-    inline: bool = False
 
     _argnames = LeafNode._argnames + (
         'conditions', 'bodies', 'default', 'inline'
@@ -1557,7 +1672,14 @@ class MaskedStatement(LeafNode):
 
 
 @dataclass(frozen=True)
-class Intrinsic(LeafNode):
+class _IntrinsicBase():
+    """ Type definitions for :any:`Intrinsic` node type. """
+
+    text: str
+
+
+@dataclass(frozen=True)
+class Intrinsic(LeafNode, _IntrinsicBase):
     """
     Catch-all generic node for corner-cases.
 
@@ -1575,8 +1697,6 @@ class Intrinsic(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    text: str = None
-
     _argnames = LeafNode._argnames + ('text', )
 
     def __post_init__(self):
@@ -1587,7 +1707,14 @@ class Intrinsic(LeafNode):
 
 
 @dataclass(frozen=True)
-class Enumeration(LeafNode):
+class _EnumerationBase():
+    """ Type definitions for :any:`Enumeration` node type. """
+
+    symbols: Tuple[Expression, ...]
+
+
+@dataclass(frozen=True)
+class Enumeration(LeafNode, _EnumerationBase):
     """
     Internal representation of an ``ENUM``
 
@@ -1603,8 +1730,6 @@ class Enumeration(LeafNode):
         Other parameters that are passed on to the parent class constructor.
     """
 
-    symbols: Tuple[Expression, ...] = None
-
     _argnames = LeafNode._argnames + ('symbols', )
 
     def __post_init__(self):
@@ -1617,7 +1742,14 @@ class Enumeration(LeafNode):
 
 
 @dataclass(frozen=True)
-class RawSource(LeafNode):
+class _RawSourceBase():
+    """ Type definitions for :any:`RawSource` node type. """
+
+    text: str
+
+
+@dataclass(frozen=True)
+class RawSource(LeafNode, _RawSourceBase):
     """
     Generic node for unparsed source code sections
 
@@ -1632,8 +1764,6 @@ class RawSource(LeafNode):
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
-
-    text: str = None
 
     _argnames = LeafNode._argnames + ('text', )
 

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -70,7 +70,7 @@ class ProgramUnit(Scope):
             spec = ir.Section(body=as_tuple(spec))
         if contains is not None:
             if not isinstance(contains, ir.Section):
-                contains = ir.Section(body=contains)
+                contains = ir.Section(body=as_tuple(contains))
             for node in contains.body:
                 if isinstance(node, ir.Intrinsic) and 'contains' in node.text.lower():
                     break

--- a/loki/scope.py
+++ b/loki/scope.py
@@ -259,7 +259,6 @@ class Scope:
     """
 
     def __init__(self, parent=None, symbol_attrs=None, rescope_symbols=False, **kwargs):
-        super().__init__(**kwargs)
         assert symbol_attrs is None or isinstance(symbol_attrs, SymbolTable)
         self.parent = parent
 
@@ -270,6 +269,9 @@ class Scope:
             assert isinstance(symbol_attrs, SymbolTable)
             symbol_attrs._parent = weakref.ref(parent_symbol_attrs) if parent_symbol_attrs is not None else None
             self.symbol_attrs = symbol_attrs
+
+        # Instantiate object after we've set up the symbol table
+        super().__init__(**kwargs)
 
         if rescope_symbols:
             self.rescope_symbols()

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -139,7 +139,7 @@ class DependencyTransformation(Transformation):
             if call.name in members:
                 continue
             if targets is None or call.name in targets:
-                call.name = call.name.clone(name=f'{call.name}{self.suffix}')
+                call._update(name=call.name.clone(name=f'{call.name}{self.suffix}'))
 
     def rename_imports(self, source, imports, **kwargs):
         """

--- a/loki/transform/fortran_c_transform.py
+++ b/loki/transform/fortran_c_transform.py
@@ -401,7 +401,7 @@ class FortranCTransformation(Transformation):
 
             elif not im.c_import and im.symbols:
                 # Create a C-header import for any converted modules
-                import_map[im] = im.clone(module=f'{im.module.lower()}_c.h', c_import=True, symbols=None)
+                import_map[im] = im.clone(module=f'{im.module.lower()}_c.h', c_import=True, symbols=())
 
             else:
                 # Remove other imports, as they might include untreated Fortran code

--- a/loki/transform/fortran_c_transform.py
+++ b/loki/transform/fortran_c_transform.py
@@ -181,7 +181,9 @@ class FortranCTransformation(Transformation):
         arguments = tuple(local_arg_map[a] if a in local_arg_map else Variable(name=a)
                           for a in routine.argnames)
         wrapper_body = casts_in
-        wrapper_body += [CallStatement(name=Variable(name=interface.body[0].name), arguments=arguments)]
+        wrapper_body += [
+            CallStatement(name=Variable(name=interface.body[0].name), arguments=arguments)  # pylint: disable=unsubscriptable-object
+        ]
         wrapper_body += casts_out
         wrapper.body = Section(body=as_tuple(wrapper_body))
 

--- a/loki/visitors/transform.py
+++ b/loki/visitors/transform.py
@@ -569,7 +569,7 @@ class NestedMaskedTransformer(MaskedTransformer):
         if not body:
             return else_body
 
-        has_elseif = o.has_elseif and else_body and isinstance(else_body[0], Conditional)
+        has_elseif = o.has_elseif and bool(else_body) and isinstance(else_body[0], Conditional)
         return self._rebuild(o, tuple((condition,) + (body,) + (else_body,)), has_elseif=has_elseif)
 
     def visit_MultiConditional(self, o, **kwargs):

--- a/loki/visitors/transform.py
+++ b/loki/visitors/transform.py
@@ -586,9 +586,9 @@ class NestedMaskedTransformer(MaskedTransformer):
 
         # need to make (value, body) pairs to track vanishing bodies
         expr = self.visit(o.expr, **kwargs)
-        branches = [(self.visit(c, **kwargs), self.visit(b, **kwargs))
-                    for c, b in zip(o.values, o.bodies)]
-        branches = [(c, b) for c, b in branches if flatten(as_tuple(b))]
+        branches = tuple((self.visit(c, **kwargs), self.visit(b, **kwargs))
+                         for c, b in zip(o.values, o.bodies))
+        branches = tuple((c, b) for c, b in branches if flatten(as_tuple(b)))
         else_body = self.visit(o.else_body, **kwargs)
 
         # retain whatever is in the else body if all other branches are gone

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     coloredlogs  # optional for loki-build utility
     junit_xml  # optional for JunitXML output in loki-lint
     codetiming  # essential for scheduler and sourcefile timings
+    pydantic
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_cufgen.py
+++ b/tests/test_cufgen.py
@@ -8,6 +8,7 @@
 import pytest
 
 from conftest import available_frontends
+from pydantic import ValidationError
 from loki import Module, FindNodes, Transformer
 from loki import ir
 from loki.expression import symbols as sym
@@ -83,9 +84,9 @@ end module transformation_module_cufgen
             with pytest.raises(AssertionError):
                 _ = call.clone(chevron=(sym.IntLiteral(1), sym.IntLiteral(1), sym.IntLiteral(1), sym.IntLiteral(1),
                                         sym.IntLiteral(1)))
-            with pytest.raises(AssertionError):
+            with pytest.raises(ValidationError):
                 _ = call.clone(chevron=(1, 1))
-            with pytest.raises(AssertionError):
+            with pytest.raises(ValidationError):
                 _ = call.clone(chevron=2)
 
             call_map[call] = call.clone(chevron=(sym.IntLiteral(1), sym.IntLiteral(1),

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -380,7 +380,7 @@ end subroutine routine_simple
     retriever = ExpressionRetriever(lambda e: isinstance(e, FloatLiteral))
     literals = ExpressionFinder(retrieve=retriever.retrieve, with_ir_node=True).visit(routine.body)
     assert len(literals) == 1
-    assert isinstance(literals[0][0], Assignment) and literals[0][0]._source.lines == (13, 13)
+    assert isinstance(literals[0][0], Assignment) and literals[0][0].source.lines == (13, 13)
 
     literal_root = FindExpressionRoot(literals[0][1].pop()).visit(literals[0][0])
     assert literal_root[0] is cast_root[0]

--- a/transformations/transformations/argument_shape.py
+++ b/transformations/transformations/argument_shape.py
@@ -151,7 +151,7 @@ class ExplicitArgumentArrayShapeTransformation(Transformation):
                            and not a.type.optional and a in dim_vars]
 
                 # Add missing dimension variables (scalars
-                new_kwargs = tuple((m, m) for m in missing if m.type.dtype == BasicType.INTEGER)
+                new_kwargs = tuple((str(m), m) for m in missing if m.type.dtype == BasicType.INTEGER)
                 call_map[call] = call.clone(kwarguments=call.kwarguments + new_kwargs)
 
         # Replace all adjusted calls on the caller-side

--- a/transformations/transformations/scc_cuf.py
+++ b/transformations/transformations/scc_cuf.py
@@ -225,7 +225,7 @@ def kernel_cuf(routine, horizontal, vertical, block_dim, transformation_type,
                                                    routine.variable_map[horizontal.size])))
 
         routine.body = ir.Section((jl_assignment, jblk_assignment, ir.Comment(''),
-                        ir.Conditional(condition=condition, body=routine.body, else_body=None)))
+                        ir.Conditional(condition=condition, body=routine.body.body, else_body=())))
 
     elif depth > 1:
         vtype = routine.variable_map[horizontal.size].type.clone(intent='in', value=True)
@@ -237,7 +237,8 @@ def kernel_cuf(routine, horizontal, vertical, block_dim, transformation_type,
             continue
 
         if not is_elemental(call.routine):
-            call.arguments += (routine.variable_map[block_dim.size], routine.variable_map[horizontal.index], jblk_var)
+            arguments = (routine.variable_map[block_dim.size], routine.variable_map[horizontal.index], jblk_var)
+            call._update(arguments=call.arguments + arguments)
 
     variables = routine.variables
     arguments = routine.arguments
@@ -302,7 +303,7 @@ def kernel_cuf(routine, horizontal, vertical, block_dim, transformation_type,
                     arguments.append(arg.clone(dimensions=None))
                 else:
                     arguments.append(arg)
-            call.arguments = arguments
+            call._update(arguments=arguments)
 
 
 def kernel_demote_private_locals(routine, horizontal, vertical):
@@ -580,8 +581,8 @@ def device_derived_types(routine, derived_types, targets=None):
     for call in FindNodes(ir.CallStatement).visit(routine.body):
         if call.name not in as_tuple(targets):
             continue
-        arguments = [var_map.get(arg, arg) for arg in call.arguments]
-        call.arguments = arguments
+        arguments = tuple(var_map.get(arg, arg) for arg in call.arguments)
+        call._update(arguments=arguments)
     return variables
 
 

--- a/transformations/transformations/single_column_claw.py
+++ b/transformations/transformations/single_column_claw.py
@@ -337,4 +337,4 @@ class CLAWTransformation(ExtractSCATransformation):
 
                 if loop.variable == self.horizontal.index:
                     pragma = Pragma(keyword='claw', content=claw_keywords)
-                    loop._update(pragma=pragma)
+                    loop._update(pragma=as_tuple(pragma))

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -229,10 +229,10 @@ def kernel_annotate_vector_loops_openacc(routine, horizontal, vertical):
             if loop.variable == horizontal.index:
                 # Construct pragma and wrap entire body in vector loop
                 private_arrs = ', '.join(v.name for v in private_arrays)
-                pragma = None
+                pragma = ()
                 private_clause = '' if not private_arrays else f' private({private_arrs})'
                 pragma = ir.Pragma(keyword='acc', content=f'loop vector{private_clause}')
-                mapper[loop] = loop.clone(pragma=pragma)
+                mapper[loop] = loop.clone(pragma=(pragma,))
 
         routine.body = Transformer(mapper).visit(routine.body)
 
@@ -258,7 +258,7 @@ def kernel_annotate_sequential_loops_openacc(routine, horizontal):
 
             if loop.variable != horizontal.index:
                 # Perform pragma addition in place to avoid nested loop replacements
-                loop._update(pragma=ir.Pragma(keyword='acc', content='loop seq'))
+                loop._update(pragma=(ir.Pragma(keyword='acc', content='loop seq'),))
 
 
 def kernel_annotate_subroutine_present_openacc(routine):
@@ -614,8 +614,8 @@ class SingleColumnCoalescedTransformation(Transformation):
 
                     if loop.pragma is None:
                         p_content = f'parallel loop gang{private_clause}'
-                        loop._update(pragma=ir.Pragma(keyword='acc', content=p_content))
-                        loop._update(pragma_post=ir.Pragma(keyword='acc', content='end parallel loop'))
+                        loop._update(pragma=(ir.Pragma(keyword='acc', content=p_content),))
+                        loop._update(pragma_post=(ir.Pragma(keyword='acc', content='end parallel loop'),))
 
                 # Apply hoisting of temporary "column arrays"
                 if self.hoist_column_arrays:
@@ -692,13 +692,15 @@ class SingleColumnCoalescedTransformation(Transformation):
         new_call._update(kwarguments=new_call.kwarguments + ((self.horizontal.index, v_index),))
 
         # Now create a vector loop around the kerne invocation
-        pragma = None
+        pragma = ()
         if self.directive == 'openacc':
             pragma = ir.Pragma(keyword='acc', content='loop vector')
         v_start = arg_map[kernel.variable_map[self.horizontal.bounds[0]]]
         v_end = arg_map[kernel.variable_map[self.horizontal.bounds[1]]]
         bounds = sym.LoopRange((v_start, v_end))
-        vector_loop = ir.Loop(variable=v_index, bounds=bounds, body=[new_call], pragma=pragma)
+        vector_loop = ir.Loop(
+            variable=v_index, bounds=bounds, body=(new_call,), pragma=as_tuple(pragma)
+        )
         call_map[call] = vector_loop
 
         routine.body = Transformer(call_map).visit(routine.body)

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -336,8 +336,10 @@ def resolve_vector_dimension(routine, loop_variable, bounds):
                   if isinstance(e, sym.RangeIndex) and e == bounds_str]
         if ranges:
             exprmap = {r: loop_variable for r in ranges}
-            loop = ir.Loop(variable=loop_variable, bounds=sym.LoopRange(bounds_v),
-                           body=SubstituteExpressions(exprmap).visit(stmt))
+            loop = ir.Loop(
+                variable=loop_variable, bounds=sym.LoopRange(bounds_v),
+                body=as_tuple(SubstituteExpressions(exprmap).visit(stmt))
+            )
             mapper[stmt] = loop
 
     routine.body = Transformer(mapper).visit(routine.body)


### PR DESCRIPTION
_Note: This is part 1 of a double-header, which is first concerned with changing the definition and constructor usage of regular IR nodes. Part 2 will specifically focus on the constructor usage of `Scope` objects and expand the change presented here to `ScopedNode`s._

The core rationale behind this change is the fact that we currently use a lot of monkey-patching and hidden magic functions in our IR node definition to enforce pseudo-immutability. However, with Python 3.7+, dataclasses have been introduced that can be used to natively express all these concepts (immutable attributes; dict-like comparison; hashes based select attributes, ...) including the ability to declare an object `frozen=True` and thus prevent direct regular-style updates to the object. We can, however, keep our explicit back for in-place updates (`Node._update`) in place by accessing `Node.__dict__` directly.

~The most crucial and high impact user-level change that this PR brings is the strict requirement to use keyword-only notation for `Node` constructors. From Python 3.10 onwards, we will be able to enforce this strictly via `kw_only=True`, but until then the requirement is implicit and will need updating of all(!) downstream scripts. On the other hand we now gain strict validation at constructor level via `pydantic`, which means any wrongly constructed (or re-constructed) Node will immediately fail if the provided type is incorrect. The reason for the keyword-only need comes from our use of inheritance, which would otherwise force the utility attributes (source, label) from the common base class to the front of `*args` (see [here](https://peps.python.org/pep-0557/#inheritance)).~

After some more soul searching, I've found a way to keep our current argument ordering in place, and thus continue to allow mixed args and keyword-arg constructor usage. To achieve this, a slightly quirky class definition pattern is used, where the typed attributes of a Node type are defined in a private base class of the form `class _NodeTypeBase`, so that we can post-pend it to the `Node`/`LeafNode`/`InternalNode` base classes, thus ensuring that the argument ordering stays as before. This modification of the PR (sorry), means that only a rigorous usage of tuples for tuple-typed attributes (like `body` or `pragma`) are needed on the user-side, keeping the impact fairly low). **However, with this style, the auto-conversion of None or list-type constructor arguments to tuples is no longer automatic, so shortcutting this will now throw errors, and likely requires user-side changes to transformation recipes / scripts.**

Some more comments on the detailed implementation:
* In-place updates via `Node._update()` are supported via direct insertion into `Node.__dict__`
* `label` and `source` are now pure attributes, not properties
* the dataflow analysis attributes are kept as private copies and inserted directly into `Node.__dict__` in the post_init; this allows us to check the attachment from the properties as before, but means they are excluded from hash and comparison operators 
* `Node._args` is gone now, but custom comparison and hashes remain for now; this will be removed in part 2 (see next point)
* `ScopedNode` objects are not yet frozen dataclasses, as the way we construct `Scope` objects conflicts with this approach; there are several follow-on restrictions due to this:
  * we store the `Node._argnames` as a class attribute, so that we don't need `Node._args` anymore; this will eventually be removed again in part 2
  * We need to maintain custom dunder methods and custom canonical caching until we can switch the `Scope` to be pseudo-immutable too (in part 2)

As a final note, the concrete type definitions might not be ideal, since in a few cases I have to use `body: Tuple[Any, ...]` instead of `body: Tuple[Node, ...]`. This is due to the fact that our transformers are prone to inserting nested tuples in some places, which would otherwise put more onus on the user scripts to `flatten` things super-rigorously. A further tidy up of the transformers could also be in order once part 2 has landed, but that is a "future work" item. 