### PR TITLE
Pool allocator update

### DIFF
--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -260,8 +260,7 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
         block_dim = scheduler.config.dimensions['block_dim']
         directive = {'idem-stack': 'openmp', 'scc-stack': 'openacc'}[mode]
         transformation = TemporariesPoolAllocatorTransformation(
-            block_dim=block_dim, allocation_dims=[horizontal, vertical],
-            directive=directive, check_bounds='scc' not in mode
+            block_dim=block_dim, directive=directive, check_bounds='scc' not in mode
         )
         scheduler.process(transformation=transformation, reverse=True)
     if mode == 'cuf-parametrise':

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -12,7 +12,7 @@ from loki import (
     SymbolAttributes, BasicType, DerivedType, Quotient, IntLiteral, IntrinsicLiteral, LogicLiteral,
     Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex, Scalar,
     Intrinsic, Assignment, Conditional, CallStatement, Import, Allocation, Deallocation,
-    Loop, Pragma, SubroutineItem, FindInlineCalls, Interface, ProcedureSymbol, LogicalNot
+    Loop, Pragma, SubroutineItem, FindInlineCalls, Interface, ProcedureSymbol, LogicalNot, dataflow_analysis_attached
 )
 
 __all__ = ['TemporariesPoolAllocatorTransformation']
@@ -505,6 +505,13 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             var for var in routine.variables
             if isinstance(var, Array) and var not in arguments
         ]
+
+        # Filter out unused vars
+        with dataflow_analysis_attached(routine):
+            temporary_arrays = [
+                var for var in temporary_arrays
+                if var.name.lower() in routine.body.defines_symbols
+            ]
 
         # Filter out variables whose size is known at compile-time
         temporary_arrays = [

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -615,8 +615,12 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                 )
             )
             # Stack increment
+            _real_size_bytes = InlineCall(Variable(name='REAL'), parameters=(
+                                         Literal(1), IntrinsicLiteral(f'kind={self.stack_type_kind}')))
+            _real_size_bytes = InlineCall(Variable(name='C_SIZEOF'),
+                                          parameters=as_tuple(_real_size_bytes))
             stack_incr = Assignment(
-                lhs=stack_end, rhs=Sum((stack_ptr, Product((stack_size_var, Literal(8)))))
+                lhs=stack_end, rhs=Sum((stack_ptr, Product((stack_size_var, _real_size_bytes))))
             )
             loop_map[loop] = loop.clone(
                 body=loop.body[:assign_pos + 1] + (ptr_assignment, stack_incr) + loop.body[assign_pos + 1:]

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -167,7 +167,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                     return
 
                 # Update iso_c_binding import
-                imp._update(symbols=as_tuple(imp.symbols + ProcedureSymbol('C_SIZEOF', scope=routine)))
+                imp._update(symbols=imp.symbols + as_tuple(ProcedureSymbol('C_SIZEOF', scope=routine)))
 
         # add qualified iso_c_binding import
         imp = Import(module='ISO_C_BINDING', symbols=as_tuple(ProcedureSymbol('C_SIZEOF', scope=routine)))

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -5,9 +5,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import pdb
 from loki import (
-    as_tuple, flatten, warning, simplify, recursive_expression_map_update, get_pragma_parameters,
+    as_tuple, warning, simplify, recursive_expression_map_update, get_pragma_parameters,
     Transformation, FindNodes, FindVariables, Transformer, SubstituteExpressions, DetachScopesMapper,
     SymbolAttributes, BasicType, DerivedType, Quotient, IntLiteral, IntrinsicLiteral, LogicLiteral,
     Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex, Scalar,
@@ -164,7 +163,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         imports = FindNodes(Import).visit(routine.spec)
         for imp in imports:
             if imp.module.lower() == 'iso_c_binding':
-                if 'c_sizeof' in [s for s in imp.symbols] or not imp.symbols:
+                if 'c_sizeof' in imp.symbols or not imp.symbols:
                     return
 
                 # Update iso_c_binding import
@@ -458,7 +457,8 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         dim = arr.dimensions[0]
         for d in arr.dimensions[1:]:
             dim = Product((dim, d))
-        arr_size = Product((dim, InlineCall(Variable(name='C_SIZEOF'), parameters=as_tuple(self._get_c_sizeof_arg(arr)))))
+        arr_size = Product((dim, InlineCall(Variable(name='C_SIZEOF'),
+                                            parameters=as_tuple(self._get_c_sizeof_arg(arr)))))
 
         # Increment stack size
         stack_size = simplify(Sum((stack_size, arr_size)))


### PR DESCRIPTION
This PR attempts to add the following enhancements to the pool allocator:
1. `allocation_dims` is removed, and any array whose size is not known at compile-time is now allocated on the stack.
2. Entries in the stack are no longer restricted to 8-bytes. `c_sizeof` is used to determine the size, based on the `kind` specifier in the variable declaration.
3. Unused temporary arrays are not placed on the stack so as not to have unnecessary memory traffic.

I've also updated the tests accordingly. The `OMNI` frontend is compatible with these new changes but it's behaviour of replacing parameters with their value makes it quite cumbersome to test with `OMNI`. If we want the test coverage to include the `OMNI` frontend then please let me know and I will modify the tests accordingly.