### PR TITLE
Pragma regions detach bug fix

### DIFF
--- a/loki/pragma_utils.py
+++ b/loki/pragma_utils.py
@@ -477,7 +477,7 @@ def detach_pragma_regions(ir):
     All replacements are performed in-place, without rebuilding any IR
     nodes.
     """
-    mapper = {region: (region.pragma, region.body, region.pragma_post)
+    mapper = {region: as_tuple(region.pragma) + region.body + as_tuple(region.pragma_post)
               for region in FindNodes(PragmaRegion).visit(ir)}
     return Transformer(mapper, inplace=True).visit(ir)
 


### PR DESCRIPTION
`detach_pragma_regions` replaces any `PragmaRegion` node with the following tuple `(region.pragma, region.body, region.pragma_post)`. This nested tuple is unnecessary, and it causes problems with some of the pydantic checks if the original `PragmaRegoin` was nested with a `Conditional` or other `InternalNode`. Here is a small fix with updated tests.