### PR TITLE
SCC updates needed for ecWam

### DIFF
--- a/cmake/loki_transform.cmake
+++ b/cmake/loki_transform.cmake
@@ -198,7 +198,7 @@ endmacro()
 
 function( loki_transform_convert )
 
-    set( options CPP DATA_OFFLOAD REMOVE_OPENMP )
+    set( options CPP DATA_OFFLOAD REMOVE_OPENMP GLOBAL_VAR_OFFLOAD )
     set( oneValueArgs MODE DIRECTIVE FRONTEND CONFIG PATH OUTPATH )
     set( multiValueArgs OUTPUT DEPENDS INCLUDES INCLUDE HEADERS HEADER DEFINITIONS DEFINE OMNI_INCLUDE XMOD )
 
@@ -233,6 +233,10 @@ function( loki_transform_convert )
 
     if( ${_PAR_REMOVE_OPENMP} )
         list( APPEND _ARGS --remove-openmp )
+    endif()
+
+    if( ${_PAR_GLOBAL_VAR_OFFLOAD} )
+        list( APPEND _ARGS --global-var-offload )
     endif()
 
     _loki_transform_env_setup()

--- a/cmake/loki_transform.cmake
+++ b/cmake/loki_transform.cmake
@@ -181,7 +181,8 @@ endmacro()
 #       [DEFINITIONS <define1> [<define2> ...]]
 #       [OMNI_INCLUDE <omni-inc1> [<omni-inc2> ...]]
 #       [XMOD <xmod-dir1> [<xmod-dir2> ...]]
-#       [REMOVE_OPENMP] [DATA_OFFLOAD]
+#       [REMOVE_OPENMP] [DATA_OFFLOAD] [GLOBAL_VAR_OFFLOAD]
+#       [TRIM_VECTOR_SECTIONS]
 #   )
 #
 # Call ``loki-transform.py convert ...`` with the provided arguments.
@@ -198,7 +199,7 @@ endmacro()
 
 function( loki_transform_convert )
 
-    set( options CPP DATA_OFFLOAD REMOVE_OPENMP GLOBAL_VAR_OFFLOAD )
+    set( options CPP DATA_OFFLOAD REMOVE_OPENMP GLOBAL_VAR_OFFLOAD TRIM_VECTOR_SECTIONS )
     set( oneValueArgs MODE DIRECTIVE FRONTEND CONFIG PATH OUTPATH )
     set( multiValueArgs OUTPUT DEPENDS INCLUDES INCLUDE HEADERS HEADER DEFINITIONS DEFINE OMNI_INCLUDE XMOD )
 
@@ -237,6 +238,10 @@ function( loki_transform_convert )
 
     if( ${_PAR_GLOBAL_VAR_OFFLOAD} )
         list( APPEND _ARGS --global-var-offload )
+    endif()
+
+    if( ${_PAR_TRIM_VECTOR_SECTIONS} )
+        list( APPEND _ARGS --trim-vector-sections )
     endif()
 
     _loki_transform_env_setup()

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -120,7 +120,6 @@ class DependencyTransformation(Transformation):
         Rename kernel modules and re-point module-level imports.
         """
         role = kwargs.get('role')
-        item = kwargs.get('item', None)
 
         if role == 'kernel':
             # Change the name of kernel modules

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -15,7 +15,6 @@ from loki.ir import CallStatement, Import, Section, Interface
 from loki.expression import Variable, FindInlineCalls, SubstituteExpressions
 from loki.backend import fgen
 from loki.tools import as_tuple
-from loki.bulk.item import GlobalVarImportItem
 
 
 __all__ = ['DependencyTransformation']
@@ -122,11 +121,6 @@ class DependencyTransformation(Transformation):
         """
         role = kwargs.get('role')
         item = kwargs.get('item', None)
-
-        # bail if module contains global variables as these are potentially used
-        # in non-offloaded CPU code
-        if isinstance(item, GlobalVarImportItem):
-            return
 
         if role == 'kernel':
             # Change the name of kernel modules

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -299,7 +299,7 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
 
     # Write out all modified source files into the build directory
     scheduler.process(transformation=FileWriteTransformation(builddir=out_path, mode=mode, cuf='cuf' in mode),
-                      item_filter=(SubroutineItem, GlobalVarImportItem))
+                      use_file_graph=True)
 
 
 @cli.command()

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -144,8 +144,10 @@ def cli(debug):
               help='Frontend parser to use (default FP)')
 @click.option('--config', default=None, type=click.Path(),
               help='Path to custom scheduler configuration file')
+@click.option('--trim-vector-sections', is_flag=True, default=False,
+              help='Trim vector loops in SCC transform to exclude scalar assignments.')
 def convert(out_path, path, header, cpp, directive, include, define, omni_include, xmod,
-            data_offload, remove_openmp, mode, frontend, config):
+            data_offload, remove_openmp, mode, frontend, config, trim_vector_sections):
     """
     Single Column Abstraction (SCA): Convert kernel into single-column
     format and adjust driver to apply it over in a horizontal loop.
@@ -225,7 +227,7 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
         vertical = scheduler.config.dimensions['vertical']
         block_dim = scheduler.config.dimensions['block_dim']
         transformation = (SCCBaseTransformation(horizontal=horizontal, directive=directive),)
-        transformation += (SCCDevectorTransformation(horizontal=horizontal),)
+        transformation += (SCCDevectorTransformation(horizontal=horizontal, trim_vector_sections=trim_vector_sections),)
         transformation += (SCCDemoteTransformation(horizontal=horizontal),)
         if not 'hoist' in mode:
             transformation += (SCCRevectorTransformation(horizontal=horizontal),)

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -197,7 +197,7 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
     # Remove DR_HOOK and other utility calls first, so they don't interfere with SCC loop hoisting
     if 'scc' in mode:
         scheduler.process(transformation=RemoveCallsTransformation(
-            routines=config.default['utility_routines'] or ['DR_HOOK', 'ABOR1', 'WRITE(NULOUT'],
+            routines=config.default.get('utility_routines', None) or ['DR_HOOK', 'ABOR1', 'WRITE(NULOUT'],
             include_intrinsics=True
         ))
     else:

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -1544,7 +1544,6 @@ def test_single_column_coalesced_vector_inlined_call(frontend, horizontal):
 
        do jl=start,end
           if(cond)then
-             !$loki inline
              call some_inlined_kernel(work(jl))
           endif
           work(jl) = work(jl) + 1.
@@ -1557,6 +1556,8 @@ def test_single_column_coalesced_vector_inlined_call(frontend, horizontal):
 
     source = Sourcefile.from_source(fcode, frontend=frontend)
     routine = source['some_kernel']
+    inlined_routine = source['some_inlined_kernel']
+    routine.enrich_calls((inlined_routine,))
 
     scc_transform = (SCCDevectorTransformation(horizontal=horizontal),)
     scc_transform += (SCCRevectorTransformation(horizontal=horizontal),)

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -11,7 +11,7 @@ from loki import (
     OMNI, OFP, Subroutine, Dimension, FindNodes, Loop, Assignment,
     CallStatement, Conditional, Scalar, Array, Pragma, pragmas_attached,
     fgen, Sourcefile, Section, SubroutineItem, pragma_regions_attached, PragmaRegion,
-    is_loki_pragma, Pragma, IntLiteral, RangeIndex, Comment
+    is_loki_pragma, IntLiteral, RangeIndex, Comment
 )
 from conftest import available_frontends
 from transformations import (

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -1539,6 +1539,7 @@ def test_single_column_coalesced_vector_inlined_call(frontend, horizontal):
 
     fcode = """
     subroutine some_inlined_kernel(work)
+    !$loki routine seq
        real, intent(inout) :: work
 
        work = work*2.

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -305,7 +305,8 @@ class GlobalVarOffloadTransformation(Transformation):
         pragmas = [p for p in FindNodes(Pragma).visit(module.spec) if p.keyword.lower() == 'acc']
         acc_pragma_parameters = get_pragma_parameters(pragmas, starts_with='declare', only_loki_pragmas=False)
         if acc_pragma_parameters:
-            if symbol in flatten([v.replace(' ','').lower().split(',') for v in acc_pragma_parameters['create']]):
+            if symbol in flatten([v.replace(' ','').lower().split(',')
+                                 for v in as_tuple(acc_pragma_parameters['create'])]):
                 return
 
         # Update the set of variables to be offloaded

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -5,6 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import re
 from collections import  defaultdict
 from loki import (
     as_tuple, warning, simplify, recursive_expression_map_update, get_pragma_parameters,
@@ -579,7 +580,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                 if pragma.content.lower().startswith('parallel') and 'gang' in pragma.content.lower():
                     parameters = get_pragma_parameters(pragma, starts_with='parallel', only_loki_pragmas=False)
                     if 'private' in [p.lower() for p in parameters]:
-                        content = pragma.content.lower().replace('private(', f'private({stack_var.name}, ')
+                        content = re.sub(r'\bprivate\(', f'private({stack_var.name}, ', pragma.content.lower())
                     else:
                         content = pragma.content + f' private({stack_var.name})'
                     pragma_map[pragma] = pragma.clone(content=content)
@@ -591,7 +592,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                 if pragma.content.lower().startswith('parallel'):
                     parameters = get_pragma_parameters(pragma, starts_with='parallel', only_loki_pragmas=False)
                     if 'private' in [p.lower() for p in parameters]:
-                        content = pragma.content.lower().replace('private(', f'private({stack_var.name}, ')
+                        content = re.sub(r'\bprivate\(', f'private({stack_var.name}, ', pragma.content.lower())
                     else:
                         content = pragma.content + f' private({stack_var.name})'
                     pragma_map[pragma] = pragma.clone(content=content)

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -316,12 +316,12 @@ class SCCAnnotateTransformation(Transformation):
                 if is_loki_pragma(region.pragma, starts_with='vector-reduction'):
                     if (reduction_clause := re.search(r'reduction\([\w:0-9 \t]+\)', region.pragma.content)):
 
-                       loops = FindNodes(ir.Loop).visit(region)
-                       assert len(loops) == 1
-                       pragma = ir.Pragma(keyword='acc', content=f'loop vector {reduction_clause[0]}')
-                       mapper[loops[0]] = loops[0].clone(pragma=(pragma,))
-                       mapper[region.pragma] = None
-                       mapper[region.pragma_post] = None
+                        loops = FindNodes(ir.Loop).visit(region)
+                        assert len(loops) == 1
+                        pragma = ir.Pragma(keyword='acc', content=f'loop vector {reduction_clause[0]}')
+                        mapper[loops[0]] = loops[0].clone(pragma=(pragma,))
+                        mapper[region.pragma] = None
+                        mapper[region.pragma_post] = None
 
         with pragmas_attached(routine, ir.Loop):
             for loop in FindNodes(ir.Loop).visit(routine.body):

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -5,12 +5,13 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import re
 from loki.expression import symbols as sym
 from loki import (
     Transformation, FindNodes, FindScopes, Transformer, info,
     pragmas_attached, as_tuple, flatten, ir, resolve_associates,
     FindExpressions, SymbolAttributes, BasicType, SubstituteExpressions, DerivedType,
-    FindVariables, CaseInsensitiveDict
+    FindVariables, CaseInsensitiveDict, pragma_regions_attached, PragmaRegion, is_loki_pragma
 )
 
 __all__ = ['SCCBaseTransformation', 'SCCAnnotateTransformation', 'SCCHoistTransformation']
@@ -309,10 +310,22 @@ class SCCAnnotateTransformation(Transformation):
         private_arrays = [v for v in private_arrays if not any(vertical.size in d for d in v.shape)]
         private_arrays = [v for v in private_arrays if not any(horizontal.size in d for d in v.shape)]
 
+        mapper = {}
+        with pragma_regions_attached(routine):
+            for region in FindNodes(PragmaRegion).visit(routine.body):
+                if is_loki_pragma(region.pragma, starts_with='vector-reduction'):
+                    if (reduction_clause := re.search(r'reduction\([\w:0-9 \t]+\)', region.pragma.content)):
+
+                       loops = FindNodes(ir.Loop).visit(region)
+                       assert len(loops) == 1
+                       pragma = ir.Pragma(keyword='acc', content=f'loop vector {reduction_clause[0]}')
+                       mapper[loops[0]] = loops[0].clone(pragma=(pragma,))
+                       mapper[region.pragma] = None
+                       mapper[region.pragma_post] = None
+
         with pragmas_attached(routine, ir.Loop):
-            mapper = {}
             for loop in FindNodes(ir.Loop).visit(routine.body):
-                if loop.variable == horizontal.index:
+                if loop.variable == horizontal.index and not loop in mapper:
                     # Construct pragma and wrap entire body in vector loop
                     private_arrs = ', '.join(v.name for v in private_arrays)
                     pragma = ()

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -79,7 +79,8 @@ class SCCDevectorTransformation(Transformation):
 
             # check if calls have been enriched
             if not call.routine is BasicType.DEFERRED:
-                if not horizontal.size in call.routine.symbol_map:
+                # check if called routine is marked as sequential
+                if SCCBaseTransformation.check_routine_pragmas(routine=call.routine, directive=None):
                     continue
 
             if call in section:


### PR DESCRIPTION
For both correctness and performance, the SCC transform needed a few updates before it could be applied to the ecWam physics. With that aim, this branch adds the following features:
- `trim_vector_sections` option to remove scalar assignments from vector loops
- Removal of calls explicitly marked with `!$loki inline` pragmas from separator nodes
- Loki-pragma driven insertion of reduction loops

The companion piece to this PR is the following ecWam branch where similar to CLOUDSC, we use Loki's cmake tools to build a range of transformations: https://github.com/ecmwf-ifs/ecwam/tree/naan-loki-trafo

NB: This is stacked on top of #92.