### PR TITLE
Additional fixes for IR

### DIFF
--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -355,8 +355,6 @@ class AttachScopes(Visitor):
         Default visitor method that dispatches the node-specific handler
         """
         kwargs.setdefault('scope', None)
-        if isinstance(o, Node):
-            kwargs['current_node'] = o
         return super().visit(o, *args, **kwargs)
 
     def visit_Expression(self, o, **kwargs):

--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -297,7 +297,7 @@ class SubstituteExpressions(Transformer):
                                                        invalidate_source=invalidate_source)
 
     def visit_Expression(self, o, **kwargs):
-        return self.expr_mapper(o)
+        return self.expr_mapper(o, parent_node=kwargs.get('current_node'))
 
 
 class AttachScopes(Visitor):
@@ -338,13 +338,15 @@ class AttachScopes(Visitor):
         Default visitor method that dispatches the node-specific handler
         """
         kwargs.setdefault('scope', None)
+        if isinstance(o, Node):
+            kwargs['current_node'] = o
         return super().visit(o, *args, **kwargs)
 
     def visit_Expression(self, o, **kwargs):
         """
         Dispatch :any:`AttachScopesMapper` for :any:`Expression` tree nodes
         """
-        return self.expr_mapper(o, scope=kwargs['scope'])
+        return self.expr_mapper(o, scope=kwargs['scope'], current_node=kwargs.get('current_node'))
 
     def visit_list(self, o, **kwargs):
         """

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -23,7 +23,6 @@ try:
 except ImportError:
     _intrinsic_fortran_names = ()
 
-from loki.ir import DECLARATION_NODES
 from loki.logging import debug
 from loki.tools import as_tuple, flatten
 from loki.types import SymbolAttributes, BasicType
@@ -521,10 +520,7 @@ class LokiIdentityMapper(IdentityMapper):
     def __call__(self, expr, *args, **kwargs):
         if expr is None:
             return None
-        kwargs.setdefault(
-            'recurse_to_declaration_attributes',
-            'current_node' not in kwargs or isinstance(kwargs['current_node'], DECLARATION_NODES)
-        )
+        kwargs.setdefault('recurse_to_declaration_attributes', False)
         new_expr = super().__call__(expr, *args, **kwargs)
         if getattr(expr, 'source', None):
             if isinstance(new_expr, tuple):

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1782,7 +1782,8 @@ class FParser2IR(GenericVisitor):
         if return_type is not None:
             routine.symbol_attrs[routine.name] = return_type
             return_var = sym.Variable(name=routine.name, scope=routine)
-            return_var_decl = ir.VariableDeclaration(symbols=(return_var,))
+            decl_source = self.get_source(subroutine_stmt, source=None)
+            return_var_decl = ir.VariableDeclaration(symbols=(return_var,), source=decl_source)
 
             decls = FindNodes((ir.VariableDeclaration, ir.ProcedureDeclaration)).visit(spec)
             if not decls:

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -609,7 +609,7 @@ class OFP2IR(GenericVisitor):
                     type=SymbolAttributes(ProcedureType(interface))
                 )
 
-            _type = interface.type
+            _type = interface.type.clone(bind_names=(interface,))
 
         elif o.attrib['procedureName']:
             # Binding provided (<bindingName> => <procedureName>)

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -205,7 +205,7 @@ def inject_statement_functions(routine):
     def create_stmt_func(assignment):
         arguments = assignment.lhs.dimensions
         variable = assignment.lhs.clone(dimensions=None)
-        return StatementFunction(variable, arguments, assignment.rhs, variable.type)
+        return StatementFunction(variable, arguments, assignment.rhs, variable.type, source=assignment.source)
 
     def create_type(stmt_func):
         name = str(stmt_func.variable)
@@ -253,7 +253,9 @@ def inject_statement_functions(routine):
             if variable.name.lower() in stmt_funcs:
                 if isinstance(variable, Array):
                     parameters = variable.dimensions
-                    expr_map_spec[variable] = InlineCall(variable.clone(dimensions=None), parameters=parameters)
+                    expr_map_spec[variable] = InlineCall(
+                        variable.clone(dimensions=None), parameters=parameters, source=variable.source
+                    )
                 elif not isinstance(variable, ProcedureSymbol):
                     expr_map_spec[variable] = variable.clone()
         expr_map_body = {}
@@ -261,7 +263,9 @@ def inject_statement_functions(routine):
             if variable.name.lower() in stmt_funcs:
                 if isinstance(variable, Array):
                     parameters = variable.dimensions
-                    expr_map_body[variable] = InlineCall(variable.clone(dimensions=None), parameters=parameters)
+                    expr_map_body[variable] = InlineCall(
+                        variable.clone(dimensions=None), parameters=parameters, source=variable.source
+                    )
                 elif not isinstance(variable, ProcedureSymbol):
                     expr_map_body[variable] = variable.clone()
 

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -271,15 +271,15 @@ def inject_statement_functions(routine):
 
         # Apply transformer with the built maps
         if spec_map:
-            routine.spec = Transformer(spec_map).visit(routine.spec)
+            routine.spec = Transformer(spec_map, invalidate_source=False).visit(routine.spec)
         if body_map:
-            routine.body = Transformer(body_map).visit(routine.body)
+            routine.body = Transformer(body_map, invalidate_source=False).visit(routine.body)
             if spec_appendix:
                 routine.spec.append(spec_appendix)
         if expr_map_spec:
-            routine.spec = SubstituteExpressions(expr_map_spec).visit(routine.spec)
+            routine.spec = SubstituteExpressions(expr_map_spec, invalidate_source=False).visit(routine.spec)
         if expr_map_body:
-            routine.body = SubstituteExpressions(expr_map_body).visit(routine.body)
+            routine.body = SubstituteExpressions(expr_map_body, invalidate_source=False).visit(routine.body)
 
         # And make sure all symbols have the right type
         routine.rescope_symbols()

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -40,8 +40,6 @@ __all__ = [
     'Import', 'VariableDeclaration', 'ProcedureDeclaration', 'DataDeclaration',
     'StatementFunction', 'TypeDef', 'MultiConditional', 'MaskedStatement',
     'Intrinsic', 'Enumeration', 'RawSource',
-    # List of nodes with specific properties
-    'DECLARATION_NODES'
 ]
 
 # Configuration for validation mechanism via pydantic
@@ -1823,9 +1821,3 @@ class RawSource(LeafNode, _RawSourceBase):
 
     def __repr__(self):
         return f'RawSource:: {truncate_string(self.text.strip())}'
-
-
-DECLARATION_NODES = (Import, VariableDeclaration, ProcedureDeclaration)
-"""
-List of IR nodes that are considered to be the authority on a symbol's attributes
-"""

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -39,7 +39,9 @@ __all__ = [
     'Comment', 'CommentBlock', 'Pragma', 'PreprocessorDirective',
     'Import', 'VariableDeclaration', 'ProcedureDeclaration', 'DataDeclaration',
     'StatementFunction', 'TypeDef', 'MultiConditional', 'MaskedStatement',
-    'Intrinsic', 'Enumeration', 'RawSource'
+    'Intrinsic', 'Enumeration', 'RawSource',
+    # List of nodes with specific properties
+    'DECLARATION_NODES'
 ]
 
 # Configuration for validation mechanism via pydantic
@@ -1821,3 +1823,9 @@ class RawSource(LeafNode, _RawSourceBase):
 
     def __repr__(self):
         return f'RawSource:: {truncate_string(self.text.strip())}'
+
+
+DECLARATION_NODES = (Import, VariableDeclaration, ProcedureDeclaration)
+"""
+List of IR nodes that are considered to be the authority on a symbol's attributes
+"""

--- a/loki/transform/transform_associates.py
+++ b/loki/transform/transform_associates.py
@@ -40,7 +40,7 @@ class ResolveAssociatesTransformer(Transformer):
     corresponding `selector` expression defined in ``associations``.
     """
 
-    def visit_Associate(self, o, **kwargs):
+    def visit_Associate(self, o, **kwargs):  # pylint: disable=unused-argument
         # First head-recurse, so that all associate blocks beneath are resolved
         body = self.visit(o.body)
 

--- a/loki/transform/transform_associates.py
+++ b/loki/transform/transform_associates.py
@@ -40,7 +40,7 @@ class ResolveAssociatesTransformer(Transformer):
     corresponding `selector` expression defined in ``associations``.
     """
 
-    def visit_Associate(self, o):
+    def visit_Associate(self, o, **kwargs):
         # First head-recurse, so that all associate blocks beneath are resolved
         body = self.visit(o.body)
 

--- a/loki/visitors/transform.py
+++ b/loki/visitors/transform.py
@@ -246,8 +246,6 @@ class Transformer(Visitor):
         :any:`Node` or tuple
             The rebuilt control flow tree.
         """
-        if isinstance(o, Node):
-            kwargs['current_node'] = o
         obj = super().visit(o, *args, **kwargs)
         if isinstance(o, Node) and obj is not o:
             self.rebuilt[o] = obj
@@ -448,8 +446,6 @@ class MaskedTransformer(Transformer):
             # to make sure that we don't include any following nodes we clear start
             self.start.clear()
             self.active = False
-        if isinstance(o, Node):
-            kwargs['current_node'] = o
         return super().visit(o, *args, **kwargs)
 
     def visit_object(self, o, **kwargs):

--- a/loki/visitors/transform.py
+++ b/loki/visitors/transform.py
@@ -246,6 +246,8 @@ class Transformer(Visitor):
         :any:`Node` or tuple
             The rebuilt control flow tree.
         """
+        if isinstance(o, Node):
+            kwargs['current_node'] = o
         obj = super().visit(o, *args, **kwargs)
         if isinstance(o, Node) and obj is not o:
             self.rebuilt[o] = obj
@@ -446,6 +448,8 @@ class MaskedTransformer(Transformer):
             # to make sure that we don't include any following nodes we clear start
             self.start.clear()
             self.active = False
+        if isinstance(o, Node):
+            kwargs['current_node'] = o
         return super().visit(o, *args, **kwargs)
 
     def visit_object(self, o, **kwargs):
@@ -502,7 +506,6 @@ class NestedMaskedTransformer(MaskedTransformer):
     """
 
     # Handler for leaf nodes
-
 
     def visit_object(self, o, **kwargs):
         """

--- a/tests/test_sourcefile.py
+++ b/tests/test_sourcefile.py
@@ -216,6 +216,7 @@ def test_sourcefile_cpp_stmt_func(here, frontend):
             assert isinstance(var, ProcedureSymbol)
             assert isinstance(var.type.dtype, ProcedureType)
             assert var.type.dtype.procedure is decl
+            assert decl.source is not None
 
     # Generate code and compile
     filepath = here/f'{module.name}.f90'

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -16,7 +16,8 @@ from loki import (
     Section, CallStatement, BasicType, Array, Scalar, Variable,
     SymbolAttributes, StringLiteral, fgen, fexprgen, VariableDeclaration,
     Transformer, FindTypedSymbols, ProcedureSymbol, ProcedureType,
-    StatementFunction, normalize_range_indexing, DeferredTypeSymbol
+    StatementFunction, normalize_range_indexing, DeferredTypeSymbol,
+    Assignment
 )
 
 
@@ -1503,6 +1504,10 @@ end subroutine subroutine_stmt_func
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     routine.name += f'_{frontend!s}'
+
+    # Make sure the statement function injection doesn't invalidate source
+    for assignment in FindNodes(Assignment).visit(routine.body):
+        assert assignment.source is not None
 
     # OMNI inlines statement functions, so we can only check correct representation
     # for fparser

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1520,6 +1520,7 @@ end subroutine subroutine_stmt_func
             assert isinstance(var, ProcedureSymbol)
             assert isinstance(var.type.dtype, ProcedureType)
             assert var.type.dtype.procedure is stmt_func_decls[var]
+            assert stmt_func_decls[var].source is not None
 
     # Make sure this produces the correct result
     filepath = here/f'{routine.name}.f90'


### PR DESCRIPTION
_Note: This sits on top of #44_

I'm filing this separately because it contributes a significant behaviour change for the `SubstituteExpressions` visitor, which I consider to be sensible but that might require extra testing to make sure it doesn't break behaviour in (untested) edge cases.

In a few places, we ran into infinite recursion in the `AttachScopes` visitor (although it's not specific to that one, it's just the first to be encountered within the frontends), more specifically, if a declared variable is being used in one of the definining attributes. Encountered examples include:

* the initializer expression, e.g. `REAL(KIND=JPRB), PARAMETER :: ZEXPLIMIT = LOG(HUGE(ZEXPLIMIT))`
* the allocation dimensions (which are injected as `shape` in the Loki IR), e.g.: `allocate(levels(jscale)%data(size(levels(jscale-1)%data, 1), size(levels(jscale-1)%data, 2)))`
* type bound procedure declarations with an explicit interface of the same name: `procedure (some_proc), deferred :: some_proc`

The cause of the infinite recursion is the fact that we traverse declaration attributes (`type.initial`, `type.shape`, `type.bind_names`) on every symbol use in the `LokiIdentityMapper`. By adding a `recurse_to_declaration_attributes` keyword argument to the visitor methods (defaults to `True` for nodes that are the "authority" on a symbol's type: `VariableDeclaration`, `ProcedureDeclaration`, `Import`), we recurse into these properties only once. Since these are properties that are cached in the symbol table, this is also sufficient (unless transformations rely on the implicit modification of a symbol's declaration when traversing a routine's body, which seems somewhat counterintuitive behaviour).

Conceptually I think this is the right thing to do but the implementation might not be the most elegant...

This also removes quite a bit of traversal overhead in the expression transformer, which shaves off about 10% of the time required to read in cloudsc.F90.