### PR TITLE
SGraph draft before Scheduler integration

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -211,7 +211,7 @@ class Item:
         current_module = None
         while scope:
             if hasattr(scope, 'import_map'):
-                import_map |= scope.import_map
+                import_map.update(scope.import_map)
             if isinstance(scope, Module):
                 current_module = scope
             scope = scope.parent
@@ -252,7 +252,7 @@ class Item:
             item_name = f'{scope_name}#{proc_name}'.lower()
             return self._get_or_create_item(ProcedureItem, item_name, item_cache, scope_name, config)
 
-        if proc_name in (intf_map := self.ir.interface_symbols):
+        if proc_name in self.ir.interface_symbols:
             # TODO: Handle declaration via interface
             raise NotImplementedError()
 
@@ -817,6 +817,28 @@ class FileItem(Item):
     def ir(self):
         return self.source
 
+    # Below properties are only here to appease the Linter and become
+    # redundant once the Item base class has been cleaned up
+    @property
+    def calls(self):
+        pass
+
+    @property
+    def function_interfaces(self):
+        pass
+
+    @property
+    def imports(self):
+        pass
+
+    @property
+    def members(self):
+        pass
+
+    @property
+    def routine(self):
+        pass
+
 
 class ModuleItem(Item):
 
@@ -836,6 +858,28 @@ class ModuleItem(Item):
     @property
     def local_name(self):
         return self.name
+
+    # Below properties are only here to appease the Linter and become
+    # redundant once the Item base class has been cleaned up
+    @property
+    def calls(self):
+        pass
+
+    @property
+    def function_interfaces(self):
+        pass
+
+    @property
+    def imports(self):
+        pass
+
+    @property
+    def members(self):
+        pass
+
+    @property
+    def routine(self):
+        pass
 
 
 class ProcedureItem(Item):
@@ -866,6 +910,28 @@ class ProcedureItem(Item):
                 imports += tuple(imprt for type_name in type_names if (imprt := import_map.get(type_name)))
         return imports + typedefs + calls
 
+    # Below properties are only here to appease the Linter and become
+    # redundant once the Item base class has been cleaned up
+    @property
+    def calls(self):
+        pass
+
+    @property
+    def function_interfaces(self):
+        pass
+
+    @property
+    def imports(self):
+        pass
+
+    @property
+    def members(self):
+        pass
+
+    @property
+    def routine(self):
+        pass
+
 
 class TypeDefItem(Item):
 
@@ -890,10 +956,54 @@ class TypeDefItem(Item):
 
         return tuple(dict.fromkeys(imports + typedefs))
 
+    # Below properties are only here to appease the Linter and become
+    # redundant once the Item base class has been cleaned up
+    @property
+    def calls(self):
+        pass
+
+    @property
+    def function_interfaces(self):
+        pass
+
+    @property
+    def imports(self):
+        pass
+
+    @property
+    def members(self):
+        pass
+
+    @property
+    def routine(self):
+        pass
+
 
 class InterfaceItem(Item):
 
     _parser_class = RegexParserClass.InterfaceClass
+
+    # Below properties are only here to appease the Linter and become
+    # redundant once the Item base class has been cleaned up
+    @property
+    def calls(self):
+        pass
+
+    @property
+    def function_interfaces(self):
+        pass
+
+    @property
+    def imports(self):
+        pass
+
+    @property
+    def members(self):
+        pass
+
+    @property
+    def routine(self):
+        pass
 
 
 class GlobalVariableItem(Item):

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -1028,6 +1028,28 @@ class GlobalVariableItem(Item):
                 return decl
         raise RuntimeError(f'Declaration for {local_name} cannot be found in {self.scope_name}')
 
+    # Below properties are only here to appease the Linter and become
+    # redundant once the Item base class has been cleaned up
+    @property
+    def calls(self):
+        pass
+
+    @property
+    def function_interfaces(self):
+        pass
+
+    @property
+    def imports(self):
+        pass
+
+    @property
+    def members(self):
+        pass
+
+    @property
+    def routine(self):
+        pass
+
 
 class SubroutineItem(Item):
     """

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -258,7 +258,7 @@ class Item:
 
         # This is a call to a subroutine declared via header-included interface
         item_name = f'#{proc_name}'.lower()
-        if config.is_disabled(item_name):
+        if config and config.is_disabled(item_name):
             return None
         return item_cache[item_name]
 

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -149,11 +149,15 @@ class Item:
             self.ir.make_complete(frontend=REGEX, parser_classes=parser_classes)
 
     def concretize_dependencies(self):
-        if self._depends_class and hasattr(self.ir, 'make_complete'):
-            ir = self.ir
-            while ir.parent:
-                ir = ir.parent
-            ir.make_complete(frontend=REGEX, parser_classes=self._depends_class)
+        if not self._depends_class:
+            return
+        scope = self.ir
+        if not isinstance(scope, Scope):
+            scope = scope.scope
+        while scope.parent:
+            scope = scope.parent
+        if hasattr(scope, 'make_complete'):
+            scope.make_complete(frontend=REGEX, parser_classes=self._depends_class)
 
     def _get_procedure_item(self, proc_symbol, item_cache, config):
         # A recursive map of all imports
@@ -211,6 +215,8 @@ class Item:
 
         # This is a call to a subroutine declared via header-included interface
         item_name = f'#{proc_name}'.lower()
+        if config.is_disabled(item_name):
+            return None
         return item_cache[item_name]
 
 

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -792,11 +792,11 @@ class Scheduler:
 
 class SGraph:
 
-    def __init__(self, seed, item_cache):
+    def __init__(self, seed, item_cache, config=None):
         self._graph = nx.DiGraph()
-        self.populate(seed, item_cache)
+        self.populate(seed, item_cache, config)
 
-    def populate(self, seed, item_cache):
+    def populate(self, seed, item_cache, config):
         queue = deque()
 
         # Insert the seed objects
@@ -809,7 +809,7 @@ class SGraph:
                 # We may have to create the corresponding module's definitions first
                 module_item = item_cache.get(name[:name.index('#')])
                 if module_item:
-                    module_item.create_definition_items(item_cache)
+                    module_item.create_definition_items(item_cache=item_cache, config=config)
                     item = item_cache.get(name)
 
             if item:
@@ -821,7 +821,7 @@ class SGraph:
         # Populate the graph
         while queue:
             item = queue.popleft()
-            dependencies = item.create_dependency_items(item_cache=item_cache)
+            dependencies = item.create_dependency_items(item_cache=item_cache, config=config)
             new_items = [item_ for item_ in dependencies if item_ not in self._graph]
             if new_items:
                 self.add_nodes(new_items)
@@ -855,7 +855,8 @@ class SGraph:
         Parameters
         ----------
         dotfile_path : str or pathlib.Path
-            Path to write the callgraph figure to.
+            Path to write the dotfile to. A corresponding graphical representation
+            will be created with an additional ``.pdf`` appendix.
         """
         try:
             import graphviz as gviz  # pylint: disable=import-outside-toplevel

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -900,7 +900,8 @@ class VariableDeclarationPattern(Pattern):
     def __init__(self):
         super().__init__(
             r'^(((?:type|class)[ \t]*\([ \t]*(?P<typename>\w+)[ \t]*\))|' # TYPE or CLASS keyword with typename
-            r'^([ \t]*(?P<basic_type>(logical|real|integer|complex|character))(?P<param>\((kind|len)=[a-z0-9_-]+\))?[ \t]*))'
+            r'^([ \t]*(?P<basic_type>(logical|real|integer|complex|character))'
+            r'(?P<param>\((kind|len)=[a-z0-9_-]+\))?[ \t]*))'
             r'(?:[ \t]*,[ \t]*[a-z]+(?:\((.(\(.*\))?)*?\))?)*'  # Optional attributes
             r'(?:[ \t]*::)?'  # Optional `::` delimiter
             r'[ \t]*'  # Some white space

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -42,6 +42,7 @@ class RegexParserClass(Flag):
     pattern matching can be switched on and off for some pattern classes, and thus the overall
     parse time reduced.
     """
+    EmptyClass = 0
     ProgramUnitClass = auto()
     InterfaceClass = auto()
     ImportClass = auto()

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -900,7 +900,7 @@ class VariableDeclarationPattern(Pattern):
     def __init__(self):
         super().__init__(
             r'^(((?:type|class)[ \t]*\([ \t]*(?P<typename>\w+)[ \t]*\))|' # TYPE or CLASS keyword with typename
-            r'^([ \t]*(?P<basic_type>(logical|real|integer|complex|character))(\((kind|len)=[a-z0-9_-]+\))?[ \t]*))'
+            r'^([ \t]*(?P<basic_type>(logical|real|integer|complex|character))(?P<param>\((kind|len)=[a-z0-9_-]+\))?[ \t]*))'
             r'(?:[ \t]*,[ \t]*[a-z]+(?:\((.(\(.*\))?)*?\))?)*'  # Optional attributes
             r'(?:[ \t]*::)?'  # Optional `::` delimiter
             r'[ \t]*'  # Some white space
@@ -931,6 +931,11 @@ class VariableDeclarationPattern(Pattern):
         else:
             type_ = SymbolAttributes(BasicType.from_str(match['basic_type']))
         assert type_
+
+        if match['param']:
+            param = match['param'].strip().strip('()').split('=')
+            if len(param) == 1 or param[0].lower() == 'kind':
+                type_ = type_.clone(kind=sym.Variable(name=param[-1], scope=scope))
 
         variables = self._remove_quoted_string_nested_parentheses(match['variables'])  # Remove dimensions
         variables = re.sub(r'=(?:>)?[^,]*(?=,|$)', r'', variables) # Remove initialization

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -447,7 +447,8 @@ class ModulePattern(Pattern):
             contains = None
 
         module.__initialize__(  # pylint: disable=unnecessary-dunder-call
-            name=module.name, spec=spec, contains=contains, source=module.source, incomplete=True
+            name=module.name, spec=spec, contains=contains, source=module.source, incomplete=True,
+            parser_classes=parser_classes
         )
 
         if match.span()[0] > 0:
@@ -538,7 +539,8 @@ class SubroutineFunctionPattern(Pattern):
 
         routine.__initialize__(  # pylint: disable=unnecessary-dunder-call
             name=routine.name, args=routine._dummies, is_function=routine.is_function,
-            prefix=prefix, spec=spec, contains=contains, source=routine.source, incomplete=True
+            prefix=prefix, spec=spec, contains=contains, source=routine.source,
+            incomplete=True, parser_classes=parser_classes
         )
 
         if match.span()[0] > 0:

--- a/loki/module.py
+++ b/loki/module.py
@@ -17,8 +17,9 @@ from loki.pragma_utils import pragmas_attached, process_dimension_pragmas
 from loki.program_unit import ProgramUnit
 from loki.scope import Scope
 from loki.subroutine import Subroutine
-from loki.tools import as_tuple
+from loki.tools import as_tuple, flatten
 from loki.types import ModuleType, SymbolAttributes
+from loki.visitors import FindNodes
 
 
 __all__ = ['Module']
@@ -292,6 +293,12 @@ class Module(ProgramUnit):
 
         # Ensure that we are attaching all symbols to the newly create ``self``.
         self.rescope_symbols()
+
+    @property
+    def variables(self):
+        return tuple(flatten(
+            decl.symbols for decl in FindNodes(VariableDeclaration).visit(self.spec or ())
+        ))
 
     @property
     def definitions(self):

--- a/loki/module.py
+++ b/loki/module.py
@@ -295,12 +295,6 @@ class Module(ProgramUnit):
         self.rescope_symbols()
 
     @property
-    def variables(self):
-        return tuple(flatten(
-            decl.symbols for decl in FindNodes(VariableDeclaration).visit(self.spec or ())
-        ))
-
-    @property
     def definitions(self):
         """
         The list of IR nodes defined by this module

--- a/loki/module.py
+++ b/loki/module.py
@@ -17,9 +17,8 @@ from loki.pragma_utils import pragmas_attached, process_dimension_pragmas
 from loki.program_unit import ProgramUnit
 from loki.scope import Scope
 from loki.subroutine import Subroutine
-from loki.tools import as_tuple, flatten
+from loki.tools import as_tuple
 from loki.types import ModuleType, SymbolAttributes
-from loki.visitors import FindNodes
 
 
 __all__ = ['Module']

--- a/loki/module.py
+++ b/loki/module.py
@@ -67,13 +67,15 @@ class Module(ProgramUnit):
         Mark the object as incomplete, i.e. only partially parsed. This is
         typically the case when it was instantiated using the :any:`Frontend.REGEX`
         frontend and a full parse using one of the other frontends is pending.
+    parser_classes : :any:`RegexParserClass`, optional
+        Provide the list of parser classes used during incomplete regex parsing
     """
 
     def __init__(
             self, name=None, docstring=None, spec=None, contains=None,
             default_access_spec=None, public_access_spec=None, private_access_spec=None,
             ast=None, source=None, parent=None, symbol_attrs=None, rescope_symbols=False,
-            incomplete=False
+            incomplete=False, parser_classes=None
     ):
         super().__init__(parent=parent)
 
@@ -84,12 +86,12 @@ class Module(ProgramUnit):
             name=name, docstring=docstring, spec=spec, contains=contains,
             default_access_spec=default_access_spec, public_access_spec=public_access_spec,
             private_access_spec=private_access_spec, ast=ast, source=source,
-            rescope_symbols=rescope_symbols, incomplete=incomplete
+            rescope_symbols=rescope_symbols, incomplete=incomplete, parser_classes=parser_classes
         )
 
     def __initialize__(
             self, name=None, docstring=None, spec=None, contains=None,
-            ast=None, source=None, rescope_symbols=False, incomplete=False,
+            ast=None, source=None, rescope_symbols=False, incomplete=False, parser_classes=None,
             default_access_spec=None, public_access_spec=None, private_access_spec=None
     ):
         # Apply dimension pragma annotations to declarations
@@ -110,7 +112,7 @@ class Module(ProgramUnit):
 
         super().__initialize__(
             name=name, docstring=docstring, spec=spec, contains=contains, ast=ast,
-            source=source, rescope_symbols=rescope_symbols, incomplete=incomplete
+            source=source, rescope_symbols=rescope_symbols, incomplete=incomplete, parser_classes=parser_classes
         )
 
     @classmethod

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -472,6 +472,15 @@ class ProgramUnit(Scope):
         return as_tuple(flatten(enum.symbols for enum in FindNodes(ir.Enumeration).visit(self.spec or ())))
 
     @property
+    def definitions(self):
+        """
+        The list of IR nodes defined by this program unit.
+
+        Returns an empty tuple by default and can be overwritten by derived nodes.
+        """
+        return ()
+
+    @property
     def symbols(self):
         """
         Return list of all symbols declared or imported in this module scope

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -244,6 +244,8 @@ class ProgramUnit(Scope):
         xmods = frontend_args.get('xmods')
         parser_classes = frontend_args.get('parser_classes', RegexParserClass.AllClasses)
         if frontend == Frontend.REGEX and self._parser_classes:
+            if self._parser_classes == parser_classes:
+                return
             parser_classes = parser_classes | self._parser_classes
 
         # If this object does not have a parent, we create a temporary parent scope

--- a/loki/scope.py
+++ b/loki/scope.py
@@ -283,6 +283,18 @@ class Scope:
         from loki.expression import AttachScopes  # pylint: disable=import-outside-toplevel,cyclic-import
         AttachScopes().visit(self)
 
+    def make_complete(self, **frontend_args):
+        """
+        Trigger a re-parse of the object if incomplete to produce a full Loki IR
+
+        See :any:`ProgramUnit.make_complete` for more details.
+
+        This method relays the call only to the :attr:`parent`.
+        """
+        if hasattr(super(), 'make_complete'):
+            super().make_complete(**frontend_args)
+        self.parent.make_complete(**frontend_args)
+
     def clone(self, **kwargs):
         """
         Create a copy of the scope object with the option to override individual

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -448,9 +448,9 @@ class Sourcefile:
     @property
     def definitions(self):
         """
-        List of all definitions made in this sourcefile, i.e. modules, subroutines and types
+        List of all definitions made in this sourcefile, i.e. modules and subroutines
         """
-        return self.modules + self.subroutines + self.typedefs
+        return self.modules + self.subroutines
 
     def __getitem__(self, name):
         name = name.lower()

--- a/loki/subroutine.py
+++ b/loki/subroutine.py
@@ -69,13 +69,15 @@ class Subroutine(ProgramUnit):
         Mark the object as incomplete, i.e. only partially parsed. This is
         typically the case when it was instantiated using the :any:`Frontend.REGEX`
         frontend and a full parse using one of the other frontends is pending.
+    parser_classes : :any:`RegexParserClass`, optional
+        Provide the list of parser classes used during incomplete regex parsing
     """
 
     def __init__(
             self, name, args=None, docstring=None, spec=None, body=None,
             contains=None, prefix=None, bind=None, result_name=None,
             is_function=False, ast=None, source=None, parent=None,
-            symbol_attrs=None, rescope_symbols=False, incomplete=False
+            symbol_attrs=None, rescope_symbols=False, incomplete=False, parser_classes=None
     ):
         super().__init__(parent=parent)
 
@@ -86,13 +88,13 @@ class Subroutine(ProgramUnit):
             name=name, args=args, docstring=docstring, spec=spec, body=body,
             contains=contains,  prefix=prefix, bind=bind, result_name=result_name,
             is_function=is_function, ast=ast, source=source,
-            rescope_symbols=rescope_symbols, incomplete=incomplete
+            rescope_symbols=rescope_symbols, incomplete=incomplete, parser_classes=parser_classes
         )
 
     def __initialize__(
             self, name, docstring=None, spec=None, contains=None,
-            ast=None, source=None, rescope_symbols=False, incomplete=False,
-            body=None, args=None, prefix=None, bind=None, result_name=None, is_function=False,
+            ast=None, source=None, rescope_symbols=False, incomplete=False, parser_classes=None,
+            body=None, args=None, prefix=None, bind=None, result_name=None, is_function=False
     ):
         # First, store additional Subroutine-specific properties
         self._dummies = as_tuple(a.lower() for a in as_tuple(args))  # Order of dummy arguments
@@ -108,7 +110,8 @@ class Subroutine(ProgramUnit):
 
         super().__initialize__(
             name=name, docstring=docstring, spec=spec, contains=contains,
-            ast=ast, source=source, rescope_symbols=rescope_symbols, incomplete=incomplete
+            ast=ast, source=source, rescope_symbols=rescope_symbols,
+            incomplete=incomplete, parser_classes=parser_classes
         )
 
     def __getstate__(self):

--- a/tests/sources/projBatch/headers/header_mod.F90
+++ b/tests/sources/projBatch/headers/header_mod.F90
@@ -1,0 +1,4 @@
+module header_mod
+    implicit none
+    integer, parameter :: k = 8
+end header_mod

--- a/tests/sources/projBatch/headers/header_mod.F90
+++ b/tests/sources/projBatch/headers/header_mod.F90
@@ -1,4 +1,4 @@
 module header_mod
     implicit none
     integer, parameter :: k = 8
-end header_mod
+end module header_mod

--- a/tests/sources/projBatch/include/comp2.intfb.h
+++ b/tests/sources/projBatch/include/comp2.intfb.h
@@ -1,0 +1,9 @@
+interface
+subroutine comp2 (arg, val)
+    use t_mod, only: t
+    use header_mod, only: k
+    implicit none
+    type(t), intent(inout) :: arg
+    real(kind=k), intent(inout) :: val(:)
+end subroutine comp2
+end interface

--- a/tests/sources/projBatch/module/a_mod.F90
+++ b/tests/sources/projBatch/module/a_mod.F90
@@ -1,0 +1,8 @@
+module a_mod
+    implicit none
+contains
+    subroutine a(arg)
+        use header_mod, only: k
+        real(kind=k), intent(inout) :: arg(:)
+    end subroutine a
+end module a_mod

--- a/tests/sources/projBatch/module/b_mod.F90
+++ b/tests/sources/projBatch/module/b_mod.F90
@@ -1,0 +1,8 @@
+module b_mod
+    implicit none
+contains
+    subroutine b(arg)
+        use header_mod, only: k
+        real(kind=k), intent(inout) :: arg(:)
+    end subroutine b
+end module b_mod

--- a/tests/sources/projBatch/module/b_mod.F90
+++ b/tests/sources/projBatch/module/b_mod.F90
@@ -1,8 +1,8 @@
 module b_mod
+    use header_mod, only: k
     implicit none
 contains
     subroutine b(arg)
-        use header_mod, only: k
         real(kind=k), intent(inout) :: arg(:)
     end subroutine b
 end module b_mod

--- a/tests/sources/projBatch/module/other_mod.F90
+++ b/tests/sources/projBatch/module/other_mod.F90
@@ -1,0 +1,11 @@
+module other_mod
+    use tt_mod, only: tt
+    use b_mod, only: b
+    implicit none
+contains
+    subroutine mod_proc(arg)
+        type(tt), intent(inout) :: arg
+        call arg%proc()
+        call b(arg%indirection)
+    end subroutine mod_proc
+end module other_mod

--- a/tests/sources/projBatch/module/t_mod.F90
+++ b/tests/sources/projBatch/module/t_mod.F90
@@ -1,5 +1,6 @@
 module t_mod
     use tt_mod, only: tt
+    use a_mod, only: a
     implicit none
 
     type t1
@@ -16,9 +17,13 @@ module t_mod
 contains
     subroutine t_proc(this)
         class(t), intent(inout) :: this
+        call a(this%yay%other)
+        call this%yay%proc()
     end subroutine t_proc
 
-    subroutine my_way(this)
+    subroutine my_way(this, recurse)
         class(t1), intent(inout) :: this
+        logical, intent(in) :: recurse
+        if (recurse) call this%way(.false.)
     end subroutine my_way
 end module t_mod

--- a/tests/sources/projBatch/module/t_mod.F90
+++ b/tests/sources/projBatch/module/t_mod.F90
@@ -21,7 +21,7 @@ contains
         call this%yay%proc()
     end subroutine t_proc
 
-    subroutine my_way(this, recurse)
+    recursive subroutine my_way(this, recurse)
         class(t1), intent(inout) :: this
         logical, intent(in) :: recurse
         if (recurse) call this%way(.false.)

--- a/tests/sources/projBatch/module/t_mod.F90
+++ b/tests/sources/projBatch/module/t_mod.F90
@@ -2,7 +2,23 @@ module t_mod
     use tt_mod, only: tt
     implicit none
 
+    type t1
+    contains
+        procedure :: way => my_way
+    end type t1
+
     type t
         type(tt) :: yay
+        type(t1) :: no
+    contains
+        procedure :: proc => t_proc
     end type t
+contains
+    subroutine t_proc(this)
+        class(t), intent(inout) :: this
+    end subroutine t_proc
+
+    subroutine my_way(this)
+        class(t1), intent(inout) :: this
+    end subroutine my_way
 end module t_mod

--- a/tests/sources/projBatch/module/t_mod.F90
+++ b/tests/sources/projBatch/module/t_mod.F90
@@ -1,0 +1,8 @@
+module t_mod
+    use tt_mod, only: tt
+    implicit none
+
+    type t
+        type(tt) :: yay
+    end type t
+end module t_mod

--- a/tests/sources/projBatch/module/tt_mod.F90
+++ b/tests/sources/projBatch/module/tt_mod.F90
@@ -8,10 +8,10 @@ module tt_mod
         real(kind=k), allocatable :: indirection(:)
         real(kind=k) :: other(nclv)
     contains
-        procedure :: proc => tt_proc
+        procedure :: proc
     end type tt
 contains
-    subroutine tt_proc(this)
+    subroutine proc(this)
         class(tt), intent(inout) :: this
-    end subroutine tt_proc
+    end subroutine proc
 end module tt_mod

--- a/tests/sources/projBatch/module/tt_mod.F90
+++ b/tests/sources/projBatch/module/tt_mod.F90
@@ -2,8 +2,11 @@ module tt_mod
     use header_mod, only: k
     implicit none
 
+    integer, parameter :: nclv = 5
+
     type tt
         real(kind=k), allocatable :: indirection(:)
+        real(kind=k) :: other(nclv)
     contains
         procedure :: proc => tt_proc
     end type tt

--- a/tests/sources/projBatch/module/tt_mod.F90
+++ b/tests/sources/projBatch/module/tt_mod.F90
@@ -1,0 +1,8 @@
+module tt_mod
+    use header_mod, only: k
+    implicit none
+
+    type tt
+        real(kind=k), allocatable :: indirection(:)
+    end type tt
+end module tt_mod

--- a/tests/sources/projBatch/module/tt_mod.F90
+++ b/tests/sources/projBatch/module/tt_mod.F90
@@ -4,5 +4,11 @@ module tt_mod
 
     type tt
         real(kind=k), allocatable :: indirection(:)
+    contains
+        procedure :: proc => tt_proc
     end type tt
+contains
+    subroutine tt_proc(this)
+        class(tt), intent(inout) :: this
+    end subroutine tt_proc
 end module tt_mod

--- a/tests/sources/projBatch/source/comp1.F90
+++ b/tests/sources/projBatch/source/comp1.F90
@@ -1,9 +1,11 @@
 subroutine comp1 (arg, val)
     use t_mod, only: t
-    use header_mod, only: k
+    use header_mod
     implicit none
     type(t), intent(inout) :: arg
     real(kind=k), intent(inout) :: val(:)
 #include "comp2.intfb.h"
+    call arg%proc()
     call comp2(arg, val)
+    call arg%no%way()
 end subroutine comp1

--- a/tests/sources/projBatch/source/comp1.F90
+++ b/tests/sources/projBatch/source/comp1.F90
@@ -1,0 +1,9 @@
+subroutine comp1 (arg, val)
+    use t_mod, only: t
+    use header_mod, only: k
+    implicit none
+    type(t), intent(inout) :: arg
+    real(kind=k), intent(inout) :: val(:)
+#include "comp2.intfb.h"
+    call comp2(arg, val)
+end subroutine comp1

--- a/tests/sources/projBatch/source/comp1.F90
+++ b/tests/sources/projBatch/source/comp1.F90
@@ -7,5 +7,6 @@ subroutine comp1 (arg, val)
 #include "comp2.intfb.h"
     call arg%proc()
     call comp2(arg, val)
-    call arg%no%way()
+    call comp2(arg, val)  ! Twice to check we're not duplicating dependencies
+    call arg%no%way(.true.)
 end subroutine comp1

--- a/tests/sources/projBatch/source/comp2.f90
+++ b/tests/sources/projBatch/source/comp2.f90
@@ -1,0 +1,12 @@
+subroutine comp2 (arg, val)
+    use t_mod, only: t
+    use header_mod, only: k
+    use a_mod, only: a
+    use b_mod, only: b
+    implicit none
+    type(t), intent(inout) :: arg
+    real(kind=k), intent(inout) :: val(:)
+
+    call a(t%yay%indirection)
+    call b(val)
+end subroutine comp2

--- a/tests/sources/projBatch/source/comp2.f90
+++ b/tests/sources/projBatch/source/comp2.f90
@@ -9,4 +9,5 @@ subroutine comp2 (arg, val)
 
     call a(t%yay%indirection)
     call b(val)
+    call arg%yay%proc()
 end subroutine comp2

--- a/tests/sources/projTypeBound/typebound_item.F90
+++ b/tests/sources/projTypeBound/typebound_item.F90
@@ -53,9 +53,10 @@ subroutine driver
     use typebound_other, only: other => other_type
     implicit none
 
+    integer, parameter :: constant = 2
     type(some_type), allocatable :: obj(:), obj2(:,:)
     type(header_type) :: header
-    type(other) :: other_obj, derived(2)
+    type(other) :: other_obj, derived(constant)
     real :: x
     integer :: i
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -11,7 +11,7 @@ import pytest
 
 from loki import (
     HAVE_FP, HAVE_OFP, REGEX, RegexParserClass,
-    FileItem, ModuleItem, SubroutineItem,
+    FileItem, ModuleItem, SubroutineItem, TypeDefItem,
     Sourcefile
 )
 
@@ -88,3 +88,33 @@ def test_module_item(here):
     assert item.name == 'a_mod'
     assert item.ir is item.source['a_mod']
     assert item.definitions == (item.source['a'],)
+
+
+def test_subroutine_item(here):
+    proj = here/'sources/projBatch'
+
+    def get_item(path, name, parser_classes):
+        filepath = proj/path
+        source = Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
+        return SubroutineItem(name, source=source)
+
+    # A file with a single subroutine definition
+    item = get_item('source/comp1.F90', '#comp1', RegexParserClass.ProgramUnitClass)
+    assert item.name == '#comp1'
+    assert item.ir is item.source['comp1']
+    assert item.definitions is ()
+
+
+def test_typedef_item(here):
+    proj = here/'sources/projBatch'
+
+    def get_item(path, name, parser_classes):
+        filepath = proj/path
+        source = Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
+        return TypeDefItem(name, source=source)
+
+    # A file with a single type definition
+    item = get_item('module/t_mod.F90', 't_mod#t', RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass)
+    assert item.name == 't_mod#t'
+    assert item.ir is item.source['t']
+    assert item.definitions is ()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -6,13 +6,15 @@
 # nor does it submit to any jurisdiction.
 
 
+from collections import deque
 from pathlib import Path
+import networkx as nx
 import pytest
 
 from loki import (
-    HAVE_FP, HAVE_OFP, REGEX, RegexParserClass,
-    FileItem, ModuleItem, SubroutineItem, TypeDefItem,
-    Sourcefile
+    HAVE_FP, HAVE_OFP, REGEX, RegexParserClass, as_tuple,
+    FileItem, ModuleItem, ProcedureItem, TypeDefItem, ProcedureBindingItem, GlobalVariableItem,
+    Sourcefile, Section, RawSource, Import, CallStatement
 )
 
 pytestmark = pytest.mark.skipif(not HAVE_FP and not HAVE_OFP, reason='Fparser and OFP not available')
@@ -34,11 +36,28 @@ def test_file_item(here):
         )
 
     # A file with simple module that contains a single subroutine
+    item = get_item('module/a_mod.F90', RegexParserClass.EmptyClass)
+    assert item.name == 'a_mod.f90'
+    assert item.ir is item.source
+    # The file is not parsed at all
+    assert not item.source.definitions
+    assert isinstance(item.source.ir, Section)
+    assert len(item.source.ir.body) == 1
+    assert isinstance(item.source.ir.body[0], RawSource)
+
+    # Querying definitions triggers a round of parsing
+    assert item.definitions == (item.source['a_mod'],)
+    assert len(item.source.definitions) == 1
+    items = item.create_definition_items(item_cache={})
+    assert len(items) == 1
+    assert items[0].name == 'a_mod'
+    assert items[0].definitions == (item.source['a'],)
+
     item = get_item('module/a_mod.F90', RegexParserClass.ProgramUnitClass)
     assert item.name == 'a_mod.f90'
     assert item.definitions == (item.source['a_mod'],)
     assert item.ir is item.source
-    items = item.get_items()
+    items = item.create_definition_items(item_cache={})
     assert len(items) == 1
     assert items[0].name == 'a_mod'
     assert items[0].definitions == (item.source['a'],)
@@ -48,30 +67,44 @@ def test_file_item(here):
     assert item.name == 't_mod.f90'
     assert item.definitions == (item.source['t_mod'],)
 
-    items = item.get_items()
+    items = item.create_definition_items(item_cache={})
     assert len(items) == 1
     assert items[0].name == 't_mod'
     assert items[0].ir is item.source['t_mod']
     # No typedefs because not selected in parser classes
     assert not items[0].ir.typedefs
     # Calling definitions automatically further completes the source
-    assert items[0].definitions == (items[0].ir.typedefs['t'],)
+    assert items[0].definitions == (
+        items[0].ir['t_proc'],
+        items[0].ir['my_way'],
+        items[0].ir.typedefs['t1'],
+        items[0].ir.typedefs['t']
+    )
+
+    # Files don't have dependencies (direct dependencies, anyway)
+    assert item.dependencies is ()
 
     # The same file but with typedefs parsed from the get-go
     item = get_item('module/t_mod.F90', RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass)
     assert item.name == 't_mod.f90'
     assert item.definitions == (item.source['t_mod'],)
 
-    items = item.get_items()
+    items = item.create_definition_items(item_cache={})
     assert len(items) == 1
     assert items[0].name == 't_mod'
-    assert len(items[0].ir.typedefs) == 1
-    assert items[0].definitions == (item.source['t'],)
+    assert len(items[0].ir.typedefs) == 2
+    assert items[0].definitions == (
+        item.source['t_proc'],
+        item.source['my_way'],
+        item.source['t1'],
+        item.source['t']
+    )
 
-    # Filter items when calling get_items()
-    assert not item.get_items(only=SubroutineItem)
-    items = item.get_items(only=ModuleItem)
+    # Filter items when calling create_definition_items()
+    assert not item.create_definition_items(only=ProcedureItem, item_cache={})
+    items = item.create_definition_items(only=ModuleItem, item_cache={})
     assert len(items) == 1
+    assert isinstance(items[0], ModuleItem)
     assert items[0].ir == item.source['t_mod']
 
 
@@ -83,26 +116,96 @@ def test_module_item(here):
         source = Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
         return ModuleItem(name, source=source)
 
-    # A file with simple module that contains a single subroutine
+    # A file with simple module that contains a single subroutine and has no dependencies on
+    # the module level
     item = get_item('module/a_mod.F90', 'a_mod', RegexParserClass.ProgramUnitClass)
     assert item.name == 'a_mod'
     assert item.ir is item.source['a_mod']
     assert item.definitions == (item.source['a'],)
 
+    items = item.create_definition_items(item_cache={})
+    assert len(items) == 1
+    assert isinstance(items[0], ProcedureItem)
+    assert items[0].ir == item.source['a']
 
-def test_subroutine_item(here):
+    assert not item.dependencies
+
+    # A different file with a simple module that contains a single subroutine but has an import
+    # dependency on the module level
+    item = get_item('module/b_mod.F90', 'b_mod', RegexParserClass.ProgramUnitClass)
+    assert item.name == 'b_mod'
+    assert item.ir is item.source['b_mod']
+    assert item.definitions == (item.source['b'],)
+
+    items = item.create_definition_items(item_cache={})
+    assert len(items) == 1
+    assert isinstance(items[0], ProcedureItem)
+    assert items[0].ir == item.source['b']
+
+    dependencies = item.dependencies
+    assert len(dependencies) == 1
+    assert isinstance(dependencies[0], Import)
+    assert dependencies[0].module == 'header_mod'
+
+    # Make sure the dependencies are also found correctly if done without parsing definitions first
+    item = get_item('module/b_mod.F90', 'b_mod', RegexParserClass.ProgramUnitClass)
+    dependencies = item.dependencies
+    assert len(dependencies) == 1 and dependencies[0].module == 'header_mod'
+
+
+def test_procedure_item(here):
     proj = here/'sources/projBatch'
 
     def get_item(path, name, parser_classes):
         filepath = proj/path
         source = Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
-        return SubroutineItem(name, source=source)
+        return ProcedureItem(name, source=source)
 
-    # A file with a single subroutine definition
+    # A file with a single subroutine definition that calls a routine via interface block
     item = get_item('source/comp1.F90', '#comp1', RegexParserClass.ProgramUnitClass)
     assert item.name == '#comp1'
     assert item.ir is item.source['comp1']
     assert item.definitions is ()
+
+    assert not item.create_definition_items(item_cache={})
+
+    dependencies = item.dependencies
+    assert len(dependencies) == 5
+    assert isinstance(dependencies[0], Import)
+    assert dependencies[0].module == 't_mod'
+    assert isinstance(dependencies[1], Import)
+    assert dependencies[1].module == 'header_mod'
+    assert isinstance(dependencies[2], CallStatement)
+    assert dependencies[2].name == 'arg%proc'
+    assert isinstance(dependencies[3], CallStatement)
+    assert dependencies[3].name == 'comp2'
+    assert isinstance(dependencies[4], CallStatement)
+    assert dependencies[4].name == 'arg%no%way'
+
+    # A file with a single subroutine definition that calls two routines via module imports
+    item = get_item('source/comp2.F90', '#comp2', RegexParserClass.ProgramUnitClass)
+    assert item.name == '#comp2'
+    assert item.ir is item.source['comp2']
+    assert item.definitions is ()
+
+    assert not item.create_definition_items(item_cache={})
+
+    dependencies = item.dependencies
+    assert len(dependencies) == 7
+    assert isinstance(dependencies[0], Import)
+    assert dependencies[0].module == 't_mod'
+    assert isinstance(dependencies[1], Import)
+    assert dependencies[1].module == 'header_mod'
+    assert isinstance(dependencies[2], Import)
+    assert dependencies[2].module == 'a_mod'
+    assert isinstance(dependencies[3], Import)
+    assert dependencies[3].module == 'b_mod'
+    assert isinstance(dependencies[4], CallStatement)
+    assert dependencies[4].name == 'a'
+    assert isinstance(dependencies[5], CallStatement)
+    assert dependencies[5].name == 'b'
+    assert isinstance(dependencies[6], CallStatement)
+    assert dependencies[6].name == 'arg%yay%proc'
 
 
 def test_typedef_item(here):
@@ -118,3 +221,101 @@ def test_typedef_item(here):
     assert item.name == 't_mod#t'
     assert item.ir is item.source['t']
     assert item.definitions is ()
+
+    assert not item.create_definition_items(item_cache={})
+    assert item.dependencies == as_tuple(item.ir.parent.imports)
+
+
+def test_item_graph(here):
+    """
+    Build a :any:`nx.Digraph` from a dummy call hierarchy to check the incremental parsing and
+    discovery behaves as expected.
+
+    Expected dependencies:
+
+    .. code-block::
+             + -------------- + --(imports)-->  t_mod#t  --(imports)-->  tt_mod#tt
+           /                  |
+       comp1  --(calls)-->  comp2  --(calls)-->  a_mod#a
+         |                    |
+         |                    + --(calls)-->  b_mod#b
+         |                    |
+         |                    + --(calls)--> tt_mod#tt%proc --(binds to) --> tt_mod#tt_proc
+         |
+         + --(calls)-->  t_mod#t%proc  --(binds to)--> t_mod#t_proc
+         |
+         + --(calls)-->  t_mod#t%no%way --(binds to)-->  t_mod#t1%way  --(binds to)-->  t_mod#my_way
+
+    Additionally, ``comp`` depends on ``header_mod`` (for a kind-parameter ``k``), while
+    all others except ``t_mod``/``t_mod#t`` depend directly on the kind-parameter ``header_mod#k``.
+
+    """
+    proj = here/'sources/projBatch'
+    suffixes = ['.f90', '.F90']
+
+    path_list = [f for ext in suffixes for f in proj.glob(f'**/*{ext}')]
+    assert len(path_list) == 7
+
+    # Map item names to items
+    item_cache = {}
+
+    # Instantiate the basic list of items (files, modules, subroutines)
+    for path in path_list:
+        relative_path = str(path.relative_to(proj))
+        source = Sourcefile.from_file(path, frontend=REGEX, parser_classes=RegexParserClass.ProgramUnitClass)
+        file_item = FileItem(name=relative_path, source=source)
+        item_cache[relative_path] = file_item
+        item_cache.update((item.name, item) for item in file_item.create_definition_items(item_cache={}))
+
+    # Populate a graph from a seed routine
+    seed = '#comp1'
+    full_graph = nx.DiGraph()
+    full_graph.add_node(item_cache[seed])
+
+    dependencies = item_cache[seed].create_dependency_items(item_cache=item_cache)
+    full_graph.add_nodes_from(dependencies)
+    full_graph.add_edges_from((item_cache[seed], item) for item in dependencies)
+
+    queue = deque()
+    queue.extend(dependencies)
+
+    while queue:
+        item = queue.popleft()
+        dependencies = item.create_dependency_items(item_cache=item_cache)
+        new_items = [i for i in dependencies if i not in full_graph]
+        if new_items:
+            full_graph.add_nodes_from(new_items)
+            queue.extend(new_items)
+        full_graph.add_edges_from((item, dependency) for dependency in dependencies)
+
+    expected_dependencies = {
+        '#comp1': ('header_mod', 't_mod#t', '#comp2', 't_mod#t%proc', 't_mod#t%no%way'),
+        '#comp2': ('header_mod#k', 't_mod#t', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc'),
+        'a_mod#a': ('header_mod#k',),
+        'b_mod#b': ('header_mod#k',),
+        't_mod#t': ('tt_mod#tt',),
+        't_mod#t%proc': ('t_mod#t_proc',),
+        't_mod#t_proc': ('tt_mod#tt',),
+        't_mod#t%no%way': ('t_mod#t1%way',),
+        't_mod#t%yay%proc': ('tt_mod#tt%proc',),
+        't_mod#t1%way': ('t_mod#my_way',),
+        't_mod#my_way': ('tt_mod#tt',),
+        'tt_mod#tt': ('header_mod#k',),
+        'tt_mod#tt%proc': ('tt_mod#tt_proc',),
+        'tt_mod#tt_proc': ('header_mod#k',),
+        'header_mod': (),
+        'header_mod#k': (),
+    }
+
+    assert len(full_graph) == len(expected_dependencies)
+    assert all(key in full_graph for key in expected_dependencies)
+
+    edges = tuple((a.name, b.name) for a, b in full_graph.edges)
+    for node, dependencies in expected_dependencies.items():
+        for dependency in dependencies:
+            assert (node, dependency) in edges
+    assert len(edges) == sum(len(dependencies) for dependencies in expected_dependencies.values())
+
+    # Note: quick visualization for debugging can be done using matplotlib
+    #   import matplotlib.pyplot as plt
+    #   nx.draw_planar(full_graph, with_labels=True)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -305,7 +305,7 @@ def test_procedure_item1(here):
     item_cache = {
         (i := get_item(ModuleItem, proj/path, name, RegexParserClass.ProgramUnitClass)).name: i
         for path, name in [
-            ('module/t_mod.F90', 't_mod'), ('source/comp2.F90', '#comp2'), ('headers/header_mod.F90', 'header_mod')
+            ('module/t_mod.F90', 't_mod'), ('source/comp2.f90', '#comp2'), ('headers/header_mod.F90', 'header_mod')
         ]
     }
 
@@ -327,7 +327,7 @@ def test_procedure_item2(here):
     proj = here/'sources/projBatch'
 
     # A file with a single subroutine definition that calls two routines via module imports
-    item = get_item(ProcedureItem, proj/'source/comp2.F90', '#comp2', RegexParserClass.ProgramUnitClass)
+    item = get_item(ProcedureItem, proj/'source/comp2.f90', '#comp2', RegexParserClass.ProgramUnitClass)
     assert item.name == '#comp2'
     assert item.ir is item.source['comp2']
     assert item.definitions is ()
@@ -442,7 +442,7 @@ def test_procedure_item_with_config2(here, disable):
     proj = here/'sources/projBatch'
 
     # Similar to the previous test but checking disabling of subroutines without scope
-    item = get_item(ProcedureItem, proj/'source/comp1.f90', '#comp1', RegexParserClass.ProgramUnitClass)
+    item = get_item(ProcedureItem, proj/'source/comp1.F90', '#comp1', RegexParserClass.ProgramUnitClass)
 
     item_cache = {item.name: item}
     item_cache['t_mod'] = get_item(ModuleItem, proj/'module/t_mod.F90', 't_mod', RegexParserClass.ProgramUnitClass)
@@ -491,7 +491,7 @@ def test_typedef_item(here):
     assert not items[0].dependencies
 
 
-def test_interface_item(here):
+def test_interface_item():
     pass
 
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -80,7 +80,10 @@ def fixture_mod_proc_expected_dependencies():
 
 @pytest.fixture(name='expected_dependencies')
 def fixture_expected_dependencies(comp1_expected_dependencies, mod_proc_expected_dependencies):
-    return comp1_expected_dependencies | mod_proc_expected_dependencies
+    dependencies = {}
+    dependencies.update(comp1_expected_dependencies)
+    dependencies.update(mod_proc_expected_dependencies)
+    return dependencies
 
 
 @pytest.fixture(name='no_expected_dependencies')
@@ -426,13 +429,13 @@ def test_procedure_item_with_config(here, config, expected_dependencies):
 
     # We need to have suitable dependency modules in the cache to spawn the dependency items
     item_cache = {item.name: item}
-    item_cache |= {
+    item_cache.update({
         (i := get_item(ModuleItem, proj/path, name, RegexParserClass.ProgramUnitClass)).name: i
         for path, name in [
             ('module/t_mod.F90', 't_mod'), ('module/a_mod.F90', 'a_mod'),
             ('module/b_mod.F90', 'b_mod'), ('headers/header_mod.F90', 'header_mod')
         ]
-    }
+    })
     scheduler_config = SchedulerConfig.from_dict(config)
     assert item.create_dependency_items(item_cache=item_cache, config=scheduler_config) == expected_dependencies
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,62 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+from pathlib import Path
+import pytest
+
+from loki import (
+    HAVE_FP, HAVE_OFP, REGEX, RegexParserClass,
+    FileItem,
+    Sourcefile
+)
+
+pytestmark = pytest.mark.skipif(not HAVE_FP and not HAVE_OFP, reason='Fparser and OFP not available')
+
+
+@pytest.fixture(scope='module', name='here')
+def fixture_here():
+    return Path(__file__).parent
+
+
+def test_file_item(here):
+    proj = here/'sources/projBatch'
+
+    def get_item(path, parser_classes):
+        filepath = proj/path
+        return FileItem(
+            filepath.name.lower(),
+            Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
+        )
+
+    # A file with simple module that contains a single subroutine
+    item = get_item('module/a_mod.F90', RegexParserClass.ProgramUnitClass)
+    assert item.name == 'a_mod.f90'
+    assert item.definitions == (item.source['a_mod'],)
+    items = item.get_items()
+    assert len(items) == 1
+    assert items[0].name == 'a_mod'
+    assert items[0].definitions == (item.source['a'],)
+
+    # A file with a simple module that contains a single typedef
+    item = get_item('module/t_mod.F90', RegexParserClass.ProgramUnitClass)
+    assert item.name == 't_mod.f90'
+    assert item.definitions == (item.source['t_mod'],)
+
+    items = item.get_items()
+    assert len(items) == 1
+    assert items[0].name == 't_mod'
+    assert items[0].definitions == ()  # No typedefs because not selected in parser classes
+
+    item = get_item('module/t_mod.F90', RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass)
+    assert item.name == 't_mod.f90'
+    assert item.definitions == (item.source['t_mod'],)
+
+    items = item.get_items()
+    assert len(items) == 1
+    assert items[0].name == 't_mod'
+    assert items[0].definitions == (item.source['t'],)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -12,9 +12,9 @@ import networkx as nx
 import pytest
 
 from loki import (
-    HAVE_FP, HAVE_OFP, REGEX, RegexParserClass, as_tuple,
+    HAVE_FP, HAVE_OFP, REGEX, RegexParserClass, as_tuple, CaseInsensitiveDict,
     FileItem, ModuleItem, ProcedureItem, TypeDefItem, ProcedureBindingItem, GlobalVariableItem,
-    Sourcefile, Section, RawSource, Import, CallStatement
+    Sourcefile, Section, RawSource, Import, CallStatement, Scalar
 )
 
 pytestmark = pytest.mark.skipif(not HAVE_FP and not HAVE_OFP, reason='Fparser and OFP not available')
@@ -25,20 +25,52 @@ def fixture_here():
     return Path(__file__).parent
 
 
-def test_file_item(here):
+@pytest.fixture(scope='module', name='comp1_expected_dependencies')
+def fixture_comp1_expected_dependencies():
+    return {
+        '#comp1': ('header_mod', 't_mod#t', '#comp2', 't_mod#t%proc', 't_mod#t%no%way'),
+        '#comp2': ('header_mod#k', 't_mod#t', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc'),
+        'a_mod#a': ('header_mod#k',),
+        'b_mod#b': (),
+        't_mod#t': ('tt_mod#tt', 't_mod#t1'),
+        't_mod#t1': (),
+        't_mod#t%proc': ('t_mod#t_proc',),
+        't_mod#t_proc': ('t_mod#t', 'a_mod#a', 't_mod#t%yay%proc'),
+        't_mod#t%no%way': ('t_mod#t1%way',),
+        't_mod#t%yay%proc': ('tt_mod#tt%proc',),
+        't_mod#t1%way': ('t_mod#my_way',),
+        't_mod#my_way': ('t_mod#t1', 't_mod#t1%way'),
+        'tt_mod#tt': (),
+        'tt_mod#tt%proc': ('tt_mod#tt_proc',),
+        'tt_mod#tt_proc': ('tt_mod#tt',),
+        'header_mod': (),
+        'header_mod#k': (),
+    }
+
+
+
+def get_item(cls, path, name, parser_classes):
+    source = Sourcefile.from_file(path, frontend=REGEX, parser_classes=parser_classes)
+    return cls(name, source=source)
+
+
+def test_file_item1(here):
     proj = here/'sources/projBatch'
 
-    def get_item(path, parser_classes):
-        filepath = proj/path
-        return FileItem(
-            filepath.name.lower(),
-            Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
-        )
-
     # A file with simple module that contains a single subroutine
-    item = get_item('module/a_mod.F90', RegexParserClass.EmptyClass)
-    assert item.name == 'a_mod.f90'
+    item = get_item(FileItem, proj/'module/a_mod.F90', 'module/a_mod.F90', RegexParserClass.EmptyClass)
+    assert item.name == 'module/a_mod.F90'
+    assert item.local_name == item.name
+    assert item.scope_name is None
+    assert not item.scope
     assert item.ir is item.source
+    assert str(item) == 'loki.bulk.FileItem<module/a_mod.F90>'
+
+    # A few checks on the item comparison
+    assert item == 'module/a_mod.F90'
+    assert item != FileItem('some_name', source=item.source)
+    assert item == FileItem(item.name, source=item.source)
+
     # The file is not parsed at all
     assert not item.source.definitions
     assert isinstance(item.source.ir, Section)
@@ -50,11 +82,12 @@ def test_file_item(here):
     assert len(item.source.definitions) == 1
     items = item.create_definition_items(item_cache={})
     assert len(items) == 1
+    assert items[0] != None  # pylint: disable=singleton-comparison  # (intentionally trigger __eq__ here)
     assert items[0].name == 'a_mod'
     assert items[0].definitions == (item.source['a'],)
 
-    item = get_item('module/a_mod.F90', RegexParserClass.ProgramUnitClass)
-    assert item.name == 'a_mod.f90'
+    item = get_item(FileItem, proj/'module/a_mod.F90', 'module/a_mod.F90', RegexParserClass.ProgramUnitClass)
+    assert item.name == 'module/a_mod.F90'
     assert item.definitions == (item.source['a_mod'],)
     assert item.ir is item.source
     items = item.create_definition_items(item_cache={})
@@ -62,9 +95,13 @@ def test_file_item(here):
     assert items[0].name == 'a_mod'
     assert items[0].definitions == (item.source['a'],)
 
+
+def test_file_item2(here):
+    proj = here/'sources/projBatch'
+
     # A file with a simple module that contains a single typedef
-    item = get_item('module/t_mod.F90', RegexParserClass.ProgramUnitClass)
-    assert item.name == 't_mod.f90'
+    item = get_item(FileItem, proj/'module/t_mod.F90', 'module/t_mod.F90', RegexParserClass.ProgramUnitClass)
+    assert item.name == 'module/t_mod.F90'
     assert item.definitions == (item.source['t_mod'],)
 
     items = item.create_definition_items(item_cache={})
@@ -77,16 +114,23 @@ def test_file_item(here):
     assert items[0].definitions == (
         items[0].ir['t_proc'],
         items[0].ir['my_way'],
-        items[0].ir.typedefs['t1'],
-        items[0].ir.typedefs['t']
+        items[0].ir.typedef_map['t1'],
+        items[0].ir.typedef_map['t']
     )
 
     # Files don't have dependencies (direct dependencies, anyway)
     assert item.dependencies is ()
 
+
+def test_file_item3(here):
+    proj = here/'sources/projBatch'
+
     # The same file but with typedefs parsed from the get-go
-    item = get_item('module/t_mod.F90', RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass)
-    assert item.name == 't_mod.f90'
+    item = get_item(
+        FileItem, proj/'module/t_mod.F90', 'module/t_mod.F90',
+        RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass
+    )
+    assert item.name == 'module/t_mod.F90'
     assert item.definitions == (item.source['t_mod'],)
 
     items = item.create_definition_items(item_cache={})
@@ -108,18 +152,15 @@ def test_file_item(here):
     assert items[0].ir == item.source['t_mod']
 
 
-def test_module_item(here):
+def test_module_item1(here):
     proj = here/'sources/projBatch'
-
-    def get_item(path, name, parser_classes):
-        filepath = proj/path
-        source = Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
-        return ModuleItem(name, source=source)
 
     # A file with simple module that contains a single subroutine and has no dependencies on
     # the module level
-    item = get_item('module/a_mod.F90', 'a_mod', RegexParserClass.ProgramUnitClass)
+    item = get_item(ModuleItem, proj/'module/a_mod.F90', 'a_mod', RegexParserClass.ProgramUnitClass)
     assert item.name == 'a_mod'
+    assert item == 'a_mod'
+    assert str(item) == 'loki.bulk.ModuleItem<a_mod>'
     assert item.ir is item.source['a_mod']
     assert item.definitions == (item.source['a'],)
 
@@ -130,9 +171,13 @@ def test_module_item(here):
 
     assert not item.dependencies
 
+
+def test_module_item2(here):
+    proj = here/'sources/projBatch'
+
     # A different file with a simple module that contains a single subroutine but has an import
     # dependency on the module level
-    item = get_item('module/b_mod.F90', 'b_mod', RegexParserClass.ProgramUnitClass)
+    item = get_item(ModuleItem, proj/'module/b_mod.F90', 'b_mod', RegexParserClass.ProgramUnitClass)
     assert item.name == 'b_mod'
     assert item.ir is item.source['b_mod']
     assert item.definitions == (item.source['b'],)
@@ -147,23 +192,24 @@ def test_module_item(here):
     assert isinstance(dependencies[0], Import)
     assert dependencies[0].module == 'header_mod'
 
+
+def test_module_item3(here):
+    proj = here/'sources/projBatch'
+
     # Make sure the dependencies are also found correctly if done without parsing definitions first
-    item = get_item('module/b_mod.F90', 'b_mod', RegexParserClass.ProgramUnitClass)
+    item = get_item(ModuleItem, proj/'module/b_mod.F90', 'b_mod', RegexParserClass.ProgramUnitClass)
     dependencies = item.dependencies
     assert len(dependencies) == 1 and dependencies[0].module == 'header_mod'
 
 
-def test_procedure_item(here):
+def test_procedure_item1(here):
     proj = here/'sources/projBatch'
 
-    def get_item(path, name, parser_classes):
-        filepath = proj/path
-        source = Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
-        return ProcedureItem(name, source=source)
-
     # A file with a single subroutine definition that calls a routine via interface block
-    item = get_item('source/comp1.F90', '#comp1', RegexParserClass.ProgramUnitClass)
+    item = get_item(ProcedureItem, proj/'source/comp1.F90', '#comp1', RegexParserClass.ProgramUnitClass)
     assert item.name == '#comp1'
+    assert item == '#comp1'
+    assert str(item) == 'loki.bulk.ProcedureItem<#comp1>'
     assert item.ir is item.source['comp1']
     assert item.definitions is ()
 
@@ -182,8 +228,34 @@ def test_procedure_item(here):
     assert isinstance(dependencies[4], CallStatement)
     assert dependencies[4].name == 'arg%no%way'
 
+    # We need to have suitable dependency modules in the cache to spawn the dependency items
+    item_cache = {item.name: item}
+    item_cache = {
+        (i := get_item(ModuleItem, proj/path, name, RegexParserClass.ProgramUnitClass)).name: i
+        for path, name in [
+            ('module/t_mod.F90', 't_mod'), ('source/comp2.F90', '#comp2'), ('headers/header_mod.F90', 'header_mod')
+        ]
+    }
+
+    # To ensure any existing items from the item_cache are re-used, we instantiate one for
+    # the procedure binding
+    t_mod_t_proc = get_item(
+        ProcedureBindingItem, proj/'module/t_mod.F90', 't_mod#t%proc',
+        RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass | RegexParserClass.DeclarationClass
+    )
+    item_cache[t_mod_t_proc.name] = t_mod_t_proc
+
+    items = item.create_dependency_items(item_cache=item_cache)
+    assert items == ('t_mod#t', 'header_mod', 't_mod#t%proc', '#comp2', 't_mod#t%no%way')
+    assert item_cache[t_mod_t_proc.name] is t_mod_t_proc
+    assert items[2] is t_mod_t_proc
+
+
+def test_procedure_item2(here):
+    proj = here/'sources/projBatch'
+
     # A file with a single subroutine definition that calls two routines via module imports
-    item = get_item('source/comp2.F90', '#comp2', RegexParserClass.ProgramUnitClass)
+    item = get_item(ProcedureItem, proj/'source/comp2.F90', '#comp2', RegexParserClass.ProgramUnitClass)
     assert item.name == '#comp2'
     assert item.ir is item.source['comp2']
     assert item.definitions is ()
@@ -207,77 +279,204 @@ def test_procedure_item(here):
     assert isinstance(dependencies[6], CallStatement)
     assert dependencies[6].name == 'arg%yay%proc'
 
+    # We need to have suitable dependency modules in the cache to spawn the dependency items
+    item_cache = {item.name: item}
+    item_cache = {
+        (i := get_item(ModuleItem, proj/path, name, RegexParserClass.ProgramUnitClass)).name: i
+        for path, name in [
+            ('module/t_mod.F90', 't_mod'), ('module/a_mod.F90', 'a_mod'),
+            ('module/b_mod.F90', 'b_mod'), ('headers/header_mod.F90', 'header_mod')
+        ]
+    }
+    items = item.create_dependency_items(item_cache=item_cache)
+    assert items == ('t_mod#t', 'header_mod#k', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc')
+
+    # Does it still work if we call it again?
+    assert items == item.create_dependency_items(item_cache=item_cache)
+
+
+def test_procedure_item3(here):
+    proj = here/'sources/projBatch'
+
+    # A file with a single subroutine declared in a module that calls a typebound procedure
+    # where the type is imported via an import statement in the module scope
+    item = get_item(
+        ProcedureItem, proj/'module/other_mod.F90', 'other_mod#mod_proc',
+        RegexParserClass.ProgramUnitClass
+    )
+    dependencies = item.dependencies
+    assert len(dependencies) == 3
+    assert dependencies[0].module == 'tt_mod'
+    assert dependencies[1].name == 'arg%proc'
+    assert dependencies[2].name == 'b'
+
+    item_cache = {
+        item.name: item,
+        'tt_mod': get_item(ModuleItem, proj/'module/tt_mod.F90', 'tt_mod', RegexParserClass.ProgramUnitClass),
+        'b_mod': get_item(ModuleItem, proj/'module/b_mod.F90', 'b_mod', RegexParserClass.ProgramUnitClass)
+    }
+    assert item.create_dependency_items(item_cache=item_cache) == ('tt_mod#tt', 'tt_mod#tt%proc', 'b_mod#b')
+
+
+def test_procedure_item4(here):
+    proj = here/'sources/projBatch'
+
+    # A routine with a typebound procedure call where the typedef is in the same module
+    item = get_item(
+        ProcedureItem, proj/'module/t_mod.F90', 't_mod#my_way', RegexParserClass.ProgramUnitClass
+    )
+    dependencies = item.dependencies
+    assert len(dependencies) == 2
+    assert dependencies[0].name == 't1'
+    assert dependencies[1].name == 'this%way'
+
+    item_cache = {
+        item.name: item,
+        't_mod': ModuleItem('t_mod', source=item.source)
+    }
+    items = item.create_dependency_items(item_cache=item_cache)
+    assert items == ('t_mod#t1', 't_mod#t1%way')
+
 
 def test_typedef_item(here):
     proj = here/'sources/projBatch'
 
-    def get_item(path, name, parser_classes):
-        filepath = proj/path
-        source = Sourcefile.from_file(filepath, frontend=REGEX, parser_classes=parser_classes)
-        return TypeDefItem(name, source=source)
-
-    # A file with a single type definition
-    item = get_item('module/t_mod.F90', 't_mod#t', RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass)
+    # A file with multiple type definitions, of which we pick one
+    item = get_item(
+        TypeDefItem, proj/'module/t_mod.F90', 't_mod#t',
+        RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass
+    )
     assert item.name == 't_mod#t'
+    assert str(item) == 'loki.bulk.TypeDefItem<t_mod#t>'
     assert item.ir is item.source['t']
     assert item.definitions is ()
 
     assert not item.create_definition_items(item_cache={})
-    assert item.dependencies == as_tuple(item.ir.parent.imports)
+    assert item.dependencies == (item.scope.import_map['tt'], item.ir.parent['t1'])
+
+    item_cache = CaseInsensitiveDict()
+    item_cache[item.name] = item
+    with pytest.raises(RuntimeError):
+        item.create_dependency_items(item_cache=item_cache)
+
+    # Need to add the module of the dependent type
+    item_cache['tt_mod'] = get_item(
+        ModuleItem, proj/'module/tt_mod.F90', 'tt_mod', RegexParserClass.ProgramUnitClass
+    )
+    assert 'tt_mod#tt' not in item_cache
+    assert 't_mod#t1' not in item_cache
+    items = item.create_dependency_items(item_cache=item_cache)
+    assert 'tt_mod#tt' in item_cache
+    assert 't_mod#t1' in item_cache
+    assert items == (item_cache['tt_mod#tt'], item_cache['t_mod#t1'])
+    assert all(isinstance(i, TypeDefItem) for i in items)
+    assert not items[0].dependencies
 
 
-def test_item_graph(here):
+def test_interface_item(here):
+    pass
+
+
+def test_global_variable_item(here):
+    proj = here/'sources/projBatch'
+
+    # A file with a global parameter definition
+    item = get_item(
+        GlobalVariableItem, proj/'headers/header_mod.F90', 'header_mod#k',
+        RegexParserClass.ProgramUnitClass | RegexParserClass.DeclarationClass
+    )
+    assert item.name == 'header_mod#k'
+    assert str(item) == 'loki.bulk.GlobalVariableItem<header_mod#k>'
+    assert item.ir == item.source['header_mod'].declarations[0]
+    assert item.definitions is ()
+    assert not item.create_definition_items(item_cache={})
+    assert item.dependencies is ()
+    assert not item.create_dependency_items(item_cache={})
+
+
+def test_procedure_binding_item1(here):
+    proj = here/'sources/projBatch'
+    parser_classes = (
+        RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass | RegexParserClass.DeclarationClass
+    )
+
+    # A typedef with a procedure binding as well as nested types that have in turn procedure bindings
+
+    # 1. A direct procedure binding
+    item = get_item(ProcedureBindingItem, proj/'module/t_mod.F90', 't_mod#t%proc', parser_classes)
+    assert item.name == 't_mod#t%proc'
+    assert str(item) == 'loki.bulk.ProcedureBindingItem<t_mod#t%proc>'
+    assert item.ir is item.source['t'].variable_map['proc']
+    assert item.definitions is ()
+    assert not item.create_definition_items(item_cache={})
+    assert item.dependencies == as_tuple(item.source['t_proc'])
+    items = item.create_dependency_items(item_cache={})
+    assert len(items) == 1
+    assert isinstance(items[0], ProcedureItem)
+    assert items[0].ir is item.source['t_proc']
+
+
+def test_procedure_binding_item2(here):
+    proj = here/'sources/projBatch'
+    parser_classes = (
+        RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass | RegexParserClass.DeclarationClass
+    )
+
+    # 2. An indirect procedure binding via a nested type member, where the type is declared in the same module
+    item = get_item(ProcedureBindingItem, proj/'module/t_mod.F90', 't_mod#t%no%way', parser_classes)
+    assert item.name == 't_mod#t%no%way'
+    assert isinstance(item.ir, Scalar)
+    assert item.definitions is ()
+    assert not item.create_definition_items(item_cache={})
+    assert item.dependencies == ('no%way',)
+
+    item_cache = {item.name: item}
+    with pytest.raises(RuntimeError):
+        # Fails because item_cache does not contain the relevant module
+        item.create_dependency_items(item_cache=item_cache)
+
+    item_cache['t_mod'] = ModuleItem('t_mod', source=item.source)
+    items = item.create_dependency_items(item_cache=item_cache)
+    assert len(items) == 1
+    assert isinstance(items[0], ProcedureBindingItem)
+    assert items[0].name == 't_mod#t1%way'
+    assert 't_mod#t1%way' in item_cache
+
+    assert 't_mod#my_way' not in item_cache
+    next_items = items[0].create_dependency_items(item_cache=item_cache)
+    assert len(next_items) == 1
+    assert isinstance(next_items[0], ProcedureItem)
+    assert next_items[0].ir is item.source['my_way']
+    assert 't_mod#my_way' in item_cache
+
+
+def test_item_graph(here, comp1_expected_dependencies):
     """
     Build a :any:`nx.Digraph` from a dummy call hierarchy to check the incremental parsing and
     discovery behaves as expected.
-
-    Expected dependencies:
-
-    .. code-block::
-             + -------------- + --(imports)-->  t_mod#t  --(imports)-->  tt_mod#tt
-           /                  |
-       comp1  --(calls)-->  comp2  --(calls)-->  a_mod#a
-         |                    |
-         |                    + --(calls)-->  b_mod#b
-         |                    |
-         |                    + --(calls)--> tt_mod#tt%proc --(binds to) --> tt_mod#tt_proc
-         |
-         + --(calls)-->  t_mod#t%proc  --(binds to)--> t_mod#t_proc
-         |
-         + --(calls)-->  t_mod#t%no%way --(binds to)-->  t_mod#t1%way  --(binds to)-->  t_mod#my_way
-
-    Additionally, ``comp`` depends on ``header_mod`` (for a kind-parameter ``k``), while
-    all others except ``t_mod``/``t_mod#t`` depend directly on the kind-parameter ``header_mod#k``.
-
     """
     proj = here/'sources/projBatch'
     suffixes = ['.f90', '.F90']
 
     path_list = [f for ext in suffixes for f in proj.glob(f'**/*{ext}')]
-    assert len(path_list) == 7
+    assert len(path_list) == 8
 
     # Map item names to items
-    item_cache = {}
+    item_cache = CaseInsensitiveDict()
 
     # Instantiate the basic list of items (files, modules, subroutines)
     for path in path_list:
         relative_path = str(path.relative_to(proj))
-        source = Sourcefile.from_file(path, frontend=REGEX, parser_classes=RegexParserClass.ProgramUnitClass)
-        file_item = FileItem(name=relative_path, source=source)
+        file_item = get_item(FileItem, path, relative_path, RegexParserClass.ProgramUnitClass)
         item_cache[relative_path] = file_item
-        item_cache.update((item.name, item) for item in file_item.create_definition_items(item_cache={}))
+        item_cache.update((item.name, item) for item in file_item.create_definition_items(item_cache=item_cache))
 
     # Populate a graph from a seed routine
     seed = '#comp1'
+    queue = deque()
     full_graph = nx.DiGraph()
     full_graph.add_node(item_cache[seed])
-
-    dependencies = item_cache[seed].create_dependency_items(item_cache=item_cache)
-    full_graph.add_nodes_from(dependencies)
-    full_graph.add_edges_from((item_cache[seed], item) for item in dependencies)
-
-    queue = deque()
-    queue.extend(dependencies)
+    queue.append(item_cache[seed])
 
     while queue:
         item = queue.popleft()
@@ -288,34 +487,18 @@ def test_item_graph(here):
             queue.extend(new_items)
         full_graph.add_edges_from((item, dependency) for dependency in dependencies)
 
-    expected_dependencies = {
-        '#comp1': ('header_mod', 't_mod#t', '#comp2', 't_mod#t%proc', 't_mod#t%no%way'),
-        '#comp2': ('header_mod#k', 't_mod#t', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc'),
-        'a_mod#a': ('header_mod#k',),
-        'b_mod#b': ('header_mod#k',),
-        't_mod#t': ('tt_mod#tt',),
-        't_mod#t%proc': ('t_mod#t_proc',),
-        't_mod#t_proc': ('tt_mod#tt',),
-        't_mod#t%no%way': ('t_mod#t1%way',),
-        't_mod#t%yay%proc': ('tt_mod#tt%proc',),
-        't_mod#t1%way': ('t_mod#my_way',),
-        't_mod#my_way': ('tt_mod#tt',),
-        'tt_mod#tt': ('header_mod#k',),
-        'tt_mod#tt%proc': ('tt_mod#tt_proc',),
-        'tt_mod#tt_proc': ('header_mod#k',),
-        'header_mod': (),
-        'header_mod#k': (),
-    }
-
-    assert len(full_graph) == len(expected_dependencies)
-    assert all(key in full_graph for key in expected_dependencies)
+    assert set(full_graph) == set(comp1_expected_dependencies)
+    assert all(key in full_graph for key in comp1_expected_dependencies)
 
     edges = tuple((a.name, b.name) for a, b in full_graph.edges)
-    for node, dependencies in expected_dependencies.items():
+    for node, dependencies in comp1_expected_dependencies.items():
         for dependency in dependencies:
             assert (node, dependency) in edges
-    assert len(edges) == sum(len(dependencies) for dependencies in expected_dependencies.values())
+    assert len(edges) == sum(len(dependencies) for dependencies in comp1_expected_dependencies.values())
 
     # Note: quick visualization for debugging can be done using matplotlib
-    #   import matplotlib.pyplot as plt
-    #   nx.draw_planar(full_graph, with_labels=True)
+    # import matplotlib.pyplot as plt
+    # nx.draw_planar(full_graph, with_labels=True)
+    # plt.show()
+    # # -or-
+    # plt.savefig('test_item_graph.png')

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1180,6 +1180,11 @@ end subroutine test
     calls = FindNodes(CallStatement).visit(source['test'].ir)
     assert [call.name for call in calls] == ['RANDOM_CALL_0', 'random_call_2']
 
+    variable_map_test = source['test'].variable_map
+    v_in_type = variable_map_test['v_in'].type
+    assert v_in_type.dtype is BasicType.REAL
+    assert v_in_type.kind == 'jprb'
+
 
 def test_regex_variable_declaration(here):
     """
@@ -1189,7 +1194,7 @@ def test_regex_variable_declaration(here):
     source = Sourcefile.from_file(filepath, frontend=REGEX)
 
     driver = source['driver']
-    assert driver.variables == ('obj', 'obj2', 'header', 'other_obj', 'derived', 'x', 'i')
+    assert driver.variables == ('constant', 'obj', 'obj2', 'header', 'other_obj', 'derived', 'x', 'i')
     assert source['module_routine'].variables == ('m',)
     assert source['other_routine'].variables == ('self', 'm', 'j')
     assert source['routine'].variables == ('self',)


### PR DESCRIPTION

I'm filing this in a very rough shape against the scheduler staging development branch because the list of changes is already growing significantly and I want to give you at least a fighting chance to work through them. There is currently also some duplication in the `item.py` file, while the current Scheduler infrastructure still exists, of which substantial amounts are going to become redundant.

I fully intending to clean this up in the subsequent dev-PRs against the staging branch. In particular, proper documentation needs to be added. The downside of this approach is that the final picture is not clearly visible, yet. 

For context, the next steps would be:
1) to swap out the existing callgraph under the Scheduler, and replace this with an SGraph;
2) to add the SFilter view methodology for graph traversals;
3) to annotate Transformations with the relevant metadata for the SFilter traversals;

# Design philosophy

## Items

Dependencies are based on `Item` nodes, currently with the following node implementations:

* `FileItem`: represents a `Sourcefile` object
* `ModuleItem`: represents a `Module`
* `ProcedureItem`: represents a `Subroutine` object (i.e. Fortran subroutine or function)
* `TypeDefItem`: represents a `TypeDef` object
* `GlobalVariableItem`: represents a variable declared in a module
* `ProcedureBindingItem`: represents a procedure binding to a typedef
* `InterfaceItem`: represents a Fortran interface declaration (not implemented, yet)

Each `Item` object can provide two key properties:
1. `definitions`: All the things, that a node can define and which other nodes can potentially depend on (i.e. procedures, type definitions etc). Currently, this makes sense only on `FileItem` and `ModuleItem`.
2. `dependencies`: All the things, that a node depends on (e.g. `Import`, `CallStatement`)

Importantly, since we now base everything on (incomplete) IR nodes from the beginning, both these properties return proper IR nodes rather than strings as before.

_Note: `ProcedureItem` takes the place of the current `SubroutineItem` but I prefer the new name because it avoids the implicit link to the Fortran concept of subroutines._

## Populating the “main tree”

Take a look at the `test_item_graph` test case, which illustrates the tree building without the container objects, which will then encapsulate this. It performs the following steps:

1. Start with the set of `FileItem` for every path in the search tree, only parsing `ProgramUnitClass` (Module or subroutine) nodes with the `REGEX` frontend, and fills an `item_cache` with those.
2. For every such `FileItem` it creates the “definition items”, i.e. the `ModuleItem` or `ProcedureItem` entries that are defined on the top level of the source file (notably, this excludes all the procedures declared inside modules). These provide our basic search space for the next step
3. We instantiate the `DiGraph` and add the item corresponding to the seed routine as a node and as the only entry in a “work queue”.
4. We run through the FIFO work queue, take out the top item, create the items corresponding to that item’s dependencies and add them to the graph as well as the queue.
5. Repeat until the queue is empty

In the actual Scheduler, it is intended that steps 1 and 2 are carried out by the `Scheduler` object, and step 3-5 is done in the `SGraph` class.

## Incremental parsing while populating the tree

The above population method is almost identical to what we had before, but the important difference is under the hood:  The “definitions” and “dependencies” on items are now formalised, and every `Item` class has three class attributes:
- `_parser_class`: The parser class that the REGEX frontend has to recurse into, in order to match the relevant IR nodes that are represented by that `Item` (Example: `TypeDefItem._parser_class` is `RegexParserClass.TypeDefClass`)
- `_defines_items`: A list of Item class names that the `Item` can define, e.g., `FileItem._defines_items` is `(’ModuleItem’, ‘SubroutineItem’)`.
- `_depends_class`: The parser class that the REGEX frontend has to recurse into, to be able to match the relevant dependencies of this `Item` (Example: `ModuleItem._defines_items` is `('ProcedureItem', 'TypeDefItem', 'GlobalVariableItem’)`, which are the three things that a module can depend on via `USE` statements).

Whenever `definitions` of an `Item` are queried, we first “concretise” that Item’s IR by calling `make_complete` on it, adding just the parser classes that the defined item types list as their `_parser_class`. For that, we store the previously used parser classes on the relevant IR objects (next to the existing `_incomplete` property), thus incrementally expanding the details of the file. Or not doing anything if the requested parser classes are already included.

Similarly when querying `dependencies` of an `Item`, we are concretising with the `_depends_class` of the `Item` itself.

All generated `Item` objects via either of this method are always cached in the `item_cache`, ready to be used again in the future instead of re-generating them. The factory for this functionality is the `Item._create_from_ir` method, where dependency nodes are translated to the relevant item names and then either picked up from the cache or newly instantiated.

## Scheduler

The new Scheduler is then intended to work similar to before. This has not been implemented, yet, but should in principle be possible now using the new structure introduced in this PR, and will be covered in a subsequent PR:

1. "Discovery" takes only the minimum set of inventory for all files in the search tree, i.e., the top-level items in each source file: Modules or Subroutines - the latter if and only if (!) they are not wrapped in a module. This creates the initial `item_cache` that contains `FileItem`, `ModuleItem` and `SubroutineItem` nodes. This corresponds to step 1 and 2 above.
2. "Populate" starts from the seed nodes to populate the actual dependency graph (SGraph)
3. A full parse is triggered for the nodes in the graph
4. Graph traversals to apply transformations, using `SFilter` to prune the tree to the relevant item classes