### PR TITLE
Fix infinite recursion in SubstituteExpression

### DIFF
--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -261,9 +261,32 @@ class FindExpressionRoot(ExpressionFinder):
 
 class SubstituteExpressions(Transformer):
     """
-    A dedicated visitor to perform expression substitution in all IR nodes.
+    A dedicated visitor to perform expression substitution in all IR nodes
 
-    :param expr_map: Expression mapping to apply to all expressions in a tree.
+    It applies :any:`SubstituteExpressionsMapper` with the provided :data:`expr_map`
+    to every expression in the traversed IR tree.
+
+    .. note::
+       No recursion is performed on substituted expression nodes, they are taken
+       as-is from the map. Otherwise substitutions that involve the original node
+       would result in infinite recursion - for example a replacement that wraps
+       a variable in an inline call:  ``my_var -> wrapped_in_call(my_var)``.
+
+       When there is a need to recursively apply the mapping, the mapping needs to
+       be applied to itself first. A potential use-case is renaming of variables,
+       which may appear as the name of an array subscript as well as in the ``dimensions``
+       attribute of the same expression: ``SOME_ARR(SOME_ARR > SOME_VAL)``.
+       The mapping can be applied to itself using the utility function
+       :any:`recursive_expression_map_update`.
+
+    Parameters
+    ----------
+    expr_map : dict
+        Expression mapping to apply to the expression tree.
+    invalidate_source : bool, optional
+        By default the :attr:`source` property of nodes is discarded
+        when rebuilding the node, setting this to `False` allows to
+        retain that information
     """
     # pylint: disable=unused-argument
 

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -521,12 +521,18 @@ class LokiIdentityMapper(IdentityMapper):
         if expr is None:
             return None
         new_expr = super().__call__(expr, *args, **kwargs)
-        if new_expr is not expr and hasattr(expr, '_source'):
-            if expr._source:
+        if getattr(expr, 'source', None):
+            if isinstance(new_expr, tuple):
+                for e in new_expr:
+                    if self.invalidate_source:
+                        e.source = None
+                    else:
+                        e.source = deepcopy(expr.source)
+            else:
                 if self.invalidate_source:
-                    new_expr._source = None
+                    new_expr.source = None
                 else:
-                    new_expr._source = deepcopy(expr._source)
+                    new_expr.source = deepcopy(expr.source)
         return new_expr
 
     rec = __call__

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -679,7 +679,31 @@ class SubstituteExpressionsMapper(LokiIdentityMapper):
     defines on-the-fly handlers from a given substitution map.
 
     It returns a copy of the expression tree with expressions substituted according
-    to the given `expr_map`.
+    to the given :data:`expr_map`. If an expression node is encountered that is
+    found in :data:`expr_map`, it is replaced with the corresponding expression from
+    the map. For any other nodes, traversal is performed via :any:`LokiIdentityMapper`.
+
+    .. note::
+       No recursion is performed on substituted expression nodes, they are taken
+       as-is from the map. Otherwise substitutions that involve the original node
+       would result in infinite recursion - for example a replacement that wraps
+       a variable in an inline call:  ``my_var -> wrapped_in_call(my_var)``.
+
+       When there is a need to recursively apply the mapping, the mapping needs to
+       be applied to itself first. A potential use-case is renaming of variables,
+       which may appear as the name of an array subscript as well as in the ``dimensions``
+       attribute of the same expression: ``SOME_ARR(SOME_ARR > SOME_VAL)``.
+       The mapping can be applied to itself using the utility function
+       :any:`recursive_expression_map_update`.
+
+    Parameters
+    ----------
+    expr_map : dict
+        Expression mapping to apply to the expression tree.
+    invalidate_source : bool, optional
+        By default the :attr:`source` property of nodes is discarded
+        when rebuilding the node, setting this to `False` allows to
+        retain that information
     """
     # pylint: disable=abstract-method
 

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -685,11 +685,12 @@ class SubstituteExpressionsMapper(LokiIdentityMapper):
             setattr(self, expr.mapper_method, self.map_from_expr_map)
 
     def map_from_expr_map(self, expr, *args, **kwargs):
-        # We have to recurse here to make sure we are applying the substitution also to
-        # "hidden" places (such as dimension expressions inside an array).
-        # And we have to actually carry out the expression first before looking up the
-        # super()-method as the node type might change.
-        expr = self.expr_map.get(expr, expr)
+        """
+        Replace an expr with its substitution, if found in the :attr:`expr_map`,
+        otherwise continue tree traversal
+        """
+        if expr in self.expr_map:
+            return self.expr_map[expr]
         map_fn = getattr(super(), expr.mapper_method)
         return map_fn(expr, *args, **kwargs)
 

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -67,7 +67,7 @@ class ExprMetadataMixin:
 
     @property
     def init_arg_names(self):
-        return super().init_arg_names + ('_source', )
+        return super().init_arg_names + ('source', )
 
     def __init__(self, *args, **kwargs):
         self._source = kwargs.pop('source', None)
@@ -80,6 +80,10 @@ class ExprMetadataMixin:
     def source(self):
         """The :any:`Source` object for this expression node."""
         return self._source
+
+    @source.setter
+    def source(self, source):
+        self._source = source
 
     make_stringifier = loki_make_stringifier
 
@@ -301,7 +305,7 @@ class TypedSymbol:
             List of member variables in a derived type
         """
         _type = self.type
-        if isinstance(_type.dtype, DerivedType):
+        if _type and isinstance(_type.dtype, DerivedType):
             if _type.dtype.typedef is BasicType.DEFERRED:
                 return ()
             return tuple(
@@ -424,11 +428,6 @@ class VariableSymbol(ExprMetadataMixin, StrCompareMixin, TypedSymbol, pmbl.Varia
         The type of that symbol. Defaults to :any:`SymbolAttributes` with
         :any:`BasicType.DEFERRED`.
     """
-
-    def __init__(self, name, scope=None, type=None, **kwargs):
-        # Stop complaints about `type` in this function
-        # pylint: disable=redefined-builtin
-        super().__init__(name=name, scope=scope, type=type, **kwargs)
 
     @property
     def initial(self):
@@ -616,11 +615,19 @@ class MetaSymbol(StrCompareMixin, pmbl.AlgebraicLeaf):
     def source(self):
         return self.symbol.source
 
+    @source.setter
+    def source(self, source):
+        self.symbol.source = source
+
     mapper_method = intern('map_meta_symbol')
     make_stringifier = loki_make_stringifier
 
     def __getinitargs__(self):
         return self.symbol.__getinitargs__()
+
+    @property
+    def init_arg_names(self):
+        return self.symbol.init_arg_names
 
     def clone(self, **kwargs):
         """
@@ -725,6 +732,10 @@ class Array(MetaSymbol):
 
     def __getinitargs__(self):
         return super().__getinitargs__() + (self.dimensions, )
+
+    @property
+    def init_arg_names(self):
+        return super().init_arg_names + ('dimensions', )
 
     mapper_method = intern('map_array')
 

--- a/loki/transform/fortran_python_transform.py
+++ b/loki/transform/fortran_python_transform.py
@@ -64,6 +64,10 @@ class FortranPythonTransformation(Transformation):
             invert_array_indices(kernel)
         shift_to_zero_indexing(kernel)
 
+        # We replace calls to intrinsic functions with their Python counterparts
+        # Note that this substitution is case-insensitive, and therefore we have
+        # this seemingly identity mapping to make sure Python function names are
+        # lower-case
         intrinsic_map = {'min': 'min', 'max': 'max', 'abs': 'abs'}
         replace_intrinsics(kernel, function_map=intrinsic_map)
 

--- a/loki/transform/transform_associates.py
+++ b/loki/transform/transform_associates.py
@@ -7,6 +7,7 @@
 
 from loki.expression import FindVariables, SubstituteExpressions
 from loki.tools import CaseInsensitiveDict
+from loki.transform import recursive_expression_map_update
 from loki.visitors import Transformer
 
 
@@ -53,6 +54,9 @@ class ResolveAssociatesTransformer(Transformer):
                 # Clone the expression to update its parentage and scoping
                 inv = invert_assoc[v.name]
                 vmap[v] = v.clone(name=inv.name, parent=inv.parent, scope=inv.scope)
+
+        # Apply the expression substitution map to itself to handle nested expressions
+        vmap = recursive_expression_map_update(vmap)
 
         # Return the body of the associate block with all expressions replaced
         return SubstituteExpressions(vmap).visit(body)

--- a/loki/transform/transform_associates.py
+++ b/loki/transform/transform_associates.py
@@ -7,7 +7,7 @@
 
 from loki.expression import FindVariables, SubstituteExpressions
 from loki.tools import CaseInsensitiveDict
-from loki.transform import recursive_expression_map_update
+from loki.transform.transform_utilities import recursive_expression_map_update
 from loki.visitors import Transformer
 
 

--- a/loki/transform/transform_utilities.py
+++ b/loki/transform/transform_utilities.py
@@ -90,18 +90,10 @@ def convert_to_lower_case(routine):
             if isinstance(v, (sym.Scalar, sym.Array)) and not v.name.islower()}
 
     # Capture nesting by applying map to itself before applying to the routine
-    for _ in range(2):
-        mapper = SubstituteExpressionsMapper(vmap)
-        vmap = {k: mapper(v) for k, v in vmap.items()}
+    vmap = recursive_expression_map_update(vmap)
 
     routine.body = SubstituteExpressions(vmap).visit(routine.body)
     routine.spec = SubstituteExpressions(vmap).visit(routine.spec)
-
-    # Down-case all subroutine arguments and variables
-    mapper = SubstituteExpressionsMapper(vmap)
-
-    routine.arguments = [mapper(arg) for arg in routine.arguments]
-    routine.variables = [mapper(var) for var in routine.variables]
 
 
 def replace_intrinsics(routine, function_map=None, symbol_map=None, case_sensitive=False):

--- a/loki/transform/transform_utilities.py
+++ b/loki/transform/transform_utilities.py
@@ -18,7 +18,6 @@ from loki.expression import (
     SubstituteExpressions, SubstituteExpressionsMapper, ExpressionFinder,
     ExpressionRetriever, TypedSymbol, MetaSymbol
 )
-from loki.frontend import Source
 from loki.ir import Import, TypeDef, VariableDeclaration
 from loki.module import Module
 from loki.subroutine import Subroutine

--- a/tests/test_pygen.py
+++ b/tests/test_pygen.py
@@ -268,7 +268,7 @@ subroutine pygen_intrinsics(v1, v2, v3, v4, vmin, vmax, vabs, vmin_nested, vmax_
   vmin = MIN(v1, v2)
   vmax = MAX(v1, v2)
   vabs = ABS(v1 - v2)
-  vmin_nested = MIN(MIN(v1, v2), MIN(v3, v4))
+  vmin_nested = MIN(MIN(MAX(v1, -1._real64), v2), MIN(v3, v4))
   vmax_nested = MAX(MAX(v1, v2), MAX(v3, v4))
 end subroutine pygen_intrinsics
 """

--- a/tests/test_transform_utilities.py
+++ b/tests/test_transform_utilities.py
@@ -115,11 +115,13 @@ subroutine my_NOT_ALL_lowercase_ROUTINE(VAR1, another_VAR, lower_case, MiXeD_Cas
     implicit none
     integer, intent(in) :: VAR1, another_VAR
     integer, intent(inout) :: lower_case(ANOTHER_VAR)
-    integer, intent(inout) :: MiXeD_CasE(Var1)
+    integer, intent(inout) :: MiXeD_CasE(Var1, ANOTHER_VAR)
     integer :: J, k
 
-    do J=1,VAR1
-        mixed_CASE(J) = J + j
+    do k=1,ANOTHER_VAR
+        do J=1,VAR1
+            mixed_CASE(J, K) = J + K
+        end do
     end do
 
     do K=1,ANOTHER_VAR

--- a/transformations/transformations/single_column_claw.py
+++ b/transformations/transformations/single_column_claw.py
@@ -13,9 +13,10 @@ Single Column Abstraction (SCA), as defined by CLAW (Clement et al., 2018)
 from collections import OrderedDict
 from loki import (
     Transformation, FindVariables, FindNodes, Transformer, SubstituteExpressions,
-    SubstituteExpressionsMapper, Assignment, CallStatement, Loop, Variable,
+    Assignment, CallStatement, Loop, Variable,
     Array, Pragma, VariableDeclaration, LoopRange, RangeIndex,
-    SymbolAttributes, BasicType, CaseInsensitiveDict, as_tuple, warning
+    SymbolAttributes, BasicType, CaseInsensitiveDict, as_tuple, warning,
+    recursive_expression_map_update
 )
 
 
@@ -126,12 +127,11 @@ class ExtractSCATransformation(Transformation):
         routine.variables = [vmap.get(v, v) for v in routine.variables]
 
         # Apply substitution map to replacements to capture nesting
-        mapper = SubstituteExpressionsMapper(vmap)
-        vmap2 = {k: mapper(v) for k, v in vmap.items()}
+        vmap = recursive_expression_map_update(vmap)
 
-        routine.body = SubstituteExpressions(vmap2).visit(routine.body)
+        routine.body = SubstituteExpressions(vmap).visit(routine.body)
         for m in as_tuple(routine.members):
-            m.body = SubstituteExpressions(vmap2).visit(m.body)
+            m.body = SubstituteExpressions(vmap).visit(m.body)
 
     def hoist_dimension_from_call(self, caller, wrap=True):
         """


### PR DESCRIPTION
As discussed offline, this fixes the infinite recursion issue when we have expression maps like `{var: var + 1}`. Solution is to remove the recursion on the replaced node and rather have a dedicated utility that allows applying that recursion to the expression map before carrying out the substitution.

@MichaelSt98 could you please let me know if this fixes your issue?