### PR TITLE
Make rescoping in post_apply optional

### DIFF
--- a/loki/transform/transform_parametrise.py
+++ b/loki/transform/transform_parametrise.py
@@ -275,7 +275,7 @@ class ParametriseTransformation(Transformation):
                         name = str(call.name)
                         successor_map[name].trafo_data[self._key][str(arg_map_reversed[call.arguments[index]])] = \
                             dic2p[call.arguments[index].name]
-                    arguments = [arg for i, arg in enumerate(call.arguments) if arg not in vars2p]
+                    arguments = tuple(arg for arg in call.arguments if arg not in vars2p)
                     call_map[call] = call.clone(arguments=arguments)
             routine.body = Transformer(call_map).visit(routine.body)
 

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -85,7 +85,7 @@ class Transformation:
             Keyword arguments for the transformation.
         """
 
-    def apply(self, source, **kwargs):
+    def apply(self, source, post_apply_rescope_symbols=False, **kwargs):
         """
         Dispatch method to apply transformation to all source items in
         :data:`source`.
@@ -97,6 +97,9 @@ class Transformation:
         ----------
         source : :any:`Sourcefile` or :any:`Module` or :any:`Subroutine`
             The source item to transform.
+        post_apply_rescope_symbols : bool, optional
+            Call ``rescope_symbols`` on :data:`source` after applying the
+            transformation to clean up any scoping issues.
         **kwargs : optional
             Keyword arguments that are passed on to the methods defining the
             actual transformation.
@@ -110,7 +113,7 @@ class Transformation:
         if isinstance(source, Module):
             self.apply_module(source, **kwargs)
 
-        self.post_apply(source)
+        self.post_apply(source, rescope_symbols=post_apply_rescope_symbols)
 
     def apply_file(self, sourcefile, **kwargs):
         """
@@ -136,10 +139,10 @@ class Transformation:
         self.transform_file(sourcefile, **kwargs)
 
         for module in sourcefile.modules:
-            self.apply(module, **kwargs)
+            self.apply_module(module, **kwargs)
 
         for routine in sourcefile.subroutines:
-            self.apply(routine, **kwargs)
+            self.apply_subroutine(routine, **kwargs)
 
     def apply_subroutine(self, subroutine, **kwargs):
         """
@@ -166,7 +169,7 @@ class Transformation:
 
         # Recurse on subroutine members
         for member in subroutine.members:
-            self.apply(member, **kwargs)
+            self.apply_subroutine(member, **kwargs)
 
     def apply_module(self, module, **kwargs):
         """
@@ -193,9 +196,9 @@ class Transformation:
 
         # Call the dispatch for all contained subroutines
         for routine in module.subroutines:
-            self.apply(routine, **kwargs)
+            self.apply_subroutine(routine, **kwargs)
 
-    def post_apply(self, source):
+    def post_apply(self, source, rescope_symbols=False):
         """
         Dispatch method for actions to be carried out after applying a transformation
         to :data:`source`.
@@ -207,17 +210,19 @@ class Transformation:
         ----------
         source : :any:`Sourcefile` or :any:`Module` or :any:`Subroutine`
             The source item to transform.
+        rescope_symbols : bool, optional
+            Call ``rescope_symbols`` on :data:`source`
         """
         if isinstance(source, Sourcefile):
-            self.post_apply_file(source)
+            self.post_apply_file(source, rescope_symbols)
 
         if isinstance(source, Subroutine):
-            self.post_apply_subroutine(source)
+            self.post_apply_subroutine(source, rescope_symbols)
 
         if isinstance(source, Module):
-            self.post_apply_module(source)
+            self.post_apply_module(source, rescope_symbols)
 
-    def post_apply_file(self, sourcefile):
+    def post_apply_file(self, sourcefile, rescope_symbols):
         """
         Apply actions after applying a transformation to :data:`sourcefile`.
 
@@ -225,11 +230,20 @@ class Transformation:
         ----------
         sourcefile : :any:`Sourcefile`
             The file to transform.
+        rescope_symbols : bool
+            Call ``rescope_symbols`` on modules and subroutines in :data:`sourcefile`
         """
         if not isinstance(sourcefile, Sourcefile):
             raise TypeError('Transformation.post_apply_file can only be applied to Sourcefile object')
 
-    def post_apply_subroutine(self, subroutine):
+        for module in sourcefile.modules:
+            self.post_apply_module(module, rescope_symbols)
+
+        for routine in sourcefile.subroutines:
+            self.post_apply_subroutine(routine, rescope_symbols)
+
+
+    def post_apply_subroutine(self, subroutine, rescope_symbols):
         """
         Apply actions after applying a transformation to :data:`subroutine`.
 
@@ -237,14 +251,20 @@ class Transformation:
         ----------
         subroutine : :any:`Subroutine`
             The file to transform.
+        rescope_symbols : bool
+            Call ``rescope_symbols`` on :data:`subroutine`
         """
         if not isinstance(subroutine, Subroutine):
             raise TypeError('Transformation.post_apply_subroutine can only be applied to Subroutine object')
 
-        # Ensure all objects in the IR are in the subroutine's or a parent scope.
-        subroutine.rescope_symbols()
+        for routine in subroutine.members:
+            self.post_apply_subroutine(routine, False)
 
-    def post_apply_module(self, module):
+        # Ensure all objects in the IR are in the subroutine's or a parent scope.
+        if rescope_symbols:
+            subroutine.rescope_symbols()
+
+    def post_apply_module(self, module, rescope_symbols):
         """
         Apply actions after applying a transformation to :data:`module`.
 
@@ -252,9 +272,15 @@ class Transformation:
         ----------
         module : :any:`Module`
             The file to transform.
+        rescope_symbols : bool
+            Call ``rescope_symbols`` on :data:`module`
         """
         if not isinstance(module, Module):
             raise TypeError('Transformation.post_apply_module can only be applied to Module object')
 
+        for routine in module.subroutines:
+            self.post_apply_subroutine(routine, False)
+
         # Ensure all objects in the IR are in the module's scope.
-        module.rescope_symbols()
+        if rescope_symbols:
+            module.rescope_symbols()

--- a/transformations/transformations/scc_cuf.py
+++ b/transformations/transformations/scc_cuf.py
@@ -303,7 +303,7 @@ def kernel_cuf(routine, horizontal, vertical, block_dim, transformation_type,
                     arguments.append(arg.clone(dimensions=None))
                 else:
                     arguments.append(arg)
-            call._update(arguments=arguments)
+            call._update(arguments=as_tuple(arguments))
 
 
 def kernel_demote_private_locals(routine, horizontal, vertical):
@@ -468,7 +468,7 @@ def driver_device_variables(routine, targets=None):
                 arguments.append(arg.clone(name=f"{arg.name}_d", type=vtype, dimensions=None))
             else:
                 arguments.append(arg)
-        call_map[call] = call.clone(arguments=arguments)
+        call_map[call] = call.clone(arguments=as_tuple(arguments))
     routine.body = Transformer(call_map).visit(routine.body)
 
 


### PR DESCRIPTION
Due to some unfortunate nesting, we are currently calling excessively often `rescope_symbols` after a transformation.
This is because `post_apply` was called for every subroutine and every module to which a transformation was applied, even if the actual transformation only implements a handler for one of them.

Out of caution, we had put a `rescope_symbols()` call into this `post_apply` method to catch some of the more subtle scope abuse. However, it seems that most transformations are actually fairly good in avoiding scoping errors, as tests pass even without that.

Now, either already at that time or slightly after, the `rescope_symbols()` call has learned to be properly recursive, i.e. also fix scopes for its member routines if called on a subroutine or module. This meant an abundantly often call to `rescope_symbols`, which can cause a significant overhead, as it isn't cheap either.

On practical test cases this hasn't showed up so far, as typical IFS files only contain a single subroutine, so it would only be called once. However, in code written in an object-oriented fashion, everything is encapsulated in modules, which contain multiple subroutines/functions, and there it makes a huge difference.

My proposal (as implemented in this PR) would be to make the rescoping entirely optional but allow activating this for quick fixing of "legacy" transformations where there is a scoping issue.

This PR contains three contributions:
1. Rework the `apply` and `post_apply` logic in `Transformation` to avoid excessive calls to `post_apply`
2. Make rescoping entirely optional and off by default
3. Fix a few type errors in IR node constructor uses.