### PR TITLE
Include Stack transformation in CLOUDSC regression testing

### DIFF
--- a/transformations/tests/test_cloudsc.py
+++ b/transformations/tests/test_cloudsc.py
@@ -108,6 +108,8 @@ def test_cloudsc(here, frontend):
         ('dwarf-cloudsc-loki-scc', '1', '16000', '32'),
         ('dwarf-cloudsc-loki-scc-hoist', '1', '16000', '32'),
         ('dwarf-cloudsc-loki-c', '2', '16000', '32'),
+        ('dwarf-cloudsc-loki-idem-stack', '2', '16000', '32'),
+        ('dwarf-cloudsc-loki-scc-stack', '1', '16000', '32'),
     ]
 
     if HAVE_OMNI:


### PR DESCRIPTION
With ecmwf-ifs/dwarf-p-cloudsc#49 merged, we can enable the "stack" variants in the test_cloudsc.py regression tests.

For OMNI, this requires a little fix to normalize the silly range index behaviour.