### PR TITLE
Fixing OMNI get_source()

### DIFF
--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -129,6 +129,7 @@ class OMNI2IR(GenericVisitor):
         self.symbol_map = symbol_map or {}
         self.raw_source = raw_source.splitlines(keepends=True)
         self.default_scope = scope
+        self.lineno = None  # use to save lineno of last element with attribute lineno
 
     @staticmethod
     def warn_or_fail(msg):
@@ -166,11 +167,11 @@ class OMNI2IR(GenericVisitor):
     def get_source(self, o):
         """Helper method that builds the source object for a node"""
         file = o.attrib.get('file', None)
-        lineno = o.attrib.get('lineno', None)
+        lineno = o.attrib.get('lineno', self.lineno)
         if lineno:
-            lineno = int(lineno)
-            lines = (lineno, lineno)
-            string = self.raw_source[lineno-1]
+            self.lineno = int(lineno)
+            lines = (self.lineno, self.lineno)
+            string = self.raw_source[self.lineno-1]
         else:
             lines = (None, None)
             string = None

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1263,3 +1263,24 @@ end program
 
     source = Sourcefile.from_source(fcode, frontend=frontend)
     assert source.ir.body == ()
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_frontend_source_lineno(frontend):
+    """
+    ...
+    """
+    fcode = """
+    subroutine driver
+        call kernel()
+        call kernel()
+        call kernel()
+    end subroutine driver
+    """
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['driver']
+    calls = FindNodes(CallStatement).visit(routine.body)
+    assert calls[0] != calls[1]
+    assert calls[1] != calls[2]
+    assert calls[0].source.lines[0] < calls[1].source.lines[0] < calls[2].source.lines[0]


### PR DESCRIPTION
in order to have unique nodes e.g. call statements to the same subroutine ...

which solves some problems e.g. regarding transformer with mapper/dictionary entries which would otherwise be overwritten as the nodes e.g. subroutines are not distinguishable. 