### PR TITLE
Add module imports as scheduler dependencies

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -698,6 +698,17 @@ class GenericImportItem(Item):
         """
         return ()
 
+    @property
+    def function_interfaces(self):
+        """
+        Empty tuple as generic import items cannot include interface blocks
+
+        Returns
+        -------
+        tuple
+        """
+        return ()
+
     @cached_property
     def imports(self):
         """
@@ -725,8 +736,8 @@ class GenericImportItem(Item):
                 if i.spec.name == self.local_name:
                     for b in i.body:
                         if isinstance(b, ProcedureDeclaration):
-                           for s in b.symbols:
-                               _children += as_tuple(s.name)
+                            for s in b.symbols:
+                                _children += as_tuple(s.name)
                         elif isinstance(b, Subroutine):
                             if b.is_function:
                                 _children += as_tuple(b.name)
@@ -757,6 +768,17 @@ class GlobalVarImportItem(Item):
     def members(self):
         """
         Empty tuple as variable imports have no member routines
+
+        Returns
+        -------
+        tuple
+        """
+        return ()
+
+    @property
+    def function_interfaces(self):
+        """
+        Empty tuple as global variable imports cannot include interface blocks
 
         Returns
         -------

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -676,7 +676,7 @@ class GenericImportItem(Item):
 
     def __init__(self, name, source, config=None):
         name_parts = name.split('#')
-        assert len(name_parts) > 1 #only accept fully-qualified module imports
+        assert len(name_parts) > 1 and all(name_parts) #only accept fully-qualified module imports
         super().__init__(name, source, config)
         assert self.scope
 
@@ -753,7 +753,7 @@ class GlobalVarImportItem(Item):
 
     def __init__(self, name, source, config=None):
         name_parts = name.split('#')
-        assert len(name_parts) > 1 #only accept fully-qualified module imports
+        assert len(name_parts) > 1 and all(name_parts) #only accept fully-qualified module imports
         super().__init__(name, source, config)
         assert self.scope
 

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -20,7 +20,7 @@ from loki.tools import as_tuple
 from loki.tools.util import CaseInsensitiveDict
 from loki.visitors import FindNodes
 from loki.ir import CallStatement, TypeDef, ProcedureDeclaration
-from loki import Subroutine
+from loki.subroutine import Subroutine
 
 
 __all__ = ['Item', 'SubroutineItem', 'ProcedureBindingItem', 'GlobalVarImportItem', 'GenericImportItem']

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -666,12 +666,12 @@ class ProcedureBindingItem(Item):
 
 class GenericImportItem(Item):
     """
-    Implementation of :class:`Item` to represent a generic Fortran module import.
+    Implementation of :class:`Item` to represent a catchall for any Fortran module import.
 
     This does not constitute a work item when applying transformations across the
     call tree in the :any:`Scheduler` and is skipped during the processing phase.
-    However, it is needed to determine whether the import corresponds to a type
-    declaration or a procedure interface.
+    It is needed when the type of the symbol being imported isn't immediately obvious
+    from the `USE` statement and more context is needed.
     """
 
     def __init__(self, name, source, config=None):
@@ -747,8 +747,10 @@ class GenericImportItem(Item):
 
 class GlobalVarImportItem(Item):
     """
-    Implementation of :class:`Item` to represent a global variable import.
-    These only appear at the end of dependency trees and do not have children.
+    Implementation of :class:`Item` to represent a global variable import. These encapsulate variables
+    that store data. Whilst such variables can clearly have dependencies, in the current implementation
+    items of type :class:`GlobalVarImportItem` do not have any children (mainly due to a lack of practical
+    benefit).
     """
 
     def __init__(self, name, source, config=None):

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -556,6 +556,32 @@ class SubroutineItem(Item):
 
         return names
 
+    @property
+    def children(self):
+        """
+        Set of all child routines that this work item has in the call tree
+
+        Note that this is not the set of active children that a traversal
+        will apply a transformation over, but rather the set of nodes that
+        defines the next level of the internal call tree.
+
+        This returns the local names of children which can be fully qualified
+        via :meth:`qualify_names`.
+
+        Returns
+        -------
+        list of str
+        """
+        disabled = as_tuple(str(b).lower() for b in self.disable)
+
+        # Base definition of child is a procedure call (for now)
+        children = self.calls + self.inline_function_interfaces + tuple([v for v in self.qualified_imports.values()])
+
+        # Filter out local members and disabled sub-branches
+        children = [c for c in children if c not in self.members]
+        children = [c for c in children if c not in disabled]
+        return as_tuple(children)
+
 class ProcedureBindingItem(Item):
     """
     Implementation of :class:`Item` to represent a Fortran procedure binding

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -291,6 +291,14 @@ class Item:
         return self.config.get('enrich', tuple())
 
     @property
+    def disable_imports(self):
+        """
+        Configurable option to disable the addition of module imports as children.
+        """
+
+        return self.config.get('disable_imports', False)
+
+    @property
     def children(self):
         """
         Set of all child routines that this work item has in the call tree
@@ -566,9 +574,11 @@ class SubroutineItem(Item):
         Comprises of inline function declarations and qualified module imports.
         """
 
-        # avoid duplicates in list of children
-        _imports = tuple([v for v in self.qualified_imports.keys()])
-        _imports = tuple([i for i in _imports if i not in self.calls])
+        _imports = ()
+        if not self.disable_imports:
+            # avoid duplicates of import calls in list of children
+            _imports = tuple([v for v in self.qualified_imports.keys()])
+            _imports = tuple([i for i in _imports if i not in self.calls])
 
         return self.inline_function_interfaces + _imports
 

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -290,12 +290,12 @@ class Item:
         return self.config.get('enrich', tuple())
 
     @property
-    def disable_imports(self):
+    def enable_imports(self):
         """
-        Configurable option to disable the addition of module imports as children.
+        Configurable option to enable the addition of module imports as children.
         """
 
-        return self.config.get('disable_imports', False)
+        return self.config.get('enable_imports', False)
 
     @property
     def children(self):
@@ -318,7 +318,7 @@ class Item:
         # Base definition of child is a procedure call
         children = self.calls
 
-        if not self.disable_imports:
+        if self.enable_imports:
             if isinstance(self, SubroutineItem):
                 children += tuple(self.qualified_imports.keys())
             elif isinstance(self, GenericImportItem):
@@ -464,7 +464,7 @@ class Item:
         # Base definition of child is a procedure call
         targets = self.calls
 
-        if not self.disable_imports:
+        if self.enable_imports:
             if isinstance(self, SubroutineItem):
                 targets += tuple(self.qualified_imports.keys())
             elif isinstance(self, GenericImportItem):

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -234,6 +234,7 @@ class Scheduler:
             for r in module.interfaces
         )
 
+        # Create maps of routines and module variables to help with fast sorting in create_item later
         self.routine_map = CaseInsensitiveDict(
             (f'#{r.name}', obj) for obj in obj_list for r in obj.subroutines
         )
@@ -242,7 +243,6 @@ class Scheduler:
             for obj in obj_list for module in obj.modules
             for r in module.subroutines
         )
-
         self.modvars_map = CaseInsensitiveDict(
             (f'{module.name}#{r.name}', obj) for obj in obj_list for module in obj.modules
             for r in module.variables

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -42,9 +42,12 @@ class SchedulerConfig:
         visualisation. These are intended for utility routines that
         pop up in many routines but can be ignored in terms of program
         control flow, like ``flush`` or ``abort``.
+    enable_imports : bool
+        Disable the inclusion of module imports as scheduler dependencies.
     """
 
-    def __init__(self, default, routines, disable=None, dimensions=None, dic2p=None, derived_types=None):
+    def __init__(self, default, routines, disable=None, dimensions=None, dic2p=None, derived_types=None,
+                 enable_imports=False):
         self.default = default
         if isinstance(routines, dict):
             self.routines = CaseInsensitiveDict(routines)
@@ -52,6 +55,8 @@ class SchedulerConfig:
             self.routines = CaseInsensitiveDict((r.name, r) for r in as_tuple(routines))
         self.disable = as_tuple(disable)
         self.dimensions = dimensions
+        self.enable_imports = enable_imports
+
         if dic2p is not None:
             self.dic2p = dic2p
         else:
@@ -70,6 +75,7 @@ class SchedulerConfig:
             config['routines'] = []
         routines = config['routines']
         disable = default.get('disable', None)
+        enable_imports = default.get('enable_imports', False)
 
         # Add any dimension definitions contained in the config dict
         dimensions = {}

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -229,6 +229,15 @@ class Scheduler:
             for r in module.subroutines + tuple(module.typedefs.values())
         )
 
+        self.routine_map = CaseInsensitiveDict(
+            (f'#{r.name}', obj) for obj in obj_list for r in obj.subroutines
+        )
+        self.routine_map.update(
+            (f'{module.name}#{r.name}', obj)
+            for obj in obj_list for module in obj.modules
+            for r in module.subroutines
+        )
+
     @property
     def routines(self):
         return as_tuple(item.routine for item in self.item_graph.nodes if item.routine is not None)
@@ -353,7 +362,8 @@ class Scheduler:
         debug(f'[Loki] Scheduler creating Item: {name} => {sourcefile.path}')
         if '%' in name:
             return ProcedureBindingItem(name=name, source=sourcefile, config=item_conf)
-        return SubroutineItem(name=name, source=sourcefile, config=item_conf)
+        elif self.routine_map.get(name):
+            return SubroutineItem(name=name, source=sourcefile, config=item_conf)
 
     def find_routine(self, routine):
         """

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -237,7 +237,7 @@ class Scheduler:
         self.obj_map.update(
             (f'{module.name}#{r.spec.name}', obj)
             for obj in obj_list for module in obj.modules
-            for r in module.interfaces
+            for r in module.interfaces if r.spec
         )
 
         # Create maps of routines and module variables to help with fast sorting in create_item later

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -92,7 +92,7 @@ class SchedulerConfig:
             derived_types = config['derived_types']
 
         return cls(default=default, routines=routines, disable=disable, dimensions=dimensions, dic2p=dic2p,
-                   derived_types=derived_types)
+                   derived_types=derived_types, enable_imports=enable_imports)
 
     @classmethod
     def from_file(cls, path):
@@ -378,12 +378,11 @@ class Scheduler:
         debug(f'[Loki] Scheduler creating Item: {name} => {sourcefile.path}')
         if '%' in name:
             return ProcedureBindingItem(name=name, source=sourcefile, config=item_conf)
-        elif self.routine_map.get(name):
+        if self.routine_map.get(name):
             return SubroutineItem(name=name, source=sourcefile, config=item_conf)
-        elif self.modvars_map.get(name):
+        if self.modvars_map.get(name):
             return GlobalVarImportItem(name=name, source=sourcefile, config=item_conf)
-        else:
-            return GenericImportItem(name=name, source=sourcefile, config=item_conf)
+        return GenericImportItem(name=name, source=sourcefile, config=item_conf)
 
     def find_routine(self, routine):
         """

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -869,7 +869,7 @@ class DerivedTypeDeclarationPattern(Pattern):
     """
     Pattern to match :any:`VariableDeclaration` nodes
 
-    For the moment, this only matches variable declarations for derived type objects
+    This subclass only matches variable declarations for derived type objects
     (via ``TYPE`` or ``CLASS`` keywords).
     """
 
@@ -887,7 +887,7 @@ class DerivedTypeDeclarationPattern(Pattern):
 
     def match(self, reader, parser_classes, scope):
         """
-        Match the provided source string against the pattern for a :any:`Import`
+        Match the provided source string against the pattern for a :any:`VariableDeclaration`
 
         Parameters
         ----------
@@ -913,8 +913,8 @@ class IntrinsicDeclarationPattern(Pattern):
     """
     Pattern to match :any:`VariableDeclaration` nodes
 
-    For the moment, this only matches variable declarations for derived type objects
-    (via ``TYPE`` or ``CLASS`` keywords).
+    This subclass only matches variable declarations for intrinsic types,
+    e.g. REAL, INTEGER, LOGICAL, etc.
     """
 
     parser_class = RegexParserClass.DeclarationClass
@@ -931,7 +931,7 @@ class IntrinsicDeclarationPattern(Pattern):
 
     def match(self, reader, parser_classes, scope):
         """
-        Match the provided source string against the pattern for a :any:`Import`
+        Match the provided source string against the pattern for a :any:`VariableDeclaration`
 
         Parameters
         ----------

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -921,7 +921,7 @@ class IntrinsicDeclarationPattern(Pattern):
 
     def __init__(self):
         super().__init__(
-            r'^[ \t]*(?P<typename>real(\(kind=.+\))?|integer(\(kind=.+\))?|logical(\(kind=.+\))?)[ \t]*'
+            r'^[ \t]*(?P<typename>real(\(kind=.+\))?|integer(\(kind=.+\))?|logical(\(kind=.+\))?|character\(len=.+\))[ \t]*'
             r'(?:[ \t]*,[ \t]*[a-z]+(?:\(.*?\))?)*'  # Optional attributes
             r'(?:[ \t]*::)?'  # Optional `::` delimiter
             r'[ \t]*'  # Some white space
@@ -949,7 +949,7 @@ class IntrinsicDeclarationPattern(Pattern):
 
         type_ = SymbolAttributes(DerivedType(match['typename']))
         variables = self._remove_quoted_string_nested_parentheses(match['variables'])  # Remove dimensions
-        variables = re.sub(r'[ \t]*=(>)?[ \t]*\w+[ \t]*', r'', variables) # Remove initialization
+        variables = re.sub(r'[ \t]*=(>)?[ \t]*[-.\w/]+[ \t]*', r'', variables) # Remove initialization
         variables = variables.replace(' ', '').split(',')  # Variable names without white space
         variables = tuple(sym.Variable(name=v, type=type_, scope=scope) for v in variables)
         return ir.VariableDeclaration(variables, source=reader.source_from_current_line())

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -949,6 +949,7 @@ class IntrinsicDeclarationPattern(Pattern):
 
         type_ = SymbolAttributes(DerivedType(match['typename']))
         variables = self._remove_quoted_string_nested_parentheses(match['variables'])  # Remove dimensions
+        variables = re.sub(r'[ \t]*=(>)?[ \t]*\w+[ \t]*', r'', variables) # Remove initialization
         variables = variables.replace(' ', '').split(',')  # Variable names without white space
         variables = tuple(sym.Variable(name=v, type=type_, scope=scope) for v in variables)
         return ir.VariableDeclaration(variables, source=reader.source_from_current_line())

--- a/tests/sources/projInlineCalls/driver.F90
+++ b/tests/sources/projInlineCalls/driver.F90
@@ -12,12 +12,11 @@ subroutine driver(n, work)
   real, intent(out) :: work(n)
   type(some_type) :: var
   integer :: i
-  
+
   do i=1,n
     work(i) = double_real(i) + return_one()
     work(i) = work(i) + dble(some_var)
     work(i) = work(i) + add_args(i,1) + add_args(i,2)
-    call var%do_something(work(i))
   enddo
 
 end subroutine driver

--- a/tests/sources/projInlineCalls/driver.F90
+++ b/tests/sources/projInlineCalls/driver.F90
@@ -17,6 +17,7 @@ subroutine driver(n, work)
     work(i) = double_real(i) + return_one()
     work(i) = work(i) + dble(some_var)
     work(i) = work(i) + add_args(i,1) + add_args(i,2)
+    call var%do_something(work(i))
   enddo
 
 end subroutine driver

--- a/tests/sources/projInlineCalls/driver.F90
+++ b/tests/sources/projInlineCalls/driver.F90
@@ -1,4 +1,5 @@
 subroutine driver(n, work)
+  use some_module, only: return_one, some_var, add_args, some_type
   implicit none
 
   interface
@@ -9,10 +10,14 @@ subroutine driver(n, work)
 
   integer, intent(in) :: n
   real, intent(out) :: work(n)
+  type(some_type) :: var
   integer :: i
-
+  
   do i=1,n
-    work(i) = double_real(i)
+    work(i) = double_real(i) + return_one()
+    work(i) = work(i) + dble(some_var)
+    work(i) = work(i) + add_args(i,1) + add_args(i,2)
+    call var%do_something(work(i))
   enddo
 
 end subroutine driver

--- a/tests/sources/projInlineCalls/some_module.F90
+++ b/tests/sources/projInlineCalls/some_module.F90
@@ -1,0 +1,43 @@
+module some_module
+implicit none
+
+  integer, parameter :: some_var=1
+
+  interface add_args
+    procedure add_two_args
+    procedure add_three_args
+  end interface add_args
+
+  type some_type
+    real :: c = 1.
+    contains
+      procedure :: do_something => add_const
+  end type
+
+contains
+
+  function return_one() result(one)
+     real :: one
+     one = 1.
+  end function return_one
+
+  function add_two_args(i,j) result(res)
+     integer, intent(in) :: i,j
+     real :: res
+     res = dble(i+j)
+  end function add_two_args
+
+  function add_three_args(i,j,k) result(res)
+     integer, intent(in) :: i,j,k
+     real :: res
+     res = dble(i+j+k)
+  end function add_three_args
+
+  subroutine add_const(self, a)
+     class(some_type), intent(in) :: self
+     real, intent(inout) :: a
+
+     a = a + self%c
+  end subroutine add_const
+
+end module some_module

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -13,7 +13,7 @@ from loki import (
     Deallocation, Associate, BasicType, OMNI, OFP, FP, Enumeration,
     config, REGEX, Sourcefile, Import, RawSource, CallStatement,
     RegexParserClass, ProcedureType, DerivedType, Comment, Pragma,
-    PreprocessorDirective, config_override, BasicType
+    PreprocessorDirective, config_override
 )
 from loki.expression import symbols as sym
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1918,3 +1918,27 @@ end subroutine caller
     assert (scheduler['some_mod#some_type%other'], scheduler['some_mod#some_other']) in scheduler.dependencies
 
     rmtree(workdir)
+
+
+def test_scheduler_unqualified_imports(config):
+    """
+    Test that only qualified imports are added as children.
+    """
+
+    my_config = config.copy()
+    my_config['default']['enable_imports'] = True
+
+    kernel = """
+    subroutine kernel()
+       use some_mod
+       use other_mod, only: other_routine
+
+       call other_routine
+    end subroutine kernel
+    """
+
+    source = Sourcefile.from_source(kernel, frontend=REGEX)
+    item = SubroutineItem(name='#kernel', source=source, config=my_config['default'])
+
+    assert item.enable_imports
+    assert item.children == ('other_routine',)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1635,7 +1635,7 @@ def test_scheduler_import_dependencies(here, config, frontend):
             assert isinstance(i, GenericImportItem)
         elif i.name == 'some_module#some_var':
             assert isinstance(i, GlobalVarImportItem)
-        elif i.name == 'some_module#add_two_args' or i.name == 'some_module#add_three_args':
+        elif i.name in ('some_module#add_two_args', 'some_module#add_three_args'):
             assert isinstance(i, SubroutineItem)
         elif i.name == '#double_real':
             assert isinstance(i, SubroutineItem)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1587,8 +1587,10 @@ def test_scheduler_inline_call(here, config, frontend):
 
     scheduler = Scheduler(paths=here/'sources/projInlineCalls', config=my_config, frontend=frontend)
 
-    expected_items = {'#driver', '#double_real'}
-    expected_dependencies = {('#driver', '#double_real')}
+    expected_items = {'#driver', '#double_real', 'some_module#some_type%do_something', 'some_module#add_const'}
+    expected_dependencies = {('#driver', '#double_real'),
+                             ('#driver', 'some_module#some_type%do_something'),
+                             ('some_module#some_type%do_something', 'some_module#add_const')}
 
     assert expected_items == {i.name for i in scheduler.items}
     assert expected_dependencies == {(d[0].name, d[1].name) for d in scheduler.dependencies}
@@ -1617,12 +1619,14 @@ def test_scheduler_import_dependencies(here, config, frontend):
 
     expected_items = {
         '#driver', '#double_real', 'some_module#return_one', 'some_module#some_var', 'some_module#add_args',
-        'some_module#some_type', 'some_module#add_two_args', 'some_module#add_three_args'
+        'some_module#some_type', 'some_module#add_two_args', 'some_module#add_three_args',
+        'some_module#some_type%do_something', 'some_module#add_const'
     }
     expected_dependencies = {
-        ('#driver', '#double_real'), ('#driver', 'some_module#return_one'), ('#driver', 'some_module#some_var'),
-        ('#driver', 'some_module#add_args'), ('#driver', 'some_module#some_type'),
-        ('some_module#add_args', 'some_module#add_two_args'), ('some_module#add_args', 'some_module#add_three_args')
+     ('#driver', '#double_real'), ('#driver', 'some_module#return_one'), ('#driver', 'some_module#some_var'),
+     ('#driver', 'some_module#add_args'), ('#driver', 'some_module#some_type'),
+     ('#driver', 'some_module#some_type%do_something'), ('some_module#some_type%do_something', 'some_module#add_const'),
+     ('some_module#add_args', 'some_module#add_two_args'), ('some_module#add_args', 'some_module#add_three_args'),
     }
 
     assert expected_items == {i.name for i in scheduler.items}


### PR DESCRIPTION
Applying Loki transformations to more complex control flows requires generating GPU offload instructions for global (module) variable imports in an automated way. To write these transformations, we first need to extend the definition of scheduler dependencies to also include global variable imports.

This PR addresses the latter, and tries to provide a clean way to add global variable imports as scheduler dependencies. Importantly, the default behaviour remains unchanged; module imports are not added as dependencies unless explicitly stated in the scheduler config. Therefore existing scheduler workflows should not be affected.

Finally, this will likely have some conflicts with #50, and so a rebase is needed once that is merged.

NB: This now relies on a bug-fix in #68.