### PR TITLE
Procedure interface scheduler bug fix

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -537,8 +537,10 @@ class SubroutineItem(Item):
         names = ()
         interfaces = self.routine.interfaces
 
+        # Named interfaces defined in the parent module should not be included to remove
+        # the risk of adding a procedure interface defined in the current scope
         if (scope := self.scope) is not None:
-            interfaces += scope.interfaces
+            interfaces += as_tuple(i for i in scope.interfaces if not i.spec)
 
         names = tuple(
             s.name.lower() for intf in interfaces for s in intf.symbols

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1545,7 +1545,16 @@ module some_mod
     use other_mod
     use MORE_MOD
     implicit none
+
+    interface override
+      module procedure some_random_function
+    end interface ovveride
+
 contains
+
+    function some_random_function
+    end function
+
     subroutine DRIVER
         use YET_another_mod
         call routine


### PR DESCRIPTION
One of my recent PRs added the ability to include inline function calls as scheduler dependencies if they are defined in an explicit interface. A pretty nasty bug went unnoticed; if the calling subroutine is part of a module, it will add any procedure interfaces defined in that module as a child of the subroutine. This is a very small PR to fix that bug and test for it.