### PR TITLE
Bug fix in dependency transform for routines declared using explicit interface

### DIFF
--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -238,7 +238,7 @@ class DependencyTransformation(Transformation):
             new_imports = ()
             for b in i.body:
                 if isinstance(b, Subroutine):
-                    if targets is not None and b.name in targets:
+                    if targets is not None and b.name.lower() in targets:
                         # Create a new module import with explicitly qualified symbol
                         new_module = self.derive_module_name(b.name)
                         new_symbol = Variable(name=f'{b.name}{self.suffix}', scope=source)

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -383,9 +383,9 @@ def test_dependency_transformation_replace_interface(frontend):
     driver = Sourcefile.from_source(source="""
 SUBROUTINE driver(a, b, c)
   INTERFACE
-    SUBROUTINE kernel(a, b, c)
+    SUBROUTINE KERNEL(a, b, c)
       INTEGER, INTENT(INOUT) :: a, b, c
-    END SUBROUTINE kernel
+    END SUBROUTINE KERNEL
   END INTERFACE
 
   INTEGER, INTENT(INOUT) :: a, b, c
@@ -429,8 +429,8 @@ END SUBROUTINE kernel
     assert calls[0].name == 'kernel_test'
     imports = FindNodes(Import).visit(driver['driver'].spec)
     assert len(imports) == 1
-    assert imports[0].module == 'kernel_test_mod'
-    assert 'kernel_test' in [str(s) for s in imports[0].symbols]
+    assert imports[0].module == 'KERNEL_test_mod'
+    assert 'KERNEL_test' in [str(s) for s in imports[0].symbols]
 
 @pytest.mark.parametrize('frontend', available_frontends(
                          xfail=[(OFP, 'OFP does not correctly handle result variable declaration.')]))

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -429,8 +429,12 @@ END SUBROUTINE kernel
     assert calls[0].name == 'kernel_test'
     imports = FindNodes(Import).visit(driver['driver'].spec)
     assert len(imports) == 1
-    assert imports[0].module == 'KERNEL_test_mod'
-    assert 'KERNEL_test' in [str(s) for s in imports[0].symbols]
+    if frontend == OMNI:
+        assert imports[0].module == 'kernel_test_mod'
+        assert 'kernel_test' in [str(s) for s in imports[0].symbols]
+    else:
+        assert imports[0].module == 'KERNEL_test_mod'
+        assert 'KERNEL_test' in [str(s) for s in imports[0].symbols]
 
 @pytest.mark.parametrize('frontend', available_frontends(
                          xfail=[(OFP, 'OFP does not correctly handle result variable declaration.')]))


### PR DESCRIPTION
The mechanism in the dependency transform to replace a subroutine interface with a module import relied on the subroutine name in the interface block being lower-case. This is now fixed, along with an update to the relevant test.