### PR TITLE
Fix #37: regex frontend hangs if end is missing subroutine

### DIFF
--- a/loki/__init__.py
+++ b/loki/__init__.py
@@ -73,6 +73,9 @@ config.register('disk-cache', False, env_variable='LOKI_DISK_CACHE',
 config.register('case-sensitive', False, env_variable='LOKI_CASE_SENSITIVE',
                 preprocess=lambda i: bool(i) if isinstance(i, int) else i)
 
+# Specify a timeout for the REGEX frontend to catch catastrophic backtracking
+config.register('regex-frontend-timeout', 30, env_variable='LOKI_REGEX_FRONTEND_TIMEOUT', preprocess=int)
+
 # Trigger configuration initialisation, including
 # a scan of the current environment variables
 config.initialize()

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -18,11 +18,12 @@ import re
 from codetiming import Timer
 
 from loki import ir
+from loki.config import config
 from loki.expression import symbols as sym
 from loki.frontend.source import Source, FortranReader
 from loki.logging import debug
 from loki.scope import SymbolAttributes
-from loki.tools import as_tuple
+from loki.tools import as_tuple, timeout
 from loki.types import BasicType, ProcedureType, DerivedType
 
 __all__ = ['RegexParserClass', 'parse_regex_source', 'HAVE_REGEX']
@@ -343,7 +344,9 @@ def parse_regex_source(source, parser_classes=None, scope=None):
         reader = FortranReader(source.string)
     else:
         reader = FortranReader(source)
-    ir_ = Pattern.match_block_candidates(reader, candidates, parser_classes=parser_classes, scope=scope)
+    timeout_message = f'REGEX frontend timeout of {config["regex-frontend-timeout"]} s exceeded'
+    with timeout(config['regex-frontend-timeout'], message=timeout_message):
+        ir_ = Pattern.match_block_candidates(reader, candidates, parser_classes=parser_classes, scope=scope)
     return ir.Section(body=as_tuple(ir_), source=source)
 
 


### PR DESCRIPTION
Add a timeout utility with the option to specify (or disable) a default timeout for the REGEX frontend to gracefully fail on catastrophic backtracking.