### PR TITLE
Minor scheduler and dependency injection bugfixes

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -297,7 +297,9 @@ class Item:
         # Filter out local members and disabled sub-branches
         children = [c for c in children if c not in self.members]
         children = [c for c in children if c not in disabled]
-        return as_tuple(children)
+
+        # Remove duplicates
+        return as_tuple(dict.fromkeys(children))
 
     def qualify_names(self, names, available_names=None):
         """

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -376,8 +376,8 @@ class Item:
             # scope (i.e. defined directly in a source file). We add all
             # possibilities, of which only one should match (otherwise we would
             # have duplicate symbols in this compilation unit)
-            candidates = [f'#{name}']
-            candidates += [f'{import_}#{name}' for import_ in self.unqualified_imports]
+            candidates = [f'#{name}'.lower()]
+            candidates += [f'{import_}#{name}'.lower() for import_ in self.unqualified_imports]
             qualified_names += [as_tuple(candidates)]
 
         if available_names is None:

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -198,11 +198,11 @@ class DependencyTransformation(Transformation):
 
         # First step through known suffix variants to determine canonical basename
         if modname.lower().endswith(self.suffix.lower()+self.module_suffix.lower()):
-            idx = modname.lower().index(self.suffix.lower()+self.module_suffix.lower())
+            idx = modname.lower().rindex(self.suffix.lower()+self.module_suffix.lower())
         elif modname.lower().endswith(self.suffix.lower()):
-            idx = modname.lower().index(self.suffix.lower())
+            idx = modname.lower().rindex(self.suffix.lower())
         elif modname.lower().endswith(self.module_suffix.lower()):
-            idx = modname.lower().index(self.module_suffix.lower())
+            idx = modname.lower().rindex(self.module_suffix.lower())
         else:
             idx = len(modname)
         base = modname[:idx]

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -129,12 +129,15 @@ class DependencyTransformation(Transformation):
         """
         targets = as_tuple(kwargs.get('targets', None))
         targets = as_tuple(str(t).upper() for t in targets)
+        members = [r.name for r in routine.subroutines]
 
         if self.replace_ignore_items:
             item = kwargs.get('item', None)
             targets += as_tuple(str(i).upper() for i in item.ignore) if item else ()
 
         for call in FindNodes(CallStatement).visit(routine.body):
+            if call.name in members:
+                continue
             if targets is None or call.name in targets:
                 call.name = call.name.clone(name=f'{call.name}{self.suffix}')
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -833,6 +833,38 @@ def test_scheduler_item(here):
     assert item_b.targets == ('contained_c',)
 
 
+def test_scheduler_item_children(here):
+    """
+    Make sure children are correct and unique for items
+    """
+    config = SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': True},
+        'routine': [
+            {'name': 'driver', 'role': 'driver'},
+            {'name': 'another_driver', 'role': 'driver'}
+        ]
+    })
+
+    proj_hoist = here/'sources/projHoist'
+
+    scheduler = Scheduler(paths=proj_hoist, config=config)
+
+    assert scheduler.item_map['transformation_module_hoist#driver'].children == (
+        'kernel1', 'kernel2'
+    )
+    assert scheduler.item_map['transformation_module_hoist#another_driver'].children == (
+        'kernel1',
+    )
+    assert not scheduler.item_map['subroutines_mod#kernel1'].children
+    assert scheduler.item_map['subroutines_mod#kernel2'].children == (
+        'device1', 'device2'
+    )
+    assert scheduler.item_map['subroutines_mod#device1'].children == (
+        'device2',
+    )
+    assert not scheduler.item_map['subroutines_mod#device2'].children
+
+
 @pytest.fixture(name='loki_69_dir')
 def fixture_loki_69_dir(here):
     """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1460,3 +1460,27 @@ end subroutine driver
         assert isinstance(call.function.parent.parent.type.dtype.typedef, TypeDef)
 
     rmtree(workdir)
+
+
+def test_scheduler_qualify_names():
+    """
+    Make sure qualified names are all lower case
+    """
+    fcode = """
+module some_mod
+    use other_mod
+    use MORE_MOD
+    implicit none
+contains
+    subroutine DRIVER
+        use YET_another_mod
+        call routine
+    end subroutine DRIVER
+end module some_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=REGEX)
+    item = SubroutineItem(name='some_mod#driver', source=source)
+    assert item.qualify_names(item.children) == (
+        ('#routine', 'yet_another_mod#routine', 'other_mod#routine', 'more_mod#routine'),
+    )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1026,14 +1026,13 @@ def test_scheduler_typebound_item(here):
     assert driver.qualified_imports == {'other': 'typebound_other#other_type'}
 
     # Check that calls are propagated as children
-    assert driver.children == driver.calls
+    assert set(driver.children) == set(driver.calls)
 
     # Check that fully-qualified names are correctly picked from the available names
     assert driver.qualify_names(driver.children, available_names) == (
         'typebound_item#some_type%other_routine', 'typebound_item#some_type%some_routine',
         'typebound_header#header_type%member_routine', 'typebound_header#header_type%routine',
-        'typebound_header#header_type%routine', 'typebound_other#other_type%member',
-        'typebound_other#other_type%var%member_routine'
+        'typebound_other#other_type%member', 'typebound_other#other_type%var%member_routine'
     )
 
     other_routine = SubroutineItem(name='typebound_item#other_routine', source=source)


### PR DESCRIPTION
Two little bugfixes/enhancements for the Scheduler:

1. Resolve a case-sensitivity issue in `Item.qualify_names`
2. Remove duplicates from `Item.children`

Two little fixes for the dependency injection transformation:

1. Canonical basename needs to look for the suffix via `rindex` to avoid aliasing problems (e.g., when looking for `_mod` in `some_model_thing_mod`).
2. Calls to contained member routines can be ignored.