### PR TITLE
Scheduler enhancements for dealing with derived types

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -113,6 +113,13 @@ class Item:
     def __hash__(self):
         return hash(self.name)
 
+    def clear_cached_property(self, property_name):
+        """
+        Clear the cached value for a cached property
+        """
+        if property_name in self.__dict__:
+            del self.__dict__[property_name]
+
     @property
     def scope_name(self):
         """
@@ -169,7 +176,7 @@ class Item:
         list of :any:`Import`
         """
 
-    @cached_property
+    @property
     def qualified_imports(self):
         """
         Return the mapping of named imports (i.e. explicitly qualified imports via a use-list
@@ -181,7 +188,7 @@ class Item:
             for symbol in import_.symbols + tuple(s for _, s in as_tuple(import_.rename_list))
         )
 
-    @cached_property
+    @property
     def unqualified_imports(self):
         """
         Return names of imported modules without explicit ``ONLY`` list
@@ -360,7 +367,7 @@ class Item:
                 # Search for named import of the derived type
                 type_name = name[:pos]
                 if type_name in qualified_imports:
-                    qualified_names += [self.qualified_imports[type_name] + name[pos:]]
+                    qualified_names += [qualified_imports[type_name] + name[pos:]]
                     continue
 
                 # Search for definition of the type in parent scope
@@ -370,7 +377,7 @@ class Item:
             else:
                 # Search for named import of the subroutine
                 if name in qualified_imports:
-                    qualified_names += [self.qualified_imports[name]]
+                    qualified_names += [qualified_imports[name]]
                     continue
 
                 # Search for subroutine in parent scope

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -628,5 +628,7 @@ class ProcedureBindingItem(Item):
         if type_.initial is not None:
             # This has a bind name explicitly specified:
             return (type_.initial.name.lower(), )
+        if type_.bind_names is not None and len(type_.bind_names) == 1:
+            return (type_.bind_names[0].name.lower(),)
         # The name of the procedure is identical to the name of the binding
         return (name_parts[1],)

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -645,12 +645,18 @@ class Scheduler:
 
         # Insert all nodes in the schedulers graph
         for item in self.items:
+            style = {
+                'color': 'black',
+                'shape': 'box',
+                'fillcolor': 'limegreen',
+                'style': 'filled'
+            }
+            if isinstance(item, ProcedureBindingItem):
+                style['fillcolor'] = 'palegreen'
             if item.replicate:
-                callgraph.node(item.name.upper(), color='black', shape='diamond',
-                               fillcolor='limegreen', style='rounded,filled')
-            else:
-                callgraph.node(item.name.upper(), color='black', shape='box',
-                               fillcolor='limegreen', style='filled')
+                style['shape'] = 'diamond'
+                style['style'] += ',rounded'
+            callgraph.node(item.name.upper(), **style)
 
         # Insert all edges in the schedulers graph
         for parent, child in self.dependencies:

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -472,6 +472,34 @@ class Scheduler:
                 self.obj_map[lookup_name].make_complete(**self.build_args)
                 item.routine.enrich_calls(self.obj_map[lookup_name].all_subroutines)
 
+    def item_successors(self, item):
+        """
+        Yields list of successor :any:`Item` for the given :data:`item`
+
+        Successors are all items onto which a dependency exists, such as
+        call targets.
+
+        For intermediate items, such as :any:`ProcedureBindingItem`, this
+        yields also the successors of these items to provide direct access
+        to the called routine.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            The item for which to yield the successors
+
+        Returns
+        -------
+        list of :any:`Item`
+        """
+        successors = []
+        for child in self.item_graph.successors(item):
+            if isinstance(child, SubroutineItem):
+                successors += [child]
+            else:
+                successors += [child] + self.item_successors(child)
+        return successors
+
     def process(self, transformation, reverse=False, use_file_graph=False):
         """
         Process all :attr:`items` in the scheduler's graph
@@ -508,12 +536,12 @@ class Scheduler:
                     if not isinstance(item, SubroutineItem):
                         continue
 
-                    # Process work item with appropriate kernel
-                    transformation.apply(
-                        item.source, role=item.role, mode=item.mode,
-                        item=item, targets=item.targets, successors=list(graph.successors(item)),
-                        depths=self.depths
-                    )
+                # Process work item with appropriate kernel
+                transformation.apply(
+                    item.source, role=item.role, mode=item.mode,
+                    item=item, targets=item.targets, successors=self.item_successors(item),
+                    depths=self.depths
+                )
 
     def callgraph(self, path, with_file_graph=False):
         """

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -471,6 +471,7 @@ class Scheduler:
             item = self.create_item(item_name)
 
             if item:
+                item.clear_cached_property('imports')
                 queue.append(item)
 
                 if item.name not in self.item_map:

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -185,6 +185,8 @@ class Scheduler:
             seed_routines = self.config.routines.keys()
         self._populate(routines=seed_routines)
 
+        self._break_cycles()
+
         if self.full_parse:
             self._parse_items()
 
@@ -456,6 +458,21 @@ class Scheduler:
 
             if new_items:
                 queue.extend(new_items)
+
+    def _break_cycles(self):
+        """
+        Remove cyclic dependencies by deleting the first outgoing edge of
+        each cyclic dependency for all subroutine items with a ``RECURSIVE`` prefix
+        """
+        for item in self.items:
+            if item.routine and any('recursive' in prefix.lower() for prefix in item.routine.prefix or []):
+                try:
+                    while True:
+                        cycle_path = nx.find_cycle(self.item_graph, item)
+                        debug(f'Removed edge {cycle_path[0]!s} to break cyclic dependency {cycle_path!s}')
+                        self.item_graph.remove_edge(*cycle_path[0])
+                except nx.NetworkXNoCycle:
+                    pass
 
     def add_dependencies(self, dependencies):
         """

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -234,6 +234,10 @@ class Scheduler:
         return as_tuple(item.routine for item in self.item_graph.nodes if item.routine is not None)
 
     @property
+    def typedefs(self):
+        return as_tuple(flatten(module.typedefs.values() for obj in self.obj_map.values() for module in obj.modules))
+
+    @property
     def items(self):
         """
         All :any:`Item` objects contained in the :any:`Scheduler` call graph.
@@ -535,6 +539,7 @@ class Scheduler:
 
             # Enrich with all routines in the call tree
             item.routine.enrich_calls(routines=self.routines)
+            item.routine.enrich_types(typedefs=self.typedefs)
 
             # Enrich item with meta-info from outside of the callgraph
             for routine in item.enrich:

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -584,7 +584,7 @@ class Scheduler:
         """
         Process all :attr:`items` in the scheduler's graph
 
-        By default, the traversal is performed in topologicalal order, which
+        By default, the traversal is performed in topological order, which
         ensures that :any:`CallStatement` objects are always processed before
         their target :any:`Subroutine`.
         This order can be reversed by setting :data:`reverse` to ``True``.
@@ -592,6 +592,7 @@ class Scheduler:
         Optionally, the traversal can be performed on a source file level only,
         by setting :data:`use_file_graph` to ``True``. Currently, this calls
         the transformation on the first `item` associated with a file only.
+        In this mode, :data:`item_filter` does not have any effect.
         """
         trafo_name = transformation.__class__.__name__
         log = f'[Loki::Scheduler] Applied transformation <{trafo_name}>' + ' in {:.2f}s'
@@ -616,12 +617,12 @@ class Scheduler:
                     if item_filter and not isinstance(item, item_filter):
                         continue
 
-                # Process work item with appropriate kernel
-                transformation.apply(
-                    item.source, role=item.role, mode=item.mode,
-                    item=item, targets=item.targets, successors=self.item_successors(item),
-                    depths=self.depths
-                )
+                    # Process work item with appropriate kernel
+                    transformation.apply(
+                        item.source, role=item.role, mode=item.mode,
+                        item=item, targets=item.targets, successors=self.item_successors(item),
+                        depths=self.depths
+                    )
 
     def callgraph(self, path, with_file_graph=False):
         """

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -580,7 +580,7 @@ class Scheduler:
                 successors += [child] + self.item_successors(child)
         return successors
 
-    def process(self, transformation, reverse=False, use_file_graph=False):
+    def process(self, transformation, reverse=False, item_filter=SubroutineItem, use_file_graph=False):
         """
         Process all :attr:`items` in the scheduler's graph
 
@@ -613,7 +613,7 @@ class Scheduler:
 
             else:
                 for item in traversal:
-                    if not isinstance(item, SubroutineItem):
+                    if item_filter and not isinstance(item, item_filter):
                         continue
 
                 # Process work item with appropriate kernel

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -855,6 +855,8 @@ class OMNI2IR(GenericVisitor):
             prefix += ['PURE']
         if o.attrib.get('is_elemental') == 'true':
             prefix += ['ELEMENTAL']
+        if o.attrib.get('is_recursive') == 'true':
+            prefix += ['RECURSIVE']
         return SymbolAttributes(dtype, prefix=prefix or None)
 
     def visit_FstructType(self, o, **kwargs):

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -443,7 +443,7 @@ class SubroutineFunctionPattern(Pattern):
 
     def __init__(self):
         super().__init__(
-            r'^[ \t\w()=]*?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
+            r'^(?P<prefix>[ \t\w()=]*)?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
             r'(?P<spec>(?:.*?(?:^(?:abstract[ \t]+)?interface\b.*?^end[ \t]+interface)?)+)'
             r'(?P<contains>^contains\n(?:'
             r'(?:[ \t\w()]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
@@ -508,9 +508,14 @@ class SubroutineFunctionPattern(Pattern):
         else:
             contains = None
 
+        if match['prefix'].strip():
+            prefix = match['prefix'].strip()
+        else:
+            prefix=None
+
         routine.__init__(  # pylint: disable=unnecessary-dunder-call
             name=routine.name, args=routine._dummies, is_function=routine.is_function,
-            spec=spec, contains=contains, parent=routine.parent, source=routine.source,
+            prefix=prefix, spec=spec, contains=contains, parent=routine.parent, source=routine.source,
             symbol_attrs=routine.symbol_attrs, incomplete=True
         )
 

--- a/loki/subroutine.py
+++ b/loki/subroutine.py
@@ -15,7 +15,7 @@ from loki.pragma_utils import is_loki_pragma, pragmas_attached
 from loki.program_unit import ProgramUnit
 from loki.visitors import FindNodes, Transformer
 from loki.tools import as_tuple, CaseInsensitiveDict
-from loki.types import BasicType, ProcedureType, SymbolAttributes
+from loki.types import BasicType, ProcedureType, DerivedType, SymbolAttributes
 
 
 __all__ = ['Subroutine']
@@ -461,6 +461,15 @@ class Subroutine(ProgramUnit):
 
         # TODO: Could extend this to module and header imports to
         # facilitate user-directed inlining.
+
+    def enrich_types(self, typedefs):
+
+        type_map = CaseInsensitiveDict((t.name, t) for t in as_tuple(typedefs))
+        for variable in self.variables:
+            type_ = variable.type
+            if isinstance(type_.dtype, DerivedType) and type_.dtype.typedef is BasicType.DEFERRED:
+                if type_.dtype.name in type_map:
+                    variable.type = type_.clone(dtype=DerivedType(typedef=type_map[type_.dtype.name]))
 
     def __repr__(self):
         """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1689,3 +1689,92 @@ end subroutine caller
     }
 
     rmtree(workdir)
+
+
+@pytest.mark.parametrize('full_parse', [True, False])
+def test_scheduler_add_dependencies(config, full_parse):
+    fcode_mod = """
+module some_mod
+    implicit none
+    type some_type
+        integer :: a
+    contains
+        procedure :: some_routine
+        procedure :: some_function
+    end type some_type
+contains
+    subroutine some_routine(t)
+        class(some_type), intent(inout) :: t
+        t%a = 5
+    end subroutine some_routine
+
+    integer function some_function(t)
+        class(some_type), intent(in) :: t
+        some_function = t%a
+    end function some_function
+end module some_mod
+    """.strip()
+
+    fcode_caller = """
+subroutine caller(b)
+    use some_mod, only: some_type
+    implicit none
+    integer, intent(inout) :: b
+    type(some_type) :: t
+    t%a = b
+    call t%some_routine()
+    b = t%some_function()
+end subroutine caller
+    """.strip()
+
+    workdir = gettempdir()/'test_scheduler_add_dependencies'
+    workdir.mkdir(exist_ok=True)
+    (workdir/'some_mod.F90').write_text(fcode_mod)
+    (workdir/'caller.F90').write_text(fcode_caller)
+
+    def verify_graph(scheduler, expected_items, expected_dependencies):
+        assert len(scheduler.items) == len(expected_items)
+        assert all(n in scheduler.items for n in expected_items)
+        assert len(scheduler.dependencies) == len(expected_dependencies)
+        assert all(e in scheduler.dependencies for e in expected_dependencies)
+
+        assert all(item.source._incomplete is not full_parse for item in scheduler.items)
+
+        # Testing of callgraph visualisation
+        cg_path = workdir/'callgraph'
+        scheduler.callgraph(cg_path)
+
+        vgraph = VisGraphWrapper(cg_path)
+        assert all(n.upper() in vgraph.nodes for n in expected_items)
+        assert all((e[0].upper(), e[1].upper()) in vgraph.edges for e in expected_dependencies)
+
+    scheduler = Scheduler(paths=[workdir], config=config, seed_routines=['caller'], full_parse=full_parse)
+
+    expected_items = [
+        '#caller', 'some_mod#some_type%some_routine', 'some_mod#some_routine'
+    ]
+    expected_dependencies = [
+        ('#caller', 'some_mod#some_type%some_routine'),
+        ('some_mod#some_type%some_routine', 'some_mod#some_routine')
+    ]
+    verify_graph(scheduler, expected_items, expected_dependencies)
+
+    # Function should be in the obj map already
+    assert 'some_mod#some_function' in scheduler.obj_map
+
+    # Add inline call dependency
+    scheduler.add_dependencies(
+        {'#caller': ['some_mod#some_type%some_function']}
+    )
+
+    # Scheduler should have automatically added further relevant dependencies
+    expected_items += [
+        'some_mod#some_type%some_function', 'some_mod#some_function'
+    ]
+    expected_dependencies += [
+        ('#caller', 'some_mod#some_type%some_function'),
+        ('some_mod#some_type%some_function', 'some_mod#some_function')
+    ]
+    verify_graph(scheduler, expected_items, expected_dependencies)
+
+    rmtree(workdir)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6,6 +6,7 @@
 # nor does it submit to any jurisdiction.
 
 # pylint: disable=too-many-lines
+
 """
 Specialised test that exercises the bulk-processing capabilities and
 source-injection mechanism provided by the `loki.scheduler` and

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1892,7 +1892,7 @@ end function f_elem
 
     routine = Subroutine.from_source(fcode, frontend=REGEX)
     assert routine._incomplete
-    assert routine.prefix == ()
+    assert routine.prefix == ('pure elemental real',)
     assert routine.arguments == ()
     assert routine.is_function is True
     assert routine.return_type is None


### PR DESCRIPTION
A set of Scheduler changes aimed at enhancing the capabilities when working with derived types and dependencies from typebound procedure calls.

* When handing successors for an `Item` to a transformation, it follows the indirection of typebound procedures and yields the actual subroutine items in addition to the type binding
* In addition to enriching calls, a new `enrich_types` method provides type annotation for derived types after the initial parse
* A new `add_dependencies` method allows to introduce additional dependencies to an existing Scheduler graph. This may become useful in multiple situations in the future. I am using this to post-hoc introduce dependencies due to inline calls via a bespoke transformation that I will file as a separate PR. This includes a new mechanism to invalidate cached properties.
* Not related to derived types, the scheduler is now able to break circular dependencies that are introduced by recursive Fortran procedures.

This will likely have conflicts with #49 and I'm happy to rebase on top of these changes once they are merged to main.