### PR TITLE
SCC-hoist: Add test and fix corner case, where no arrays are hoisted

### DIFF
--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -700,7 +700,7 @@ class SingleColumnCoalescedTransformation(Transformation):
                                       for v, dims in zip(column_locals, arg_dims))
 
         # Add explicit OpenACC statements for creating device variables
-        if self.directive == 'openacc':
+        if self.directive == 'openacc' and column_locals:
             vnames = ', '.join(v.name for v in column_locals)
             pragma = ir.Pragma(keyword='acc', content=f'enter data create({vnames})')
             pragma_post = ir.Pragma(keyword='acc', content=f'exit data delete({vnames})')


### PR DESCRIPTION
When no arrays are hoisted, we would still insert empty `!$acc create/delete` pragmas, which is incorrect and invalid.