### PR TITLE
Various bugfixes

### DIFF
--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -675,6 +675,10 @@ class Scheduler:
             }
             if isinstance(item, ProcedureBindingItem):
                 style['fillcolor'] = 'palegreen'
+            elif isinstance(item, GlobalVarImportItem):
+                style['fillcolor'] = 'lightgoldenrod1'
+            elif isinstance(item, GenericImportItem):
+                style['fillcolor'] = 'lightgoldenrodyellow'
             if item.replicate:
                 style['shape'] = 'diamond'
                 style['style'] += ',rounded'

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1401,7 +1401,7 @@ class InlineCall(ExprMetadataMixin, pmbl.CallWithKwargs):
         """
         routine = self.routine
         assert routine is not BasicType.DEFERRED
-        r_args = {arg.name: arg for arg in routine.arguments}
+        r_args = CaseInsensitiveDict((arg.name, arg) for arg in routine.arguments)
         args = zip(routine.arguments, self.arguments)
         kwargs = ((r_args[kw], arg) for kw, arg in as_tuple(self.kwarguments))
         return chain(args, kwargs)

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -9,6 +9,8 @@
 Expression tree node classes for
 :ref:`internal_representation:Expression tree`.
 """
+
+from itertools import chain
 import weakref
 from sys import intern
 import pymbolic.primitives as pmbl
@@ -1350,6 +1352,57 @@ class InlineCall(ExprMetadataMixin, pmbl.CallWithKwargs):
         ``BasicType.DEFFERED`` otherwise.
         """
         return self.function.type.dtype
+
+    @property
+    def arguments(self):
+        """
+        Alias for :attr:`parameters`
+        """
+        return self.parameters
+
+    @property
+    def kwarguments(self):
+        """
+        Alias for :attr:`kw_parameters`
+        """
+        return self.kw_parameters
+
+    @property
+    def routine(self):
+        """
+        The :any:`Subroutine` object of the called routine
+
+        Shorthand for ``call.function.type.dtype.procedure``
+
+        Returns
+        -------
+        :any:`Subroutine` or :any:`BasicType.DEFERRED`
+            If the :any:`ProcedureType` object of the :any:`ProcedureSymbol`
+            in :attr:`function` is linked up to the target routine, this returns
+            the corresponding :any:`Subroutine` object, otherwise `None`.
+        """
+        procedure_type = self.procedure_type
+        if procedure_type is BasicType.DEFERRED:
+            return BasicType.DEFERRED
+        return procedure_type.procedure
+
+    def arg_iter(self):
+        """
+        Iterator that maps argument definitions in the target :any:`Subroutine`
+        to arguments and keyword arguments in the call.
+
+        Returns
+        -------
+        iterator
+            An iterator that traverses the mapping ``(arg name, call arg)`` for
+            all positional and then keyword arguments.
+        """
+        routine = self.routine
+        assert routine is not BasicType.DEFERRED
+        r_args = {arg.name: arg for arg in routine.arguments}
+        args = zip(routine.arguments, self.arguments)
+        kwargs = ((r_args[kw], arg) for kw, arg in as_tuple(self.kwarguments))
+        return chain(args, kwargs)
 
     def clone(self, **kwargs):
         """

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1365,7 +1365,7 @@ class InlineCall(ExprMetadataMixin, pmbl.CallWithKwargs):
         """
         Alias for :attr:`kw_parameters`
         """
-        return self.kw_parameters
+        return as_tuple(self.kw_parameters.items())
 
     @property
     def routine(self):

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -5,6 +5,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+# pylint: disable=too-many-lines
+
 """
 Expression tree node classes for
 :ref:`internal_representation:Expression tree`.

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1477,7 +1477,7 @@ class FParser2IR(GenericVisitor):
         associations = as_tuple(rescoped_associations)
 
         # The body
-        body = as_tuple(self.visit(c, **kwargs) for c in o.children[assoc_stmt_index+1:end_assoc_stmt_index])
+        body = as_tuple(flatten(self.visit(c, **kwargs) for c in o.children[assoc_stmt_index+1:end_assoc_stmt_index]))
         associate._update(associations=associations, body=body)
 
         # Everything past the END ASSOCIATE (should be empty)

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -907,7 +907,7 @@ class CallStatement(LeafNode, _CallStatementBase):
         """
         routine = self.routine
         assert routine is not BasicType.DEFERRED
-        r_args = {arg.name: arg for arg in routine.arguments}
+        r_args = CaseInsensitiveDict((arg.name, arg) for arg in routine.arguments)
         args = zip(routine.arguments, self.arguments)
         kwargs = ((r_args[kw], arg) for kw, arg in as_tuple(self.kwarguments))
         return chain(args, kwargs)

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1216,6 +1216,7 @@ type(tfpdata), intent(in) :: ydfpdata
 type(tfpofn) :: ylofn(size(ydfpdata%yfpos%yfpgeometry%yfpusergeo))
 real, dimension(nproma, max(nang, 1), max(nfre, 1)) :: not_an_annoying_ecwam_var
 character(len=511) :: cloud_type_name(NMaxCloudTypes) = ["","","","","","","","","","","",""], other_name = "", names(3) = (/ "", "", "" /)
+character(len=511) :: more_names(2) = (/ "What", " is" /), naaaames(2) = [ " going ", "on?" ]
 end subroutine definitely_not_allfpos
     """.strip()
 
@@ -1223,7 +1224,7 @@ end subroutine definitely_not_allfpos
     routine = source['definitely_not_allfpos']
     assert routine.variables == (
         'nmaxcloudtypes', 'ydfpdata', 'ylofn', 'not_an_annoying_ecwam_var',
-        'cloud_type_name', 'other_name', 'names'
+        'cloud_type_name', 'other_name', 'names', 'more_names', 'naaaames'
     )
     assert routine.symbol_map['not_an_annoying_ecwam_var'].type.dtype is BasicType.REAL
     assert routine.symbol_map['cloud_type_name'].type.dtype is BasicType.CHARACTER

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1211,16 +1211,22 @@ def test_regex_variable_declaration_parentheses():
     fcode = """
 subroutine definitely_not_allfpos(ydfpdata)
 implicit none
+integer, parameter :: NMaxCloudTypes = 12
 type(tfpdata), intent(in) :: ydfpdata
 type(tfpofn) :: ylofn(size(ydfpdata%yfpos%yfpgeometry%yfpusergeo))
 real, dimension(nproma, max(nang, 1), max(nfre, 1)) :: not_an_annoying_ecwam_var
+character(len=511) :: cloud_type_name(NMaxCloudTypes) = ["","","","","","","","","","","",""], other_name = "", names(3) = (/ "", "", "" /)
 end subroutine definitely_not_allfpos
     """.strip()
 
     source = Sourcefile.from_source(fcode, frontend=REGEX)
     routine = source['definitely_not_allfpos']
-    assert routine.variables == ('ydfpdata', 'ylofn', 'not_an_annoying_ecwam_var')
+    assert routine.variables == (
+        'nmaxcloudtypes', 'ydfpdata', 'ylofn', 'not_an_annoying_ecwam_var',
+        'cloud_type_name', 'other_name', 'names'
+    )
     assert routine.symbol_map['not_an_annoying_ecwam_var'].type.dtype is BasicType.REAL
+    assert routine.symbol_map['cloud_type_name'].type.dtype is BasicType.CHARACTER
 
 
 def test_regex_preproc_in_contains():

--- a/tests/test_interprocedural_analysis.py
+++ b/tests/test_interprocedural_analysis.py
@@ -65,9 +65,67 @@ end module some_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_ipa_call_statement_arg_iter_optional(frontend):
+    """
+    Test that :any:`CallStatement.arg_iter` works as expected with optional arguments
+    """
+    fcode_caller = """
+subroutine caller
+    use some_mod, only: callee
+    implicit none
+    integer :: arg1, arg3(10)
+    real :: arg2
+    call callee(arg1, arg2, arg3, 4)
+    call callee(arg1, arg2, VAL=4, arr=arg3, opt2=1)
+    call callee(arg1, arg2, arg3, 4, 1, 2)
+end subroutine caller
+    """.strip()
+
+    fcode_callee = """
+module some_mod
+    implicit none
+contains
+    subroutine callee(var, VAR2, arr, val, OPT1, opt2)
+        integer, intent(inout) :: var
+        real, intent(in) :: var2
+        integer, intent(in) :: arr(:)
+        integer, intent(in) :: val
+        integer, intent(in), optional :: OPT1, opt2
+    end subroutine callee
+end module some_mod
+    """.strip()
+
+    callee_source = Sourcefile.from_source(fcode_callee, frontend=frontend)
+    caller_source = Sourcefile.from_source(fcode_caller, frontend=frontend, definitions=callee_source.definitions)
+
+    callee = callee_source['callee']
+    caller = caller_source['caller']
+
+    calls = FindNodes(CallStatement).visit(caller.body)
+    assert len(calls) == 3
+    arg_iter = list(calls[0].arg_iter())
+    assert arg_iter == [
+        ('var', 'arg1'), ('var2', 'arg2'), ('arr(:)', 'arg3'), ('val', '4')
+    ]
+    arg_iter = list(calls[1].arg_iter())
+    assert arg_iter == [
+        ('var', 'arg1'), ('var2', 'arg2'), ('val', '4'), ('arr(:)', 'arg3'), ('opt2', '1')
+    ]
+    arg_iter = list(calls[2].arg_iter())
+    assert arg_iter == [
+        ('var', 'arg1'), ('var2', 'arg2'), ('arr(:)', 'arg3'), ('val', '4'), ('opt1', '1'), ('opt2', '2')
+    ]
+
+    for call in calls:
+        for kernel_arg, caller_arg in call.arg_iter():
+            assert kernel_arg.scope is callee
+            assert isinstance(caller_arg, IntLiteral) or caller_arg.scope is caller
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_ipa_inline_call_arg_iter(frontend):
     """
-    Test that :any:`CallStatement.arg_iter` works as expected
+    Test that :any:`InlineCall.arg_iter` works as expected
     """
     fcode_caller = """
 subroutine caller
@@ -109,3 +167,62 @@ end module some_mod
     for kernel_arg, caller_arg in calls[0].arg_iter():
         assert kernel_arg.scope is callee
         assert isinstance(caller_arg, IntLiteral) or caller_arg.scope is caller
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_ipa_inline_call_arg_iter_optional(frontend):
+    """
+    Test that :any:`InlineCall.arg_iter` works as expected
+    """
+    fcode_caller = """
+subroutine caller
+    use some_mod, only: callee
+    implicit none
+    integer :: arg1, arg3(10)
+    real :: arg2, ret
+    ret = callee(arg1, arg2, arg3, 4)
+    ret = ret + callee(arg1, ARR=arg3, var2=arg2, opt2=2, val=4)
+    ret = ret + callee(arg1, arg2, arg3, 4, 1, 2)
+end subroutine caller
+    """.strip()
+
+    fcode_callee = """
+module some_mod
+    implicit none
+contains
+    function callee(var, VAR2, arr, val, opt1, OPT2)
+        integer, intent(inout) :: var
+        real, intent(in) :: var2
+        integer, intent(in) :: arr(:)
+        integer, intent(in) :: val
+        integer, intent(in) :: opt1, OPT2
+        real :: callee
+    end function callee
+end module some_mod
+    """.strip()
+
+    callee_source = Sourcefile.from_source(fcode_callee, frontend=frontend)
+    caller_source = Sourcefile.from_source(fcode_caller, frontend=frontend, definitions=callee_source.definitions)
+
+    callee = callee_source['callee']
+    caller = caller_source['caller']
+
+    calls = list(FindInlineCalls(unique=False).visit(caller.body))
+    assert len(calls) == 3
+    arg_iter = list(calls[0].arg_iter())
+    assert arg_iter == [
+        ('var', 'arg1'), ('var2', 'arg2'), ('arr(:)', 'arg3'), ('val', '4')
+    ]
+    arg_iter = list(calls[1].arg_iter())
+    assert arg_iter == [
+        ('var', 'arg1'), ('arr(:)', 'arg3'), ('var2', 'arg2'), ('opt2', '2'), ('val', '4')
+    ]
+    arg_iter = list(calls[2].arg_iter())
+    assert arg_iter == [
+        ('var', 'arg1'), ('var2', 'arg2'), ('arr(:)', 'arg3'), ('val', '4'), ('opt1', '1'), ('opt2', '2')
+    ]
+
+    for call in calls:
+        for kernel_arg, caller_arg in call.arg_iter():
+            assert kernel_arg.scope is callee
+            assert isinstance(caller_arg, IntLiteral) or caller_arg.scope is caller

--- a/tests/test_interprocedural_analysis.py
+++ b/tests/test_interprocedural_analysis.py
@@ -14,7 +14,7 @@ import pytest
 from conftest import available_frontends
 from loki import (
     Sourcefile, FindNodes, FindInlineCalls,
-    CallStatement, InlineCall, IntLiteral
+    CallStatement, IntLiteral
 )
 
 

--- a/tests/test_interprocedural_analysis.py
+++ b/tests/test_interprocedural_analysis.py
@@ -1,0 +1,111 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Various tests for interprocedural analysis features in Loki
+"""
+
+import pytest
+
+from conftest import available_frontends
+from loki import (
+    Sourcefile, FindNodes, FindInlineCalls,
+    CallStatement, InlineCall, IntLiteral
+)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_ipa_call_statement_arg_iter(frontend):
+    """
+    Test that :any:`CallStatement.arg_iter` works as expected
+    """
+    fcode_caller = """
+subroutine caller
+    use some_mod, only: callee
+    implicit none
+    integer :: arg1, arg3(10)
+    real :: arg2
+    call callee(arg1, arg2, arg3, 4)
+end subroutine caller
+    """.strip()
+
+    fcode_callee = """
+module some_mod
+    implicit none
+contains
+    subroutine callee(var, VAR2, arr, val)
+        integer, intent(inout) :: var
+        real, intent(in) :: var2
+        integer, intent(in) :: arr(:)
+        integer, intent(in) :: val
+    end subroutine callee
+end module some_mod
+    """.strip()
+
+    callee_source = Sourcefile.from_source(fcode_callee, frontend=frontend)
+    caller_source = Sourcefile.from_source(fcode_caller, frontend=frontend, definitions=callee_source.definitions)
+
+    callee = callee_source['callee']
+    caller = caller_source['caller']
+
+    calls = FindNodes(CallStatement).visit(caller.body)
+    assert len(calls) == 1
+    arg_iter = list(calls[0].arg_iter())
+    assert arg_iter == [
+        ('var', 'arg1'), ('var2', 'arg2'), ('arr(:)', 'arg3'), ('val', '4')
+    ]
+
+    for kernel_arg, caller_arg in calls[0].arg_iter():
+        assert kernel_arg.scope is callee
+        assert isinstance(caller_arg, IntLiteral) or caller_arg.scope is caller
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_ipa_inline_call_arg_iter(frontend):
+    """
+    Test that :any:`CallStatement.arg_iter` works as expected
+    """
+    fcode_caller = """
+subroutine caller
+    use some_mod, only: callee
+    implicit none
+    integer :: arg1, arg3(10)
+    real :: arg2, ret
+    ret = callee(arg1, arg2, arg3, 4)
+end subroutine caller
+    """.strip()
+
+    fcode_callee = """
+module some_mod
+    implicit none
+contains
+    function callee(var, VAR2, arr, val)
+        integer, intent(inout) :: var
+        real, intent(in) :: var2
+        integer, intent(in) :: arr(:)
+        integer, intent(in) :: val
+        real :: callee
+    end function callee
+end module some_mod
+    """.strip()
+
+    callee_source = Sourcefile.from_source(fcode_callee, frontend=frontend)
+    caller_source = Sourcefile.from_source(fcode_caller, frontend=frontend, definitions=callee_source.definitions)
+
+    callee = callee_source['callee']
+    caller = caller_source['caller']
+
+    calls = list(FindInlineCalls().visit(caller.body))
+    assert len(calls) == 1
+    arg_iter = list(calls[0].arg_iter())
+    assert arg_iter == [
+        ('var', 'arg1'), ('var2', 'arg2'), ('arr(:)', 'arg3'), ('val', '4')
+    ]
+
+    for kernel_arg, caller_arg in calls[0].arg_iter():
+        assert kernel_arg.scope is callee
+        assert isinstance(caller_arg, IntLiteral) or caller_arg.scope is caller

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1651,6 +1651,19 @@ def test_scheduler_import_dependencies(here, config, frontend):
         elif i.name == '#double_real':
             assert isinstance(i, SubroutineItem)
 
+    # Testing of callgraph visualisation with imports
+    workdir = gettempdir()/'test_scheduler_import_dependencies'
+    workdir.mkdir(exist_ok=True)
+    cg_path = workdir/'callgraph'
+    scheduler.callgraph(cg_path)
+
+    vgraph = VisGraphWrapper(cg_path)
+    assert all(n.upper() in vgraph.nodes for n in expected_items)
+    assert all((e[0].upper(), e[1].upper()) in vgraph.edges for e in expected_dependencies)
+
+    rmtree(workdir)
+
+
 def test_scheduler_globalvarimportitem_id(here, config, frontend):
     """
     Test that scheduler.item_successors always returns the original item.
@@ -1684,6 +1697,7 @@ def test_scheduler_globalvarimportitem_id(here, config, frontend):
             assert id(successor) == idA
         if successor.name == importB_item.name:
             assert id(successor) == idB
+
 
 def test_scheduler_globalvarimportitem_children(config):
     """

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -393,7 +393,10 @@ class GlobalVarOffloadTransformation(Transformation):
         routine.body = Transformer(pragma_map).visit(routine.body)
 
         # build set of symbols to be offloaded
-        _var_set = set.union(*[s.trafo_data[self._key]['var_set'] for s in successors], set())
+        _var_set = set.union(
+            *[s.trafo_data.get(self._key, {}).get('var_set', set()) for s in successors],
+            set()
+        )
         #build map of module imports corresponding to offloaded symbols
         _modules = {}
         _modules.update({k: v
@@ -434,8 +437,10 @@ class GlobalVarOffloadTransformation(Transformation):
         import_mod = CaseInsensitiveDict((s.name, i.module) for i in routine.imports for s in i.symbols)
 
         #build set of offloaded symbols
-        item.trafo_data[self._key]['var_set'] = set.union(*[s.trafo_data[self._key]['var_set'] for s in successors],
-                                                          set())
+        item.trafo_data[self._key]['var_set'] = set.union(
+            *[s.trafo_data.get(self._key, {}).get('var_set', set()) for s in successors],
+            set()
+        )
 
         #build map of module imports corresponding to offloaded symbols
         item.trafo_data[self._key]['modules'].update({k: v

--- a/transformations/transformations/utility_routines.py
+++ b/transformations/transformations/utility_routines.py
@@ -100,6 +100,9 @@ class RemoveCallsTransformation(Transformation):
         """
         Apply transformation to subroutine object
         """
+        if 'item' in kwargs and kwargs['item'].local_name != routine.name.lower():
+            return
+
         mapper = {}
 
         # First remove inline conditionals with calls to specified routines or intrinsics


### PR DESCRIPTION
A collection of commits with various minor bugfixes/improvements:

- Add a different colour for import items in the Scheduler's callgraph
- Equip `InlineCall` with the same set of inter-procedural properties as `CallStatement`, with associated testing
- Fix a bug with nested tuples in `Associates` for fparser
- Fix a bug with nested tuples in the `resolve_associates` transformation
- Fix REGEX frontend when square brackets are used in an initialiser list
- Apply `RemoveCallsTransformation` only on Scheduler graph items
- Fix `GlobalVarOffload` to not fail when `trafo_data` is empty for a successor