### PR TITLE
Homogenize access to typedefs and imports in program units

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -387,7 +387,7 @@ class Item:
                     continue
 
                 # Search for definition of the type in parent scope
-                if scope is not None and type_name in scope.typedefs:
+                if scope is not None and type_name in scope.typedef_map:
                     qualified_names += [f'{self.scope_name}#{name}']
                     continue
             else:

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -234,7 +234,7 @@ class Scheduler:
         self.obj_map.update(
             (f'{module.name}#{r.name}', obj)
             for obj in obj_list for module in obj.modules
-            for r in module.subroutines + tuple(module.typedefs.values()) + module.variables
+            for r in module.subroutines + module.typedefs + module.variables
         )
         self.obj_map.update(
             (f'{module.name}#{r.spec.name}', obj)
@@ -248,7 +248,7 @@ class Scheduler:
 
     @property
     def typedefs(self):
-        return as_tuple(flatten(module.typedefs.values() for obj in self.obj_map.values() for module in obj.modules))
+        return as_tuple(flatten(module.typedefs for obj in self.obj_map.values() for module in obj.modules))
 
     @property
     def items(self):

--- a/loki/module.py
+++ b/loki/module.py
@@ -273,3 +273,13 @@ class Module(ProgramUnit):
 
         # Ensure that we are attaching all symbols to the newly create ``self``.
         self.rescope_symbols()
+
+    @property
+    def definitions(self):
+        """
+        The list of IR nodes defined by this module
+
+        Returns :any:`Subroutine` and :any:`TypeDef` nodes declared
+        in this module
+        """
+        return self.subroutines + self.typedefs + self.variables

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -329,17 +329,23 @@ class ProgramUnit(Scope):
     @property
     def typedefs(self):
         """
+        Return the :any:`TypeDef` defined in the :attr:`spec` of this unit
+        """
+        return as_tuple(FindNodes(ir.TypeDef).visit(self.spec))
+
+    @property
+    def typedef_map(self):
+        """
         Map of names and :any:`TypeDef` defined in the :attr:`spec` of this unit
         """
-        types = FindNodes(ir.TypeDef).visit(self.spec)
-        return CaseInsensitiveDict((td.name, td) for td in types)
+        return CaseInsensitiveDict((td.name, td) for td in self.typedefs)
 
     @property
     def declarations(self):
         """
         Return the declarations from the :attr:`spec` of this unit
         """
-        return FindNodes((ir.VariableDeclaration, ir.ProcedureDeclaration)).visit(self.spec)
+        return as_tuple(FindNodes((ir.VariableDeclaration, ir.ProcedureDeclaration)).visit(self.spec))
 
     @property
     def variables(self):
@@ -389,7 +395,14 @@ class ProgramUnit(Scope):
         """
         Return the list of :any:`Import` in this unit
         """
-        return FindNodes(ir.Import).visit(self.spec or ())
+        return as_tuple(FindNodes(ir.Import).visit(self.spec or ()))
+
+    @property
+    def import_map(self):
+        """
+        Map of imported symbol names to :any:`Import` objects
+        """
+        return CaseInsensitiveDict((s.name, imprt) for imprt in self.imports for s in imprt.symbols)
 
     @property
     def imported_symbols(self):
@@ -586,7 +599,7 @@ class ProgramUnit(Scope):
         Check if a symbol, type or subroutine with the given name is declared
         inside this unit
         """
-        return name in self.symbols or name in self.typedefs
+        return name in self.symbols or name in self.typedef_map
 
     def __getitem__(self, name):
         """
@@ -598,7 +611,7 @@ class ProgramUnit(Scope):
 
         item = self.subroutine_map.get(name)
         if item is None:
-            item = self.typedefs.get(name)
+            item = self.typedef_map.get(name)
         if item is None:
             item = self.symbol_map[name]
         return item

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -437,9 +437,7 @@ class Sourcefile:
         """
         if self.ir is None:
             return ()
-        return as_tuple(
-            tdef for module in self.modules for tdef in module.typedefs.values()
-        )
+        return as_tuple(flatten(module.typedefs for module in self.modules))
 
     @property
     def all_subroutines(self):
@@ -455,18 +453,19 @@ class Sourcefile:
         return self.modules + self.subroutines + self.typedefs
 
     def __getitem__(self, name):
-        module_map = {m.name.lower(): m for m in self.modules}
-        if name.lower() in module_map:
-            return module_map[name.lower()]
+        name = name.lower()
+        for module in self.modules:
+            if name == module.name.lower():
+                return module
 
-        subroutine_map = {s.name.lower(): s for s in self.all_subroutines}  # pylint: disable=no-member
-        if name.lower() in subroutine_map:
-            return subroutine_map[name.lower()]
+        for routine in self.all_subroutines:
+            if name == routine.name.lower():
+                return routine
 
-        for module in module_map.values():
-            typedef_map = module.typedefs
-            if name in typedef_map:
-                return typedef_map[name]
+        for module in self.modules:
+            for typedef in module.typedefs:
+                if name == typedef.name.lower():
+                    return typedef
 
         return None
 

--- a/loki/transform/fortran_c_transform.py
+++ b/loki/transform/fortran_c_transform.py
@@ -60,7 +60,7 @@ class FortranCTransformation(Transformation):
         path = Path(kwargs.get('path'))
         role = kwargs.get('role', 'kernel')
 
-        for name, td in module.typedefs.items():
+        for name, td in module.typedef_map.items():
             self.c_structs[name.lower()] = self.c_struct_typedef(td)
 
         if role == 'header':

--- a/tests/test_derived_types.py
+++ b/tests/test_derived_types.py
@@ -423,7 +423,7 @@ end module derived_type_bind_c
     """.strip()
 
     module = Module.from_source(fcode, frontend=frontend)
-    myftype = module.typedefs['myftype']
+    myftype = module.typedef_map['myftype']
     assert myftype.bind_c is True
     assert ', BIND(C)' in fgen(myftype)
 
@@ -460,8 +460,8 @@ end module derived_type_private_mod
 
     module = Module.from_source(fcode, frontend=frontend)
 
-    base_type = module.typedefs['base_type']
-    some_type = module.typedefs['some_type']
+    base_type = module.typedef_map['base_type']
+    some_type = module.typedef_map['some_type']
 
     # Verify correct properties on the `TypeDef` object
     assert base_type.abstract is True
@@ -492,7 +492,7 @@ end module derived_type_private_mod
 
     module = Module.from_source(fcode, frontend=frontend)
 
-    priv_type = module.typedefs['priv_type']
+    priv_type = module.typedef_map['priv_type']
     assert priv_type.private is True
     assert priv_type.public is False
     assert ', PRIVATE' in fgen(priv_type)
@@ -512,7 +512,7 @@ end module derived_type_public_mod
 
     module = Module.from_source(fcode, frontend=frontend)
 
-    pub_type = module.typedefs['pub_type']
+    pub_type = module.typedef_map['pub_type']
     assert pub_type.public is True
     assert pub_type.private is False
     assert ', PUBLIC' in fgen(pub_type)
@@ -555,8 +555,8 @@ end module derived_type_private_comp_mod
 
     module = Module.from_source(fcode, frontend=frontend)
 
-    some_private_comp_type = module.typedefs['some_private_comp_type']
-    type_bound_proc_type = module.typedefs['type_bound_proc_type']
+    some_private_comp_type = module.typedef_map['some_private_comp_type']
+    type_bound_proc_type = module.typedef_map['type_bound_proc_type']
 
     intrinsic_nodes = FindNodes(Intrinsic).visit(type_bound_proc_type.body)
     assert len(intrinsic_nodes) == 2
@@ -628,8 +628,8 @@ end subroutine derived_type_procedure_designator
     """.strip()
 
     module = Module.from_source(mcode, frontend=frontend)
-    assert 'some_type' in module.typedefs
-    assert 'other_type' in module.typedefs
+    assert 'some_type' in module.typedef_map
+    assert 'other_type' in module.typedef_map
     assert 'some_type' in module.symbol_attrs
     assert 'other_type' in module.symbol_attrs
 
@@ -643,7 +643,7 @@ end subroutine derived_type_procedure_designator
         assert isinstance(routine.symbol_attrs[name].dtype.typedef, TypeDef)
 
     # Make sure type-bound procedure declarations exist
-    some_type = module.typedefs['some_type']
+    some_type = module.typedef_map['some_type']
     proc_decls = FindNodes(ProcedureDeclaration).visit(some_type.body)
     assert len(proc_decls) == 3
     assert all(decl.interface is None for decl in proc_decls)
@@ -726,7 +726,7 @@ end module derived_types_bind_attrs_mod
 
     module = Module.from_source(fcode, frontend=frontend)
 
-    some_type = module.typedefs['some_type']
+    some_type = module.typedef_map['some_type']
 
     proc_decls = FindNodes(ProcedureDeclaration).visit(some_type.body)
     assert len(proc_decls) == 3
@@ -782,7 +782,7 @@ end module derived_type_bind_deferred_mod
 
     module = Module.from_source(fcode, frontend=frontend)
 
-    file_handle = module.typedefs['file_handle']
+    file_handle = module.typedef_map['file_handle']
     assert len(file_handle.body) == 2
 
     proc_decl = file_handle.body[1]
@@ -854,7 +854,7 @@ end module derived_type_final_generic_mod
     """.strip()
 
     mod = Module.from_source(fcode, frontend=frontend)
-    hdf5_file = mod.typedefs['hdf5_file']
+    hdf5_file = mod.typedef_map['hdf5_file']
     proc_decls = FindNodes(ProcedureDeclaration).visit(hdf5_file.body)
     assert len(proc_decls) == 5
 
@@ -897,7 +897,7 @@ end module
 """
     module = Module.from_source(fcode, frontend=frontend)
 
-    explicit = module.typedefs['explicit']
+    explicit = module.typedef_map['explicit']
     other = explicit.clone(name='other')
 
     assert explicit.name == 'explicit'
@@ -952,7 +952,7 @@ end module derived_type_linked_list
     for name in ('beg', 'cur'):
         assert name in module.variables
         assert isinstance(module.variable_map[name].type.dtype, DerivedType)
-        assert module.variable_map[name].type.dtype.typedef is module.typedefs['list_t']
+        assert module.variable_map[name].type.dtype.typedef is module.typedef_map['list_t']
 
         variables = module.variable_map[name].type.dtype.typedef.variables
         assert all(v.scope is module.variable_map[name].type.dtype.typedef for v in variables)
@@ -968,7 +968,7 @@ end module derived_type_linked_list
     routine = module['find']
     for name in ('this', 'x'):
         var = routine.variable_map[name]
-        assert var.type.dtype.typedef is module.typedefs['list_t']
+        assert var.type.dtype.typedef is module.typedef_map['list_t']
 
         assert 'payload' in var.variable_map
         assert 'next' in var.variable_map
@@ -981,7 +981,7 @@ end module derived_type_linked_list
     for _ in range(min(1000, getrecursionlimit()-len(stack())-50)):
         var = var.variable_map['next']
         assert var
-        assert var.type.dtype.typedef is module.typedefs['list_t']
+        assert var.type.dtype.typedef is module.typedef_map['list_t']
         name = f'{name}%next'
         assert var.name == name
 
@@ -1067,7 +1067,7 @@ end module derived_type_sequence
     """.strip()
 
     module = Module.from_source(fcode, frontend=frontend)
-    numeric_seq = module.typedefs['numeric_seq']
+    numeric_seq = module.typedef_map['numeric_seq']
     assert 'SEQUENCE' in fgen(numeric_seq)
 
 
@@ -1153,7 +1153,7 @@ def test_derived_type_rescope_symbols_shadowed(here, shadowed_typedef_symbols_fc
     assert mod_var.scope is module
 
     # Verify scope of variables in type def
-    rng_type = module.typedefs['rng_type']
+    rng_type = module.typedef_map['rng_type']
     istate = rng_type.variable_map['istate']
     tdef_var = rng_type.variable_map['nmaxstreams']
 

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -374,7 +374,7 @@ end module frontend_strict_mode
     config['frontend-strict-mode'] = False
     module = Module.from_source(fcode, frontend=frontend)
     assert 'matrix' in module.symbol_attrs
-    assert 'matrix' in module.typedefs
+    assert 'matrix' in module.typedef_map
 
 
 def test_regex_subroutine_from_source():
@@ -694,7 +694,7 @@ def test_regex_sourcefile_from_file_parser_classes(here):
         else:
             assert not sourcefile[unit].imports
 
-    assert sorted(sourcefile['bar'].typedefs) == ['food', 'organic']
+    assert sorted(sourcefile['bar'].typedef_map) == ['food', 'organic']
 
 
 def test_regex_raw_source():
@@ -1003,8 +1003,8 @@ end module typebound_item
 
     module = Module.from_source(fcode, frontend=REGEX)
 
-    assert 'some_type' in module.typedefs
-    some_type = module.typedefs['some_type']
+    assert 'some_type' in module.typedef_map
+    some_type = module.typedef_map['some_type']
 
     proc_bindings = {
         'routine': 'module_routine',
@@ -1056,8 +1056,8 @@ end module typebound_header
 
     module = Module.from_source(fcode, frontend=REGEX)
 
-    assert 'header_type' in module.typedefs
-    header_type = module.typedefs['header_type']
+    assert 'header_type' in module.typedef_map
+    header_type = module.typedef_map['header_type']
 
     proc_bindings = {
         'member_routine': 'header_member_routine',

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -46,7 +46,7 @@ end module a_module
     module = Module.from_source(fcode, frontend=frontend)
     assert len([o for o in module.spec.body if isinstance(o, VariableDeclaration)]) == 2
     assert len([o for o in module.spec.body if isinstance(o, TypeDef)]) == 1
-    assert 'derived_type' in module.typedefs
+    assert 'derived_type' in module.typedef_map
     assert len(module.routines) == 1
     assert module.routines[0].name == 'my_routine'
     if frontend != OMNI:
@@ -87,7 +87,7 @@ end module a_module
 """
 
     external = Module.from_source(fcode_external, frontend=frontend)
-    assert'ext_type' in external.typedefs
+    assert 'ext_type' in external.typedef_map
 
     module = Module.from_source(fcode_module, frontend=frontend, definitions=external)
     routine = module.subroutines[0]
@@ -162,10 +162,10 @@ end module a_module
 """
 
     external = Module.from_source(fcode_external, frontend=frontend)
-    assert 'ext_type' in external.typedefs
+    assert 'ext_type' in external.typedef_map
 
     other = Module.from_source(fcode_other, frontend=frontend)
-    assert 'other_type' in other.typedefs
+    assert 'other_type' in other.typedef_map
 
     if frontend != OMNI:  # OMNI needs to know imported modules
         module = Module.from_source(fcode_module, frontend=frontend)
@@ -176,7 +176,7 @@ end module a_module
         assert module['other_routine'].symbol_attrs['pt'].dtype.typedef is BasicType.DEFERRED
 
     module = Module.from_source(fcode_module, frontend=frontend, definitions=[external, other])
-    nested = module.typedefs['nested_type']
+    nested = module.typedef_map['nested_type']
     ext = nested.variables[0]
 
     # Verify correct attachment of type information
@@ -241,7 +241,7 @@ end module type_mod
     exptected_array_shape = '(1:2, 1:3)' if frontend == OMNI else '(x, y)'
 
     module = Module.from_source(fcode, frontend=frontend)
-    parent = module.typedefs['parent_type']
+    parent = module.typedef_map['parent_type']
     pt = parent.variables[0]
     assert 'array' in pt.variable_map
     arr = pt.variable_map['array']
@@ -266,7 +266,7 @@ module type_mod
 end module type_mod
 """
     module = Module.from_source(fcode, frontend=frontend)
-    mytype = module.typedefs['mytype']
+    mytype = module.typedef_map['mytype']
     assert fexprgen(mytype.variables[0].shape) == '(size,)'
 
 
@@ -291,8 +291,8 @@ module type_mod
 end module type_mod
 """
     module = Module.from_source(fcode, frontend=frontend)
-    parent = module.typedefs['parent_type']
-    child = module.typedefs['sub_type']
+    parent = module.typedef_map['parent_type']
+    child = module.typedef_map['sub_type']
     assert fexprgen(child.variables[0].shape) == '(size,)'
 
     pt_x = parent.variables[0].variable_map['x']

--- a/tests/test_nested_types/test_nested_types.py
+++ b/tests/test_nested_types/test_nested_types.py
@@ -21,13 +21,13 @@ def test_nested_types(frontend):
 
     # First, get the sub_type and check that the dimension annotation is honoured
     subtypes = Sourcefile.from_file(here/'sub_types.f90', frontend=frontend)['sub_types']
-    child = subtypes.typedefs['sub_type']
+    child = subtypes.typedef_map['sub_type']
     assert fexprgen(child.variables[0].shape) == '(size,)'
 
     # Check that dimension in sub_type has propagated to parent_type
     types = Sourcefile.from_file(here/'types.f90', definitions=subtypes,
                                  frontend=frontend)['types']
-    parent = types.typedefs['parent_type']
+    parent = types.typedef_map['parent_type']
     x = parent.variables[1].variable_map['x']
     assert fexprgen(x.shape) == '(size,)'
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1042,8 +1042,8 @@ def test_scheduler_typebound_item(here):
     available_names = []
     for s in [source, header, other]:
         available_names += [f'#{r.name.lower()}' for r in s.subroutines]
-        available_names += [f'{m.name.lower()}#{r.name.lower()}' for m in s.modules for r in m.subroutines]
-        available_names += [f'{m.name.lower()}#{t.lower()}' for m in s.modules for t in m.typedefs]
+        available_names += [f'{m.name}#{r.name}'.lower() for m in s.modules for r in m.subroutines]
+        available_names += [f'{m.name}#{t.name}'.lower() for m in s.modules for t in m.typedefs]
 
     driver = SubroutineItem(name='#driver', source=source)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -159,7 +159,7 @@ end module types
     source = Sourcefile.from_source(fcode, frontend=frontend)
     pragma_type = source['types'].symbol_attrs['pragma_type'].dtype
 
-    assert pragma_type.typedef is source['types'].typedefs['pragma_type']
+    assert pragma_type.typedef is source['types'].typedef_map['pragma_type']
     assert fsymgen(pragma_type.typedef.variables[0].shape) == '(3, 3)'
     assert fsymgen(pragma_type.typedef.variables[1].shape) == '(klon, klat, 2)'
 
@@ -520,7 +520,7 @@ END MODULE some_mod
             assert 'PROCEDURE(SUB)' in fgen(decl_map[name]).upper()
 
     # Assert procedure pointer component in the derived_type is sane
-    struct_type = module.typedefs['struct_type']
+    struct_type = module.typedef_map['struct_type']
     decls = FindNodes(ProcedureDeclaration).visit(struct_type.body)
     assert len(decls) == 1
     assert decls[0].symbols == ('component',)


### PR DESCRIPTION
A small utility PR:

On `ProgramUnit` objects, we have various convenience properties: imports, variables, declarations, ...
The naming "convention" so far was, e.g.:
- `.variables`: list of `Variable` symbols declared in the module or subroutine
- `.variable_map`: `CaseInsensitivDict` to map variable names to variable objects

Only exception was `.typedefs`, which returned a mapping rather than the list of typedefs. This PR homogenizes this by introducing `.typedef_map` and making `.typedefs` a list.