### PR TITLE
Limited recursion and made boz code gfortran compliant

### DIFF
--- a/tests/test_derived_types.py
+++ b/tests/test_derived_types.py
@@ -5,11 +5,13 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from sys import getrecursionlimit
+from inspect import stack
+
 from pathlib import Path
 import re
 import pytest
 import numpy as np
-from sys import getrecursionlimit
 
 from conftest import jit_compile, jit_compile_lib, clean_test, available_frontends
 from loki import (
@@ -976,7 +978,7 @@ end module derived_type_linked_list
     # Chase the next-chain to the limit with a buffer
     var = routine.variable_map['x']
     name = 'x'
-    for _ in range(min(1000, getrecursionlimit()-100)):
+    for _ in range(min(1000, getrecursionlimit()-len(stack())-50)):
         var = var.variable_map['next']
         assert var
         assert var.type.dtype.typedef is module.typedefs['list_t']

--- a/tests/test_derived_types.py
+++ b/tests/test_derived_types.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import re
 import pytest
 import numpy as np
+from sys import getrecursionlimit
 
 from conftest import jit_compile, jit_compile_lib, clean_test, available_frontends
 from loki import (
@@ -972,9 +973,10 @@ end module derived_type_linked_list
         assert all(v.scope is var.scope for v in var.variables)
 
     # Test on-the-fly creation of variable lists
+    # Chase the next-chain to the limit with a buffer
     var = routine.variable_map['x']
     name = 'x'
-    for _ in range(1000):  # Let's chase the next-chain 1000x
+    for _ in range(min(1000, getrecursionlimit()-100)):
         var = var.variable_map['next']
         assert var
         assert var.type.dtype.typedef is module.typedefs['list_t']

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -173,12 +173,12 @@ def test_boz_literals(here, frontend):
 subroutine boz_literals(n1, n2, n3, n4, n5, n6)
   integer, intent(out) :: n1, n2, n3, n4, n5, n6
 
-  n1 = B'00000'
-  n2 = b"101010"
-  n3 = O'737'
-  n4 = o"007"
-  n5 = Z'CAFE'
-  n6 = z"babe"
+  n1 = int(B'00000')
+  n2 = int(b"101010")
+  n3 = int(O'737')
+  n4 = int(o"007")
+  n5 = int(Z'CAFE')
+  n6 = int(z"babe")
 end subroutine boz_literals
 """
     filepath = here/(f'expression_boz_literals_{frontend}.f90')
@@ -194,12 +194,16 @@ end subroutine boz_literals
         # Note: Omni evaluates BOZ constants, so it creates IntegerLiteral instead...
         # Note: FP converts constants to upper case
         stmts = FindNodes(Assignment).visit(routine.body)
-        assert isinstance(stmts[0].rhs, IntrinsicLiteral) and stmts[0].rhs.value == "B'00000'"
-        assert isinstance(stmts[1].rhs, IntrinsicLiteral) and stmts[1].rhs.value == 'b"101010"'
-        assert isinstance(stmts[2].rhs, IntrinsicLiteral) and stmts[2].rhs.value == "O'737'"
-        assert isinstance(stmts[3].rhs, IntrinsicLiteral) and stmts[3].rhs.value == 'o"007"'
-        assert isinstance(stmts[4].rhs, IntrinsicLiteral) and stmts[4].rhs.value == "Z'CAFE'"
-        assert isinstance(stmts[5].rhs, IntrinsicLiteral) and stmts[5].rhs.value == 'z"babe"'
+
+        for stmt in stmts:
+            assert isinstance(stmt.rhs.parameters[0], IntrinsicLiteral)
+
+        assert stmts[0].rhs.parameters[0].value == "B'00000'"
+        assert stmts[1].rhs.parameters[0].value == 'b"101010"'
+        assert stmts[2].rhs.parameters[0].value == "O'737'"
+        assert stmts[3].rhs.parameters[0].value == 'o"007"'
+        assert stmts[4].rhs.parameters[0].value == "Z'CAFE'"
+        assert stmts[5].rhs.parameters[0].value == 'z"babe"'
 
 
 @pytest.mark.parametrize('frontend', available_frontends(


### PR DESCRIPTION
Modified `test_derived_type_linked_list` to iterate to `min(1000, getrecursionlimit()-100)`.
On my system, `getrecursionlimit()` returned 1000. I set 100 as a buffer somewhat arbitrarily. 50 was not enough.

Changed the boz test code to be compliant with the Fortran standard. gfortran 12 refused to compile and looks like `n1 = B'00000'` has not been acceptable since gfortran 10.