### PR TITLE
Different way of creating documentation comment

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -52,15 +52,35 @@ jobs:
         SITES_TOKEN: ${{ secrets.SITES_TOKEN }}
       working-directory: ./docs
       run: |
-        ./sites-manager.py --space=docs --name=loki --token "$SITES_TOKEN" upload build/html ${{ github.ref_name }} || true
+        ./sites-manager.py --space=docs --name=loki --token "$SITES_TOKEN" upload build/html ${{ github.event.pull_request.number }} || true
 
-    - uses: actions/github-script@v6
+    - name: Find Comment
       if: github.ref_name != 'main'
+      uses: peter-evans/find-comment@v2
+      id: fc
       with:
-        script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'Documentation for this branch can be viewed at https://sites.ecmwf.int/docs/loki/${{ github.ref_name }}'
-          })
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: Documentation for this branch can be viewed at
+
+    - name: Create or update comment
+      if: github.ref_name != 'main'
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Documentation for this branch can be viewed at https://sites.ecmwf.int/docs/loki/${{ github.event.pull_request.number }}
+        edit-mode: replace
+
+    # Alternative way of creating the comment but without a way to edit it (thus potentially creating many duplicate comments)
+    # - uses: actions/github-script@v6
+    #   if: github.ref_name != 'main'
+    #   with:
+    #     script: |
+    #       github.rest.issues.createComment({
+    #         issue_number: context.issue.number,
+    #         owner: context.repo.owner,
+    #         repo: context.repo.repo,
+    #         body: 'Documentation for this branch can be viewed at https://sites.ecmwf.int/docs/loki/${{ github.ref_name }}'
+    #       })

--- a/.github/workflows/documentation_clean-up.yml
+++ b/.github/workflows/documentation_clean-up.yml
@@ -40,4 +40,4 @@ jobs:
         SITES_TOKEN: ${{ secrets.SITES_TOKEN }}
       working-directory: ./docs
       run: |
-        ./sites-manager.py --space=docs --name=loki --token "$SITES_TOKEN" delete ${{ github.ref_name }} || true
+        ./sites-manager.py --space=docs --name=loki --token "$SITES_TOKEN" delete ${{ github.event.pull_request.number }} || true


### PR DESCRIPTION
This changes the way the documentation comment is provided, to avoid these duplicate messages.

Also another stab at the cleanup after merging, but that one we'll know only after merging.