### PR TITLE
SCC: Insert vector_length directive into the gang loop

### DIFF
--- a/transformations/tests/test_cloudsc.py
+++ b/transformations/tests/test_cloudsc.py
@@ -96,7 +96,7 @@ def test_cloudsc(here, frontend):
     # Raise stack limit
     resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
     env = os.environ.copy()
-    env.update({'OMP_STACKSIZE': '2G'})
+    env.update({'OMP_STACKSIZE': '2G', 'NVCOMPILER_ACC_CUDA_HEAPSIZE': '2G'})
 
     # For some reason, the 'data' dir symlink is not created???
     os.symlink(here/'data', here/'build/data')

--- a/transformations/transformations/single_column_coalesced_wrapper.py
+++ b/transformations/transformations/single_column_coalesced_wrapper.py
@@ -233,6 +233,15 @@ class SingleColumnCoalescedTransformation(Transformation):
                 if self.directive == 'openacc':
                     SCCAnnotateTransformation.device_alloc_column_locals(routine, column_locals)
 
+        # For the thread block size, find the horizontal size variable that is available in
+        # the driver
+        num_threads = None
+        symbol_map = routine.symbol_map
+        for size_expr in self.horizontal.size_expressions:
+            if size_expr in symbol_map:
+                num_threads = size_expr
+                break
+
         with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
 
             for call in FindNodes(ir.CallStatement).visit(routine.body):
@@ -254,4 +263,4 @@ class SingleColumnCoalescedTransformation(Transformation):
 
                 # Mark driver loop as "gang parallel".
                 SCCAnnotateTransformation.annotate_driver(self.directive, driver_loop, kernel_loop,
-                                                          self.block_dim, column_locals)
+                                                          self.block_dim, column_locals, num_threads)


### PR DESCRIPTION
Setting the vector_length directive to the block size has shown to significantly improve performance for NPROMA numbers that don't match the default value of the architecture. This aims to add this directive to the OpenACC directives inserted in the driver as part of the SCC transformations.

For that, it attempts to find any of the `size_expressions` of the horizontal dimension and use that. Note, that this only works with NVIDIA, the Cray compiler will ignore this value if it is not a compile-time constant.