### PR TITLE
Pool allocator transformation

### DIFF
--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -30,7 +30,7 @@ from loki.types import SymbolAttributes, BasicType
 
 __all__ = ['LokiStringifyMapper', 'ExpressionRetriever', 'ExpressionDimensionsMapper',
            'ExpressionCallbackMapper', 'SubstituteExpressionsMapper',
-           'LokiIdentityMapper', 'AttachScopesMapper']
+           'LokiIdentityMapper', 'AttachScopesMapper', 'DetachScopesMapper']
 
 
 
@@ -813,6 +813,29 @@ class AttachScopesMapper(LokiIdentityMapper):
             new_expr.type = SymbolAttributes(dtype=BasicType.DEFERRED)
 
         return map_fn(new_expr, *args, **kwargs)
+
+    map_deferred_type_symbol = map_variable_symbol
+    map_procedure_symbol = map_variable_symbol
+
+
+class DetachScopesMapper(LokiIdentityMapper):
+    """
+    A Pymbolic expression mapper (i.e., a visitor for the expression tree)
+    that rebuilds an expression unchanged but with the scope for every
+    :any:`TypedSymbol` detached.
+
+    This will ensure that type information is stored locally on the object
+    itself, which is useful when storing information for inter-procedural
+    analysis passes.
+    """
+
+    def __init__(self):
+        super().__init__(invalidate_source=False)
+
+    def map_variable_symbol(self, expr, *args, **kwargs):
+        new_expr = super().map_variable_symbol(expr, *args, **kwargs)
+        new_expr = new_expr.clone(scope=None)
+        return new_expr
 
     map_deferred_type_symbol = map_variable_symbol
     map_procedure_symbol = map_variable_symbol

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1612,7 +1612,7 @@ class OFP2IR(GenericVisitor):
             intrinsic_calls = (
                 'MIN', 'MAX', 'EXP', 'SQRT', 'ABS', 'LOG', 'MOD', 'SELECTED_INT_KIND',
                 'SELECTED_REAL_KIND', 'ALLOCATED', 'PRESENT', 'SIGN', 'EPSILON', 'NULL',
-                'SIZE', 'LBOUND', 'UBOUND'
+                'SIZE', 'LBOUND', 'UBOUND', 'LOC'
             )
             if str(name).upper() in intrinsic_calls or kwarguments:
                 return sym.InlineCall(name, parameters=arguments, kw_parameters=kwarguments, source=source)

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -131,7 +131,7 @@ def cli(debug):
 @click.option('--remove-openmp', is_flag=True, default=False,
               help='Removes existing OpenMP pragmas in "!$loki data" regions.')
 @click.option('--mode', '-m', default='sca',
-              type=click.Choice(['idem', 'sca', 'claw', 'scc', 'scc-hoist', 'scc-stack',
+              type=click.Choice(['idem', 'idem-stack', 'sca', 'claw', 'scc', 'scc-hoist', 'scc-stack',
                                  'cuf-parametrise', 'cuf-hoist', 'cuf-dynamic']),
               help='Transformation mode, selecting which code transformations to apply.')
 @click.option('--frontend', default='fp', type=click.Choice(['fp', 'ofp', 'omni']),
@@ -192,7 +192,7 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
 
     # Now we instantiate our transformation pipeline and apply the main changes
     transformation = None
-    if mode == 'idem':
+    if mode in ['idem', 'idem-stack']:
         transformation = IdemTransformation()
 
     if mode == 'sca':
@@ -230,8 +230,8 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
     else:
         raise RuntimeError('[Loki] Convert could not find specified Transformation!')
 
-    if mode == 'scc-stack':
-        transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
+    if mode in ['idem-stack', 'scc-stack']:
+        transformation = TemporariesPoolAllocatorTransformation(block_dim=scheduler.config.dimensions['block_dim'])
         scheduler.process(transformation=transformation, reverse=True)
     if mode == 'cuf-parametrise':
         dic2p = scheduler.config.dic2p

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -211,7 +211,8 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
         block_dim = scheduler.config.dimensions['block_dim']
         transformation = SingleColumnCoalescedTransformation(
             horizontal=horizontal, vertical=vertical, block_dim=block_dim,
-            directive=directive, hoist_column_arrays='hoist' in mode
+            directive=directive, hoist_column_arrays='hoist' in mode,
+            demote_local_arrays='stack' not in mode
         )
 
     if mode in ['cuf-parametrise', 'cuf-hoist', 'cuf-dynamic']:
@@ -233,7 +234,10 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
     if mode in ['idem-stack', 'scc-stack']:
         block_dim = scheduler.config.dimensions['block_dim']
         directive = {'idem-stack': 'openmp', 'scc-stack': 'openacc'}[mode]
-        transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim, directive=directive)
+        transformation = TemporariesPoolAllocatorTransformation(
+            block_dim=block_dim, directive=directive,
+            check_bounds='scc' not in mode
+        )
         scheduler.process(transformation=transformation, reverse=True)
     if mode == 'cuf-parametrise':
         dic2p = scheduler.config.dic2p

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -211,8 +211,7 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
         block_dim = scheduler.config.dimensions['block_dim']
         transformation = SingleColumnCoalescedTransformation(
             horizontal=horizontal, vertical=vertical, block_dim=block_dim,
-            directive=directive, hoist_column_arrays='hoist' in mode,
-            demote_local_arrays='stack' not in mode
+            directive=directive, hoist_column_arrays='hoist' in mode
         )
 
     if mode in ['cuf-parametrise', 'cuf-hoist', 'cuf-dynamic']:
@@ -232,11 +231,13 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
         raise RuntimeError('[Loki] Convert could not find specified Transformation!')
 
     if mode in ['idem-stack', 'scc-stack']:
+        horizontal = scheduler.config.dimensions['horizontal']
+        vertical = scheduler.config.dimensions['vertical']
         block_dim = scheduler.config.dimensions['block_dim']
         directive = {'idem-stack': 'openmp', 'scc-stack': 'openacc'}[mode]
         transformation = TemporariesPoolAllocatorTransformation(
-            block_dim=block_dim, directive=directive,
-            check_bounds='scc' not in mode
+            block_dim=block_dim, allocation_dims=[horizontal, vertical],
+            directive=directive, check_bounds='scc' not in mode
         )
         scheduler.process(transformation=transformation, reverse=True)
     if mode == 'cuf-parametrise':

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -34,6 +34,7 @@ from transformations.argument_shape import (
 from transformations.data_offload import DataOffloadTransformation
 from transformations.derived_types import DerivedTypeArgumentsTransformation
 from transformations.utility_routines import DrHookTransformation, RemoveCallsTransformation
+from transformations.pool_allocator import TemporariesPoolAllocatorTransformation
 from transformations.single_column_claw import ExtractSCATransformation, CLAWTransformation
 from transformations.single_column_coalesced import SingleColumnCoalescedTransformation
 from transformations.scc_cuf import SccCufTransformation, HoistTemporaryArraysDeviceAllocatableTransformation
@@ -130,8 +131,8 @@ def cli(debug):
 @click.option('--remove-openmp', is_flag=True, default=False,
               help='Removes existing OpenMP pragmas in "!$loki data" regions.')
 @click.option('--mode', '-m', default='sca',
-              type=click.Choice(['idem', 'sca', 'claw', 'scc', 'scc-hoist', 'cuf-parametrise',
-                                 'cuf-hoist', 'cuf-dynamic']),
+              type=click.Choice(['idem', 'sca', 'claw', 'scc', 'scc-hoist', 'scc-stack',
+                                 'cuf-parametrise', 'cuf-hoist', 'cuf-dynamic']),
               help='Transformation mode, selecting which code transformations to apply.')
 @click.option('--frontend', default='fp', type=click.Choice(['fp', 'ofp', 'omni']),
               help='Frontend parser to use (default FP)')
@@ -204,7 +205,7 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
             horizontal=horizontal, claw_data_offload=use_claw_offload
         )
 
-    if mode in ['scc', 'scc-hoist']:
+    if mode in ['scc', 'scc-hoist', 'scc-stack']:
         horizontal = scheduler.config.dimensions['horizontal']
         vertical = scheduler.config.dimensions['vertical']
         block_dim = scheduler.config.dimensions['block_dim']
@@ -229,6 +230,9 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
     else:
         raise RuntimeError('[Loki] Convert could not find specified Transformation!')
 
+    if mode == 'scc-stack':
+        transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
+        scheduler.process(transformation=transformation, reverse=True)
     if mode == 'cuf-parametrise':
         dic2p = scheduler.config.dic2p
         disable = scheduler.config.disable
@@ -248,7 +252,7 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
     scheduler.process(transformation=dependency)
 
     # Write out all modified source files into the build directory
-    scheduler.process(transformation=FileWriteTransformation(builddir=out_path, mode=mode, cuf=('cuf' in mode)))
+    scheduler.process(transformation=FileWriteTransformation(builddir=out_path, mode=mode, cuf='cuf' in mode))
 
 
 @cli.command()

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -231,7 +231,9 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
         raise RuntimeError('[Loki] Convert could not find specified Transformation!')
 
     if mode in ['idem-stack', 'scc-stack']:
-        transformation = TemporariesPoolAllocatorTransformation(block_dim=scheduler.config.dimensions['block_dim'])
+        block_dim = scheduler.config.dimensions['block_dim']
+        directive = {'idem-stack': 'openmp', 'scc-stack': 'openacc'}[mode]
+        transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim, directive=directive)
         scheduler.process(transformation=transformation, reverse=True)
     if mode == 'cuf-parametrise':
         dic2p = scheduler.config.dic2p

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -1,0 +1,150 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from shutil import rmtree
+
+import pytest
+from loki import (
+    gettempdir, Scheduler, SchedulerConfig,
+    FindNodes,
+    CallStatement, Assignment
+)
+from conftest import available_frontends
+
+from transformations.pool_allocator import TemporariesPoolAllocatorTransformation
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_pool_allocator_temporaries(frontend):
+    fcode_driver = """
+subroutine driver(KLON, KLEV, NGPBLK, FIELD1, FIELD2)
+    use stack_mod, only: stack
+    use kernel_mod, only: kernel
+    implicit none
+    INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+    INTEGER, INTENT(IN) :: KLON, KLEV, NGPBLK
+    real(kind=jprb), intent(inout) :: field1(klon, ngpblk)
+    real(kind=jprb), intent(inout) :: field2(klon, klev, ngpblk)
+    integer :: jblk
+    integer :: istsz
+    REAL(KIND=JPRGB), ALLOCATABLE :: PSTACK(:, :)
+    type(stack) :: ylstack
+
+    istsz = (klev+1) * klon
+    ALLOCATE(PSTACK(ISTSZ, NGPBLK))
+    do jblk=1,ngpblk
+        ylstack%l = loc(pstack, (1, jblk))
+        ylstack%u = ylstack%l + 8 * istsz
+        call KERNEL(klon, klev, field1(:,jblk), field2(:,:,jblk))
+    end do
+end subroutine driver
+    """.strip()
+    fcode_kernel = """
+module kernel_mod
+    implicit none
+contains
+    subroutine kernel(klon, klev, field1, field2)
+        implicit none
+        integer, parameter :: jprb = selected_real_kind(13,300)
+        integer, intent(in) :: klon, klev
+        real(kind=jprb), intent(inout) :: field1(klon)
+        real(kind=jprb), intent(inout) :: field2(klon,klev)
+        real(kind=jprb) :: tmp1(klon)
+        real(kind=jprb) :: tmp2(klon, klev)
+        integer :: jk, jl
+
+        do jk=1,klev
+            tmp1(jl) = 0.0_jprb
+            do jl=1,klon
+                tmp2(jl, jk) = field2(jl, jk)
+                tmp1(jl) = field2(jl, jk)
+            end do
+            field1(jl) = tmp1(jl)
+        end do
+    end subroutine kernel
+end module kernel_mod
+    """.strip()
+
+    basedir = gettempdir()/'test_pool_allocator_temporaries'
+    basedir.mkdir(exist_ok=True)
+    (basedir/'driver.F90').write_text(fcode_driver)
+    (basedir/'kernel_mod.F90').write_text(fcode_kernel)
+
+    config = {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True
+        },
+        'routine': [{
+            'name': 'driver',
+            'role': 'driver',
+        }]
+    }
+    scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config), frontend=frontend)
+    transformation = TemporariesPoolAllocatorTransformation()
+    scheduler.process(transformation=transformation, reverse=True)
+
+    #
+    # A few checks on the driver
+    #
+    driver = scheduler['#driver'].routine
+
+    # Has the stack been added to the call statement?
+    calls = FindNodes(CallStatement).visit(driver.body)
+    assert len(calls) == 1
+    assert calls[0].arguments == ('klon', 'klev', 'field1(:,jblk)', 'field2(:,:,jblk)', 'ylstack')
+
+    #
+    # A few checks on the kernel
+    #
+    kernel = scheduler['kernel_mod#kernel'].routine
+
+    # Has the stack been added to the arguments?
+    assert 'ydstack' in kernel.arguments
+
+    # Is it being assigned to a local variable?
+    assert 'ylstack' in kernel.variables
+
+    # Let's check for the relevant "allocations" happening in the right order
+    assign_idx = {}
+    for idx, assign in enumerate(FindNodes(Assignment).visit(kernel.body)):
+        if assign.lhs == 'ylstack' and assign.rhs == 'ydstack':
+            # Local copy of stack status
+            assign_idx['stack_assign'] = idx
+        elif assign.lhs == 'ip_tmp1' and assign.rhs == 'ylstack%l':
+            # Assign Cray pointer for tmp1
+            assign_idx['tmp1_ptr_assign'] = idx
+        elif assign.lhs == 'ip_tmp2' and assign.rhs == 'ylstack%l':
+            # Assign Cray pointer for tmp2
+            assign_idx['tmp2_ptr_assign'] = idx
+        elif assign.lhs == 'ylstack%l' and 'ylstack%l' in assign.rhs and 'size' in assign.rhs and 'tmp1' in assign.rhs:
+            # Stack increment for tmp1
+            assign_idx['tmp1_stack_incr'] = idx
+        elif assign.lhs == 'ylstack%l' and 'ylstack%l' in assign.rhs and 'tmp2' in assign.rhs and 'tmp2' in assign.rhs:
+            # Stack increment for tmp2
+            assign_idx['tmp2_stack_incr'] = idx
+
+    expected_assign_in_order = [
+        'stack_assign', 'tmp1_ptr_assign', 'tmp1_stack_incr', 'tmp2_ptr_assign', 'tmp2_stack_incr'
+    ]
+    assert set(expected_assign_in_order) == set(assign_idx.keys())
+
+    for assign1, assign2 in zip(expected_assign_in_order, expected_assign_in_order[1:]):
+        assert assign_idx[assign2] > assign_idx[assign1]
+
+    # Check for pointer declarations in generated code
+    fcode = kernel.to_fortran()
+    assert 'pointer(ip_tmp1, tmp1)' in fcode.lower()
+    assert 'pointer(ip_tmp2, tmp2)' in fcode.lower()
+
+    # Check for stack size safegurads in generated code
+    assert fcode.lower().count('if (ylstack%l > ylstack%u)') == 2
+    assert fcode.lower().count('stop') == 2
+
+    rmtree(basedir)

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -18,9 +18,9 @@ from conftest import available_frontends
 from transformations.pool_allocator import TemporariesPoolAllocatorTransformation
 
 
-@pytest.fixture(scope='module', name='blocking')
-def fixture_blocking():
-    return Dimension(name='blocking', size='nb', index='b')
+@pytest.fixture(scope='module', name='block_dim')
+def fixture_block_dim():
+    return Dimension(name='block_dim', size='nb', index='b')
 
 
 def check_stack_module_import(routine):
@@ -66,7 +66,7 @@ def check_stack_created_in_driver(driver, stack_size, first_kernel_call, num_blo
 
 @pytest.mark.parametrize('generate_driver_stack', [False, True])
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_pool_allocator_temporaries(frontend, generate_driver_stack, blocking):
+def test_pool_allocator_temporaries(frontend, generate_driver_stack, block_dim):
     fcode_stack_import = "use stack_mod, only: stack"
     fcode_stack_decl = """
     integer :: istsz
@@ -144,7 +144,7 @@ end module kernel_mod
         }]
     }
     scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config), frontend=frontend)
-    transformation = TemporariesPoolAllocatorTransformation(block_dim=blocking)
+    transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
     scheduler.process(transformation=transformation, reverse=True)
     kernel_item = scheduler['kernel_mod#kernel']
 
@@ -220,9 +220,8 @@ end module kernel_mod
     rmtree(basedir)
 
 
-
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_pool_allocator_temporaries_kernel_sequence(frontend, blocking):
+def test_pool_allocator_temporaries_kernel_sequence(frontend, block_dim):
     fcode_driver = """
 subroutine driver(NLON, NZ, NGPBLK, FIELD1, FIELD2)
     use kernel_mod, only: kernel, kernel2
@@ -302,7 +301,7 @@ end module kernel_mod
         }]
     }
     scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config), frontend=frontend)
-    transformation = TemporariesPoolAllocatorTransformation(block_dim=blocking)
+    transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
     scheduler.process(transformation=transformation, reverse=True)
     kernel_item = scheduler['kernel_mod#kernel']
     kernel2_item = scheduler['kernel_mod#kernel2']
@@ -346,20 +345,184 @@ end module kernel_mod
 
         # Let's check for the relevant "allocations" happening in the right order
         assign_idx = {}
-        for idx, assign in enumerate(FindNodes(Assignment).visit(kernel.body)):
-            if assign.lhs == 'ylstack' and assign.rhs == 'ydstack':
+        for idx, ass in enumerate(FindNodes(Assignment).visit(kernel.body)):
+            if ass.lhs == 'ylstack' and ass.rhs == 'ydstack':
                 # Local copy of stack status
                 assign_idx['stack_assign'] = idx
-            elif assign.lhs == 'ip_tmp1' and assign.rhs == 'ylstack%l':
-                # Assign Cray pointer for tmp1
+            elif ass.lhs == 'ip_tmp1' and ass.rhs == 'ylstack%l':
+                # ass Cray pointer for tmp1
                 assign_idx['tmp1_ptr_assign'] = idx
-            elif assign.lhs == 'ip_tmp2' and assign.rhs == 'ylstack%l':
-                # Assign Cray pointer for tmp2
+            elif ass.lhs == 'ip_tmp2' and ass.rhs == 'ylstack%l':
+                # ass Cray pointer for tmp2
                 assign_idx['tmp2_ptr_assign'] = idx
-            elif assign.lhs == 'ylstack%l' and 'ylstack%l' in assign.rhs and 'size' in assign.rhs and 'tmp1' in assign.rhs:
+            elif ass.lhs == 'ylstack%l' and 'ylstack%l' in ass.rhs and 'size' in ass.rhs and 'tmp1' in ass.rhs:
                 # Stack increment for tmp1
                 assign_idx['tmp1_stack_incr'] = idx
-            elif assign.lhs == 'ylstack%l' and 'ylstack%l' in assign.rhs and 'tmp2' in assign.rhs and 'tmp2' in assign.rhs:
+            elif ass.lhs == 'ylstack%l' and 'ylstack%l' in ass.rhs and 'tmp2' in ass.rhs and 'tmp2' in ass.rhs:
+                # Stack increment for tmp2
+                assign_idx['tmp2_stack_incr'] = idx
+
+        expected_assign_in_order = [
+            'stack_assign', 'tmp1_ptr_assign', 'tmp1_stack_incr', 'tmp2_ptr_assign', 'tmp2_stack_incr'
+        ]
+        assert set(expected_assign_in_order) == set(assign_idx.keys())
+
+        for assign1, assign2 in zip(expected_assign_in_order, expected_assign_in_order[1:]):
+            assert assign_idx[assign2] > assign_idx[assign1]
+
+        # Check for pointer declarations in generated code
+        fcode = kernel.to_fortran()
+        assert 'pointer(ip_tmp1, tmp1)' in fcode.lower()
+        assert 'pointer(ip_tmp2, tmp2)' in fcode.lower()
+
+        # Check for stack size safegurads in generated code
+        assert fcode.lower().count('if (ylstack%l > ylstack%u)') == 2
+        assert fcode.lower().count('stop') == 2
+
+    rmtree(basedir)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_pool_allocator_temporaries_kernel_nested(frontend, block_dim):
+    fcode_driver = """
+subroutine driver(NLON, NZ, NGPBLK, FIELD1, FIELD2)
+    use kernel_mod, only: kernel
+    implicit none
+    INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+    INTEGER, INTENT(IN) :: NLON, NZ, NGPBLK
+    real(kind=jprb), intent(inout) :: field1(nlon, nb)
+    real(kind=jprb), intent(inout) :: field2(nlon, nz, nb)
+    integer :: b
+    do b=1,nb
+        call KERNEL(1, nlon, nlon, nz, field1(:,b), field2(:,:,b))
+    end do
+end subroutine driver
+    """.strip()
+    fcode_kernel = """
+module kernel_mod
+    implicit none
+contains
+    subroutine kernel(start, end, nlon, nz, field1, field2)
+        implicit none
+        integer, parameter :: jprb = selected_real_kind(13,300)
+        integer, intent(in) :: start, end, nlon, nz
+        real(kind=jprb), intent(inout) :: field1(nlon)
+        real(kind=jprb), intent(inout) :: field2(nlon,nz)
+        real(kind=jprb) :: tmp1(nlon)
+        real(kind=jprb) :: tmp2(nlon, nz)
+        integer :: jk, jl
+
+        do jk=1,nz
+            tmp1(jl) = 0.0_jprb
+            do jl=start,end
+                tmp2(jl, jk) = field2(jl, jk)
+                tmp1(jl) = field2(jl, jk)
+            end do
+            field1(jl) = tmp1(jl)
+        end do
+
+        call kernel2(start, end, nlon, nz, field2)
+    end subroutine kernel
+
+    subroutine kernel2(start, end, nlon, nz, field2)
+        implicit none
+        integer, parameter :: jprb = selected_real_kind(13,300)
+        integer, intent(in) :: start, end, nlon, nz
+        real(kind=jprb), intent(inout) :: field2(nlon,nz)
+        real(kind=jprb) :: tmp1(nlon, nz), tmp2(nlon, nz)
+        integer :: jk, jl
+
+        do jk=1,nz
+            do jl=start,end
+                tmp1(jl, jk) = field2(jl, jk)
+                tmp2(jl, jk) = tmp1(jl, jk) + 1._jprb
+                field2(jl, jk) = tmp2(jl, jk)
+            end do
+        end do
+    end subroutine kernel2
+
+end module kernel_mod
+    """.strip()
+
+    basedir = gettempdir()/'test_pool_allocator_temporaries_kernel_nested'
+    basedir.mkdir(exist_ok=True)
+    (basedir/'driver.F90').write_text(fcode_driver)
+    (basedir/'kernel_mod.F90').write_text(fcode_kernel)
+
+    config = {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True
+        },
+        'routine': [{
+            'name': 'driver',
+            'role': 'driver',
+        }]
+    }
+    scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config), frontend=frontend)
+    transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
+    scheduler.process(transformation=transformation, reverse=True)
+    kernel_item = scheduler['kernel_mod#kernel']
+    kernel2_item = scheduler['kernel_mod#kernel2']
+
+    assert transformation._key in kernel_item.trafo_data
+    assert kernel_item.trafo_data[transformation._key] == 'nlon + 3 * nlon * nz'
+    assert kernel2_item.trafo_data[transformation._key] == '2 * nlon * nz'
+    assert all(v.scope is None for v in FindVariables().visit(kernel_item.trafo_data[transformation._key]))
+    assert all(v.scope is None for v in FindVariables().visit(kernel2_item.trafo_data[transformation._key]))
+
+    #
+    # A few checks on the driver
+    #
+    driver = scheduler['#driver'].routine
+
+    # Has the stack module been imported?
+    check_stack_module_import(driver)
+
+    # Has the stack been added to the call statements?
+    calls = FindNodes(CallStatement).visit(driver.body)
+    assert len(calls) == 1
+    assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack')
+
+    check_stack_created_in_driver(driver, 'nlon + 3 * nlon * nz', calls[0], 1)
+
+    #
+    # A few checks on the kernels
+    #
+    calls = FindNodes(CallStatement).visit(kernel_item.routine.body)
+    assert len(calls) == 1
+    assert calls[0].arguments == ('start', 'end', 'nlon', 'nz', 'field2', 'ylstack')
+
+    for item in [kernel_item, kernel2_item]:
+        kernel = item.routine
+
+        # Has the stack module been imported?
+        check_stack_module_import(kernel)
+
+        # Has the stack been added to the arguments?
+        assert 'ydstack' in kernel.arguments
+
+        # Is it being assigned to a local variable?
+        assert 'ylstack' in kernel.variables
+
+        # Let's check for the relevant "allocations" happening in the right order
+        assign_idx = {}
+        for idx, ass in enumerate(FindNodes(Assignment).visit(kernel.body)):
+            if ass.lhs == 'ylstack' and ass.rhs == 'ydstack':
+                # Local copy of stack status
+                assign_idx['stack_assign'] = idx
+            elif ass.lhs == 'ip_tmp1' and ass.rhs == 'ylstack%l':
+                # ass Cray pointer for tmp1
+                assign_idx['tmp1_ptr_assign'] = idx
+            elif ass.lhs == 'ip_tmp2' and ass.rhs == 'ylstack%l':
+                # ass Cray pointer for tmp2
+                assign_idx['tmp2_ptr_assign'] = idx
+            elif ass.lhs == 'ylstack%l' and 'ylstack%l' in ass.rhs and 'size' in ass.rhs and 'tmp1' in ass.rhs:
+                # Stack increment for tmp1
+                assign_idx['tmp1_stack_incr'] = idx
+            elif ass.lhs == 'ylstack%l' and 'ylstack%l' in ass.rhs and 'tmp2' in ass.rhs and 'tmp2' in ass.rhs:
                 # Stack increment for tmp2
                 assign_idx['tmp2_stack_incr'] = idx
 

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -9,7 +9,7 @@ from shutil import rmtree
 
 import pytest
 from loki import (
-    gettempdir, Scheduler, SchedulerConfig,
+    gettempdir, Scheduler, SchedulerConfig, Dimension,
     FindNodes,
     CallStatement, Assignment
 )
@@ -18,28 +18,51 @@ from conftest import available_frontends
 from transformations.pool_allocator import TemporariesPoolAllocatorTransformation
 
 
+@pytest.fixture(scope='module', name='horizontal')
+def fixture_horizontal():
+    return Dimension(name='horizontal', size='nlon', index='jl', bounds=('start', 'end'))
+
+
+@pytest.fixture(scope='module', name='vertical')
+def fixture_vertical():
+    return Dimension(name='vertical', size='nz', index='jk')
+
+
+@pytest.fixture(scope='module', name='blocking')
+def fixture_blocking():
+    return Dimension(name='blocking', size='nb', index='b')
+
+
+@pytest.mark.parametrize('generate_driver_stack', [False, True])
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_pool_allocator_temporaries(frontend):
-    fcode_driver = """
-subroutine driver(KLON, KLEV, NGPBLK, FIELD1, FIELD2)
-    use stack_mod, only: stack
-    use kernel_mod, only: kernel
-    implicit none
-    INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
-    INTEGER, INTENT(IN) :: KLON, KLEV, NGPBLK
-    real(kind=jprb), intent(inout) :: field1(klon, ngpblk)
-    real(kind=jprb), intent(inout) :: field2(klon, klev, ngpblk)
-    integer :: jblk
+def test_pool_allocator_temporaries(frontend, generate_driver_stack, horizontal, vertical, blocking):
+    fcode_stack_decl = """
     integer :: istsz
     REAL(KIND=JPRGB), ALLOCATABLE :: PSTACK(:, :)
     type(stack) :: ylstack
 
-    istsz = (klev+1) * klon
-    ALLOCATE(PSTACK(ISTSZ, NGPBLK))
-    do jblk=1,ngpblk
-        ylstack%l = loc(pstack, (1, jblk))
+    istsz = (nz+1) * nlon
+    ALLOCATE(PSTACK(ISTSZ, nb))
+    """
+    fcode_stack_assign = """
+        ylstack%l = loc(pstack, (1, b))
         ylstack%u = ylstack%l + 8 * istsz
-        call KERNEL(klon, klev, field1(:,jblk), field2(:,:,jblk))
+    """
+
+    fcode_driver = f"""
+subroutine driver(NLON, NZ, NGPBLK, FIELD1, FIELD2)
+    use stack_mod, only: stack
+    use kernel_mod, only: kernel
+    implicit none
+    INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+    INTEGER, INTENT(IN) :: NLON, NZ, NGPBLK
+    real(kind=jprb), intent(inout) :: field1(nlon, nb)
+    real(kind=jprb), intent(inout) :: field2(nlon, nz, nb)
+    integer :: b
+    {fcode_stack_decl if not generate_driver_stack else ''}
+    do b=1,nb
+        {fcode_stack_assign if not generate_driver_stack else ''}
+        call KERNEL(nlon, nz, field1(:,b), field2(:,:,b))
     end do
 end subroutine driver
     """.strip()
@@ -47,19 +70,19 @@ end subroutine driver
 module kernel_mod
     implicit none
 contains
-    subroutine kernel(klon, klev, field1, field2)
+    subroutine kernel(start, end, nlon, nz, field1, field2)
         implicit none
         integer, parameter :: jprb = selected_real_kind(13,300)
-        integer, intent(in) :: klon, klev
-        real(kind=jprb), intent(inout) :: field1(klon)
-        real(kind=jprb), intent(inout) :: field2(klon,klev)
-        real(kind=jprb) :: tmp1(klon)
-        real(kind=jprb) :: tmp2(klon, klev)
+        integer, intent(in) :: start, end, nlon, nz
+        real(kind=jprb), intent(inout) :: field1(nlon)
+        real(kind=jprb), intent(inout) :: field2(nlon,nz)
+        real(kind=jprb) :: tmp1(nlon)
+        real(kind=jprb) :: tmp2(nlon, nz)
         integer :: jk, jl
 
-        do jk=1,klev
+        do jk=1,nz
             tmp1(jl) = 0.0_jprb
-            do jl=1,klon
+            do jl=start,end
                 tmp2(jl, jk) = field2(jl, jk)
                 tmp1(jl) = field2(jl, jk)
             end do
@@ -87,7 +110,9 @@ end module kernel_mod
         }]
     }
     scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config), frontend=frontend)
-    transformation = TemporariesPoolAllocatorTransformation()
+    transformation = TemporariesPoolAllocatorTransformation(
+        horizontal=horizontal, vertical=vertical, block_dim=blocking
+    )
     scheduler.process(transformation=transformation, reverse=True)
 
     #
@@ -98,12 +123,16 @@ end module kernel_mod
     # Has the stack been added to the call statement?
     calls = FindNodes(CallStatement).visit(driver.body)
     assert len(calls) == 1
-    assert calls[0].arguments == ('klon', 'klev', 'field1(:,jblk)', 'field2(:,:,jblk)', 'ylstack')
+    assert calls[0].arguments == ('nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack')
 
     #
     # A few checks on the kernel
     #
     kernel = scheduler['kernel_mod#kernel'].routine
+
+    # Has the stack module been imported?
+    assert any(import_.module.lower() == 'stack_mod' for import_ in kernel.imports)
+    assert 'stack' in kernel.imported_symbols
 
     # Has the stack been added to the arguments?
     assert 'ydstack' in kernel.arguments
@@ -146,5 +175,8 @@ end module kernel_mod
     # Check for stack size safegurads in generated code
     assert fcode.lower().count('if (ylstack%l > ylstack%u)') == 2
     assert fcode.lower().count('stop') == 2
+
+    if generate_driver_stack:
+        breakpoint()
 
     rmtree(basedir)

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -28,7 +28,7 @@ def check_stack_module_import(routine):
     assert 'stack' in routine.imported_symbols
 
 
-def check_stack_created_in_driver(driver, stack_size, first_kernel_call, generate_driver_stack=True):
+def check_stack_created_in_driver(driver, stack_size, first_kernel_call, num_block_loops, generate_driver_stack=True):
     # Are stack size, storage and stack derived type declared?
     assert 'istsz' in driver.variables
     assert 'pstack(:,:)' in driver.variables
@@ -44,12 +44,12 @@ def check_stack_created_in_driver(driver, stack_size, first_kernel_call, generat
     assignments = FindNodes(Assignment).visit(driver.body)
     for assignment in assignments:
         if assignment.lhs == 'istsz':
-            assert simplify(assignment.rhs) == stack_size
+            assert str(simplify(assignment.rhs)).lower().replace(' ', '') == str(stack_size).lower().replace(' ', '')
             break
 
     # Check for stack assignment inside loop
     loops = FindNodes(Loop).visit(driver.body)
-    assert len(loops) == 1
+    assert len(loops) == num_block_loops
     assignments = FindNodes(Assignment).visit(loops[0].body)
     assert len(assignments) == 2
     assert assignments[0].lhs == 'ylstack%l'
@@ -95,7 +95,7 @@ subroutine driver(NLON, NZ, NGPBLK, FIELD1, FIELD2)
     {fcode_stack_decl if not generate_driver_stack else ''}
     do b=1,nb
         {fcode_stack_assign if not generate_driver_stack else ''}
-        call KERNEL(nlon, nz, field1(:,b), field2(:,:,b))
+        call KERNEL(1, nlon, nlon, nz, field1(:,b), field2(:,:,b))
     end do
     {fcode_stack_dealloc if not generate_driver_stack else ''}
 end subroutine driver
@@ -163,9 +163,9 @@ end module kernel_mod
     # Has the stack been added to the call statement?
     calls = FindNodes(CallStatement).visit(driver.body)
     assert len(calls) == 1
-    assert calls[0].arguments == ('nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack')
+    assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack')
 
-    check_stack_created_in_driver(driver, 'nlon + nlon * nz', calls[0], generate_driver_stack)
+    check_stack_created_in_driver(driver, 'nlon + nlon * nz', calls[0], 1, generate_driver_stack)
 
     #
     # A few checks on the kernel
@@ -216,5 +216,168 @@ end module kernel_mod
     # Check for stack size safegurads in generated code
     assert fcode.lower().count('if (ylstack%l > ylstack%u)') == 2
     assert fcode.lower().count('stop') == 2
+
+    rmtree(basedir)
+
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_pool_allocator_temporaries_kernel_sequence(frontend, blocking):
+    fcode_driver = """
+subroutine driver(NLON, NZ, NGPBLK, FIELD1, FIELD2)
+    use kernel_mod, only: kernel, kernel2
+    implicit none
+    INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+    INTEGER, INTENT(IN) :: NLON, NZ, NGPBLK
+    real(kind=jprb), intent(inout) :: field1(nlon, nb)
+    real(kind=jprb), intent(inout) :: field2(nlon, nz, nb)
+    integer :: b
+    do b=1,nb
+        call KERNEL(1, nlon, nlon, nz, field1(:,b), field2(:,:,b))
+    end do
+    do b=1,nb
+        call KERNEL2(1, nlon, nlon, nz, field2(:,:,b))
+    end do
+end subroutine driver
+    """.strip()
+    fcode_kernel = """
+module kernel_mod
+    implicit none
+contains
+    subroutine kernel(start, end, nlon, nz, field1, field2)
+        implicit none
+        integer, parameter :: jprb = selected_real_kind(13,300)
+        integer, intent(in) :: start, end, nlon, nz
+        real(kind=jprb), intent(inout) :: field1(nlon)
+        real(kind=jprb), intent(inout) :: field2(nlon,nz)
+        real(kind=jprb) :: tmp1(nlon)
+        real(kind=jprb) :: tmp2(nlon, nz)
+        integer :: jk, jl
+
+        do jk=1,nz
+            tmp1(jl) = 0.0_jprb
+            do jl=start,end
+                tmp2(jl, jk) = field2(jl, jk)
+                tmp1(jl) = field2(jl, jk)
+            end do
+            field1(jl) = tmp1(jl)
+        end do
+    end subroutine kernel
+
+    subroutine kernel2(start, end, nlon, nz, field2)
+        implicit none
+        integer, parameter :: jprb = selected_real_kind(13,300)
+        integer, intent(in) :: start, end, nlon, nz
+        real(kind=jprb), intent(inout) :: field2(nlon,nz)
+        real(kind=jprb) :: tmp1(nlon, nz), tmp2(nlon, nz)
+        integer :: jk, jl
+
+        do jk=1,nz
+            do jl=start,end
+                tmp1(jl, jk) = field2(jl, jk)
+                tmp2(jl, jk) = tmp1(jl, jk) + 1._jprb
+                field2(jl, jk) = tmp2(jl, jk)
+            end do
+        end do
+    end subroutine kernel2
+
+end module kernel_mod
+    """.strip()
+
+    basedir = gettempdir()/'test_pool_allocator_temporaries_kernel_sequence'
+    basedir.mkdir(exist_ok=True)
+    (basedir/'driver.F90').write_text(fcode_driver)
+    (basedir/'kernel_mod.F90').write_text(fcode_kernel)
+
+    config = {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True
+        },
+        'routine': [{
+            'name': 'driver',
+            'role': 'driver',
+        }]
+    }
+    scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config), frontend=frontend)
+    transformation = TemporariesPoolAllocatorTransformation(block_dim=blocking)
+    scheduler.process(transformation=transformation, reverse=True)
+    kernel_item = scheduler['kernel_mod#kernel']
+    kernel2_item = scheduler['kernel_mod#kernel2']
+
+    assert transformation._key in kernel_item.trafo_data
+    assert kernel_item.trafo_data[transformation._key] == 'nlon + nlon * nz'
+    assert kernel2_item.trafo_data[transformation._key] == '2 * nlon * nz'
+    assert all(v.scope is None for v in FindVariables().visit(kernel_item.trafo_data[transformation._key]))
+    assert all(v.scope is None for v in FindVariables().visit(kernel2_item.trafo_data[transformation._key]))
+
+    #
+    # A few checks on the driver
+    #
+    driver = scheduler['#driver'].routine
+
+    # Has the stack module been imported?
+    check_stack_module_import(driver)
+
+    # Has the stack been added to the call statements?
+    calls = FindNodes(CallStatement).visit(driver.body)
+    assert len(calls) == 2
+    assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack')
+    assert calls[1].arguments == ('1', 'nlon', 'nlon', 'nz', 'field2(:,:,b)', 'ylstack')
+
+    check_stack_created_in_driver(driver, 'max(nlon + nlon * nz, 2 * nlon * nz)', calls[0], 2)
+
+    #
+    # A few checks on the kernel
+    #
+    for item in [kernel_item, kernel2_item]:
+        kernel = item.routine
+
+        # Has the stack module been imported?
+        check_stack_module_import(kernel)
+
+        # Has the stack been added to the arguments?
+        assert 'ydstack' in kernel.arguments
+
+        # Is it being assigned to a local variable?
+        assert 'ylstack' in kernel.variables
+
+        # Let's check for the relevant "allocations" happening in the right order
+        assign_idx = {}
+        for idx, assign in enumerate(FindNodes(Assignment).visit(kernel.body)):
+            if assign.lhs == 'ylstack' and assign.rhs == 'ydstack':
+                # Local copy of stack status
+                assign_idx['stack_assign'] = idx
+            elif assign.lhs == 'ip_tmp1' and assign.rhs == 'ylstack%l':
+                # Assign Cray pointer for tmp1
+                assign_idx['tmp1_ptr_assign'] = idx
+            elif assign.lhs == 'ip_tmp2' and assign.rhs == 'ylstack%l':
+                # Assign Cray pointer for tmp2
+                assign_idx['tmp2_ptr_assign'] = idx
+            elif assign.lhs == 'ylstack%l' and 'ylstack%l' in assign.rhs and 'size' in assign.rhs and 'tmp1' in assign.rhs:
+                # Stack increment for tmp1
+                assign_idx['tmp1_stack_incr'] = idx
+            elif assign.lhs == 'ylstack%l' and 'ylstack%l' in assign.rhs and 'tmp2' in assign.rhs and 'tmp2' in assign.rhs:
+                # Stack increment for tmp2
+                assign_idx['tmp2_stack_incr'] = idx
+
+        expected_assign_in_order = [
+            'stack_assign', 'tmp1_ptr_assign', 'tmp1_stack_incr', 'tmp2_ptr_assign', 'tmp2_stack_incr'
+        ]
+        assert set(expected_assign_in_order) == set(assign_idx.keys())
+
+        for assign1, assign2 in zip(expected_assign_in_order, expected_assign_in_order[1:]):
+            assert assign_idx[assign2] > assign_idx[assign1]
+
+        # Check for pointer declarations in generated code
+        fcode = kernel.to_fortran()
+        assert 'pointer(ip_tmp1, tmp1)' in fcode.lower()
+        assert 'pointer(ip_tmp2, tmp2)' in fcode.lower()
+
+        # Check for stack size safegurads in generated code
+        assert fcode.lower().count('if (ylstack%l > ylstack%u)') == 2
+        assert fcode.lower().count('stop') == 2
 
     rmtree(basedir)

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -1124,7 +1124,7 @@ def test_single_column_coalesced_multiple_acc_pragmas(frontend, horizontal, vert
     transformation.transform_subroutine(routine, role='driver', targets=['some_kernel',])
 
     # Check that both acc pragmas are created
-    pragmas = FindNodes(Pragma).visit(routine.body)
+    pragmas = FindNodes(Pragma).visit(routine.ir)
     assert len(pragmas) == 4
     assert pragmas[0].keyword == 'acc'
     assert pragmas[1].keyword == 'acc'

--- a/transformations/transformations/__init__.py
+++ b/transformations/transformations/__init__.py
@@ -12,5 +12,6 @@ from transformations.single_column_claw import * # noqa
 from transformations.single_column_coalesced import * # noqa
 from transformations.utility_routines import * # noqa
 from transformations.scc_cuf import * # noqa
+from transformations.pool_allocator import * # noqa
 
 __version__ = "0.0.0"

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -124,6 +124,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         self.local_ptr_var_name_pattern = local_ptr_var_name_pattern
         self.directive = directive
         self.check_bounds = check_bounds
+
         if key:
             self._key = key
 
@@ -133,8 +134,12 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         item = kwargs.get('item', None)
         targets = kwargs.get('targets', None)
 
-        if item and item.local_name != routine.name.lower():
-            return
+        self.stack_type_kind = 'JPRB'
+        if item:
+            if item.local_name != routine.name.lower():
+                return
+            if (real_kind := item.config.get('real_kind', None)):
+                self.stack_type_kind = real_kind
 
         successors = kwargs.get('successors', ())
 
@@ -256,7 +261,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             # allocation/deallocation statements
             stack_type = SymbolAttributes(
                 dtype=BasicType.REAL,
-                kind=Variable(name='JPRB', scope=routine),
+                kind=Variable(name=self.stack_type_kind, scope=routine),
                 shape=(RangeIndex((None, None)), RangeIndex((None, None))),
                 allocatable=True,
             )

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -6,10 +6,10 @@
 # nor does it submit to any jurisdiction.
 
 from loki import (
-    as_tuple, warning, simplify,
-    Transformation, FindNodes, Transformer, DetachScopesMapper,
+    as_tuple, warning, simplify, recursive_expression_map_update,
+    Transformation, FindNodes, FindVariables, Transformer, SubstituteExpressions, DetachScopesMapper,
     SymbolAttributes, BasicType, DerivedType,
-    Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex, IntrinsicLiteral,
+    Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex,
     Intrinsic, Assignment, Conditional, CallStatement, Import, Allocation, Deallocation,
     Loop
 )
@@ -62,12 +62,12 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         if role == 'kernel':
             stack_size = self.apply_temporaries_pool_allocator(routine)
             if item:
-                stack_size = self._determine_stack_size(successors, stack_size)
+                stack_size = self._determine_stack_size(routine, successors, stack_size)
                 stack_size = DetachScopesMapper()(stack_size)
                 item.trafo_data[self._key] = stack_size
 
         elif role == 'driver':
-            stack_size = self._determine_stack_size(successors)
+            stack_size = self._determine_stack_size(routine, successors)
             self.create_temporaries_pool_allocator(routine, stack_size)
 
         self.inject_pool_allocator_into_calls(routine, targets)
@@ -110,7 +110,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             scope=routine
         )
 
-    def _get_stack_storage_and_size(self, routine, stack_size):
+    def _get_stack_storage_and_size_var(self, routine, stack_size):
         variable_map = routine.variable_map
         body_prepend = []
         body_append = []
@@ -150,9 +150,26 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             routine.body.append(body_append)
         return stack_storage, stack_size_var
 
-    def _determine_stack_size(self, successors, local_stack_size=None):
+    def _determine_stack_size(self, routine, successors, local_stack_size=None):
+        successor_map = {successor.routine.name.lower(): successor for successor in successors}
         # Collect stack sizes for successors
-        stack_sizes = [s.trafo_data[self._key] for s in successors if self._key in s.trafo_data]
+        stack_sizes = []
+        for call in FindNodes(CallStatement).visit(routine.body):
+            if call.name in successor_map and self._key in successor_map[call.name].trafo_data:
+                successor_stack_size = successor_map[call.name].trafo_data[self._key]
+                # Replace any occurence of routine arguments in the stack size expression
+                arg_map = {
+                    kernel_parameter: call_arg for kernel_parameter, call_arg in call.arg_iter()
+                }
+                expr_map = {
+                    expr: arg_map[expr] for expr in FindVariables().visit(successor_stack_size)
+                    if expr in arg_map
+                }
+                if expr_map:
+                    expr_map = recursive_expression_map_update(expr_map)
+                    successor_stack_size = SubstituteExpressions(expr_map).visit(successor_stack_size)
+                stack_sizes += [successor_stack_size]
+        # stack_sizes = [s.trafo_data[self._key] for s in successors if self._key in s.trafo_data]
         # Unwind "max" expressions from successors
         stack_sizes = [
             d for s in stack_sizes
@@ -216,7 +233,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
 
     def create_temporaries_pool_allocator(self, routine, stack_size):
         # Create and allocate the stack
-        stack_storage, stack_size = self._get_stack_storage_and_size(routine, stack_size)
+        stack_storage, stack_size = self._get_stack_storage_and_size_var(routine, stack_size)
         self._get_stack_var(routine)
         stack_ptr = self._get_stack_ptr(routine)
         stack_end = self._get_stack_end(routine)
@@ -224,30 +241,38 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         # Find first block loop and assign local stack pointers there
         loop_map = {}
         for loop in FindNodes(Loop).visit(routine.body):
-            if loop.variable == self.block_dim.index:
-                # Check for existing pointer assignment
-                if any(a.lhs == stack_ptr.name for a in FindNodes(Assignment).visit(loop.body)):  # pylint: disable=no-member
-                    break
+            assignments = FindNodes(Assignment).visit(loop.body)
+            if loop.variable != self.block_dim.index:
+                # Check if block variable is assigned in loop body
+                if not any(a.lhs == self.block_dim.index for a in assignments):
+                    continue
 
-                ptr_assignment = Assignment(
-                    lhs=stack_ptr, rhs=InlineCall(
-                        function=Variable(name='LOC'),
-                        parameters=(
-                            stack_storage.clone(dimensions=None),
-                            IntrinsicLiteral(f'(1, {loop.variable.name})')
-                        ),
-                        kw_parameters=None
-                    )
-                )
-                # Stack increment
-                stack_incr = Assignment(
-                    lhs=stack_end, rhs=Sum((stack_ptr, Product((stack_size, Literal(8)))))
-                )
-                loop_map[loop] = loop.clone(body=(ptr_assignment, stack_incr) + loop.body)
+            # Check for existing pointer assignment
+            if any(a.lhs == stack_ptr.name for a in FindNodes(Assignment).visit(loop.body)):  # pylint: disable=no-member
                 break
+
+            ptr_assignment = Assignment(
+                lhs=stack_ptr, rhs=InlineCall(
+                    function=Variable(name='LOC'),
+                    parameters=(
+                        stack_storage.clone(
+                            dimensions=(Literal(1), Variable(name=self.block_dim.index, scope=routine))
+                        ),
+                    ),
+                    kw_parameters=None
+                )
+            )
+            # Stack increment
+            stack_incr = Assignment(
+                lhs=stack_end, rhs=Sum((stack_ptr, Product((stack_size, Literal(8)))))
+            )
+            loop_map[loop] = loop.clone(body=(ptr_assignment, stack_incr) + loop.body)
+            break
+
         else:
+            breakpoint()
             warning(
-                f'{self.__class__.__name__}:'
+                f'{self.__class__.__name__}: '
                 'Could not find a block dimension loop; no stack pointer assignment inserted.'
             )
 

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -508,7 +508,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                 assign_pos = -1
 
             # Check for existing pointer assignment
-            if any(a.lhs == stack_ptr.name for a in FindNodes(Assignment).visit(loop.body)):  # pylint: disable=no-member
+            if any(a.lhs == stack_ptr.name for a in assignments):  # pylint: disable=no-member
                 break
 
             ptr_assignment = Assignment(

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -544,13 +544,12 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         """
         call_map = {}
         stack_var = self._get_local_stack_var(routine)
-        intfs = FindNodes(Interface).visit(routine.spec)
         for call in FindNodes(CallStatement).visit(routine.body):
             if call.name in targets:
                # If call is declared via an explicit interface, the ProcedureSymbol corresponding to the call is the
                # interface block rather than the Subroutine itself. This means we have to update the interface block
                # accordingly
-                if call.name in [s for i in intfs for s in i.symbols]:
+                if call.name in [s for i in FindNodes(Interface).visit(routine.spec) for s in i.symbols]:
                     _ = self._get_stack_arg(call.routine)
 
                 if call.routine != BasicType.DEFERRED and self.stack_argument_name in call.routine.arguments:

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -11,7 +11,7 @@ from loki import (
     SymbolAttributes, BasicType, DerivedType,
     Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex,
     Intrinsic, Assignment, Conditional, CallStatement, Import, Allocation, Deallocation,
-    Loop, Pragma, SubroutineItem, FindInlineCalls
+    Loop, Pragma, SubroutineItem, FindInlineCalls, Interface
 )
 
 __all__ = ['TemporariesPoolAllocatorTransformation']
@@ -531,8 +531,15 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         """
         call_map = {}
         stack_var = self._get_local_stack_var(routine)
+        intfs = FindNodes(Interface).visit(routine.spec)
         for call in FindNodes(CallStatement).visit(routine.body):
             if call.name in targets:
+               # If call is declared via an explicit interface, the ProcedureSymbol corresponding to the call is the
+               # interface block rather than the Subroutine itself. This means we have to update the interface block
+               # accordingly
+                if call.name in [s for i in intfs for s in i.symbols]:
+                    stack_arg = self._get_stack_arg(call.routine)
+
                 if call.routine != BasicType.DEFERRED and self.stack_argument_name in call.routine.arguments:
                     arg_idx = call.routine.arguments.index(self.stack_argument_name)
                     arguments = call.arguments

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -6,25 +6,45 @@
 # nor does it submit to any jurisdiction.
 
 from loki import (
+    as_tuple,
     Transformation, FindNodes, Transformer,
     SymbolAttributes, BasicType, DerivedType,
     Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex,
-    Intrinsic, Assignment, Conditional, CallStatement, Import
+    Intrinsic, Assignment, Conditional, CallStatement, Import, Allocation, Deallocation,
+    Loop
 )
 
 __all__ = ['TemporariesPoolAllocatorTransformation']
 
 
 class TemporariesPoolAllocatorTransformation(Transformation):
+    """
+    Parameters
+    ----------
+    horizontal : :any:`Dimension`
+        :any:`Dimension` object describing the variable conventions used in code
+        to define the horizontal data dimension and iteration space.
+    vertical : :any:`Dimension`
+        :any:`Dimension` object describing the variable conventions used in code
+        to define the vertical dimension, as needed to decide array privatization.
+    block_dim : :any:`Dimension`
+        Optional ``Dimension`` object to define the blocking dimension
+        to use for hoisted column arrays if hoisting is enabled.
+    """
 
-    def __init__(self, stack_module_name='STACK_MOD', stack_type_name='STACK', stack_ptr_name='L',
-                 stack_size_name='U', stack_storage_name='PSTACK',
+    def __init__(self, horizontal, vertical, block_dim,
+                 stack_module_name='STACK_MOD', stack_type_name='STACK', stack_ptr_name='L',
+                 stack_end_name='U', stack_size_name='ISTSZ', stack_storage_name='PSTACK',
                  stack_arg_name='YDSTACK', stack_var_name='YLSTACK', pointer_var_name_pattern='IP_{name}',
                  **kwargs):
         super().__init__(**kwargs)
+        self.horizontal = horizontal
+        self.vertical = vertical
+        self.block_dim = block_dim
         self.stack_module_name = stack_module_name
         self.stack_type_name = stack_type_name
         self.stack_ptr_name = stack_ptr_name
+        self.stack_end_name = stack_end_name
         self.stack_size_name = stack_size_name
         self.stack_storage_name = stack_storage_name
         self.stack_arg_name = stack_arg_name
@@ -81,34 +101,58 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             scope=routine
         )
 
-    def _get_stack_size(self, routine):
+    def _get_stack_end(self, routine):
         return Variable(
-            name=f'{self.stack_var_name}%{self.stack_size_name}',
+            name=f'{self.stack_var_name}%{self.stack_end_name}',
             parent=self._get_stack_var(routine),
             scope=routine
         )
 
-    def _get_stack_storage(self, routine):
+    def _get_stack_storage_and_size(self, routine):
+        body_prepend = []
+        body_append = []
+        variables_append = []
+        if self.stack_size_name in routine.variables:
+            stack_size = routine.variable_map[self.stack_size_name]
+        else:
+            stack_size = Variable(name=self.stack_size_name, type=SymbolAttributes(BasicType.INTEGER))
+            stack_size_assign = Assignment(
+                lhs=stack_size,
+                rhs=Product((
+                    Literal(50),
+                    Variable(name=self.horizontal.size, scope=routine),
+                    Variable(name=self.vertical.size, scope=routine)
+                ))
+            )
+            variables_append += [stack_size]
+            body_prepend += [stack_size_assign]
         if self.stack_storage_name in routine.variables:
-            return routine.variable_map[self.stack_storage_name]
-
-        stack_type = SymbolAttributes(
-            dtype=BasicType.REAL,
-            kind=Variable(name='JPRB', scope=routine),
-            shape=(
-                Product((Literal(5000), Variable(name='KLON', scope=routine))),
-                Variable(name='NGPBLK', scope=routine)
-            ),
-            allocatable=True,
-        )
-        stack_storage = Variable(
-            name=self.stack_storage_name, type=stack_type,
-            dimensions=(RangeIndex((None, None)), RangeIndex((None, None))),
-            scope=routine
-        )
-        routine.variables += (stack_storage,)
-        return stack_storage
-
+            stack_storage = routine.variable_map[self.stack_storage_name]
+        else:
+            stack_type = SymbolAttributes(
+                dtype=BasicType.REAL,
+                kind=Variable(name='JPRB', scope=routine),
+                shape=(RangeIndex((None, None)), RangeIndex((None, None))),
+                allocatable=True,
+            )
+            stack_storage = Variable(
+                name=self.stack_storage_name, type=stack_type,
+                dimensions=stack_type.shape, scope=routine
+            )
+            variables_append += [stack_storage]
+            stack_alloc = Allocation(variables=(stack_storage.clone(dimensions=(  # pylint: disable=no-member
+                stack_size, Variable(name=self.block_dim.size, scope=routine)
+            )),))
+            body_prepend += [stack_alloc]
+            stack_dealloc = Deallocation(variables=(stack_storage.clone(dimensions=None),))  # pylint: disable=no-member
+            body_append += [stack_dealloc]
+        if variables_append:
+            routine.variables += as_tuple(variables_append)
+        if body_prepend:
+            routine.body.prepend(body_prepend)
+        if body_append:
+            routine.body.append(body_append)
+        return stack_storage, stack_size
 
     def _create_stack_allocation(self, stack_ptr, stack_size, ptr_var, arr):
         ptr_assignment = Assignment(lhs=ptr_var, rhs=stack_ptr)
@@ -136,27 +180,38 @@ class TemporariesPoolAllocatorTransformation(Transformation):
 
         # Create Cray pointer declarations and "stack allocations"
         declarations = []
-        stack_ptr = Variable(name=f'{self.stack_var_name}%{self.stack_ptr_name}', parent=stack_var, scope=routine)
-        stack_size = Variable(name=f'{self.stack_var_name}%{self.stack_size_name}', parent=stack_var, scope=routine)
+        stack_ptr = self._get_stack_ptr(routine)
+        stack_end = self._get_stack_end(routine)
         for arr in temporary_arrays:
             ptr_var = Variable(name=self.pointer_var_name_pattern.format(name=arr.name), scope=routine)
             declarations += [Intrinsic(f'POINTER({ptr_var.name}, {arr.name})')]  # pylint: disable=no-member
-            allocations += self._create_stack_allocation(stack_ptr, stack_size, ptr_var, arr)
+            allocations += self._create_stack_allocation(stack_ptr, stack_end, ptr_var, arr)
 
         routine.spec.append(declarations)
         routine.body.prepend(allocations)
 
     def create_temporaries_pool_allocator(self, routine):
-        # TODO
-        # Create local stack var
-        # stack_storage = self._get_stack_storage(routine)
-        # stack_var = self._get_stack_var(routine)
-        # stack_alloc = Allocation(variables=stack_storage.clone(dimensions=stack_storage.shape))
-        # ptr_assignment = Assignment(
-        #     lhs=self._get_stack_ptr(routine),
-        #     rhs=InlineCall(Variable(name='LOC'), parameters=)
-        # )
-        pass
+        # Create and allocate the stack
+        stack_storage, stack_size = self._get_stack_storage_and_size(routine)
+        self._get_stack_var(routine)
+        stack_ptr = self._get_stack_ptr(routine)
+        stack_end = self._get_stack_end(routine)
+
+        # Find block loops and assign local stack pointers there
+        loop_map = {}
+        for loop in FindNodes(Loop).visit(routine.body):
+            if loop.variable == self.block_dim.index:
+                ptr_assignment = Intrinsic(
+                    f'{stack_ptr.name} = LOC({stack_storage.name}, (1, {loop.variable.name}))'  # pylint: disable=no-member
+                )
+                # Stack increment
+                stack_incr = Assignment(
+                    lhs=stack_end, rhs=Sum((stack_end, Product((stack_size, Literal(8)))))
+                )
+                loop_map[loop] = loop.clone(body=(ptr_assignment, stack_incr) + loop.body)
+
+        if loop_map:
+            routine.body = Transformer(loop_map).visit(routine.body)
 
     def inject_pool_allocator_into_calls(self, routine, targets):
         call_map = {}

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -1,0 +1,171 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki import (
+    Transformation, FindNodes, Transformer,
+    SymbolAttributes, BasicType, DerivedType,
+    Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex,
+    Intrinsic, Assignment, Conditional, CallStatement, Import
+)
+
+__all__ = ['TemporariesPoolAllocatorTransformation']
+
+
+class TemporariesPoolAllocatorTransformation(Transformation):
+
+    def __init__(self, stack_module_name='STACK_MOD', stack_type_name='STACK', stack_ptr_name='L',
+                 stack_size_name='U', stack_storage_name='PSTACK',
+                 stack_arg_name='YDSTACK', stack_var_name='YLSTACK', pointer_var_name_pattern='IP_{name}',
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.stack_module_name = stack_module_name
+        self.stack_type_name = stack_type_name
+        self.stack_ptr_name = stack_ptr_name
+        self.stack_size_name = stack_size_name
+        self.stack_storage_name = stack_storage_name
+        self.stack_arg_name = stack_arg_name
+        self.stack_var_name = stack_var_name
+        self.pointer_var_name_pattern = pointer_var_name_pattern
+
+    def transform_subroutine(self, routine, **kwargs):
+
+        role = kwargs['role']
+        item = kwargs.get('item', None)
+        targets = kwargs.get('targets', None)
+
+        if item  and item.local_name != routine.name.lower():
+            return
+
+        self.inject_pool_allocator_import(routine)
+
+        if role == 'kernel':
+            self.apply_temporaries_pool_allocator(routine)
+
+        elif role == 'driver':
+            self.create_temporaries_pool_allocator(routine)
+
+        self.inject_pool_allocator_into_calls(routine, targets)
+
+    def inject_pool_allocator_import(self, routine):
+        if self.stack_type_name not in routine.imported_symbols:
+            routine.spec.prepend(Import(
+                module=self.stack_module_name, symbols=(Variable(name=self.stack_type_name, scope=routine),)
+            ))
+
+    def _get_stack_var(self, routine):
+        if self.stack_var_name in routine.variables:
+            return routine.variable_map[self.stack_var_name]
+
+        stack_type = SymbolAttributes(dtype=DerivedType(name=self.stack_type_name))
+        stack_var = Variable(name=self.stack_var_name, type=stack_type, scope=routine)
+        routine.variables += (stack_var,)
+        return stack_var
+
+    def _get_stack_arg(self, routine):
+        if self.stack_arg_name in routine.arguments:
+            return routine.variable_map[self.stack_arg_name]
+
+        stack_type = SymbolAttributes(dtype=DerivedType(name=self.stack_type_name), intent='inout')
+        stack_arg = Variable(name=self.stack_arg_name, type=stack_type, scope=routine)
+        routine.arguments += (stack_arg,)
+        return stack_arg
+
+    def _get_stack_ptr(self, routine):
+        return Variable(
+            name=f'{self.stack_var_name}%{self.stack_ptr_name}',
+            parent=self._get_stack_var(routine),
+            scope=routine
+        )
+
+    def _get_stack_size(self, routine):
+        return Variable(
+            name=f'{self.stack_var_name}%{self.stack_size_name}',
+            parent=self._get_stack_var(routine),
+            scope=routine
+        )
+
+    def _get_stack_storage(self, routine):
+        if self.stack_storage_name in routine.variables:
+            return routine.variable_map[self.stack_storage_name]
+
+        stack_type = SymbolAttributes(
+            dtype=BasicType.REAL,
+            kind=Variable(name='JPRB', scope=routine),
+            shape=(
+                Product((Literal(5000), Variable(name='KLON', scope=routine))),
+                Variable(name='NGPBLK', scope=routine)
+            ),
+            allocatable=True,
+        )
+        stack_storage = Variable(
+            name=self.stack_storage_name, type=stack_type,
+            dimensions=(RangeIndex((None, None)), RangeIndex((None, None))),
+            scope=routine
+        )
+        routine.variables += (stack_storage,)
+        return stack_storage
+
+
+    def _create_stack_allocation(self, stack_ptr, stack_size, ptr_var, arr):
+        ptr_assignment = Assignment(lhs=ptr_var, rhs=stack_ptr)
+        kind_bytes = Literal(8)  # TODO: Use c_sizeof
+        arr_size = InlineCall(Variable(name='SIZE'), parameters=(arr.clone(dimensions=None),))
+        ptr_increment = Assignment(lhs=stack_ptr, rhs=Sum((stack_ptr, Product((kind_bytes, arr_size)))))
+        stack_size_check = Conditional(
+            condition=Comparison(stack_ptr, '>', stack_size), inline=True,
+            body=(Intrinsic('STOP'),), else_body=None
+        )
+        return [ptr_assignment, ptr_increment, stack_size_check]
+
+    def apply_temporaries_pool_allocator(self, routine):
+        # Find all temporary arrays
+        arguments = routine.arguments
+        temporary_arrays = [
+            var for var in routine.variables
+            if isinstance(var, Array) and var not in arguments
+        ]
+
+        # Create stack argument and local stack var
+        stack_var = self._get_stack_var(routine)
+        stack_arg = self._get_stack_arg(routine)
+        allocations = [Assignment(lhs=stack_var, rhs=stack_arg)]
+
+        # Create Cray pointer declarations and "stack allocations"
+        declarations = []
+        stack_ptr = Variable(name=f'{self.stack_var_name}%{self.stack_ptr_name}', parent=stack_var, scope=routine)
+        stack_size = Variable(name=f'{self.stack_var_name}%{self.stack_size_name}', parent=stack_var, scope=routine)
+        for arr in temporary_arrays:
+            ptr_var = Variable(name=self.pointer_var_name_pattern.format(name=arr.name), scope=routine)
+            declarations += [Intrinsic(f'POINTER({ptr_var.name}, {arr.name})')]  # pylint: disable=no-member
+            allocations += self._create_stack_allocation(stack_ptr, stack_size, ptr_var, arr)
+
+        routine.spec.append(declarations)
+        routine.body.prepend(allocations)
+
+    def create_temporaries_pool_allocator(self, routine):
+        # TODO
+        # Create local stack var
+        # stack_storage = self._get_stack_storage(routine)
+        # stack_var = self._get_stack_var(routine)
+        # stack_alloc = Allocation(variables=stack_storage.clone(dimensions=stack_storage.shape))
+        # ptr_assignment = Assignment(
+        #     lhs=self._get_stack_ptr(routine),
+        #     rhs=InlineCall(Variable(name='LOC'), parameters=)
+        # )
+        pass
+
+    def inject_pool_allocator_into_calls(self, routine, targets):
+        call_map = {}
+        stack_var = self._get_stack_var(routine)
+        for call in FindNodes(CallStatement).visit(routine.body):
+            if call.name in targets:
+                if call.routine != BasicType.DEFERRED and self.stack_arg_name in call.routine.arguments:
+                    arg_idx = call.routine.arguments.index(self.stack_arg_name)
+                    arguments = call.arguments
+                    call_map[call] = call.clone(arguments=arguments[:arg_idx] + (stack_var,) + arguments[arg_idx:])
+        if call_map:
+            routine.body = Transformer(call_map).visit(routine.body)

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -551,7 +551,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                # interface block rather than the Subroutine itself. This means we have to update the interface block
                # accordingly
                 if call.name in [s for i in intfs for s in i.symbols]:
-                    stack_arg = self._get_stack_arg(call.routine)
+                    _ = self._get_stack_arg(call.routine)
 
                 if call.routine != BasicType.DEFERRED and self.stack_argument_name in call.routine.arguments:
                     arg_idx = call.routine.arguments.index(self.stack_argument_name)

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -6,7 +6,7 @@
 # nor does it submit to any jurisdiction.
 
 from loki import (
-    as_tuple, warning, simplify, recursive_expression_map_update, get_pragma_parameters, pragmas_attached,
+    as_tuple, warning, simplify, recursive_expression_map_update, get_pragma_parameters,
     Transformation, FindNodes, FindVariables, Transformer, SubstituteExpressions, DetachScopesMapper,
     SymbolAttributes, BasicType, DerivedType,
     Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex,
@@ -237,9 +237,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             if call.name in successor_map and self._key in successor_map[call.name].trafo_data:
                 successor_stack_size = successor_map[call.name].trafo_data[self._key]
                 # Replace any occurence of routine arguments in the stack size expression
-                arg_map = {
-                    kernel_parameter: call_arg for kernel_parameter, call_arg in call.arg_iter()
-                }
+                arg_map = dict(call.arg_iter())
                 expr_map = {
                     expr: DetachScopesMapper()(arg_map[expr]) for expr in FindVariables().visit(successor_stack_size)
                     if expr in arg_map

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -11,7 +11,7 @@ from loki import (
     SymbolAttributes, BasicType, DerivedType,
     Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex,
     Intrinsic, Assignment, Conditional, CallStatement, Import, Allocation, Deallocation,
-    Loop, Pragma
+    Loop, Pragma, SubroutineItem
 )
 
 __all__ = ['TemporariesPoolAllocatorTransformation']
@@ -306,7 +306,8 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         # Note: we are not using a CaseInsensitiveDict here to be able to search directly with
         # Variable instances in the dict. The StrCompareMixin takes care of case-insensitive
         # comparisons in that case
-        successor_map = {successor.routine.name.lower(): successor for successor in successors}
+        successor_map = {successor.routine.name.lower(): successor for successor in successors
+                                                         if isinstance(successor, SubroutineItem)}
 
         # Collect stack sizes for successors
         # Note that we need to translate the names of variables used in the expressions to the


### PR DESCRIPTION
Filing this as a draft to provide a platform for discussions on the implementation. It is not ready for merging, yet, but I would appreciate some input on how to proceed.

This is an implementation of a pool allocator (akin to M-F's "stack") that allocates a large scratch space per block on the driver and maps temporary arrays in the kernels to this space. For an example implementation in CLOUDSC, see https://github.com/ecmwf-ifs/dwarf-p-cloudsc/pull/49

It is built on top of a derived type declared in a separate Fortran module [`stack_mod`](https://github.com/ecmwf-ifs/dwarf-p-cloudsc/blob/nabr-scc-stack/src/cloudsc_loki/stack_mod.F90), which should simply be commited to the target code base. Naming is flexible and can also be provided as options to the transformation.

The transformation needs to be applied in reverse order, which will do the following for each kernel:

* import the stack derived type
* Add an argument for the stack
* Create a local copy of the stack
* Determine the combined size of all local arrays that need to be placed on the stack, taking into account calls to nested kernels. This is reported in the `trafo_data`.
* Inject the Cray pointer assignments and stack pointer increments for all temporaries
* pass stack arguments to any nested kernel calls

In a driver routine, it will

* determine the required stack space from `trafo_data`
* allocate the scratch space to that size
* insert data transfers for openacc
* insert data sharing clauses into openmp and openacc pragmas
* assign stack base pointer and end pointer for each block
* pass the stack argument to kernel calls

Implemented are two transformation modes:

* idem-stack: Will apply the stack to an idem pass, which is useful to verify correctness of the stack implementation on the CPU
* scc-stack: Will apply the stack after applying the SCC transformation

What is not working, yet:

* Handling of other data types/kinds (it allocates always 8 byte per temporary "unit")
* ~~Demotion of local arrays in SCC has to be switched off (because they are marked as vector-private)~~
* ~~Performance is poor (presumably because of increased memory traffic due to the lack of demotion?)~~
* Testing on a broader range of codes, which will _for sure_ highlight bugs in the implementation. I'm assuming @awnawab might have a few good candidates to try out?

And generally, interested in your feedback and ideas!