### PR TITLE
Scheduler: Only apply transformations to requested subroutines 

### DIFF
--- a/loki/transform/build_system_transform.py
+++ b/loki/transform/build_system_transform.py
@@ -77,10 +77,6 @@ class CMakePlanner(Transformation):
         item = kwargs['item']
         role = kwargs.get('role')
 
-        # Back out, if this Subroutine is not part of the plan
-        if not item.local_name == routine.name.lower():
-            return
-
         sourcepath = item.path.resolve()
         newsource = sourcepath.with_suffix(f'.{self.mode.lower()}.F90')
         if self.build is not None:

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -79,11 +79,6 @@ class DependencyTransformation(Transformation):
         'strict' mode, also  re-generate the kernel interface headers.
         """
         role = kwargs.get('role')
-        item = kwargs.get('item', None)
-
-        # Bail if this routine is not part of a scheduler traversal
-        if item and not item.local_name == routine.name.lower():
-            return
 
         if role == 'kernel':
             # Change the name of kernel routines

--- a/loki/transform/transform_hoist_variables.py
+++ b/loki/transform/transform_hoist_variables.py
@@ -139,9 +139,6 @@ class HoistVariablesAnalysis(Transformation):
         successors = [_ for _ in _successors if _.local_name.lower()
                       not in self.disable and _.name.lower() not in self.disable]
 
-        if item and not item.local_name == routine.name.lower() or item.local_name.lower() in self.disable:
-            return
-
         item.trafo_data[self._key] = {}
 
         if role != 'driver':
@@ -240,7 +237,7 @@ class HoistVariablesTransformation(Transformation):
                       not in self.disable and _.name.lower() not in self.disable]
         successor_map = {successor.routine.name: successor for successor in successors}
 
-        if item and not item.local_name == routine.name.lower() or item.local_name.lower() in self.disable:
+        if item.local_name.lower() in self.disable:
             return
 
         if self._key not in item.trafo_data:

--- a/loki/transform/transform_parametrise.py
+++ b/loki/transform/transform_parametrise.py
@@ -187,9 +187,6 @@ class ParametriseTransformation(Transformation):
         item = kwargs.get('item', None)
         role = kwargs.get('role', None)
 
-        if item and not item.local_name == routine.name.lower():
-            return
-
         _successors = kwargs.get('successors', None)
         successors = []
         for successor in _successors:

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -164,6 +164,10 @@ class Transformation:
         if subroutine._incomplete:
             raise RuntimeError('Transformation.apply_subroutine requires Subroutine to be complete')
 
+        # Bail if the subroutine has not actually been scheduled for processing
+        if (item := kwargs.get('item', None)) and item.local_name != subroutine.name.lower():
+            return
+
         # Apply the actual transformation for subroutines
         self.transform_subroutine(subroutine, **kwargs)
 

--- a/tests/sources/projA/module/driverE_mod.f90
+++ b/tests/sources/projA/module/driverE_mod.f90
@@ -1,0 +1,27 @@
+module driverE_mod
+  use header_mod, only: jprb, header_type
+  use kernelE_mod, only: kernelE, kernelET
+
+  implicit none
+
+contains
+
+  ! Two driver routines, but we process only one!
+
+  subroutine driverE_single()
+    type(header_type) :: mystruct
+
+    call kernelE(mystruct%vector, mystruct%matrix)
+
+  end subroutine driverE_single
+
+
+  subroutine driverE_multiple()
+    type(header_type) :: mystruct
+
+    call kernelE(mystruct%vector, mystruct%matrix)
+
+    call kernelET(mystruct%vector, mystruct%matrix)
+  end subroutine driverE_multiple
+
+end module driverE_mod

--- a/tests/sources/projA/module/kernelE_mod.f90
+++ b/tests/sources/projA/module/kernelE_mod.f90
@@ -1,0 +1,37 @@
+module kernelE_mod
+  use header_mod, only: jprb
+  use compute_l1_mod, only: compute_l1
+
+  implicit none
+
+contains
+
+  ! Two kernel routines, but we process only one!
+
+  subroutine kernelE(vector, matrix)
+    real(kind=jprb), intent(inout) :: vector(:)
+    real(kind=jprb), intent(inout) :: matrix(:)
+
+    call compute_l1(vector)
+
+    call ghost_busters(vector)
+
+  contains
+
+    subroutine ghost_busters(vector)
+      real(kind=jprb), intent(inout) :: vector(:)
+
+      vector(:) = 42.0
+    end subroutine ghost_busters
+
+  end subroutine kernelE
+
+  subroutine kernelET(vector, matrix)
+    real(kind=jprb), intent(inout) :: vector(:)
+    real(kind=jprb), intent(inout) :: matrix(:)
+
+    call compute_l2(vector)
+
+  end subroutine kernelET
+
+end module kernelE_mod

--- a/tests/test_lint/test_linter.py
+++ b/tests/test_lint/test_linter.py
@@ -345,33 +345,37 @@ class PicklableTestHandler(GenericHandler):
 
 @pytest.mark.parametrize('max_workers', [None, 1, 4])
 @pytest.mark.parametrize('counter,exclude,files', [
-    (13, None, [
+    (15, None, [
         'projA/module/compute_l1_mod.f90',
         'projA/module/compute_l2_mod.f90',
         'projA/module/driverA_mod.f90',
         'projA/module/driverB_mod.f90',
         'projA/module/driverC_mod.f90',
         'projA/module/driverD_mod.f90',
+        'projA/module/driverE_mod.f90',
         'projA/module/header_mod.f90',
         'projA/module/kernelA_mod.F90',
         'projA/module/kernelB_mod.F90',
         'projA/module/kernelC_mod.f90',
         'projA/module/kernelD_mod.f90',
+        'projA/module/kernelE_mod.f90',
         'projA/source/another_l1.F90',
         'projA/source/another_l2.F90'
     ]),
-    (13, [], [
+    (15, [], [
         'projA/module/compute_l1_mod.f90',
         'projA/module/compute_l2_mod.f90',
         'projA/module/driverA_mod.f90',
         'projA/module/driverB_mod.f90',
         'projA/module/driverC_mod.f90',
         'projA/module/driverD_mod.f90',
+        'projA/module/driverE_mod.f90',
         'projA/module/header_mod.f90',
         'projA/module/kernelA_mod.F90',
         'projA/module/kernelB_mod.F90',
         'projA/module/kernelC_mod.f90',
         'projA/module/kernelD_mod.f90',
+        'projA/module/kernelE_mod.f90',
         'projA/source/another_l1.F90',
         'projA/source/another_l2.F90'
     ]),

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -319,10 +319,6 @@ class GlobalVarOffloadTransformation(Transformation):
         role = kwargs.get('role')
         item = kwargs['item']
 
-        # Bail if this routine is not part of a scheduler traversal
-        if item and not item.local_name == routine.name.lower():
-            return
-
         if not item.trafo_data.get(self._key, None):
             item.trafo_data[self._key] = {}
 

--- a/transformations/transformations/derived_types.py
+++ b/transformations/transformations/derived_types.py
@@ -402,10 +402,6 @@ class TypeboundProcedureCallTransformation(Transformation):
         """
         item = kwargs.get('item')
 
-        # Bail out if the current subroutine is not part of the call tree
-        if item and item.local_name != routine.name.lower():
-            return
-
         # Fix any wrong intents on polymorphic arguments
         # (sadly, it's not uncommon to omit the intent specification on the CLASS declaration,
         # so we set them to `inout` here for any missing intents)

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -132,8 +132,6 @@ class TemporariesPoolAllocatorTransformation(Transformation):
 
         self.stack_type_kind = 'JPRB'
         if item:
-            if item.local_name != routine.name.lower():
-                return
             if (real_kind := item.config.get('real_kind', None)):
                 self.stack_type_kind = real_kind
 

--- a/transformations/transformations/scc_cuf.py
+++ b/transformations/transformations/scc_cuf.py
@@ -681,9 +681,6 @@ class SccCufTransformation(Transformation):
     def transform_subroutine(self, routine, **kwargs):
 
         item = kwargs.get('item', None)
-        if item and not item.local_name == routine.name.lower():
-            return
-
         role = kwargs.get('role')
         depths = kwargs.get('depths', None)
         targets = kwargs.get('targets', None)

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -200,12 +200,6 @@ class SCCBaseTransformation(Transformation):
         role : string
             Role of the subroutine in the call tree; should be ``"kernel"``
         """
-
-        # TODO: we only need this here until the scheduler can combine multiple transformations into single pass
-        # Bail if routine has already been processed
-        if (item := kwargs.get('item', None)) and item.local_name != routine.name.lower():
-            return
-
         role = kwargs['role']
 
         if role == 'kernel':
@@ -405,12 +399,8 @@ class SCCAnnotateTransformation(Transformation):
             Role of the subroutine in the call tree; should be ``"kernel"``
         """
 
-        # TODO: we only need this here until the scheduler can combine multiple transformations into single pass
-        # Bail if routine has already been processed
-        if (item := kwargs.get('item', None)) and item.local_name != routine.name.lower():
-            return
-
         role = kwargs['role']
+        item = kwargs.get('item', None)
         targets = kwargs.get('targets', None)
 
         if role == 'kernel':
@@ -725,13 +715,8 @@ class SCCHoistTransformation(Transformation):
         role : string
             Role of the subroutine in the call tree; should be ``"kernel"``
         """
-
-        # TODO: we only need this here until the scheduler can combine multiple transformations into single pass
-        # Bail if routine has already been processed
-        if (item := kwargs.get('item', None)) and item.local_name != routine.name.lower():
-            return
-
         role = kwargs['role']
+        item = kwargs.get('item', None)
         targets = kwargs.get('targets', None)
 
         if role == 'kernel':

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -127,12 +127,6 @@ class SCCDevectorTransformation(Transformation):
         role : string
             Role of the subroutine in the call tree; should be ``"kernel"``
         """
-
-        # TODO: we only need this here until the scheduler can combine multiple transformations into single pass
-        # Bail if routine has already been processed
-        if (item := kwargs.get('item', None)) and item.local_name != routine.name.lower():
-            return
-
         role = kwargs['role']
 
         if role == 'kernel':
@@ -213,12 +207,6 @@ class SCCRevectorTransformation(Transformation):
         role : string
             Role of the subroutine in the call tree; should be ``"kernel"``
         """
-
-        # TODO: we only need this here until the scheduler can combine multiple transformations into single pass
-        # Bail if routine has already been processed
-        if (item := kwargs.get('item', None)) and item.local_name != routine.name.lower():
-            return
-
         role = kwargs['role']
 
         if role == 'kernel':
@@ -312,13 +300,8 @@ class SCCDemoteTransformation(Transformation):
         role : string
             Role of the subroutine in the call tree; should be ``"kernel"``
         """
-
-        # TODO: we only need this here until the scheduler can combine multiple transformations into single pass
-        # Bail if routine has already been processed
-        if (item := kwargs.get('item', None)) and item.local_name != routine.name.lower():
-            return
-
         role = kwargs['role']
+        item = kwargs.get('item', None)
 
         if role == 'kernel':
             demote_locals = self.demote_local_arrays


### PR DESCRIPTION
Mnay(!) of our transformations require the same entry-point check that the subroutine about to be processed has indeed been requested by the scheduler. This PR moves this check up to the `Transformation` base class and adds a test to check for the most common violation of this. The problem really arrives if we have modules with multiple subroutines, of which only a subset is meant to be transformed.

As this touches the SCC cases, it would be good to run full regression on this. I've verified that it works with the current EC-physics demonstrator case.