### PR TITLE
Support for multiple kernel calls in DataOffloadTransformation

### DIFF
--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -137,3 +137,59 @@ def test_data_offload_region_complex_remove_openmp(frontend):
     assert 'copyin( a )' in transformed
     assert 'copy( b, c )' in transformed
     assert '!$omp' not in transformed
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_data_offload_region_multiple(frontend):
+    """
+    Test the creation of a device data offload region (`!$acc update`)
+    from a `!$loki data` region with multiple kernel calls.
+    """
+
+    fcode_driver = """
+  SUBROUTINE driver_routine(nlon, nlev, a, b, c, d)
+    INTEGER, INTENT(IN)   :: nlon, nlev
+    REAL, INTENT(INOUT)   :: a(nlon,nlev)
+    REAL, INTENT(INOUT)   :: b(nlon,nlev)
+    REAL, INTENT(INOUT)   :: c(nlon,nlev)
+    REAL, INTENT(INOUT)   :: d(nlon,nlev)
+
+    !$loki data
+    call kernel_routine(nlon, nlev, a, b, c)
+
+    call kernel_routine(nlon, nlev, d, b, a)
+    !$loki end data
+
+  END SUBROUTINE driver_routine
+"""
+    fcode_kernel = """
+  SUBROUTINE kernel_routine(nlon, nlev, a, b, c)
+    INTEGER, INTENT(IN)   :: nlon, nlev
+    REAL, INTENT(IN)      :: a(nlon,nlev)
+    REAL, INTENT(INOUT)   :: b(nlon,nlev)
+    REAL, INTENT(OUT)     :: c(nlon,nlev)
+    INTEGER :: i, j
+
+    do j=1, nlon
+      do i=1, nlev
+        b(i,j) = a(i,j) + 0.1
+        c(i,j) = 0.1
+      end do
+    end do
+  END SUBROUTINE kernel_routine
+"""
+    driver = Sourcefile.from_source(fcode_driver, frontend=frontend)['driver_routine']
+    kernel = Sourcefile.from_source(fcode_kernel, frontend=frontend)['kernel_routine']
+    driver.enrich_calls(kernel)
+
+    driver.apply(DataOffloadTransformation(), role='driver', targets=['kernel_routine'])
+
+    assert len(FindNodes(Pragma).visit(driver.body)) == 2
+    assert all(p.keyword == 'acc' for p in FindNodes(Pragma).visit(driver.body))
+
+    # Ensure that the copy direction is the union of the two calls, ie.
+    # "a" is "copyin" in first call and "copyout" in second, so it should be "copy"
+    transformed = driver.to_fortran()
+    assert 'copyin( d )' in transformed
+    assert 'copy( b, a )' in transformed
+    assert 'copyout( c )' in transformed

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -132,9 +132,9 @@ class DataOffloadTransformation(Transformation):
                 inoutargs = tuple(dict.fromkeys(inoutargs))
 
                 # Now geenerate the pre- and post pragmas (OpenACC)
-                copyin = f'copyin( {", ".join(inargs)} )' if inargs else ''
-                copy = f'copy( {", ".join(inoutargs)} )' if inoutargs else ''
-                copyout = f'copyout( {", ".join(outargs)} )' if outargs else ''
+                copyin = f'copyin({", ".join(inargs)})' if inargs else ''
+                copy = f'copy({", ".join(inoutargs)})' if inoutargs else ''
+                copyout = f'copyout({", ".join(outargs)})' if outargs else ''
                 pragma = Pragma(keyword='acc', content=f'data {copyin} {copy} {copyout}')
                 pragma_post = Pragma(keyword='acc', content='end data')
                 pragma_map[region.pragma] = pragma


### PR DESCRIPTION
This PR adds support for multiple calls to kernel subroutines in the `DataOffloadTransformation`. This is required for CLOUDSC2, where we need this transformation to correctly place timers to separate compute and data movement timings.

The implementation itself adds a new test, updates the use of tuples and f-strings for code generation, and adds some logic to ensure repeated array arguments used with different intents on the kernel side are classed correctly and only put into one category 