### PR TITLE
Dataflow analysis multi-conditional `live_symbols` bug

### DIFF
--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -162,8 +162,9 @@ class DataflowAnalysisAttacher(Transformer):
         body = ()
         defines = set()
         for b in o.bodies:
-            _b, defines, uses = self._visit_body(b, live=live, uses=uses, defines=defines, **kwargs)
+            _b, _d, uses = self._visit_body(b, live=live, uses=uses, **kwargs)
             body += (as_tuple(_b),)
+            defines |= _d
         else_body, else_defines, uses = self._visit_body(o.else_body, live=live, uses=uses, **kwargs)
         o._update(bodies=body, else_body=else_body)
         defines = defines | else_defines

--- a/tests/test_analyse_dataflow.py
+++ b/tests/test_analyse_dataflow.py
@@ -480,6 +480,10 @@ end subroutine test
         assert all(i in mcond.uses_symbols for i in ['ic', 'ia', 'ib'])
         assert all(i in mcond.defines_symbols for i in ['a', 'b'])
 
+        assigns = FindNodes(Assignment).visit(routine.body)
+        for assign in assigns:
+            assert assign.live_symbols == {'ia', 'ib', 'ic'}
+
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_analyse_maskedstatement(frontend):


### PR DESCRIPTION
Consider the following example:
```
subroutine multicond(ic)
integer, intent(in) :: ic
integer :: a,b,c

select case(ic)
case(0)
a = 0
case(1)
b=0
case(2)
c=0
end select

end subroutine multicond
```
The variables defined exclusively in one of the branches of the multi-conditional should not be in the `live_symbols` set for subsequent branches. In the current implementation of the dataflow analysis they were however live.

This PR fixes the above bug and updates the relevant test to check against this behaviour. 