### PR TITLE
Subroutine: Fix array declarations in interface generation

### DIFF
--- a/loki/subroutine.py
+++ b/loki/subroutine.py
@@ -404,8 +404,8 @@ class Subroutine(ProgramUnit):
         routine = Subroutine(name=self.name, args=arg_names, spec=None, body=None)
         decl_map = {}
         for decl in FindNodes((ir.VariableDeclaration, ir.ProcedureDeclaration)).visit(self.spec):
-            if any(v in arg_names for v in decl.symbols):
-                assert all(v in arg_names and v.type.intent is not None for v in decl.symbols), \
+            if any(v.name in arg_names for v in decl.symbols):
+                assert all(v.name in arg_names and v.type.intent is not None for v in decl.symbols), \
                     "Declarations must have intents and dummy and local arguments cannot be mixed."
                 # Replicate declaration with re-scoped variables
                 variables = as_tuple(v.clone(scope=routine) for v in decl.symbols)

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1239,10 +1239,11 @@ def test_subroutine_interface(here, frontend):
     Test auto-generation of an interface block for a given subroutine.
     """
     fcode = """
-subroutine test_subroutine_interface (in1, in2, out1, out2)
+subroutine test_subroutine_interface (in1, in2, in3, out1, out2)
   use header, only: jprb
   IMPLICIT NONE
   integer, intent(in) :: in1, in2
+  real(kind=jprb), intent(in) :: in3(in1, in2)
   real(kind=jprb), intent(out) :: out1, out2
   integer :: localvar
   localvar = in1 + in2
@@ -1255,11 +1256,12 @@ end subroutine
     if frontend == OMNI:
         assert fgen(routine.interface).strip() == """
 INTERFACE
-  SUBROUTINE test_subroutine_interface (in1, in2, out1, out2)
+  SUBROUTINE test_subroutine_interface (in1, in2, in3, out1, out2)
     USE header, ONLY: jprb
     IMPLICIT NONE
     INTEGER, INTENT(IN) :: in1
     INTEGER, INTENT(IN) :: in2
+    REAL(KIND=selected_real_kind(13, 300)), INTENT(IN) :: in3(1:in1, 1:in2)
     REAL(KIND=selected_real_kind(13, 300)), INTENT(OUT) :: out1
     REAL(KIND=selected_real_kind(13, 300)), INTENT(OUT) :: out2
   END SUBROUTINE test_subroutine_interface
@@ -1268,10 +1270,11 @@ END INTERFACE
     else:
         assert fgen(routine.interface).strip() == """
 INTERFACE
-  SUBROUTINE test_subroutine_interface (in1, in2, out1, out2)
+  SUBROUTINE test_subroutine_interface (in1, in2, in3, out1, out2)
     USE header, ONLY: jprb
     IMPLICIT NONE
     INTEGER, INTENT(IN) :: in1, in2
+    REAL(KIND=jprb), INTENT(IN) :: in3(in1, in2)
     REAL(KIND=jprb), INTENT(OUT) :: out1, out2
   END SUBROUTINE test_subroutine_interface
 END INTERFACE


### PR DESCRIPTION
We were dropping arrays due to faulty comparison with array symbols; instead we should only test against array name.

This addresses issue #59. Many thanks to @JoeffreyLegaux for reporting and suggesting the fix.