### PR TITLE
Transformation to resolve calls to typebound procedures

### DIFF
--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -295,6 +295,22 @@ class TypedSymbol:
         self._parent = parent
 
     @property
+    def parents(self):
+        """
+        Variables nodes for all parents
+
+        Returns
+        -------
+        tuple
+            The list of parent variables, e.g., for a variable ``a%b%c%d`` this
+            yields the nodes corresponding to ``(a, a%b, a%b%c)``
+        """
+        parent = self.parent
+        if parent:
+            return parent.parents + (parent,)
+        return ()
+
+    @property
     def variables(self):
         """
         List of member variables in a derived type
@@ -552,6 +568,13 @@ class MetaSymbol(StrCompareMixin, pmbl.AlgebraicLeaf):
         which it belongs
         """
         return self.symbol.parent
+
+    @property
+    def parents(self):
+        """
+        Yield all parent symbols for derived type members
+        """
+        return self.symbol.parents
 
     @property
     def scope(self):

--- a/transformations/tests/test_transform_derived_types.py
+++ b/transformations/tests/test_transform_derived_types.py
@@ -5,11 +5,37 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from shutil import rmtree
 import pytest
 
-from loki import OMNI, Module, FindNodes, CallStatement
+from loki import OMNI, Module, Scheduler, FindNodes, FindInlineCalls, CallStatement, gettempdir
 from conftest import available_frontends
-from transformations import DerivedTypeArgumentsTransformation
+from transformations import (
+    DerivedTypeArgumentsTransformation,
+    TypeboundProcedureCallTransformation
+)
+
+
+@pytest.fixture(name='config')
+def fixture_config():
+    """
+    Default configuration dict with basic options.
+    """
+    return {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True,
+        },
+        'routines': [
+            {
+                'name': 'driver',
+                'role': 'driver',
+                'expand': True,
+            },
+        ]
+    }
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -124,3 +150,179 @@ end module transform_derived_type_arguments_mod
     # as the shape of another variable
     assert module['caller'].variable_map['m'].type.intent is None
     assert module['caller'].variable_map['n'].type.intent is None
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_typebound_procedure_calls(frontend, config):
+    fcode1 = """
+module typebound_procedure_calls_mod
+    implicit none
+
+    type my_type
+        integer :: val
+    contains
+        procedure :: reset
+        procedure :: add => add_my_type
+    end type my_type
+
+    type other_type
+        type(my_type) :: arr(3)
+    contains
+        procedure :: add => add_other_type
+        procedure :: total_sum
+    end type other_type
+
+contains
+
+    subroutine reset(this)
+        class(my_type), intent(inout) :: this
+        this%val = 0
+    end subroutine reset
+
+    subroutine add_my_type(this, val)
+        class(my_type), intent(inout) :: this
+        integer, intent(in) :: val
+        this%val = this%val + val
+    end subroutine add_my_type
+
+    subroutine add_other_type(this, other)
+        class(other_type) :: this
+        type(other_type) :: other
+        integer :: i
+        do i=1,3
+            call this%arr(i)%add(other%arr(i)%val)
+        end do
+    end subroutine add_other_type
+
+    function total_sum(this) result(result)
+        class(other_type), intent(in) :: this
+        integer :: result
+        integer :: i
+        result = 0
+        do i=1,3
+            result = result + this%arr(i)%val
+        end do
+    end function total_sum
+
+end module typebound_procedure_calls_mod
+    """.strip()
+
+    fcode2 = """
+module other_typebound_procedure_calls_mod
+    use typebound_procedure_calls_mod, only: other_type
+    implicit none
+
+    type third_type
+        type(other_type) :: stuff(2)
+    contains
+        procedure :: init
+        procedure :: print => print_content
+    end type third_type
+
+contains
+
+    subroutine init(this)
+        class(third_type), intent(inout) :: this
+        integer :: i, j
+        do i=1,2
+            do j=1,3
+                call this%stuff(i)%arr(j)%reset()
+                call this%stuff(i)%arr(j)%add(i+j)
+            end do
+        end do
+    end subroutine init
+
+    subroutine print_content(this)
+        class(third_type), intent(inout) :: this
+        integer :: val
+        call this%stuff(1)%add(this%stuff(2))
+        val = this%stuff(1)%total_sum()
+        print *, val
+    end subroutine print_content
+end module other_typebound_procedure_calls_mod
+    """.strip()
+
+    fcode3 = """
+subroutine driver
+    use other_typebound_procedure_calls_mod, only: third_type
+    implicit none
+    type(third_type) :: data
+    integer :: mysum
+
+    call data%init()
+    call data%stuff(1)%arr(1)%add(1)
+    mysum = data%stuff(1)%total_sum() + data%stuff(2)%total_sum()
+    call data%print
+end subroutine driver
+    """.strip()
+
+    workdir = gettempdir()/'test_transform_typebound_procedure_calls'
+    workdir.mkdir(exist_ok=True)
+    (workdir/'typebound_procedure_calls_mod.F90').write_text(fcode1)
+    (workdir/'other_typebound_procedure_calls_mod.F90').write_text(fcode2)
+    (workdir/'driver.F90').write_text(fcode3)
+
+    scheduler = Scheduler(paths=[workdir], config=config, seed_routines=['driver'], frontend=frontend)
+
+    transformation = TypeboundProcedureCallTransformation()
+    scheduler.process(transformation=transformation)
+
+    # Verify that new dependencies have been identified correctly...
+    assert transformation.inline_call_dependencies == {
+        '#driver': {'typebound_procedure_calls_mod#total_sum'},
+        'other_typebound_procedure_calls_mod#print_content': {'typebound_procedure_calls_mod#total_sum'}
+    }
+
+    # ...which are not yet in the scheduler
+    assert 'typebound_procedure_calls_mod#total_sum' not in scheduler.item_graph.nodes
+
+    # Make sure that we can add them successfully to the scheduler
+    scheduler.add_dependencies(transformation.inline_call_dependencies)
+    assert 'typebound_procedure_calls_mod#total_sum' in scheduler.item_graph.nodes
+
+    driver = scheduler['#driver'].routine
+    calls = FindNodes(CallStatement).visit(driver.body)
+    assert len(calls) == 3
+    assert calls[0].name == 'init'
+    assert calls[0].arguments == ('data',)
+    assert calls[1].name == 'add_my_type'
+    assert calls[1].arguments == ('data%stuff(1)%arr(1)', '1')
+    assert calls[2].name == 'print_content'
+    assert calls[2].arguments == ('data',)
+
+    calls = FindInlineCalls().visit(driver.body)
+    assert len(calls) == 2
+    assert {str(call).lower() for call in calls} == {
+        'total_sum(data%stuff(1))', 'total_sum(data%stuff(2))'
+    }
+
+    assert 'init' in driver.imported_symbols
+    assert 'add_my_type' in driver.imported_symbols
+    assert 'print_content' in driver.imported_symbols
+    assert 'total_sum' in driver.imported_symbols
+
+    add_other_type = scheduler['typebound_procedure_calls_mod#add_other_type'].routine
+    calls = FindNodes(CallStatement).visit(add_other_type.body)
+    assert len(calls) == 1
+    assert calls[0].name == 'add_my_type'
+    assert calls[0].arguments == ('this%arr(i)', 'other%arr(i)%val')
+
+    init = scheduler['other_typebound_procedure_calls_mod#init'].routine
+    calls = FindNodes(CallStatement).visit(init.body)
+    assert len(calls) == 2
+    assert calls[0].name == 'reset'
+    assert calls[0].arguments == ('this%stuff(i)%arr(j)',)
+    assert calls[1].name == 'add_my_type'
+    assert calls[1].arguments == ('this%stuff(i)%arr(j)', 'i + j')
+
+    print_content = scheduler['other_typebound_procedure_calls_mod#print_content'].routine
+    calls = FindNodes(CallStatement).visit(print_content.body)
+    assert len(calls) == 1
+    assert calls[0].name == 'add_other_type'
+    assert calls[0].arguments == ('this%stuff(1)', 'this%stuff(2)')
+
+    calls = list(FindInlineCalls().visit(print_content.body))
+    assert len(calls) == 1
+    assert str(calls[0]).lower() == 'total_sum(this%stuff(1))'
+
+    rmtree(workdir)

--- a/transformations/transformations/derived_types.py
+++ b/transformations/transformations/derived_types.py
@@ -16,13 +16,14 @@ derived-type arguments in complex calling structures.
 
 from collections import defaultdict
 from loki import (
-    Transformation, FindVariables, FindNodes, Transformer,
-    SubstituteExpressions, CallStatement, Variable, SymbolAttributes,
-    RangeIndex, as_tuple, BasicType
+    Transformation, FindVariables, FindNodes, Transformer, SubstituteExpressions,
+    ExpressionRetriever, SubstituteExpressionsMapper, recursive_expression_map_update,
+    Module, Import, CallStatement, InlineCall, Variable, SymbolAttributes,  RangeIndex,
+    as_tuple, BasicType, warning
 )
 
 
-__all__ = ['DerivedTypeArgumentsTransformation']
+__all__ = ['DerivedTypeArgumentsTransformation', 'TypeboundProcedureCallTransformation']
 
 
 class DerivedTypeArgumentsTransformation(Transformation):
@@ -168,3 +169,271 @@ class DerivedTypeArgumentsTransformation(Transformation):
                 for v in variables}
 
         routine.body = SubstituteExpressions(vmap).visit(routine.body)
+
+
+def get_procedure_symbol_from_typebound_procedure_symbol(proc_symbol, routine_name):
+    """
+    Utility routine that returns the :any:`ProcedureSymbol` of the :any:`Subroutine`
+    that a typebound procedure corresponds to.
+
+    .. warning::
+       Resolving generic bindings is currently not implemented
+
+    This uses binding information (such as ``proc_symbol.type.bind_names``) or the
+    :any:`TypeDef` to resolve the procedure binding. If the type information is
+    incomplete or the resolution fails for other reasons, ``None`` is returned.
+
+    Parameters
+    ----------
+    proc_symbol : :any:`ProcedureSymbol`
+        The typebound procedure symbol that is to be resolved
+    routine_name : str
+        The name of the routine :data:`proc_symbol` appears in. This is used for
+        logging purposes only
+
+    Returns
+    -------
+    :any:`ProcedureSymbol` or None
+        The procedure symbol of the :any:`Subroutine` or ``None`` if it fails to resolve
+    """
+    if proc_symbol.type.bind_names is not None:
+        return proc_symbol.type.bind_names[0]
+
+    parent = proc_symbol.parents[0]
+    if parent.type.dtype.typedef is not BasicType.DEFERRED:
+        # Fiddle our way through derived type nesting until we obtain the symbol corresponding
+        # to the procedure-binding in the TypeDef
+        local_parent = None
+        local_var = parent
+        try:
+            for local_name in proc_symbol.name_parts[1:]:
+                local_parent = local_var
+                local_var = local_var.type.dtype.typedef.variable_map[local_name]
+        except AttributeError:
+            warning('Type definitions incomplete for %s in %s', proc_symbol, routine_name)
+            return None
+
+        if local_var.type.dtype.is_generic:
+            warning('Cannot resolve generic binding %s (not implemented) in %s', proc_symbol, routine_name)
+            return None
+
+        if local_var.type.bind_names is not None:
+            # Although this should have ben taken care of by the first if branch,
+            # this may trigger here when the bind_names property hasn't been imported
+            # into the local symbol table
+            new_name = local_var.type.bind_names[0]
+        else:
+            # If the binding doesn't have any specific bind_names, this means the
+            # corresponding subroutine has the same name and should be declared
+            # in the same module as the typedef
+            new_name = Variable(name=local_var.name, scope=local_parent.type.dtype.typedef.parent)
+        return new_name
+
+    # We don't have any binding information available
+    return None
+
+
+class TypeboundProcedureCallTransformer(Transformer):
+    """
+    Transformer to carry out the replacement of subroutine and inline function
+    calls to typebound procedures by direct calls to the respective procedures
+
+    During the transformer pass, this identifies also new dependencies due to
+    inline function calls, which the :any:`Scheduler` may not be able to
+    discover otherwise at the moment.
+
+    Parameters
+    ----------
+    routine_name : str
+        The name of the :any:`Subroutine` the replacement takes place. This is used
+        for logging purposes only.
+    current_module : str
+        The name of the enclosing module. This is used to determine whether the
+        resolved procedure needs to be added as an import.
+
+    Attributes
+    ----------
+    new_procedure_imports : dict
+        After a transformer pass, this will contain the mapping
+        ``{module: {proc_name, proc_name, ...}}`` for new imports that are required
+        as a consequence of the replacement.
+    new_dependencies : set
+        New dependencies due to inline function calls that are identified during the
+        transformer pass.
+    """
+
+    def __init__(self, routine_name, current_module, **kwargs):
+        super().__init__(inplace=True, **kwargs)
+        self.routine_name = routine_name
+        self.current_module = current_module
+        self.new_procedure_imports = defaultdict(set)
+        self.new_dependencies = set()
+        self._retriever = ExpressionRetriever(
+            lambda e: isinstance(e, InlineCall) and e.function.parent,
+            recurse_to_parent=False
+        )
+
+    def retrieve(self, o):
+        return self._retriever.retrieve(o)
+
+    def visit_CallStatement(self, o, **kwargs):
+        """
+        Rebuild a :any:`CallStatement`
+
+        If this is a call to a typebound procedure, resolve the procedure binding and
+        insert the derived type as the first argument in the call statement.
+        """
+        rebuilt = {k: self.visit(c, **kwargs) for k, c in zip(o._traversable, o.children)}
+        if rebuilt['name'].parent:
+            new_proc_symbol = get_procedure_symbol_from_typebound_procedure_symbol(rebuilt['name'], self.routine_name)
+
+            if new_proc_symbol:
+                # Add the derived type as first argument to the call
+                rebuilt['arguments'] = (rebuilt['name'].parent, ) + rebuilt['arguments']
+
+                # Add the subroutine to the list of symbols that need to be imported
+                if isinstance(new_proc_symbol.scope, Module):
+                    module_name = new_proc_symbol.scope.name.lower()
+                else:
+                    module_name = new_proc_symbol.type.dtype.procedure.procedure_symbol.scope.name.lower()
+
+                if module_name != self.current_module:
+                    self.new_procedure_imports[module_name].add(new_proc_symbol.name.lower())
+
+                rebuilt['name'] = new_proc_symbol
+        children = [rebuilt[k] for k in o._traversable]
+        return self._rebuild(o, children)
+
+    def visit_Expression(self, o, **kwargs):
+        """
+        Return the expression unchanged unless there are :any:`InlineCall` nodes in the expression
+        that are calls to typebound procedures, which are replaced by direct calls to the function
+        with the derived type added as the first argument.
+        """
+        inline_calls = self.retrieve(o)
+        if not inline_calls:
+            return o
+
+        expr_map = {}
+        for call in inline_calls:
+            new_proc_symbol = get_procedure_symbol_from_typebound_procedure_symbol(call.function, self.routine_name)
+
+            if new_proc_symbol:
+                new_arguments = (call.function.parent,) + call.parameters
+                expr_map[call] = call.clone(
+                    function=new_proc_symbol.rescope(scope=kwargs['scope']),
+                    parameters=new_arguments
+                )
+                # Add the function to the list of symbols that need to be imported
+                if isinstance(new_proc_symbol.scope, Module):
+                    module_name = new_proc_symbol.scope.name.lower()
+                else:
+                    module_name = new_proc_symbol.type.dtype.procedure.procedure_symbol.scope.name.lower()
+
+                if module_name != self.current_module:
+                    self.new_procedure_imports[module_name].add(new_proc_symbol.name.lower())
+                    self.new_dependencies.add(call.function.type.dtype.procedure)
+
+        if not expr_map:
+            return o
+
+        expr_map = recursive_expression_map_update(expr_map)
+        return SubstituteExpressionsMapper(expr_map)(o)
+
+
+class TypeboundProcedureCallTransformation(Transformation):
+    """
+    Replace calls to type-bound procedures with direct calls to the
+    corresponding subroutines/functions
+
+    Instead of calling a type-bound procedure, e.g. ``CALL my_type%proc``,
+    it is possible to import the bound procedure and call it directly, with
+    the derived type as first argument, i.e. ``CALL proc(my_type)``.
+    This transformation replaces all calls to type-bound procedures accordingly
+    and inserts necessary imports.
+
+    Also, for some compilers these direct calls seem to require an explicit
+    ``INTENT`` specification on the polymorphic derived type dummy argument,
+    which is set to `INOUT` by default, if missing. This behaviour can be switched
+    off by setting :data:`fix_intent` to `False`.
+
+    Parameters
+    ----------
+    fix_intent : bool
+        Supply ``INOUT`` as intent on polymorphic dummy arguments missing an intent
+
+    Attributes
+    ----------
+    inline_call_dependencies : dict
+        Additional call dependencies identified during the transformer pass that can
+        be registered in the :any:`Scheduler` via :any:`Scheduler.add_dependencies`.
+    """
+
+    def __init__(self, fix_intent=True, **kwargs):
+        super().__init__(**kwargs)
+        self.fix_intent = fix_intent
+        self.inline_call_dependencies = defaultdict(set)
+
+    def apply_default_polymorphic_intent(self, routine):
+        """
+        Utility routine to set a default ``INTENT(INOUT)`` on polymorphic dummy
+        arguments (i.e. declared via ``CLASS``) that don't have an explicit intent
+        """
+        for arg in routine.arguments:
+            type_ = arg.type
+            if type_.polymorphic and not type_.intent:
+                arg.type = type_.clone(intent='inout')
+
+    def add_inline_call_dependency(self, caller, callee):
+        """
+        Register a new dependency due to an inline call from :data:`caller` to :data:`callee`
+
+        These dependencies are later on available to query via :attr:`inline_call_dependencies`.
+        """
+        caller_module = getattr(caller.parent, 'name', '')
+        callee_module = getattr(callee.parent, 'name', '')
+        self.inline_call_dependencies[f'{caller_module}#{caller.name}'.lower()] |= {
+            f'{callee_module}#{callee.name}'.lower()
+        }
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Apply the transformation of calls to the given :data:`routine`
+        """
+        item = kwargs.get('item')
+
+        # Bail out if the current subroutine is not part of the call tree
+        if item and item.local_name != routine.name.lower():
+            return
+
+        # Fix any wrong intents on polymorphic arguments
+        # (sadly, it's not uncommon to omit the intent specification on the CLASS declaration,
+        # so we set them to `inout` here for any missing intents)
+        if self.fix_intent:
+            self.apply_default_polymorphic_intent(routine)
+
+        if routine.parent:
+            current_module = routine.parent.name.lower()
+        else:
+            current_module = None
+
+        transformer = TypeboundProcedureCallTransformer(routine.name, current_module)
+        routine.body = transformer.visit(routine.body, scope=routine)
+        new_procedure_imports = transformer.new_procedure_imports
+
+        # Add new dependencies
+        for callee in transformer.new_dependencies:
+            self.add_inline_call_dependency(routine, callee)
+
+        # Add missing imports
+        imported_symbols = routine.imported_symbols
+        new_imports = []
+        for module_name, proc_symbols in new_procedure_imports.items():
+            new_symbols = tuple(Variable(name=s, scope=routine) for s in proc_symbols if s not in imported_symbols)
+            if new_symbols:
+                new_imports += [Import(module=module_name, symbols=new_symbols)]
+
+        if new_imports:
+            routine.spec.prepend(as_tuple(new_imports))
+            if item:
+                item.clear_cached_property('imports')


### PR DESCRIPTION
~~_Note: This is based on #51._~~
_Update: This is now separated from #51._

A new transformation that allows resolving calls to typebound procedures by replacing them with direct calls to the corresponding routine. For example:
Given a derived type
```f90
TYPE SOME_TYPE
CONTAINS
    PROCEDURE :: SOME_ROUTINE => SOME_TYPE_SOME_ROUTINE
END TYPE SOME_TYPE
```
then a call statement
```f90
CALL SOME_TYPE_VAR%SOME_ROUTINE(ARG1, ARG2, KW=KWARG)
```
is replaced by 
```f90
CALL SOME_TYPE_SOME_ROUTINE(SOME_TYPE_VAR, ARG1, ARG2, KW=KWARG)
```
This takes also care of adding the relevant import to the caller. The same is applied also to InlineCalls in expressions. As a side-effect, these calls are identified as additional dependencies and made available after the Transformer pass. These can then be provided to the scheduler, as introduced in #50.