### PR TITLE
Add inline function calls as scheduler dependencies

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -93,8 +93,6 @@ class Item:
         self.source = source
         self.config = config or {}
         self.trafo_data = {}
-        self._children = ()
-        self._targets = ()
 
     def __repr__(self):
         return f'loki.bulk.Item<{self.name}>'
@@ -301,7 +299,7 @@ class Item:
         disabled = as_tuple(str(b).lower() for b in self.disable)
 
         # Base definition of child is a procedure call (for now)
-        children = self.calls + self._children
+        children = self.calls
 
         # Filter out local members and disabled sub-branches
         children = [c for c in children if c not in self.members]
@@ -514,7 +512,7 @@ class SubroutineItem(Item):
         return tuple(
             self._variable_to_type_name(call.name).lower()
             for call in FindNodes(CallStatement).visit(self.routine.ir)
-        )
+        ) + self.function_interfaces
 
     def _variable_to_type_name(self, var):
         """
@@ -548,24 +546,6 @@ class SubroutineItem(Item):
         )
 
         return names
-
-    @property
-    def children(self):
-        """
-        Extend the base class' definition of children for items of type :class:`SubroutineItem`.
-        """
-
-        self._children = self.function_interfaces
-        return super().children
-
-    @property
-    def targets(self):
-        """
-        Extend the base class' definition of targets for items of type :class:`SubroutineItem`.
-        """
-
-        self._targets = self.function_interfaces
-        return super().targets
 
 class ProcedureBindingItem(Item):
     """

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -443,8 +443,7 @@ class SubroutineFunctionPattern(Pattern):
 
     def __init__(self):
         super().__init__(
-            r'^(?P<return_type>real(\(kind=.+\))?|integer(\(kind=.+\))?|logical(\(kind=.+\))?|type\(.+\))?'
-            r'[ \t\w()]*?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
+            r'^[ \t\w()=]*?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
             r'(?P<spec>(?:.*?(?:^(?:abstract[ \t]+)?interface\b.*?^end[ \t]+interface)?)+)'
             r'(?P<contains>^contains\n(?:'
             r'(?:[ \t\w()]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -443,7 +443,8 @@ class SubroutineFunctionPattern(Pattern):
 
     def __init__(self):
         super().__init__(
-            r'^[ \t\w()=]*?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
+            r'^(?P<return_type>real(\(kind=.+\))?|integer(\(kind=.+\))?|logical(\(kind=.+\))?|type\(.+\))?'
+            r'[ \t\w()]*?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
             r'(?P<spec>(?:.*?(?:^(?:abstract[ \t]+)?interface\b.*?^end[ \t]+interface)?)+)'
             r'(?P<contains>^contains\n(?:'
             r'(?:[ \t\w()]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
@@ -489,9 +490,10 @@ class SubroutineFunctionPattern(Pattern):
 
         if match['spec']:
             statement_candidates = ('ImportPattern', 'VariableDeclarationPattern', 'CallPattern')
-            spec = self.match_statement_candidates(
+            block_candidates = ('InterfacePattern',)
+            spec = self.match_block_statement_candidates(
                 reader.reader_from_sanitized_span(match.span('spec'), include_padding=True),
-                statement_candidates, parser_classes=parser_classes, scope=routine
+                block_candidates, statement_candidates, parser_classes=parser_classes, scope=routine
             )
         else:
             spec = None

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -271,7 +271,7 @@ class Sourcefile:
     @classmethod
     def from_regex(cls, raw_source, filepath, parser_classes=None):
         """
-        Parse a given source string using the fparser frontend
+        Parse a given source string using the REGEX frontend
         """
         ir = parse_regex_source(raw_source, parser_classes=parser_classes)
         lines = (1, raw_source.count('\n') + 1)

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -162,7 +162,7 @@ class DependencyTransformation(Transformation):
             if targets is None or call.name in targets:
                 call._update(name=call.name.clone(name=f'{call.name}{self.suffix}'))
 
-        for call in FindInlineCalls().visit(routine.body):
+        for call in FindInlineCalls(unique=False).visit(routine.body):
             if targets is None or call.name.upper() in targets:
                 call.function = call.function.clone(name=f'{call.name}{self.suffix}')
 

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -87,7 +87,8 @@ class DependencyTransformation(Transformation):
         if role == 'kernel':
             # Change the name of kernel routines
             if routine.is_function:
-                self.update_result_var(routine)
+                if not routine.result_name:
+                    self.update_result_var(routine)
             routine.name += self.suffix
 
         self.rename_calls(routine, **kwargs)

--- a/tests/sources/projInlineCalls/double_real.F90
+++ b/tests/sources/projInlineCalls/double_real.F90
@@ -1,0 +1,6 @@
+real function double_real(i)
+  implicit none
+  integer, intent(in) :: i
+
+  double_real =  dble(i*2)
+end function double_real

--- a/tests/sources/projInlineCalls/driver.F90
+++ b/tests/sources/projInlineCalls/driver.F90
@@ -1,0 +1,18 @@
+subroutine driver(n, work)
+  implicit none
+
+  interface
+     real function double_real(i)
+       integer, intent(in) :: i
+     end function double_real
+  end interface
+
+  integer, intent(in) :: n
+  real, intent(out) :: work(n)
+  integer :: i
+
+  do i=1,n
+    work(i) = double_real(i)
+  enddo
+
+end subroutine driver

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1399,3 +1399,7 @@ END SUBROUTINE DOT_PROD_SP_2D
     assert {
         routine.name.lower() for routine in source.subroutines
     } == {'dot_product_ecv', 'dot_prod_sp_2d'}
+
+    source.make_complete()
+    routine = source['dot_product_ecv']
+    assert 'dot_product_ecv' in routine.variables

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1575,7 +1575,6 @@ def test_scheduler_inline_call(here, config, frontend):
     ]
 
     scheduler = Scheduler(paths=here/'sources/projInlineCalls', config=my_config, frontend=frontend)
-    print(scheduler.items)
 
     expected_items = {'#driver', '#double_real'}
     expected_dependencies = {('#driver', '#double_real')}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1558,3 +1558,31 @@ end module some_mod
     assert item.qualify_names(item.children) == (
         ('#routine', 'yet_another_mod#routine', 'other_mod#routine', 'more_mod#routine'),
     )
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_scheduler_inline_call(here, config, frontend):
+    """
+    Test that inline function calls declared via an explicit interface are added as dependencies.
+    """
+
+    my_config = config.copy()
+    my_config['routine'] = [
+        {
+            'name': 'driver',
+            'role': 'driver'
+        }
+    ]
+
+    scheduler = Scheduler(paths=here/'sources/projInlineCalls', config=my_config, frontend=frontend)
+    print(scheduler.items)
+
+    expected_items = {'#driver', '#double_real'}
+    expected_dependencies = {('#driver', '#double_real')}
+
+    assert expected_items == {i.name for i in scheduler.items}
+    assert expected_dependencies == {(d[0].name, d[1].name) for d in scheduler.dependencies}
+
+    for i in scheduler.items:
+        if i.name == '#double_real':
+            assert isinstance(i, SubroutineItem)

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -432,7 +432,8 @@ END SUBROUTINE kernel
     assert imports[0].module == 'kernel_test_mod'
     assert 'kernel_test' in [str(s) for s in imports[0].symbols]
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'OFP does not add return type to variables.')]))
+@pytest.mark.parametrize('frontend', available_frontends(
+                         xfail=[(OFP, 'OFP does not correctly handle result variable declaration.')]))
 def test_dependency_transformation_inline_call(frontend):
     """
     Test injection of suffixed kernel, accessed through inline function call.

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -449,7 +449,7 @@ SUBROUTINE driver(a, b, c)
   INTEGER, INTENT(INOUT) :: a, b, c
 
   a = kernel(a)
-  b = kernel(b)
+  b = kernel(a)
   c = kernel(c)
 END SUBROUTINE driver
 """, frontend=frontend)
@@ -484,6 +484,8 @@ END FUNCTION kernel
 
     # Check that calls and imports have been diverted to the re-generated routine
     calls = tuple(FindInlineCalls().visit(driver['driver'].body))
+    assert len(calls) == 2
+    calls = tuple(FindInlineCalls(unique=False).visit(driver['driver'].body))
     assert len(calls) == 3
     assert calls[0].name == 'kernel_test'
     imports = FindNodes(Import).visit(driver['driver'].spec)

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -3,7 +3,7 @@ import pytest
 
 from conftest import jit_compile, clean_test, available_frontends
 from loki import (
-    OMNI, REGEX, Sourcefile, Subroutine, CallStatement, Import,
+    OMNI, REGEX, OFP, Sourcefile, Subroutine, CallStatement, Import,
     FindNodes, FindInlineCalls, fgen, Assignment, IntLiteral, Module,
     SubroutineItem
 )
@@ -373,6 +373,123 @@ END SUBROUTINE kernel
     assert imports[0].module == 'kernel_test_mod'
     assert 'kernel_test' in [str(s) for s in imports[0].symbols]
 
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_dependency_transformation_replace_interface(frontend):
+    """
+    Test injection of suffixed kernels defined in interface block
+    into unchanged driver routines automatic module wrapping of the kernel.
+    """
+
+    driver = Sourcefile.from_source(source="""
+SUBROUTINE driver(a, b, c)
+  INTERFACE
+    SUBROUTINE kernel(a, b, c)
+      INTEGER, INTENT(INOUT) :: a, b, c
+    END SUBROUTINE kernel
+  END INTERFACE
+
+  INTEGER, INTENT(INOUT) :: a, b, c
+
+  CALL kernel(a, b ,c)
+END SUBROUTINE driver
+""", frontend=frontend)
+
+    kernel = Sourcefile.from_source(source="""
+SUBROUTINE kernel(a, b, c)
+  INTEGER, INTENT(INOUT) :: a, b, c
+
+  a = 1
+  b = 2
+  c = 3
+END SUBROUTINE kernel
+""", frontend=frontend)
+
+    # Apply injection transformation via C-style includes by giving `include_path`
+    transformation = DependencyTransformation(suffix='_test', mode='module', module_suffix='_mod')
+    kernel.apply(transformation, role='kernel')
+    driver.apply(transformation, role='driver', targets='kernel')
+
+    # Check that the kernel has been wrapped
+    assert len(kernel.subroutines) == 0
+    assert len(kernel.all_subroutines) == 1
+    assert kernel.all_subroutines[0].name == 'kernel_test'
+    assert kernel['kernel_test'] == kernel.all_subroutines[0]
+    assert len(kernel.modules) == 1
+    assert kernel.modules[0].name == 'kernel_test_mod'
+    assert kernel['kernel_test_mod'] == kernel.modules[0]
+
+    # Check that the driver name has not changed
+    assert len(driver.modules) == 0
+    assert len(driver.subroutines) == 1
+    assert driver.subroutines[0].name == 'driver'
+
+    # Check that calls and imports have been diverted to the re-generated routine
+    calls = FindNodes(CallStatement).visit(driver['driver'].body)
+    assert len(calls) == 1
+    assert calls[0].name == 'kernel_test'
+    imports = FindNodes(Import).visit(driver['driver'].spec)
+    assert len(imports) == 1
+    assert imports[0].module == 'kernel_test_mod'
+    assert 'kernel_test' in [str(s) for s in imports[0].symbols]
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'OFP does not add return type to variables.')]))
+def test_dependency_transformation_inline_call(frontend):
+    """
+    Test injection of suffixed kernel, accessed through inline function call.
+    """
+
+    driver = Sourcefile.from_source(source="""
+SUBROUTINE driver(a, b, c)
+  INTERFACE
+    INTEGER FUNCTION kernel(a)
+      INTEGER, INTENT(IN) :: a
+    END FUNCTION kernel
+  END INTERFACE
+
+  INTEGER, INTENT(INOUT) :: a, b, c
+
+  a = kernel(a)
+  b = kernel(b)
+  c = kernel(c)
+END SUBROUTINE driver
+""", frontend=frontend)
+
+    kernel = Sourcefile.from_source(source="""
+INTEGER FUNCTION kernel(a)
+  INTEGER, INTENT(IN) :: a
+
+  kernel = 2*a
+END FUNCTION kernel
+""", frontend=frontend)
+
+    # Apply injection transformation via C-style includes by giving `include_path`
+    transformation = DependencyTransformation(suffix='_test', mode='module', module_suffix='_mod')
+    kernel.apply(transformation, role='kernel')
+    driver.apply(transformation, role='driver', targets='kernel')
+
+    # Check that the kernel has been wrapped
+    assert len(kernel.subroutines) == 0
+    assert len(kernel.all_subroutines) == 1
+    assert kernel.all_subroutines[0].name == 'kernel_test'
+    assert kernel['kernel_test'] == kernel.all_subroutines[0]
+    assert kernel['kernel_test'].is_function
+    assert len(kernel.modules) == 1
+    assert kernel.modules[0].name == 'kernel_test_mod'
+    assert kernel['kernel_test_mod'] == kernel.modules[0]
+
+    # Check that the driver name has not changed
+    assert len(driver.modules) == 0
+    assert len(driver.subroutines) == 1
+    assert driver.subroutines[0].name == 'driver'
+
+    # Check that calls and imports have been diverted to the re-generated routine
+    calls = tuple(FindInlineCalls().visit(driver['driver'].body))
+    assert len(calls) == 3
+    assert calls[0].name == 'kernel_test'
+    imports = FindNodes(Import).visit(driver['driver'].spec)
+    assert len(imports) == 1
+    assert imports[0].module == 'kernel_test_mod'
+    assert 'kernel_test' in [str(s) for s in imports[0].symbols]
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_transform_replace_selected_kind(here, frontend):


### PR DESCRIPTION
One of the recommended ways of declaring inline function calls is via an explicit interface. This PR adds inline function calls declared via an explicit interface as scheduler dependencies. The more modern way of declaring inline function calls is to wrap them in a module and use module imports. Adding this functionality requires a larger update to the scheduler, and this PR is being prepared.