### PR TITLE
Various Pygen-backend fixes

### DIFF
--- a/loki/backend/pygen.py
+++ b/loki/backend/pygen.py
@@ -87,7 +87,7 @@ class PyCodeMapper(LokiStringifyMapper):
             )
 
         f = self.rec(expr.function, PREC_NONE, *args, **kwargs)
-        return self.format(f'{str(f).lower()}({arguments})')
+        return self.format(f'{str(f)}({arguments})')
 
     def map_deferred_type_symbol(self, expr, *args, **kwargs):
         return str(expr.name).replace('%', '.')

--- a/loki/backend/pygen.py
+++ b/loki/backend/pygen.py
@@ -90,7 +90,7 @@ class PyCodeMapper(LokiStringifyMapper):
         return self.format(f'{str(f).lower()}({arguments})')
 
     def map_deferred_type_symbol(self, expr, *args, **kwargs):
-        return str(expr.name).lower().replace('%', '.')
+        return str(expr.name).replace('%', '.')
 
 
 class PyCodegen(Stringifier):

--- a/loki/backend/pygen.py
+++ b/loki/backend/pygen.py
@@ -269,7 +269,7 @@ class PyCodegen(Stringifier):
           <name>(<args>)
         """
         args = self.visit_all(o.arguments, **kwargs)
-        kw_args = [f'{kw}={self.visit(arg, **kwargs)}' for kw, arg in o.kwarguments]
+        kw_args = tuple(f'{kw}={self.visit(arg, **kwargs)}' for kw, arg in o.kwarguments)
         return self.format_line(o.name, '(', self.join_items(args + kw_args), ')')
 
     def visit_SymbolAttributes(self, o, **kwargs):  # pylint: disable=unused-argument

--- a/loki/build/builder.py
+++ b/loki/build/builder.py
@@ -8,7 +8,7 @@
 import sys
 from pathlib import Path
 from collections import deque
-from importlib import import_module, reload
+from importlib import import_module, reload, invalidate_caches
 from operator import attrgetter
 import networkx as nx
 
@@ -155,7 +155,15 @@ class Builder:
         if module in sys.modules:
             reload(sys.modules[module])
             return sys.modules[module]
-        return import_module(module)
+
+        try:
+            # Attempt to load module directly
+            return import_module(module)
+        except ModuleNotFoundError:
+            # If module caching interferes, try again with clean caches
+            invalidate_caches()
+            return import_module(module)
+
 
     def wrap_and_load(self, sources, modname=None, build=True,
                       libs=None, lib_dirs=None, incl_dirs=None,

--- a/loki/transform/fortran_python_transform.py
+++ b/loki/transform/fortran_python_transform.py
@@ -57,7 +57,7 @@ class FortranPythonTransformation(Transformation):
         path = Path(kwargs.get('path'))
 
         # Rename subroutine to generate Python kernel
-        routine.name = f'{routine.name}{self.suffix}'
+        routine.name = f'{routine.name}{self.suffix}'.lower()
 
         # Remove all "IMPLICT" intrinsic statements
         mapper = {

--- a/loki/transform/fortran_python_transform.py
+++ b/loki/transform/fortran_python_transform.py
@@ -11,7 +11,6 @@ from loki.backend import pygen, dacegen
 from loki import ir
 from loki.pragma_utils import pragmas_attached
 from loki.sourcefile import Sourcefile
-from loki.subroutine import Subroutine
 from loki.transform.transformation import Transformation
 from loki.transform.transform_array_indexing import (
     shift_to_zero_indexing, invert_array_indices, normalize_range_indexing
@@ -34,48 +33,39 @@ class FortranPythonTransformation(Transformation):
     def transform_subroutine(self, routine, **kwargs):
         path = Path(kwargs.get('path'))
 
-        # Generate Python kernel
-        kernel = self.generate_kernel(routine, **kwargs)
-        self.py_path = (path/kernel.name.lower()).with_suffix('.py')
-        self.mod_name = kernel.name.lower()
-        # Need to attach Loop pragmas to honour dataflow pragmas for loops
-        with pragmas_attached(kernel, ir.Loop):
-            source = dacegen(kernel) if kwargs.get('with_dace', False) is True else pygen(kernel)
-        Sourcefile.to_file(source=source, path=self.py_path)
-
-    @classmethod
-    def generate_kernel(cls, routine, **kwargs):
-        # Replicate the kernel to strip the Fortran-specific boilerplate
-        spec = ir.Section(body=())
-        body = ir.Section(body=Transformer({}).visit(routine.body))
-        kernel = Subroutine(name=f'{routine.name}_py', spec=spec, body=body)
-        kernel.arguments = routine.arguments
-        kernel.variables = routine.variables
+        # Rename subroutine to generate Python kernel
+        routine.name = f'{routine.name}_py'
 
         # Remove all "IMPLICT" intrinsic statements
         mapper = {
-            i: None for i in FindNodes(ir.Intrinsic).visit(kernel.spec)
+            i: None for i in FindNodes(ir.Intrinsic).visit(routine.spec)
             if 'implicit' in i.text.lower()
         }
-        kernel.spec = Transformer(mapper).visit(kernel.spec)
+        routine.spec = Transformer(mapper).visit(routine.spec)
 
         # Force all variables to lower-caps, as Python is case-sensitive
-        convert_to_lower_case(kernel)
+        convert_to_lower_case(routine)
 
         # Resolve implicit struct mappings through "associates"
-        resolve_associates(kernel)
+        resolve_associates(routine)
 
         # Do some vector and indexing transformations
-        normalize_range_indexing(kernel)
+        normalize_range_indexing(routine)
         if kwargs.get('with_dace', False) is True:
-            invert_array_indices(kernel)
-        shift_to_zero_indexing(kernel)
+            invert_array_indices(routine)
+        shift_to_zero_indexing(routine)
 
         # We replace calls to intrinsic functions with their Python counterparts
         # Note that this substitution is case-insensitive, and therefore we have
         # this seemingly identity mapping to make sure Python function names are
         # lower-case
         intrinsic_map = {'min': 'min', 'max': 'max', 'abs': 'abs'}
-        replace_intrinsics(kernel, function_map=intrinsic_map)
+        replace_intrinsics(routine, function_map=intrinsic_map)
 
-        return kernel
+        # Rename subroutine to generate Python kernel
+        self.py_path = (path/routine.name.lower()).with_suffix('.py')
+        self.mod_name = routine.name.lower()
+        # Need to attach Loop pragmas to honour dataflow pragmas for loops
+        with pragmas_attached(routine, ir.Loop):
+            source = dacegen(routine) if kwargs.get('with_dace', False) is True else pygen(routine)
+        Sourcefile.to_file(source=source, path=self.py_path)

--- a/loki/transform/transform_utilities.py
+++ b/loki/transform/transform_utilities.py
@@ -119,13 +119,14 @@ def replace_intrinsics(routine, function_map=None, symbol_map=None, case_sensiti
         function_map = CaseInsensitiveDict(function_map)
 
     callmap = {}
-    for call in FindInlineCalls(unique=False).visit(routine.body):
+    for call in FindInlineCalls(unique=False).visit(routine.ir):
         if call.name in symbol_map:
             callmap[call] = sym.Variable(name=symbol_map[call.name], scope=routine)
 
         if call.name in function_map:
             callmap[call.function] = sym.ProcedureSymbol(name=function_map[call.name], scope=routine)
 
+    routine.spec = SubstituteExpressions(callmap).visit(routine.spec)
     routine.body = SubstituteExpressions(callmap).visit(routine.body)
 
 

--- a/loki/transform/transform_utilities.py
+++ b/loki/transform/transform_utilities.py
@@ -86,8 +86,10 @@ def convert_to_lower_case(routine):
 
     # Force all variables in a subroutine body to lower-caps
     variables = FindVariables(unique=False).visit(routine.ir)
-    vmap = {v: v.clone(name=v.name.lower()) for v in variables
-            if isinstance(v, (sym.Scalar, sym.Array)) and not v.name.islower()}
+    vmap = {
+        v: v.clone(name=v.name.lower()) for v in variables
+        if isinstance(v, (sym.Scalar, sym.Array, sym.DeferredTypeSymbol)) and not v.name.islower()
+    }
 
     # Capture nesting by applying map to itself before applying to the routine
     vmap = recursive_expression_map_update(vmap)

--- a/tests/test_pygen.py
+++ b/tests/test_pygen.py
@@ -89,7 +89,7 @@ end subroutine pygen_simple_loops
     routine.name = f'{routine.name}_{str(frontend)}'
 
     # Generate and test the transpiled Python kernel
-    f2p = FortranPythonTransformation()
+    f2p = FortranPythonTransformation(suffix='_py')
     f2p.apply(source=routine, path=here)
     mod = load_module(here, f2p.mod_name)
     func = getattr(mod, f2p.mod_name)
@@ -172,7 +172,7 @@ end subroutine pygen_arguments
     routine.name = f'{routine.name}_{str(frontend)}'
 
     # Generate and test the transpiled Python kernel
-    f2p = FortranPythonTransformation()
+    f2p = FortranPythonTransformation(suffix='_py')
     f2p.apply(source=routine, path=here)
     mod = load_module(here, f2p.mod_name)
     func = getattr(mod, f2p.mod_name)
@@ -243,7 +243,7 @@ end subroutine pygen_vectorization
     routine.name = f'{routine.name}_{str(frontend)}'
 
     # Generate and test the transpiled Python kernel
-    f2p = FortranPythonTransformation()
+    f2p = FortranPythonTransformation(suffix='_py')
     f2p.apply(source=routine, path=here)
     mod = load_module(here, f2p.mod_name)
     func = getattr(mod, f2p.mod_name)
@@ -298,7 +298,7 @@ end subroutine pygen_intrinsics
     routine.name = f'{routine.name}_{str(frontend)}'
 
     # Generate and test the transpiled Python kernel
-    f2p = FortranPythonTransformation()
+    f2p = FortranPythonTransformation(suffix='_py')
     f2p.apply(source=routine, path=here)
     mod = load_module(here, f2p.mod_name)
     func = getattr(mod, f2p.mod_name)
@@ -366,7 +366,7 @@ end subroutine pygen_loop_indices
     routine.name = f'{routine.name}_{str(frontend)}'
 
     # Generate and test the transpiled Python kernel
-    f2p = FortranPythonTransformation()
+    f2p = FortranPythonTransformation(suffix='_py')
     f2p.apply(source=routine, path=here)
     mod = load_module(here, f2p.mod_name)
     func = getattr(mod, f2p.mod_name)
@@ -427,7 +427,7 @@ end subroutine pygen_logical_statements
     routine.name = f'{routine.name}_{str(frontend)}'
 
     # Generate and test the transpiled Python kernel
-    f2p = FortranPythonTransformation()
+    f2p = FortranPythonTransformation(suffix='_py')
     f2p.apply(source=routine, path=here)
     mod = load_module(here, f2p.mod_name)
     func = getattr(mod, f2p.mod_name)

--- a/tests/test_sdfg.py
+++ b/tests/test_sdfg.py
@@ -35,7 +35,14 @@ def fixture_here():
 
 def load_module(path):
     path = Path(path)
-    return importlib.import_module(path.stem)
+
+    # Trigger the actual module import
+    try:
+        return importlib.import_module(path.stem)
+    except ModuleNotFoundError:
+        # If module caching interferes, try again with clean caches
+        importlib.invalidate_caches()
+        return importlib.import_module(path.stem)
 
 
 def create_sdfg(routine, here):

--- a/tests/test_sdfg.py
+++ b/tests/test_sdfg.py
@@ -46,11 +46,11 @@ def load_module(path):
 
 
 def create_sdfg(routine, here):
-    trafo = FortranPythonTransformation()
-    routine.apply(trafo, path=here, with_dace=True)
+    trafo = FortranPythonTransformation(with_dace=True, suffix='_py')
+    routine.apply(trafo, path=here)
 
     mod = load_module(trafo.py_path)
-    function = getattr(mod, f'{routine.name}_py')
+    function = getattr(mod, routine.name)
     return function.to_sdfg()
 
 
@@ -99,7 +99,7 @@ end subroutine routine_copy
     assert all(x_ref == y)
 
     clean_test(filepath)
-    (here / (routine.name + '_py.py')).unlink()
+    (here / (routine.name + '.py')).unlink()
 
 
 @pytest.mark.xfail(reason='Scalar inout arguments do not work in dace')
@@ -145,7 +145,7 @@ end subroutine routine_axpy_scalar
     assert x_out == a * x + y
 
     clean_test(filepath)
-    (here / (routine.name + '_py.py')).unlink()
+    (here / (routine.name + '.py')).unlink()
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -194,7 +194,7 @@ end subroutine routine_copy_stream
     assert np.all(vec_out == np.array(range(length)) + alpha)
 
     clean_test(filepath)
-    (here / (routine.name + '_py.py')).unlink()
+    (here / (routine.name + '.py')).unlink()
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -256,7 +256,7 @@ end subroutine routine_fixed_loop
     assert np.all(tensor_out == ref_tensor)
 
     clean_test(filepath)
-    (here / (routine.name + '_py.py')).unlink()
+    (here / (routine.name + '.py')).unlink()
 
 
 @pytest.mark.skip(reason=('This translates successfully but the generated OpenMP code does not '
@@ -304,7 +304,7 @@ end subroutine routine_loop_carried_dependency
     assert np.all(vector == ref_vector)
 
     clean_test(filepath)
-    (here / (routine.name + '_py.py')).unlink()
+    (here / (routine.name + '.py')).unlink()
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -383,4 +383,4 @@ end subroutine routine_moving_average
     assert np.all(data_out[1:-1] == expected[1:-1])
 
     clean_test(filepath)
-    (here / (routine.name + '_py.py')).unlink()
+    (here / (routine.name + '.py')).unlink()


### PR DESCRIPTION
A small collection of fixes for the Python backend that brings the full CLOUDSC back to validating. I've added a few internal test extensions, but have probably missed a few, so please feel free to request more. CLOUDSC @ Python is not yet part of the CI cycle, so internal testing is paramount.

A few nuggets:
* Better way of ensuring dynamic kernel loading in the tests
* No longer replicate `Subroutine` object as part of F2Py transformation
* Fixed downcasing and added support for statement functions (yes!) and inline calls
* Extended line length limit, since automatic line-breaks work different for Python
* Extended intrinsic handling to include exp/sqrt/sign (the latter works differently, so somewhat cumbersome!)
* Allow explicitly triggering / overriding the index-inversion, as this is dependent on outer calling code