### PR TITLE
Remove unused import and variable from hook

### DIFF
--- a/transformations/transformations/utility_routines.py
+++ b/transformations/transformations/utility_routines.py
@@ -64,6 +64,17 @@ class DrHookTransformation(Transformation):
 
         routine.body = Transformer(mapper).visit(routine.body)
 
+        #Get rid of unused import and variable
+        if self.remove:
+            for imp in FindNodes(Import).visit(routine.spec):
+                if 'LHOOK' in [s.name for s in imp.symbols]:
+                    mapper[imp] = None
+
+            routine.spec = Transformer(mapper).visit(routine.spec)
+
+            #Remove unused zhook_handle
+            routine.variables = as_tuple(v for v in routine.variables if v.name != 'ZHOOK_HANDLE')
+
 
 class RemoveCallsTransformation(Transformation):
     """

--- a/transformations/transformations/utility_routines.py
+++ b/transformations/transformations/utility_routines.py
@@ -12,7 +12,7 @@ utility routines
 
 from loki import (
     FindNodes, Transformer, Transformation, CallStatement,
-    Conditional, as_tuple, Literal, Intrinsic
+    Conditional, as_tuple, Literal, Intrinsic, Import
 )
 
 

--- a/transformations/transformations/utility_routines.py
+++ b/transformations/transformations/utility_routines.py
@@ -67,13 +67,13 @@ class DrHookTransformation(Transformation):
         #Get rid of unused import and variable
         if self.remove:
             for imp in FindNodes(Import).visit(routine.spec):
-                if 'LHOOK' in [s.name for s in imp.symbols]:
+                if imp.module == 'yomhook':
                     mapper[imp] = None
 
             routine.spec = Transformer(mapper).visit(routine.spec)
 
             #Remove unused zhook_handle
-            routine.variables = as_tuple(v for v in routine.variables if v.name != 'ZHOOK_HANDLE')
+            routine.variables = as_tuple(v for v in routine.variables if v != 'zhook_handle')
 
 
 class RemoveCallsTransformation(Transformation):

--- a/transformations/transformations/utility_routines.py
+++ b/transformations/transformations/utility_routines.py
@@ -67,7 +67,7 @@ class DrHookTransformation(Transformation):
         #Get rid of unused import and variable
         if self.remove:
             for imp in FindNodes(Import).visit(routine.spec):
-                if imp.module == 'yomhook':
+                if imp.module.lower() == 'yomhook':
                     mapper[imp] = None
 
             routine.spec = Transformer(mapper).visit(routine.spec)


### PR DESCRIPTION
The dangling variables and imports make the compiler vomit out a ton of warnings. This will remove those as well as the calls to DR_HOOK