### PR TITLE
Parsing items in reverse topological order instead of topological order

### DIFF
--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -372,7 +372,7 @@ class Scheduler:
         the execution plan and enriching subroutine calls.
         """
         # Force the parsing of the routines
-        for item in nx.topological_sort(self.item_graph):
+        for item in reversed(list(nx.topological_sort(self.item_graph))):
             item.source.make_complete(**self.build_args)
 
     @Timer(logger=perf, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')


### PR DESCRIPTION
**Parsing items in reverse topological order instead of topological order**

* should make explicit enrichment in principle completely unnecessary

____

PR as discussion/test about whether

* changing order generally to be in reversed topological order
* or implementing parsing in reversed topological order as additional possibility 

e.g. 

`scheduler.py`:

```py
def _parse_items(self, reversed=False):
    if reversed:
        for item in reversed(list(nx.topological_sort(self.item_graph))):
             item.source.make_complete(**self.build_args)
    else:
         for item in nx.topological_sort(self.item_graph):
             item.source.make_complete(**self.build_args)
```