### PR TITLE
Internalize array demotion transform

### DIFF
--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -70,8 +70,7 @@ def is_iterable(o):
         iter(o)
     except TypeError:
         return False
-    else:
-        return True
+    return True
 
 
 def is_subset(a, b, ordered=True, subsequent=False):

--- a/loki/transform/transform_array_indexing.py
+++ b/loki/transform/transform_array_indexing.py
@@ -481,7 +481,8 @@ def demote_variables(routine, variable_names, dimensions):
         # If all symbols have the same shape (after demotion)
         sym_shape = tuple(s.shape if isinstance(s, sym.Array) else None for s in decl.symbols)
         if all(d == sym_shape[0] for d in sym_shape):
-            decl_map[decl] = decl.clone(dimensions=decl.symbols[0].shape)
+            dimensions = decl.symbols[0].shape if isinstance(decl.symbols[0], sym.Array) else None
+            decl_map[decl] = decl.clone(dimensions=dimensions)
         else:
             # If not, split into multiple declarations
             sdims = tuple(s.shape if isinstance(s, sym.Array) else None for s in decl.symbols)

--- a/loki/transform/transform_array_indexing.py
+++ b/loki/transform/transform_array_indexing.py
@@ -453,6 +453,10 @@ def demote_variables(routine, variable_names, dimensions):
 
     variables = FindVariables(unique=False).visit(routine.ir)
     variables = tuple(v for v in variables if v.name.lower() in vnames)
+    variables = tuple(v for v in variables if hasattr(v, 'shape'))
+
+    if not variables:
+        return
 
     # Record original array shapes
     shape_map = CaseInsensitiveDict({v.name: v.shape for v in variables})

--- a/loki/transform/transform_region.py
+++ b/loki/transform/transform_region.py
@@ -86,7 +86,7 @@ def region_hoist(routine):
             if collapse > 0:
                 scopes = FindScopes(start).visit(routine.body)[0]
                 if len(scopes) <= collapse:
-                    RuntimeError(f'Not enough enclosing scopes for collapse({collapse})')
+                    raise RuntimeError(f'Not enough enclosing scopes for collapse({collapse})')
                 scopes = scopes[-(collapse+1):]
                 region = NestedMaskedTransformer(start=start, stop=stop, mapper={start: None}).visit(scopes[0])
 

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -56,13 +56,13 @@ def test_symbolic_literal_comparison(a, b, lt, eq):
     """
     if lt is None:
         with pytest.raises(TypeError):
-            _ = (a < b)
+            _ = a < b
         with pytest.raises(TypeError):
-            _ = (a <= b)
+            _ = a <= b
         with pytest.raises(TypeError):
-            _ = (a > b)
+            _ = a > b
         with pytest.raises(TypeError):
-            _ = (a >= b)
+            _ = a >= b
     else:
         assert (a < b) is lt
         assert (a <= b) is (lt or eq)

--- a/tests/test_transform_array_indexing.py
+++ b/tests/test_transform_array_indexing.py
@@ -251,11 +251,13 @@ subroutine transform_demote_dimension_arguments(vec1, vec2, matrix, n, m)
   integer, intent(in) :: n, m
   integer, dimension(n), intent(inout) :: vec1, vec2
   integer, dimension(n, m), intent(inout) :: matrix
+  integer, dimension(n) :: vec_tmp
   integer :: i, j
 
   do i=1,n
     do j=1,m
-      matrix(i, j) = matrix(i, j) + vec1(i) + vec2(i)
+      vec_tmp(i) = vec1(i) + vec2(i)
+      matrix(i, j) = matrix(i, j) + vec_tmp(i)
     end do
   end do
 end subroutine transform_demote_dimension_arguments
@@ -285,7 +287,7 @@ end subroutine transform_demote_dimension_arguments
     assert np.all(vec2 == 2) and np.sum(vec2) == 6
     assert np.all(matrix == 6) and np.sum(matrix) == 36
 
-    demote_variables(routine, ['vec1', 'matrix'], ['n'])
+    demote_variables(routine, ['vec1', 'vec_tmp', 'matrix'], ['n'])
 
     assert isinstance(routine.variable_map['vec1'], sym.Scalar)
     assert isinstance(routine.variable_map['vec2'], sym.Array)

--- a/tests/test_transform_array_indexing.py
+++ b/tests/test_transform_array_indexing.py
@@ -238,6 +238,12 @@ end subroutine transform_demote_variables
     assert np.all(vector == np.arange(1, n + 1)*2)
     assert np.all(matrix == np.sum(np.mgrid[1:4,2:8:2], axis=0))
 
+    # Test that the transformation doesn't fail for scalar arguments and leaves the
+    # IR unchanged
+    demoted_fcode = routine.to_fortran()
+    demote_variables(routine, ['jl'], ['m'])
+    assert routine.to_fortran() == demoted_fcode
+
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_transform_demote_dimension_arguments(here, frontend):

--- a/tests/test_transform_array_indexing.py
+++ b/tests/test_transform_array_indexing.py
@@ -237,3 +237,73 @@ end subroutine transform_demote_variables
     assert all(scalar == 3)
     assert np.all(vector == np.arange(1, n + 1)*2)
     assert np.all(matrix == np.sum(np.mgrid[1:4,2:8:2], axis=0))
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_demote_dimension_arguments(here, frontend):
+    """
+    Apply variable demotion to array arguments defined with DIMENSION
+    keywords.
+    """
+    fcode = """
+subroutine transform_demote_dimension_arguments(vec1, vec2, matrix, n, m)
+  implicit none
+  integer, intent(in) :: n, m
+  integer, dimension(n), intent(inout) :: vec1, vec2
+  integer, dimension(n, m), intent(inout) :: matrix
+  integer :: i, j
+
+  do i=1,n
+    do j=1,m
+      matrix(i, j) = matrix(i, j) + vec1(i) + vec2(i)
+    end do
+  end do
+end subroutine transform_demote_dimension_arguments
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    normalize_range_indexing(routine) # Fix OMNI nonsense
+
+    # Test the original implementation
+    filepath = here/(f'{routine.name}_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname=routine.name)
+
+    assert isinstance(routine.variable_map['vec1'], sym.Array)
+    assert routine.variable_map['vec1'].shape == (routine.variable_map['n'],)
+    assert isinstance(routine.variable_map['vec2'], sym.Array)
+    assert routine.variable_map['vec2'].shape == (routine.variable_map['n'],)
+    assert isinstance(routine.variable_map['matrix'], sym.Array)
+    assert routine.variable_map['matrix'].shape == (routine.variable_map['n'], routine.variable_map['m'])
+
+    n = 3
+    m = 2
+    vec1 = np.zeros(shape=(n,), order='F', dtype=np.int32) + 3
+    vec2 = np.zeros(shape=(n,), order='F', dtype=np.int32) + 2
+    matrix = np.zeros(shape=(n, m), order='F', dtype=np.int32) + 1
+    function(vec1, vec2, matrix, n, m)
+
+    assert np.all(vec1 == 3) and np.sum(vec1) == 9
+    assert np.all(vec2 == 2) and np.sum(vec2) == 6
+    assert np.all(matrix == 6) and np.sum(matrix) == 36
+
+    demote_variables(routine, ['vec1', 'matrix'], ['n'])
+
+    assert isinstance(routine.variable_map['vec1'], sym.Scalar)
+    assert isinstance(routine.variable_map['vec2'], sym.Array)
+    assert routine.variable_map['vec2'].shape == (routine.variable_map['n'],)
+    assert isinstance(routine.variable_map['matrix'], sym.Array)
+    assert routine.variable_map['matrix'].shape == (routine.variable_map['m'],)
+
+    # Test promoted routine
+    demoted_filepath = here/(f'{routine.name}_demoted_{frontend}.f90')
+    demoted_function = jit_compile(routine, filepath=demoted_filepath, objname=routine.name)
+
+    n = 3
+    m = 2
+    vec1 = np.zeros(shape=(1,), order='F', dtype=np.int32) + 3
+    vec2 = np.zeros(shape=(n,), order='F', dtype=np.int32) + 2
+    matrix = np.zeros(shape=(m, ), order='F', dtype=np.int32) + 1
+    demoted_function(vec1, vec2, matrix, n, m)
+
+    assert np.all(vec1 == 3) and np.sum(vec1) == 3
+    assert np.all(vec2 == 2) and np.sum(vec2) == 6
+    assert np.all(matrix == 16) and np.sum(matrix) == 32

--- a/tests/test_transform_array_indexing.py
+++ b/tests/test_transform_array_indexing.py
@@ -12,7 +12,7 @@ import numpy as np
 from conftest import jit_compile, clean_test, available_frontends
 from loki import Subroutine
 from loki.expression import symbols as sym
-from loki.transform import promote_variables, normalize_range_indexing
+from loki.transform import promote_variables, demote_variables, normalize_range_indexing
 
 
 @pytest.fixture(scope='module', name='here')
@@ -151,3 +151,89 @@ end subroutine transform_promote_variables
 
     clean_test(filepath)
     clean_test(promoted_filepath)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_demote_variables(here, frontend):
+    """
+    Apply variable demotion to a range of array variables.
+    """
+    fcode = """
+subroutine transform_demote_variables(scalar, vector, matrix, n, m)
+  implicit none
+  integer, intent(in) :: n, m
+  integer, intent(inout) :: scalar, vector(n), matrix(n, n)
+  integer :: tmp_scalar, tmp_vector(n, m), tmp_matrix(n, m, n)
+  integer :: jl, jk, jm
+
+  do jl=1,n
+    do jm=1,m
+      tmp_vector(jl, jm) = scalar + jl
+    end do
+  end do
+
+  do jm=1,m
+    do jl=1,n
+      scalar = jl
+      vector(jl) = tmp_vector(jl, jm) + tmp_vector(jl, jm)
+
+      do jk=1,n
+        tmp_matrix(jk, jm, jl) = vector(jl) + jk
+      end do
+    end do
+  end do
+
+  do jk=1,n
+    do jm=1,m
+      do jl=1,n
+        matrix(jk, jl) = tmp_matrix(jk, jm, jl)
+      end do
+    end do
+  end do
+end subroutine transform_demote_variables
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    normalize_range_indexing(routine) # Fix OMNI nonsense
+
+    # Test the original implementation
+    filepath = here/(f'{routine.name}_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname=routine.name)
+
+    n = 3
+    m = 2
+    scalar = np.zeros(shape=(1,), order='F', dtype=np.int32)
+    vector = np.zeros(shape=(n,), order='F', dtype=np.int32)
+    matrix = np.zeros(shape=(n, n), order='F', dtype=np.int32)
+    function(scalar, vector, matrix, n, m)
+
+    assert all(scalar == 3)
+    assert np.all(vector == np.arange(1, n + 1)*2)
+    assert np.all(matrix == np.sum(np.mgrid[1:4,2:8:2], axis=0))
+
+    # Do the variable demotion for all relevant array variables
+    demote_variables(routine, ['tmp_vector', 'tmp_matrix'], ['m'])
+
+    assert isinstance(routine.variable_map['scalar'], sym.Scalar)
+    assert isinstance(routine.variable_map['vector'], sym.Array)
+    assert routine.variable_map['vector'].shape == (routine.variable_map['n'],)
+    assert isinstance(routine.variable_map['tmp_vector'], sym.Array)
+    assert routine.variable_map['tmp_vector'].shape == (routine.variable_map['n'],)
+    assert isinstance(routine.variable_map['matrix'], sym.Array)
+    assert routine.variable_map['matrix'].shape == (routine.variable_map['n'], routine.variable_map['n'])
+    assert isinstance(routine.variable_map['tmp_matrix'], sym.Array)
+    assert routine.variable_map['tmp_matrix'].shape == (routine.variable_map['n'], routine.variable_map['n'])
+
+    # Test promoted routine
+    demoted_filepath = here/(f'{routine.name}_demoted_{frontend}.f90')
+    demoted_function = jit_compile(routine, filepath=demoted_filepath, objname=routine.name)
+
+    n = 3
+    m = 2
+    scalar = np.zeros(shape=(1,), order='F', dtype=np.int32)
+    vector = np.zeros(shape=(n,), order='F', dtype=np.int32)
+    matrix = np.zeros(shape=(n, n), order='F', dtype=np.int32)
+    demoted_function(scalar, vector, matrix, n, m)
+
+    assert all(scalar == 3)
+    assert np.all(vector == np.arange(1, n + 1)*2)
+    assert np.all(matrix == np.sum(np.mgrid[1:4,2:8:2], axis=0))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -242,7 +242,7 @@ end subroutine test_type_module_imports
 
     # Ensure local variable info is correct, as far as known
     arg_a, arg_b = routine.variables
-    assert arg_a.type.kind.type.compare(routine.symbol_attrs['a_kind'], ignore=('imported'))
+    assert arg_a.type.kind.type.compare(routine.symbol_attrs['a_kind'], ignore=('imported',))
     assert arg_a.dimensions[0].type.compare(routine.symbol_attrs['a_dim'])
     assert isinstance(arg_b.type.dtype, DerivedType)
     assert arg_b.type.dtype.typedef == BasicType.DEFERRED
@@ -482,7 +482,7 @@ END MODULE some_mod
     # Check symbols are declared and have the right type
     procedure_names = ('sub', 'bessel', 'gfun', 'print_real', 'p', 'r', 'ptr_to_gfun', 'psi')  # 'real_func'
     pointer_names = ('p', 'r', 'ptr_to_gfun')
-    null_init_names = ('r')
+    null_init_names = ('r',)
     for name in procedure_names:
         assert name in module.symbols
         symbol = module.symbol_map[name]

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -523,8 +523,9 @@ class SingleColumnCoalescedTransformation(Transformation):
 
         # Demote all private local variables that do not buffer values between sections
         if demote_locals:
-            variable_names = tuple(v.name for v in to_demote)
-            demote_variables(routine, variable_names=variable_names, dimensions=self.horizontal.size)
+            variables = tuple(v.name for v in to_demote)
+            if variables:
+                demote_variables(routine, variable_names=variables, dimensions=self.horizontal.size)
 
         if self.hoist_column_arrays:
             # Promote all local arrays with column dimension to arguments


### PR DESCRIPTION
This PR creates an internal array transformation to demote individual array dimensions from a list of array variables within a routine. This was previously done in SCC via a custom utility, which we have now generalized and internalised to the core package, including the respective tests. 

As an added bonus, the new routine is now also capable of honouring `DIMENSION` keywords, and will adjust the respective `VariableDeclaration` node accordingly. This should address issue #19 .