### PR TITLE
Fix multi-call hoisting in scc-hoist and extend test

### DIFF
--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -15,7 +15,7 @@ from loki import (
     FindExpressions, Transformer, NestedTransformer,
     SubstituteExpressions, SymbolAttributes, BasicType, DerivedType,
     pragmas_attached, CaseInsensitiveDict, as_tuple, flatten,
-    demote_variables
+    demote_variables, info
 )
 
 
@@ -710,6 +710,9 @@ class SingleColumnCoalescedTransformation(Transformation):
             scope=routine
         ) for v in column_locals]
         new_call = call.clone(arguments=call.arguments + as_tuple(new_args))
+
+        info(f'[Loki-SCC] Hoisted variables in call {routine.name} => {call.name}:'
+             f'{[v.name for v in column_locals]}')
 
         # Find the iteration index variable for the specified horizontal
         v_index = get_integer_variable(routine, name=self.horizontal.index)

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -640,7 +640,12 @@ class SingleColumnCoalescedTransformation(Transformation):
                             loop._update(pragma_post=(ir.Pragma(keyword='acc', content='end parallel loop'),
                                                       loop.pragma_post[0]))
 
-                # Apply hoisting of temporary "column arrays"
+        # Apply hoisting of temporary "column arrays"
+        with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
+            for call in FindNodes(ir.CallStatement).visit(routine.body):
+                if not call.name in targets:
+                    continue
+
                 if self.hoist_column_arrays:
                     self.hoist_temporary_column_arrays(routine, call)
 

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -641,13 +641,12 @@ class SingleColumnCoalescedTransformation(Transformation):
                                                       loop.pragma_post[0]))
 
         # Apply hoisting of temporary "column arrays"
-        with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
-            for call in FindNodes(ir.CallStatement).visit(routine.body):
-                if not call.name in targets:
-                    continue
+        for call in FindNodes(ir.CallStatement).visit(routine.body):
+            if not call.name in targets:
+                continue
 
-                if self.hoist_column_arrays:
-                    self.hoist_temporary_column_arrays(routine, call)
+            if self.hoist_column_arrays:
+                self.hoist_temporary_column_arrays(routine, call)
 
     def hoist_temporary_column_arrays(self, routine, call):
         """


### PR DESCRIPTION
Small bug fix in scc-hoist that ensure that a driver loop with more than one call to kernel routines hoists argument for all of them. The bug was simply cause by lazily using the loop to find and adjust the outer block loop with the loop over all candidate calls. The respective test has been extended in place to capture the corner case that tripped this in CLOUDSC2.

As a small bonus, I've also added a log line that prints out the variables hoisted for each driver call, which should not be too polluting in practical cases.