### PR TITLE
Enrichment during parsing

### DIFF
--- a/loki/__init__.py
+++ b/loki/__init__.py
@@ -46,6 +46,9 @@ config.register('print-config', False, env_variable='LOKI_PRINT_CONFIG',
 config.register('log-level', 'INFO', env_variable='LOKI_LOGGING',
                 callback=set_log_level, preprocess=lambda i: log_levels[i])
 
+config.register('debug', None, env_variable='LOKI_DEBUG',
+                callback=set_excepthook, preprocess=lambda i: auto_post_mortem_debugger if i else None)
+
 # Define Loki's temporary directory for generating intermediate files
 config.register('tmp-dir', None, env_variable='LOKI_TMP_DIR')
 

--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -85,6 +85,8 @@ class CCodeMapper(LokiStringifyMapper):
                 index_str += self.format('[%s]', d)
         return self.format('%s%s', name_str, index_str)
 
+    map_string_subscript = map_array_subscript
+
     def map_logical_not(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
             "!" + self.rec(expr.child, PREC_UNARY, *args, **kwargs),

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -73,7 +73,7 @@ class FCodeMapper(LokiStringifyMapper):
             enclosing_prec, PREC_COMPARISON)
 
     def map_literal_list(self, expr, enclosing_prec, *args, **kwargs):
-        values = ','.join(self.rec(c, PREC_NONE, *args, **kwargs) for c in expr.elements)
+        values = ', '.join(self.rec(c, PREC_NONE, *args, **kwargs) for c in expr.elements)
         if expr.dtype is not None:
             return f'(/ {fgen(expr.dtype)} :: {values} /)'
         return f'(/ {values} /)'

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -12,7 +12,7 @@ from pymbolic.primitives import FloorDiv, Remainder
 
 from loki.visitors import Stringifier
 from loki.tools import as_tuple, JoinableStringList, flatten
-from loki.expression import LokiStringifyMapper
+from loki.expression import LokiStringifyMapper, StringLiteral
 from loki.types import DataType, BasicType, DerivedType, ProcedureType
 from loki.pragma_utils import get_pragma_parameters
 
@@ -211,7 +211,12 @@ class FortranCodegen(Stringifier):
             prefix += ' '
         arguments = self.join_items(o.argnames)
         result = f' RESULT({o.result_name})' if o.result_name else ''
-        bind_c = f' BIND(c, name={o.bind})' if o.bind else ''
+        if isinstance(o.bind, str):
+            bind_c = f' BIND(c, name="{o.bind}")'
+        elif isinstance(o.bind, StringLiteral):
+            bind_c = f' BIND(c, name={o.bind})'
+        else:
+            bind_c = ''
         header = self.format_line(prefix, ftype, ' ', o.name, ' (', arguments, ')', result, bind_c)
         footer = self.format_line('END ', ftype, ' ', o.name)
 

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -451,10 +451,10 @@ class FortranCodegen(Stringifier):
     def visit_DataDeclaration(self, o, **kwargs):
         """
         Format as
-          DATA <var> /<values>/
+          DATA <var> / <values> /
         """
         values = self.visit_all(o.values, **kwargs)
-        return self.format_line('DATA ', o.variable, '/', values, '/')
+        return self.format_line('DATA ', self.visit(o.variable, **kwargs), ' / ', self.join_items(values), ' /')
 
     def visit_StatementFunction(self, o, **kwargs):
         """

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -197,7 +197,7 @@ class FortranCodegen(Stringifier):
     def visit_Subroutine(self, o, **kwargs):
         """
         Format as
-          <ftype> [<prefix>] <name> ([<args>]) [BIND(c, name=<name>)]
+          <ftype> [<prefix>] <name> ([<args>]) [RESULT(<name>)] [BIND(c, name=<name>)]
             ...docstring...
             ...spec...
             ...body...
@@ -210,8 +210,9 @@ class FortranCodegen(Stringifier):
         if o.prefix:
             prefix += ' '
         arguments = self.join_items(o.argnames)
-        bind_c = f' BIND(c, name=\'{o.bind}\')' if o.bind else ''
-        header = self.format_line(prefix, ftype, ' ', o.name, ' (', arguments, ')', bind_c)
+        result = f' RESULT({o.result_name})' if o.result_name else ''
+        bind_c = f' BIND(c, name={o.bind})' if o.bind else ''
+        header = self.format_line(prefix, ftype, ' ', o.name, ' (', arguments, ')', result, bind_c)
         footer = self.format_line('END ', ftype, ' ', o.name)
 
         self.depth += 1

--- a/loki/backend/maxgen.py
+++ b/loki/backend/maxgen.py
@@ -73,6 +73,8 @@ class MaxjCodeMapper(LokiStringifyMapper):
                 index_str += self.format('[%s]', d)
         return self.format('%s%s', name_str, index_str)
 
+    map_string_subscript = map_array_subscript
+
     def map_range_index(self, expr, enclosing_prec, *args, **kwargs):
         return self.rec(expr.upper, enclosing_prec, *args, **kwargs) if expr.upper else ''
 

--- a/loki/backend/pygen.py
+++ b/loki/backend/pygen.py
@@ -70,6 +70,8 @@ class PyCodeMapper(LokiStringifyMapper):
             index_str = f'[{", ".join(dims)}]'
         return self.format('%s%s', name_str, index_str)
 
+    map_string_subscript = map_array_subscript
+
     def map_string_concat(self, expr, enclosing_prec, *args, **kwargs):
         return ' + '.join(self.rec(c, enclosing_prec, *args, **kwargs) for c in expr.children)
 

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -582,7 +582,7 @@ class ProcedureBindingItem(Item):
         if type_.dtype.is_generic:
             # This is a generic binding, so we need to refer to other type-bound procedures
             # in this type
-            return tuple(name_parts[0] + '%' + name for name in type_.bind_names)
+            return tuple(f'{name_parts[0]}%{name!s}' for name in type_.bind_names)
         if type_.initial is not None:
             # This has a bind name explicitly specified:
             return (type_.initial.name.lower(), )

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -215,6 +215,15 @@ class Scheduler:
         """
         return as_tuple(self.item_graph.edges)
 
+    def __getitem__(self, name):
+        """
+        Find and return an item in the Scheduler's call graph
+        """
+        for item in self.items:
+            if item == name:
+                return item
+        return None
+
     def create_item(self, name):
         """
         Create an `Item` by looking up the path and setting all inferred properties.
@@ -372,8 +381,11 @@ class Scheduler:
         the execution plan and enriching subroutine calls.
         """
         # Force the parsing of the routines
+        build_args = self.build_args.copy()
+        build_args['definitions'] = as_tuple(build_args['definitions'])
         for item in reversed(list(nx.topological_sort(self.item_graph))):
-            item.source.make_complete(**self.build_args)
+            item.source.make_complete(**build_args)
+            build_args['definitions'] += item.source.definitions
 
     @Timer(logger=perf, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')
     def _enrich(self):

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -208,6 +208,8 @@ class LokiStringifyMapper(StringifyMapper):
         index_str = self.join_rec(', ', expr.index_tuple, PREC_NONE, *args, **kwargs)
         return f'{name_str}({index_str})'
 
+    map_string_subscript = map_array_subscript
+
     def map_procedure_symbol(self, expr, enclosing_prec, *args, **kwargs):
         return expr.name
 
@@ -254,6 +256,8 @@ class LokiWalkMapper(WalkMapper):
         self.rec(expr.aggregate, *args, **kwargs)
         self.rec(expr.index, *args, **kwargs)
         self.post_visit(expr, *args, **kwargs)
+
+    map_string_subscript = map_array_subscript
 
     map_logic_literal = WalkMapper.map_constant
     map_string_literal = WalkMapper.map_constant
@@ -389,6 +393,8 @@ class ExpressionDimensionsMapper(Mapper):
     def map_array_subscript(self, expr, *args, **kwargs):
         return flatten(tuple(self.rec(d, *args, **kwargs) for d in expr.index_tuple))
 
+    map_string_subscript = map_algebraic_leaf
+
     def map_range_index(self, expr, *args, **kwargs):  # pylint: disable=unused-argument
         if expr.lower is None and expr.upper is None:
             # We have the full range
@@ -455,6 +461,8 @@ class ExpressionCallbackMapper(CombineMapper):
         rec_results = (self.rec(expr.aggregate, *args, **kwargs), )
         rec_results += (self.rec(expr.index, *args, **kwargs), )
         return self.combine(rec_results)
+
+    map_string_subscript = map_array_subscript
 
     map_inline_call = CombineMapper.map_call_with_kwargs
 
@@ -599,6 +607,11 @@ class LokiIdentityMapper(IdentityMapper):
 
     def map_array_subscript(self, expr, *args, **kwargs):
         raise RuntimeError('Recursion should have ended at map_array')
+
+    def map_string_subscript(self, expr, *args, **kwargs):
+        symbol = self.rec(expr.symbol, *args, **kwargs)
+        index_tuple = self.rec(expr.index_tuple, *args, **kwargs)
+        return expr.__class__(symbol, index_tuple)
 
     map_inline_call = IdentityMapper.map_call_with_kwargs
 

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -92,6 +92,7 @@ class LokiStringifyMapper(StringifyMapper):
         return expr.name
 
     map_deferred_type_symbol = map_variable_symbol
+    map_procedure_symbol = map_variable_symbol
 
     def map_meta_symbol(self, expr, enclosing_prec, *args, **kwargs):
         return self.rec(expr._symbol, enclosing_prec, *args, **kwargs)
@@ -209,9 +210,6 @@ class LokiStringifyMapper(StringifyMapper):
         return f'{name_str}({index_str})'
 
     map_string_subscript = map_array_subscript
-
-    def map_procedure_symbol(self, expr, enclosing_prec, *args, **kwargs):
-        return expr.name
 
 
 class LokiWalkMapper(WalkMapper):

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -34,6 +34,7 @@ __all__ = [
     # Internal nodes
     'Sum', 'Product', 'Quotient', 'Power', 'Comparison', 'LogicalAnd', 'LogicalOr',
     'LogicalNot', 'InlineCall', 'Cast', 'Range', 'LoopRange', 'RangeIndex', 'ArraySubscript',
+    'StringSubscript',
 ]
 
 
@@ -1400,3 +1401,14 @@ class ArraySubscript(ExprMetadataMixin, StrCompareMixin, pmbl.Subscript):
     Internal representation of an array subscript.
     """
     mapper_method = intern('map_array_subscript')
+
+
+class StringSubscript(ExprMetadataMixin, StrCompareMixin, pmbl.Subscript):
+    """
+    Internal representation of a substring subscript operator.
+    """
+    mapper_method = intern('map_string_subscript')
+
+    @property
+    def symbol(self):
+        return self.aggregate

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -464,25 +464,27 @@ class FParser2IR(GenericVisitor):
             symbols = () if o.children[4] is None else self.visit(o.children[4], **kwargs)
             # No rename-list
             rename_list = None
+            deferred_type = SymbolAttributes(BasicType.DEFERRED, imported=True)
             if module is None:
                 # Initialize symbol attributes as DEFERRED
                 for s in symbols:
-                    _type = SymbolAttributes(BasicType.DEFERRED, imported=True)
                     if isinstance(s, tuple):  # Renamed symbol
-                        scope.symbol_attrs[s[1].name] = _type.clone(use_name=s[0])
+                        scope.symbol_attrs[s[1].name] = deferred_type.clone(use_name=s[0])
                     else:
-                        scope.symbol_attrs[s.name] = _type
+                        scope.symbol_attrs[s.name] = deferred_type
             else:
                 # Import symbol attributes from module
                 for s in symbols:
                     if isinstance(s, tuple):  # Renamed symbol
-                        scope.symbol_attrs[s[1].name] = module.symbol_attrs[s[0]].clone(
+                        _type = module.symbol_attrs.get(s[0], deferred_type)
+                        scope.symbol_attrs[s[1].name] = _type.clone(
                             imported=True, module=module, use_name=s[0]
                         )
                     else:
                         # Need to explicitly reset use_name in case we are importing a symbol
                         # that stems from an import with a rename-list
-                        scope.symbol_attrs[s.name] = module.symbol_attrs[s.name].clone(
+                        _type = module.symbol_attrs.get(s.name, deferred_type)
+                        scope.symbol_attrs[s.name] = _type.clone(
                             imported=True, module=module, use_name=None
                         )
             symbols = tuple(

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -345,7 +345,7 @@ class FParser2IR(GenericVisitor):
 
         :class:`fparser.two.Fortran2003.Name` has no children.
         """
-        return sym.Variable(name=o.tostr(), source=kwargs.get('source'))
+        return sym.Variable(name=o.tostr(), parent=kwargs.get('parent'), source=kwargs.get('source'))
 
     def visit_Type_Name(self, o, **kwargs):
         """

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1365,23 +1365,27 @@ class OFP2IR(GenericVisitor):
             symbols = self.visit(o.find('only'), **kwargs)
             # No rename-list
             rename_list = None
+            deferred_type = SymbolAttributes(BasicType.DEFERRED, imported=True)
             if module is None:
                 # Initialize symbol attributes as DEFERRED
                 for s in symbols:
-                    _type = SymbolAttributes(BasicType.DEFERRED, imported=True)
                     if isinstance(s, tuple):  # Renamed symbol
-                        scope.symbol_attrs[s[1].name] = _type.clone(use_name=s[0])
+                        scope.symbol_attrs[s[1].name] = deferred_type.clone(use_name=s[0])
                     else:
-                        scope.symbol_attrs[s.name] = _type
+                        scope.symbol_attrs[s.name] = deferred_type
             else:
                 # Import symbol attributes from module
                 for s in symbols:
                     if isinstance(s, tuple):  # Renamed symbol
-                        scope.symbol_attrs[s[1].name] = module.symbol_attrs[s[0]].clone(
+                        _type = module.symbol_attrs.get(s[0], deferred_type)
+                        scope.symbol_attrs[s[1].name] = _type.clone(
                             imported=True, module=module, use_name=s[0]
                         )
                     else:
-                        scope.symbol_attrs[s.name] = module.symbol_attrs[s.name].clone(
+                        # Need to explicitly reset use_name in case we are importing a symbol
+                        # that stems from an import with a rename-list
+                        _type = module.symbol_attrs.get(s.name, deferred_type)
+                        scope.symbol_attrs[s.name] = _type.clone(
                             imported=True, module=module, use_name=None
                         )
             symbols = tuple(

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -1119,6 +1119,11 @@ class OMNI2IR(GenericVisitor):
         step = None if step == '1' else step
         return sym.RangeIndex((lower, upper, step), source=kwargs['source'])
 
+    def visit_FcharacterRef(self, o, **kwargs):
+        var = self.visit(o.find('varRef'), **kwargs)
+        dimensions = self.visit(o.find('indexRange'), **kwargs)
+        return sym.StringSubscript(var, dimensions)
+
     def visit_lowerBound(self, o, **kwargs):
         return self.visit(o[0], **kwargs)
 

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -329,17 +329,20 @@ class OMNI2IR(GenericVisitor):
             # We store the prefix on the Subroutine object, so let's remove it from the symbol attrs
             proc_type = proc_type.clone(prefix=None)
 
+        # Function suffix (result name and language binding, but no support for the latter in OMNI)
+        result = ftype.attrib.get('result_name')
+
         # Instantiate the object
         if routine is None:
             routine = Subroutine(
                 name=name, args=args, prefix=prefix, bind=None,
-                is_function=is_function, parent=scope,
+                result_name=result, is_function=is_function, parent=scope,
                 ast=o, source=self.get_source(o)
             )
         else:
             routine.__init__(  # pylint: disable=unnecessary-dunder-call
                 name=name, args=args, docstring=routine.docstring, spec=routine.spec, body=routine.body,
-                contains=routine.contains, prefix=prefix, bind=None, is_function=is_function,
+                contains=routine.contains, prefix=prefix, bind=None, result_name=result, is_function=is_function,
                 ast=o, source=self.get_source(o), parent=routine.parent, symbol_attrs=routine.symbol_attrs,
                 incomplete=routine._incomplete
             )
@@ -412,8 +415,8 @@ class OMNI2IR(GenericVisitor):
         # pylint: disable=unnecessary-dunder-call
         routine.__init__(
             name=routine.name, args=routine._dummies,
-            docstring=docstring, spec=spec, body=body, contains=contains,
-            ast=o, prefix=routine.prefix, bind=routine.bind, is_function=routine.is_function,
+            docstring=docstring, spec=spec, body=body, contains=contains, ast=o,
+            prefix=routine.prefix, bind=routine.bind, result_name=routine.result_name, is_function=routine.is_function,
             rescope_symbols=True, parent=routine.parent, symbol_attrs=routine.symbol_attrs,
             source=routine.source, incomplete=False
         )

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -445,6 +445,13 @@ class Sourcefile:
         routines += as_tuple(flatten(m.subroutines for m in self.modules))
         return routines
 
+    @property
+    def definitions(self):
+        """
+        List of all definitions made in this sourcefile, i.e. modules, subroutines and types
+        """
+        return self.modules + self.subroutines + self.typedefs
+
     def __getitem__(self, name):
         module_map = {m.name.lower(): m for m in self.modules}
         if name.lower() in module_map:

--- a/loki/subroutine.py
+++ b/loki/subroutine.py
@@ -44,6 +44,8 @@ class Subroutine(ProgramUnit):
         Prefix specifications for the procedure
     bind : optional
         Bind information (e.g., for Fortran ``BIND(C)`` annotation).
+    result_name : str, optional
+        The name of the result variable for functions.
     is_function : bool, optional
         Flag to indicate this is a function instead of subroutine
         (in the Fortran sense). Defaults to `False`.
@@ -70,12 +72,13 @@ class Subroutine(ProgramUnit):
     """
 
     def __init__(self, name, args=None, docstring=None, spec=None, body=None, contains=None,
-                 prefix=None, bind=None, is_function=False, ast=None, source=None, parent=None,
+                 prefix=None, bind=None, result_name=None, is_function=False, ast=None, source=None, parent=None,
                  rescope_symbols=False, symbol_attrs=None, incomplete=False):
         # First, store additional Subroutine-specific properties
         self._dummies = as_tuple(a.lower() for a in as_tuple(args))  # Order of dummy arguments
         self.prefix = as_tuple(prefix)
         self.bind = bind
+        self.result_name = result_name
         self.is_function = is_function
 
         # Additional IR components
@@ -261,6 +264,8 @@ class Subroutine(ProgramUnit):
             kwargs['prefix'] = self.prefix
         if self.bind and 'bind' not in kwargs:
             kwargs['bind'] = self.bind
+        if self.result_name and 'result_name' not in kwargs:
+            kwargs['result_name'] = self.result_name
         if self.is_function and 'is_function' not in kwargs:
             kwargs['is_function'] = self.is_function
 
@@ -311,6 +316,8 @@ class Subroutine(ProgramUnit):
         """
         if not self.is_function:
             return None
+        if self.result_name is not None:
+            return self.symbol_attrs.get(self.result_name)
         return self.symbol_attrs.get(self.name)
 
     variables = ProgramUnit.variables

--- a/loki/tools/strings.py
+++ b/loki/tools/strings.py
@@ -94,8 +94,11 @@ class JoinableStringList:
         if (isinstance(item, type(self)) and (item.separable or not item_fits_in_line) and
                 len(item.items) > 1):
             line, new_item = item._to_str(line=line, stop_on_continuation=True)
-            new_line, lines = self._add_item_to_line(self.cont[1], new_item)
-            return new_line, [line + self.cont[0], *lines]
+            if len(new_item.items) < len(item.items):
+                # If we have been able to put at least one entry from item on the line, we
+                # continue recursively:
+                new_line, lines = self._add_item_to_line(self.cont[1], new_item)
+                return new_line, [line + self.cont[0], *lines]
 
         # Otherwise, let's put it on a new line if the item as a whole fits on the next line
         if item_fits_in_line:

--- a/loki/tools/strings.py
+++ b/loki/tools/strings.py
@@ -93,24 +93,32 @@ class JoinableStringList:
         # on a line
         if (isinstance(item, type(self)) and (item.separable or not item_fits_in_line) and
                 len(item.items) > 1):
-            line, new_item = item._to_str(line=line, stop_on_continuation=True)
+            line_, new_item = item._to_str(line=line, stop_on_continuation=True)
             if len(new_item.items) < len(item.items):
                 # If we have been able to put at least one entry from item on the line, we
                 # continue recursively:
                 new_line, lines = self._add_item_to_line(self.cont[1], new_item)
-                return new_line, [line + self.cont[0], *lines]
+                return new_line, [line_ + self.cont[0], *lines]
 
         # Otherwise, let's put it on a new line if the item as a whole fits on the next line
         if item_fits_in_line:
             return item_line, [line + self.cont[0]]
 
         # The new item does not fit onto a line at all and it is not a JoinableStringList
-        # for which we know how to split it: let's try our best anyways
+        # where the first item fits onto a line, or for which we know how to split it:
+        # let's try our best by splitting the string
         # TODO: This is not safe for strings currently and may still exceed
         #       the line limit if the chunks are too big! Safest option would
         #       be to have expression mapper etc. all return JoinableStringList instances
         #       and accept violations for the remaining cases.
-        chunk_list = re.split(r'(\s|\)(?!%))', str(item))  # split on ' ' and ')' (the latter not if followed by '%')
+        if isinstance(item, str):
+            item_str = item
+        elif isinstance(item, type(self)):
+            # We simply join up the items here to avoid that any line continuations are introduced
+            item_str = item.sep.join(str(i) for i in item.items)
+        else:
+            item_str = str(item)
+        chunk_list = re.split(r'(\s|\)(?!%)|\n)', item_str)  # split on ' ', ')' (unless followed by '%') and '\n'
 
         # First, add as much as possible to the previous line
         next_chunk = 0
@@ -133,6 +141,7 @@ class JoinableStringList:
                 line = self.cont[1] + chunk
             else:
                 line = new_line
+
         return line, lines
 
     def _to_str(self, line='', stop_on_continuation=False):

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -28,7 +28,7 @@ from loki.logging import debug, error
 __all__ = ['as_tuple', 'is_iterable', 'is_subset', 'flatten', 'chunks',
            'execute', 'CaseInsensitiveDict', 'strip_inline_comments',
            'binary_insertion_sort', 'cached_func', 'optional', 'LazyNodeLookup',
-           'yaml_include_constructor', 'auto_post_mortem_debugger']
+           'yaml_include_constructor', 'auto_post_mortem_debugger', 'set_excepthook']
 
 
 def as_tuple(item, type=None, length=None):
@@ -521,7 +521,7 @@ def auto_post_mortem_debugger(type, value, tb):  # pylint: disable=redefined-bui
     """
     Exception hook that automatically attaches a debugger
 
-    Activate by setting ``sys.excepthook = auto_post_mortem_debugger``
+    Activate by calling ``set_excepthook(hook=auto_post_mortem_debugger)``.
 
     Adapted from https://code.activestate.com/recipes/65287/
     """
@@ -538,3 +538,19 @@ def auto_post_mortem_debugger(type, value, tb):  # pylint: disable=redefined-bui
         traceback.print_exception(type, value, tb)
         # ...then start the debugger in post-mortem mode.
         pdb.post_mortem(tb)   # pylint: disable=no-member
+
+
+def set_excepthook(hook=None):
+    """
+    Set an exception hook that is called for uncaught exceptions
+
+    This can be called with :meth:`auto_post_mortem_debugger` to automatically
+    attach a debugger (Pdb or, if installed, Pdb++) when exceptions occur.
+
+    With :data:`hook` set to `None`, this will restore the default exception
+    hook ``sys.__excepthook``.
+    """
+    if hook is None:
+        sys.excepthook = sys.__excepthook__
+    else:
+        sys.excepthook = hook

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -294,19 +294,19 @@ def transpile(out_path, header, source, driver, cpp, include, define, frontend, 
 @cli.command('plan')
 @click.option('--mode', '-m', default='sca',
               type=click.Choice(['idem', 'sca', 'claw', 'scc', 'scc-hoist']))
-@click.option('--config', '-cfg', type=click.Path(),
+@click.option('--config', '-c', type=click.Path(),
               help='Path to configuration file.')
 @click.option('--header', '-I', type=click.Path(), multiple=True,
               help='Path for additional header file(s).')
 @click.option('--source', '-s', type=click.Path(), multiple=True,
               help='Path to source files to transform.')
-@click.option('--build', '-s', type=click.Path(), default=None,
+@click.option('--build', '-b', type=click.Path(), default=None,
               help='Path to build directory for source generation.')
 @click.option('--root', type=click.Path(),
               help='Root path to which all paths are relative to.')
 @click.option('--frontend', default='fp', type=click.Choice(['fp', 'ofp', 'omni']),
               help='Frontend parser to use (default FP)')
-@click.option('--callgraph', '-cg', type=click.Path(), default=None,
+@click.option('--callgraph', '-g', type=click.Path(), default=None,
               help='Generate and display the subroutine callgraph.')
 @click.option('--plan-file', type=click.Path(),
               help='CMake "plan" file to generate.')
@@ -334,16 +334,16 @@ def plan(mode, config, header, source, build, root, frontend, callgraph, plan_fi
 @cli.command('ecphys')
 @click.option('--mode', '-m', default='sca',
               type=click.Choice(['idem', 'sca', 'claw', 'scc', 'scc-hoist']))
-@click.option('--config', '-cfg', type=click.Path(),
+@click.option('--config', '-c', type=click.Path(),
               help='Path to configuration file.')
 @click.option('--header', '-I', type=click.Path(), multiple=True,
               help='Path for additional header file(s).')
 @click.option('--source', '-s', type=click.Path(), multiple=True,
               help='Path to source files to transform.')
-@click.option('--build', '-s', type=click.Path(), default=None,
+@click.option('--build', '-b', type=click.Path(), default=None,
               help='Path to build directory for source generation.')
 @click.option('--frontend', default='fp', type=click.Choice(['ofp', 'omni', 'fp']),
-              help='Frontend parser to use (default OFP)')
+              help='Frontend parser to use (default FP)')
 def ecphys(mode, config, header, source, build, frontend):
     """
     Physics bulk-processing option that employs a :class:`Scheduler`

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -18,7 +18,7 @@ import click
 
 from loki import (
     Sourcefile, Transformation, Scheduler, SchedulerConfig,
-    Frontend, as_tuple, auto_post_mortem_debugger, flatten, info
+    Frontend, as_tuple, set_excepthook, auto_post_mortem_debugger, flatten, info
 )
 
 # Get generalized transformations provided by Loki
@@ -101,7 +101,7 @@ class IdemTransformation(Transformation):
                     'a debugger when exceptions occur'))
 def cli(debug):
     if debug:
-        sys.excepthook = auto_post_mortem_debugger
+        set_excepthook(hook=auto_post_mortem_debugger)
 
 
 @cli.command()

--- a/tests/test_derived_types.py
+++ b/tests/test_derived_types.py
@@ -12,9 +12,10 @@ import numpy as np
 
 from conftest import jit_compile, jit_compile_lib, clean_test, available_frontends
 from loki import (
-    OMNI, Module, Subroutine, BasicType, DerivedType, TypeDef,
+    OMNI, OFP, Module, Subroutine, BasicType, DerivedType, TypeDef,
     fgen, FindNodes, Intrinsic, ProcedureDeclaration, ProcedureType,
-    VariableDeclaration, Assignment, InlineCall, Builder
+    VariableDeclaration, Assignment, InlineCall, Builder, StringSubscript,
+    Conditional
 )
 
 
@@ -1179,3 +1180,41 @@ def test_derived_type_rescope_symbols_shadowed(here, shadowed_typedef_symbols_fc
         assert init_maxstreams == 256
 
         clean_test(filepath)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[
+    (OFP, 'OFP cannot parse the Fortran')
+]))
+def test_derived_types_character_array_subscript(frontend):
+    fcode = """
+module derived_type_char_arr_mod
+    implicit none
+
+    type char_arr_type
+        character(len=511) :: some_name(3) = ["","",""]
+    end type char_arr_type
+
+contains
+
+    subroutine some_routine(config)
+        type(char_arr_type), intent(in) :: config
+        integer :: i, strlen
+        do i=1,3
+            if (config%some_name(i)(1:1) == '/') then
+                print *, 'absolute path'
+            end if
+            strlen = len_trim(config%some_name(i))
+            if (config%some_name(i)(strlen-2:strlen) == '.nc') then
+                print *, 'netcdf file'
+            end if
+        end do
+    end subroutine some_routine
+end module derived_type_char_arr_mod
+    """.strip()
+
+    module = Module.from_source(fcode, frontend=frontend)
+    conditionals = FindNodes(Conditional).visit(module['some_routine'].body)
+    assert all(isinstance(c.condition.left, StringSubscript) for c in conditionals)
+    assert [fgen(c.condition.left) for c in conditionals] == [
+      'config%some_name(i)(1:1)', 'config%some_name(i)(strlen - 2:strlen)'
+    ]

--- a/tests/test_fgen.py
+++ b/tests/test_fgen.py
@@ -1,0 +1,37 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from conftest import available_frontends
+
+from loki import Subroutine, fgen
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_fgen_literal_list_linebreak(frontend):
+    """
+    Test correct handling of linebreaks for LiteralList expression nodes
+    """
+    fcode = """
+subroutine literal_list_linebreak
+    implicit none
+    INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+    call config_gas_optics_sw_spectral_def_allocate_bands_only( &
+         &  [2600.0_jprb, 3250.0_jprb, 4000.0_jprb, 4650.0_jprb, 5150.0_jprb, 6150.0_jprb, 7700.0_jprb, &
+         &   8050.0_jprb, 12850.0_jprb, 16000.0_jprb, 22650.0_jprb, 29000.0_jprb, 38000.0_jprb, 820.0_jprb], &
+         &  [3250.0_jprb, 4000.0_jprb, 4650.0_jprb, 5150.0_jprb, 6150.0_jprb, 7700.0_jprb, 8050.0_jprb, &
+         &   12850.0_jprb, 16000.0_jprb, 22650.0_jprb, 29000.0_jprb, 38000.0_jprb, 50000.0_jprb, 2600.0_jprb])
+end subroutine literal_list_linebreak
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    body_code = fgen(routine.body)
+    assert body_code.count(',') == 27
+    assert body_code.count('(/') == 2
+    assert body_code.count('/)') == 2
+    body_lines = body_code.splitlines()
+    assert all(len(line) < 132 for line in body_lines)

--- a/tests/test_fgen.py
+++ b/tests/test_fgen.py
@@ -9,7 +9,10 @@ import pytest
 
 from conftest import available_frontends
 
-from loki import Subroutine, fgen, OMNI, OFP, Intrinsic, DataDeclaration
+from loki import (
+    Module, Subroutine, fgen, OMNI, OFP, Intrinsic, DataDeclaration,
+)
+
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_fgen_literal_list_linebreak(frontend):
@@ -17,23 +20,72 @@ def test_fgen_literal_list_linebreak(frontend):
     Test correct handling of linebreaks for LiteralList expression nodes
     """
     fcode = """
-subroutine literal_list_linebreak
+module some_mod
+  implicit none
+  INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+  interface
+    subroutine config_gas_optics_sw_spectral_def_allocate_bands_only(a, b)
+        INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+        real(kind=jprb), intent(in) :: a(:), b(:)
+    end subroutine config_gas_optics_sw_spectral_def_allocate_bands_only
+  end interface
+contains
+  subroutine literal_list_linebreak
     implicit none
-    INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+    real(jprb), parameter, dimension(1,140) :: frac &
+        = reshape( (/ 0.21227E+00, 0.18897E+00, 0.25491E+00, 0.17864E+00, 0.11735E+00, 0.38298E-01, 0.57871E-02, &
+        &    0.31753E-02, 0.53169E-03, 0.76476E-04, 0.16388E+00, 0.15241E+00, 0.14290E+00, 0.12864E+00, &
+        &    0.11615E+00, 0.10047E+00, 0.80013E-01, 0.60445E-01, 0.44918E-01, 0.63395E-02, 0.32942E-02, &
+        &    0.54541E-03, 0.15380E+00, 0.15194E+00, 0.14339E+00, 0.13138E+00, 0.11701E+00, 0.10081E+00, &
+        &    0.82296E-01, 0.61735E-01, 0.41918E-01, 0.45918E-02, 0.37743E-02, 0.30121E-02, 0.22500E-02, &
+        &    0.14490E-02, 0.55410E-03, 0.78364E-04, 0.15938E+00, 0.15146E+00, 0.14213E+00, 0.13079E+00, &
+        &    0.11672E+00, 0.10053E+00, 0.81566E-01, 0.61126E-01, 0.41150E-01, 0.44488E-02, 0.36950E-02, &
+        &    0.29101E-02, 0.21357E-02, 0.19609E-02, 0.14134E+00, 0.14390E+00, 0.13913E+00, 0.13246E+00, &
+        &    0.12185E+00, 0.10596E+00, 0.87518E-01, 0.66164E-01, 0.44862E-01, 0.49402E-02, 0.40857E-02, &
+        &    0.32288E-02, 0.23613E-02, 0.15406E-02, 0.58258E-03, 0.82171E-04, 0.29127E+00, 0.28252E+00, &
+        &    0.22590E+00, 0.14314E+00, 0.45494E-01, 0.71792E-02, 0.38483E-02, 0.65712E-03, 0.29810E+00, &
+        &    0.27559E+00, 0.11997E+00, 0.10351E+00, 0.84515E-01, 0.62253E-01, 0.41050E-01, 0.44217E-02, &
+        &    0.36946E-02, 0.29113E-02, 0.34290E-02, 0.55993E-03, 0.31441E+00, 0.27586E+00, 0.21297E+00, &
+        &    0.14064E+00, 0.45588E-01, 0.65665E-02, 0.34232E-02, 0.53199E-03, 0.19811E+00, 0.16833E+00, &
+        &    0.13536E+00, 0.11549E+00, 0.10649E+00, 0.93264E-01, 0.75720E-01, 0.56405E-01, 0.41865E-01, &
+        &    0.59331E-02, 0.26510E-02, 0.40040E-03, 0.32328E+00, 0.26636E+00, 0.21397E+00, 0.14038E+00, &
+        &    0.52142E-01, 0.38852E-02, 0.14601E+00, 0.13824E+00, 0.27703E+00, 0.22388E+00, 0.15446E+00, &
+        &    0.48687E-01, 0.98054E-02, 0.18870E-02, 0.11961E+00, 0.12106E+00, 0.13215E+00, 0.13516E+00, &
+        &    0.25249E+00, 0.16542E+00, 0.68157E-01, 0.59725E-02, 0.49258E+00, 0.33651E+00, 0.16182E+00, &
+        &    0.90984E-02, 0.95202E+00, 0.47978E-01, 0.91716E+00, 0.82857E-01, 0.77464E+00, 0.22536E+00 /), (/ 1,140 /) )
     call config_gas_optics_sw_spectral_def_allocate_bands_only( &
          &  [2600.0_jprb, 3250.0_jprb, 4000.0_jprb, 4650.0_jprb, 5150.0_jprb, 6150.0_jprb, 7700.0_jprb, &
          &   8050.0_jprb, 12850.0_jprb, 16000.0_jprb, 22650.0_jprb, 29000.0_jprb, 38000.0_jprb, 820.0_jprb], &
          &  [3250.0_jprb, 4000.0_jprb, 4650.0_jprb, 5150.0_jprb, 6150.0_jprb, 7700.0_jprb, 8050.0_jprb, &
          &   12850.0_jprb, 16000.0_jprb, 22650.0_jprb, 29000.0_jprb, 38000.0_jprb, 50000.0_jprb, 2600.0_jprb])
-end subroutine literal_list_linebreak
+  end subroutine literal_list_linebreak
+end module some_mod
     """.strip()
 
-    routine = Subroutine.from_source(fcode, frontend=frontend)
+    module = Module.from_source(fcode, frontend=frontend)
+    routine = module['literal_list_linebreak']
+
+    # Make sure all lines are continued correctly
+    code = module.to_fortran()
+    code_lines = code.splitlines()
+    assert len(code_lines) in (35, 36) # OMNI produces an extra line
+    assert all(line.strip(' &\n') for line in code_lines)
+    assert all(len(line) < 132 for line in code_lines)
+
+    # Make sure it works also with less indentation
+    spec_code = fgen(routine.spec)
+    assert spec_code.count('&') == 32
+    spec_lines = spec_code.splitlines()
+    assert len(spec_lines) == 18
+    assert all(len(line) < 132 for line in spec_code.splitlines())
+
     body_code = fgen(routine.body)
     assert body_code.count(',') == 27
     assert body_code.count('(/') == 2
     assert body_code.count('/)') == 2
+    assert body_code.count('&') == 6
     body_lines = body_code.splitlines()
+    assert len(body_lines) == 4
     assert all(len(line) < 132 for line in body_lines)
 
 

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from conftest import available_frontends, jit_compile, jit_compile_lib, clean_test
 from loki import (
-    Sourcefile, Subroutine, OFP, OMNI, REGEX, FindVariables, FindNodes,
+    Sourcefile, Module, Subroutine, OFP, OMNI, REGEX, FindVariables, FindNodes,
     Section, CallStatement, BasicType, Array, Scalar, Variable,
     SymbolAttributes, StringLiteral, fgen, fexprgen, VariableDeclaration,
     Transformer, FindTypedSymbols, ProcedureSymbol, ProcedureType,
@@ -1579,6 +1579,79 @@ end function f_elem
     assert 'PURE' in code
     assert 'ELEMENTAL' in code
     assert fgen(decl) in code
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_subroutine_suffix(frontend):
+    """
+    Test that subroutine suffixes are supported and correctly reproduced
+    """
+    fcode = """
+module subroutine_suffix_mod
+    implicit none
+
+    interface
+        function check_value(value) bind(C, name='check_value')
+            use, intrinsic :: iso_c_binding
+            real(c_float), value :: value
+            integer(c_int) :: check_value
+        end function check_value
+    end interface
+
+    interface
+        function fix_value(value) result(fixed) bind(C, name='fix_value')
+            use, intrinsic :: iso_c_binding
+            real(c_float), value :: value
+            real(c_float) :: fixed
+        end function fix_value
+    end interface
+contains
+    function out_of_physical_bounds(field, istartcol, iendcol, do_fix) result(is_bad)
+        real, intent(inout) :: field(:)
+        integer, intent(in) :: istartcol, iendcol
+        logical, intent(in) :: do_fix
+        logical :: is_bad
+
+        integer :: jcol
+        logical :: bad_value
+
+        is_bad = .false.
+        do jcol=istartcol,iendcol
+            bad_value = check_value(field(jcol)) > 0
+            is_bad = is_bad .or. bad_value
+            if (do_fix .and. bad_value) field(jcol) = fix_value(field(jcol))
+        end do
+    end function out_of_physical_bounds
+end module subroutine_suffix_mod
+    """.strip()
+    module = Module.from_source(fcode, frontend=frontend)
+
+    check_value = module.interface_map['check_value'].body[0]
+    assert check_value.is_function
+    assert check_value.result_name is None
+    assert check_value.return_type.dtype is BasicType.INTEGER
+    assert check_value.return_type.kind == 'c_int'
+    if frontend != OMNI:
+      assert check_value.bind == 'check_value'
+      assert "bind(c, name='check_value')" in fgen(check_value).lower()
+
+    fix_value = module.interface_map['fix_value'].body[0]
+    assert fix_value.is_function
+    assert fix_value.result_name == 'fixed'
+    assert fix_value.return_type.dtype is BasicType.REAL
+    assert fix_value.return_type.kind == 'c_float'
+    if frontend == OMNI:
+        assert "result(fixed)" in fgen(fix_value).lower()
+    else:
+        assert fix_value.bind == 'fix_value'
+        assert "result(fixed) bind(c, name='fix_value')" in fgen(fix_value).lower()
+
+    routine = module['out_of_physical_bounds']
+    assert routine.is_function
+    assert routine.result_name == 'is_bad'
+    assert routine.bind is None
+    assert routine.return_type.dtype is BasicType.LOGICAL
+    assert "result(is_bad)" in fgen(routine).lower()
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1632,8 +1632,8 @@ end module subroutine_suffix_mod
     assert check_value.return_type.dtype is BasicType.INTEGER
     assert check_value.return_type.kind == 'c_int'
     if frontend != OMNI:
-      assert check_value.bind == 'check_value'
-      assert "bind(c, name='check_value')" in fgen(check_value).lower()
+        assert check_value.bind == 'check_value'
+        assert "bind(c, name='check_value')" in fgen(check_value).lower()
 
     fix_value = module.interface_map['fix_value'].body[0]
     assert fix_value.is_function


### PR DESCRIPTION
Note: This is based on #18, so review only after that one is merged to reduce diff volume.

With #17 we parse files now in the correct order to theoretically resolve all dependencies right away, thus making manual enrichment essentially superfluous. However, for this to take effect, we have to provide the already parsed program units as `definitions` to `make_complete`, which is added in this PR.

Although it should allow to entirely retire the `_enrich` step in the Scheduler, I have kept it for the moment to avoid fallout in edge cases where this doesn't work for some reason. It works on ecrad, though.

Accompanied with this are tests for nested derived types, where intermediate type definitions can only be resolved via this enrichment method.

With this in place, I have hit a situation in the frontends, where imports include symbols that we have for some reason not in the symbol table of the module they are imported from, although we have the corresponding module parsed. This happens, when these symbols themselves stem from an unqualified import from another module. Such situations are now handled gracefully in the same way as when the corresponding module was not available. We should be able to resolve this in the future cleanly by chasing also imports as dependencies in the Scheduler.

Lastly, piggy-backed is a workaround for wrongful classification of inline calls as array subscripts in the fparser frontend. We repair this already later on with type information from the symbol table, however, in the process we would only convert the `Array` node to a `ProcedureSymbol`, thus loosing the information about the inline call and its arguments. This is now being taken care of in the `LokiIdentityMapper` by detecting such conversions and creating a new `InlineCall` node with the previous `dimensions` attributes as `parameters`.