### PR TITLE
Fix Regex pattern for subroutines to account for interfaces (fix #26)

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -398,7 +398,8 @@ class Item:
                 warning(f'{candidates} not found in available_names')
                 return candidates
             if len(matched_names) != 1:
-                warning(f'Duplicate symbol: {name[name.index("#")+1:]}, can be one of {matched_names}')
+                name = matched_names[0]
+                warning(f'Duplicate symbol: {name[name.find("#")+1:]}, can be one of {matched_names}')
                 return tuple(name + member_name for name in matched_names)
             return matched_names.pop() + member_name
 

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1061,7 +1061,10 @@ class OFP2IR(GenericVisitor):
 
     def visit_interface(self, o, **kwargs):
         scope = kwargs['scope']
-        abstract = o.get('type') == 'abstract'
+        if o.get('type') is not None:
+            abstract = o.get('type').lower() == 'abstract'
+        else:
+            abstract = False
 
         if o.find('header/defined-operator') is not None:
             spec = self.visit(o.find('header/defined-operator'), **kwargs)

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -800,7 +800,7 @@ class ImportPattern(Pattern):
     def __init__(self):
         super().__init__(
             r'^use +(?P<module>\w+)(?: *, *(?P<only>only *:)?'  # The use statement including an optional ``only``
-            r'(?P<imports>(?: *\w+\b *(?:=> *\w+|\(.*?\))? *,?)+))?',  # The optional list of names (with optional renames)
+            r'(?P<imports>(?: *\w+\b *(?:=> *\w+|\(.*?\))? *,?)+))?',  # The optional list of names (w/ renames, ops)
             re.IGNORECASE
         )
 

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -441,7 +441,7 @@ class SubroutineFunctionPattern(Pattern):
     def __init__(self):
         super().__init__(
             r'^[ \t\w()]*?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
-            r'(?P<spec>.*(^[ \t\w()]*interface.+^[ \t\w()]*end interface\b.*?$)*.*?)'
+            r'(?P<spec>(?:.*?(?:^(?:abstract[ \t]+)?interface\b.*?^end[ \t]+interface)?)+)'
             r'(?P<contains>^contains\n(?:'
             r'(?:[ \t\w()]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
             r'(?:[ \t\w()]*?function.*?^end[ \t]*function\b(?:[ \t]\w+)?\n)|'

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -441,7 +441,7 @@ class SubroutineFunctionPattern(Pattern):
     def __init__(self):
         super().__init__(
             r'^[ \t\w()]*?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
-            r'(?P<spec>.*?)'
+            r'(?P<spec>.*(^[ \t\w()]*interface.+^[ \t\w()]*end interface\b.*?$)*.*?)'
             r'(?P<contains>^contains\n(?:'
             r'(?:[ \t\w()]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
             r'(?:[ \t\w()]*?function.*?^end[ \t]*function\b(?:[ \t]\w+)?\n)|'

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -398,7 +398,7 @@ class ModulePattern(Pattern):
             module = Module(name=name, source=source, parent=scope)
 
         if match['spec'] and match['spec'].strip():
-            block_candidates = ('TypedefPattern',)
+            block_candidates = ('TypedefPattern', 'InterfacePattern')
             statement_candidates = ('ImportPattern', 'VariableDeclarationPattern')
             spec = self.match_block_statement_candidates(
                 reader.reader_from_sanitized_span(match.span('spec'), include_padding=True),
@@ -515,6 +515,111 @@ class SubroutineFunctionPattern(Pattern):
         else:
             pre = None
         return pre, routine, reader.reader_from_sanitized_span((match.span()[1], None), include_padding=True)
+
+
+class InterfacePattern(Pattern):
+    """
+    Pattern to match :any:`Interface` objects
+    """
+
+    parser_class = RegexParserClass.ProgramUnitClass
+
+    def __init__(self):
+        super().__init__(
+            r'^(?P<is_abstract>abstract[ \t]+)?'
+            r'interface\b[ \t]*(?P<spec>\w+\b.*?$)?'
+            r'(?P<body>.*?)'
+            r'^end[ \t]+interface\b[ \t]*(?P=spec)?',
+            re.IGNORECASE | re.DOTALL | re.MULTILINE
+        )
+
+    def match(self, reader, parser_classes, scope):
+        """
+        Match the provided source string against the pattern for a :any:`Interface`
+
+        Parameters
+        ----------
+        reader : :any:`FortranReader`
+            The reader object containing a sanitized Fortran source
+        parser_classes : RegexParserClass
+            Active parser classes for matching
+        scope : :any:`Scope`
+            The parent scope for the current source fragment
+        """
+        from loki import Interface  # pylint: disable=import-outside-toplevel,cyclic-import
+        match = self.pattern.search(reader.sanitized_string)
+        if not match:
+            return None, None, reader
+
+        source = reader.source_from_sanitized_span(match.span())
+        is_abstract = match['is_abstract'] is not None
+
+        block_candidates = ['SubroutineFunctionPattern']
+        statement_candidates = ('ProcedureStatementPattern',)
+        body = self.match_block_statement_candidates(
+            reader.reader_from_sanitized_span(match.span('body'), include_padding=True),
+            block_candidates, statement_candidates, parser_classes=parser_classes, scope=scope
+        )
+
+        if match['spec']:
+            spec = match['spec'].replace(' ', '')
+            type_ = SymbolAttributes(ProcedureType(name=spec, is_generic=True))
+            spec = sym.Variable(name=spec, type=type_, scope=scope)
+        else:
+            spec = None
+
+        interface = Interface(body=body, abstract=is_abstract, spec=spec, source=source)
+        if match.span()[0] > 0:
+            pre = reader.reader_from_sanitized_span((0, match.span()[0]), include_padding=True)
+        else:
+            pre = None
+        return pre, interface, reader.reader_from_sanitized_span((match.span()[1], None), include_padding=True)
+
+
+class ProcedureStatementPattern(Pattern):
+    """
+    Pattern to match procedure statements in interfaces
+    """
+
+    parser_class = RegexParserClass.ProgramUnitClass
+
+    def __init__(self):
+        super().__init__(
+            r'^(?P<module>module[ \t]+)?procedure\b'  # Match ``procedure`` keyword
+            r'(?:[ \t]*::)?'  # Optional `::` delimiter
+            r'[ \t]*'  # Some white space
+            r'(?P<procedures>'  # Beginning of procedures group
+            r'\w+(?:[ \t]*,[ \t]*\w+)*' # Procedure names, separated by ``,``
+            r')',  # End of procedures group
+            re.IGNORECASE
+        )
+
+    def match(self, reader, parser_classes, scope):
+        """
+        Match the provided source string against the pattern for a procedure binding
+
+        Parameters
+        ----------
+        reader : :any:`FortranReader`
+            The reader object containing a sanitized Fortran source
+        parser_classes : RegexParserClass
+            Active parser classes for matching
+        scope : :any:`Scope`
+            The parent scope for the current source fragment
+        """
+        line = reader.current_line
+        match = self.pattern.search(line.line)
+        if not match:
+            return None
+
+        is_module = match['module'] is not None
+
+        procedures = match['procedures'].replace(' ', '').split(',')
+        symbols = [
+            sym.Variable(name=s, type=SymbolAttributes(ProcedureType(name=s)), scope=scope)
+            for s in procedures
+        ]
+        return ir.ProcedureDeclaration(symbols=symbols, module=is_module, source=reader.source_from_current_line)
 
 
 class TypedefPattern(Pattern):
@@ -695,7 +800,7 @@ class ImportPattern(Pattern):
     def __init__(self):
         super().__init__(
             r'^use +(?P<module>\w+)(?: *, *(?P<only>only *:)?'  # The use statement including an optional ``only``
-            r'(?P<imports>(?: *\w+(?: *=> *\w+)? *,?)+))?',  # The optional list of names (with optional renames)
+            r'(?P<imports>(?: *\w+\b *(?:=> *\w+|\(.*?\))? *,?)+))?',  # The optional list of names (with optional renames)
             re.IGNORECASE
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,7 +226,7 @@ def stdchannel_is_captured(capsys):
     return capturemanager._global_capturing.out is not None
 
 
-def available_frontends(xfail=None, skip=None):
+def available_frontends(xfail=None, skip=None, include_regex=False):
     """
     Provide list of available frontends to parametrize tests with
 
@@ -253,6 +253,8 @@ def available_frontends(xfail=None, skip=None):
     skip : list, optional
         Provide frontends that are always skipped, optionally as tuple with reason
         provided as string. By default `None`
+    include_regex : bool, optional
+        Include the :any:`REGEX` frontend in the list. By default `false`.
     """
     if xfail:
         xfail = dict((as_tuple(f) + (None,))[:2] for f in xfail)
@@ -278,7 +280,7 @@ def available_frontends(xfail=None, skip=None):
             params += [pytest.param(f, marks=pytest.mark.skip(reason=skip[f]))]
         elif f in xfail:
             params += [pytest.param(f, marks=pytest.mark.xfail(reason=xfail[f]))]
-        elif f != REGEX:
+        elif f != REGEX or include_regex:
             params += [f]
 
     return params

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1327,7 +1327,23 @@ call other_kernel(c)
 
 end subroutine test
     """.strip()
+
+    # Make sure only the host subroutine is captured
     source = Sourcefile.from_source(fcode, frontend=REGEX)
     assert len(source.subroutines) == 1
     assert source.subroutines[0].name == 'test'
     assert source.subroutines[0].source.lines == (1, 38)
+
+    # Make sure this also works for module procedures
+    fcode = f"""
+module my_mod
+    implicit none
+contains
+{fcode}
+end module my_mod
+    """.strip()
+    source = Sourcefile.from_source(fcode, frontend=REGEX)
+    assert not source.subroutines
+    assert len(source.all_subroutines) == 1
+    assert source.all_subroutines[0].name == 'test'
+    assert source.all_subroutines[0].source.lines == (4, 41)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -462,7 +462,6 @@ end module my_interface_mod
     intf_sim_func = mod.interface_map['sim_func']
     assert intf_sim_func.abstract
     assert intf_sim_func.symbols[0].type.dtype.procedure is intf_sim_func.body[0]
-    sim_func = intf_sim_func.body[0]
 
     intf_sub2 = mod.interface_map['sub2']
     assert intf_sub2.symbols[0].type.dtype.procedure is intf_sub2.body[0]
@@ -471,4 +470,3 @@ end module my_interface_mod
     if frontend != REGEX:
         arg_p = sub2.arguments[1]
         assert isinstance(arg_p.type.dtype, ProcedureType)
-        assert arg_p.type.dtype.procedure is sim_func

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -10,7 +10,7 @@ import pytest
 
 from conftest import available_frontends
 from loki import (
-    Module, Subroutine, FindNodes, Interface, Import, fgen, OMNI,
+    Module, Subroutine, FindNodes, Interface, Import, fgen, OMNI, REGEX,
     ProcedureSymbol, ProcedureType
 )
 
@@ -20,7 +20,7 @@ def fixture_here():
     return Path(__file__).parent
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(include_regex=True))
 def test_interface_spec(frontend):
     """
     Test basic functionality of interface representation
@@ -57,7 +57,7 @@ end module interface_spec_mod
     assert 'subroutine sub' in code
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(include_regex=True))
 def test_interface_module_integration(frontend):
     """
     Test correct integration of interfaces into modules
@@ -183,7 +183,7 @@ end module interface_import_mod
     assert 'import t' in fgen(interface).lower()
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(include_regex=True))
 def test_interface_multiple_routines(frontend):
     """
     Test interfaces with multiple subroutine/function declarations
@@ -242,7 +242,7 @@ end module interface_multiple_routines_mod
     assert 'function ext3' in code
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(include_regex=True))
 def test_interface_generic_spec(frontend):
     """
     Test interfaces with a generic identifier
@@ -291,7 +291,7 @@ end module interface_generic_spec_mod
     assert all(s in module.symbols for s in ('switch', 'int_switch', 'real_switch', 'complex_switch'))
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(include_regex=True))
 def test_interface_operator_module_procedure(frontend):
     """
     Test interfaces that declare generic operators and refer to module procedures
@@ -417,17 +417,58 @@ end module use_spectral_fields_mod
     assert other_mod.imported_symbols == ('assignment(=)', 'operator(.eqv.)')
 
     assign_sym = other_mod.imported_symbol_map['assignment(=)']
-    assert isinstance(assign_sym, ProcedureSymbol)
-    assert isinstance(assign_sym.type.dtype, ProcedureType)
-    assert assign_sym.type.dtype.is_generic is True
-    assert assign_sym.type.imported is True
-    assert assign_sym.type.module is mod
-
     op_sym = other_mod.imported_symbol_map['operator(.eqv.)']
-    assert isinstance(op_sym, ProcedureSymbol)
-    assert isinstance(op_sym.type.dtype, ProcedureType)
-    assert op_sym.type.dtype.is_generic is True
+
+    assert assign_sym.type.imported is True
     assert op_sym.type.imported is True
-    assert op_sym.type.module is mod
+
+    if frontend != REGEX:  # REGEX frontend doesn't use definitions and therefore doesn't import types
+        assert isinstance(assign_sym, ProcedureSymbol)
+        assert isinstance(assign_sym.type.dtype, ProcedureType)
+        assert assign_sym.type.dtype.is_generic is True
+        assert assign_sym.type.module is mod
+
+        assert isinstance(op_sym, ProcedureSymbol)
+        assert isinstance(op_sym.type.dtype, ProcedureType)
+        assert op_sym.type.dtype.is_generic is True
+        assert op_sym.type.module is mod
 
     assert other_code.splitlines()[1].strip() in fgen(other_mod).lower()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(include_regex=True))
+def test_interface_procedure_pointer(frontend):
+    fcode = """
+module my_interface_mod
+implicit none
+ABSTRACT INTERFACE
+  FUNCTION SIM_FUNC (X)
+    REAL, INTENT (IN) :: X
+    REAL :: SIM_FUNC
+  END FUNCTION SIM_FUNC
+END INTERFACE
+
+INTERFACE
+  SUBROUTINE SUB2 (X, P)
+    REAL, INTENT (INOUT) :: X
+    PROCEDURE(SIM_FUNC) :: P
+  END SUBROUTINE SUB2
+END INTERFACE
+end module my_interface_mod
+    """.strip()
+
+    mod = Module.from_source(fcode, frontend=frontend)
+
+    intf_sim_func = mod.interface_map['sim_func']
+    assert intf_sim_func.abstract
+    assert intf_sim_func.symbols[0].type.dtype.procedure is intf_sim_func.body[0]
+    sim_func = intf_sim_func.body[0]
+
+    intf_sub2 = mod.interface_map['sub2']
+    assert intf_sub2.symbols[0].type.dtype.procedure is intf_sub2.body[0]
+    sub2 = intf_sub2.body[0]
+
+    if frontend != REGEX:
+        arg_p = sub2.arguments[1]
+        assert isinstance(arg_p.type.dtype, ProcedureType)
+        assert arg_p.type.dtype.procedure is sim_func

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1250,7 +1250,7 @@ subroutine test_subroutine_interface (in1, in2, out1, out2)
   out2 = out1 + 2.
 end subroutine
 """
-    routine = Subroutine.from_source(fcode, xmods=[here/'source/xmod'], frontend=frontend)
+    routine = Subroutine.from_source(fcode, xmods=[here/'sources/xmod'], frontend=frontend)
 
     if frontend == OMNI:
         assert fgen(routine.interface).strip() == """


### PR DESCRIPTION
The purpose of this is to fix the regex frontend bug reported in #26. Solution is to explicitly match interface blocks in the subroutine pattern, thus shortcutting any contained subroutine declarations.

 In the process I had already developed a more sophisticated pattern for matching interface blocks. We may need this eventually to resolve #31. 