### PR TITLE
Python 3.11 compatibility

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false  # false: try to complete all jobs
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -1,0 +1,46 @@
+name: code-checks
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push events
+  push:
+    branches: [ 'main' ]
+    tags-ignore: [ '**' ]
+
+  # Triggers the workflow on pull request events
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  code_checks:
+    name: code checks
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # false: try to complete all jobs
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[tests,examples] ./transformations ./lint_rules
+        pip list
+    - name: Add pylint annotator
+      uses: pr-annotators/pylint-pr-annotator@v0.0.1
+    - name: Analysing the code with pylint
+      run: |
+        pylint --rcfile=.pylintrc loki tests
+        pushd transformations && pylint --rcfile=../.pylintrc transformations tests; popd
+        pushd lint_rules && pylint --rcfile=../.pylintrc lint_rules tests; popd
+        jupyter nbconvert --to=script --output-dir=example_converted example/*.ipynb
+        pylint --rcfile=.pylintrc_ipynb example_converted/*.py

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false  # false: try to complete all jobs
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,37 +14,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  code_checks:
-    name: code checks
-
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false  # false: try to complete all jobs
-      matrix:
-        python-version: ["3.10"]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[tests,examples] ./transformations ./lint_rules
-        pip list
-    - name: Add pylint annotator
-      uses: pr-annotators/pylint-pr-annotator@v0.0.1
-    - name: Analysing the code with pylint
-      run: |
-        pylint --rcfile=.pylintrc loki tests
-        pushd transformations && pylint --rcfile=../.pylintrc transformations tests; popd
-        pushd lint_rules && pylint --rcfile=../.pylintrc lint_rules tests; popd
-        jupyter nbconvert --to=script --output-dir=example_converted example/*.ipynb
-        pylint --rcfile=.pylintrc_ipynb example_converted/*.py
-
   pytest:
     name: Python ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false  # false: try to complete all jobs
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Loki: Freely programmable source-to-source translation
 
 [![license](https://img.shields.io/github/license/ecmwf-ifs/loki)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![code-checks](https://github.com/ecmwf-ifs/loki/actions/workflows/code_checks.yml/badge.svg)](https://github.com/ecmwf-ifs/loki/actions/workflows/code_checks.yml)
 [![tests](https://github.com/ecmwf-ifs/loki/actions/workflows/tests.yml/badge.svg)](https://github.com/ecmwf-ifs/loki/actions/workflows/tests.yml)
 [![regression-tests](https://github.com/ecmwf-ifs/loki/actions/workflows/regression_tests.yml/badge.svg)](https://github.com/ecmwf-ifs/loki/actions/workflows/regression_tests.yml)
 [![codecov](https://codecov.io/gh/ecmwf-ifs/loki/branch/main/graph/badge.svg?token=9ZDS95SFWI)](https://codecov.io/gh/ecmwf-ifs/loki)

--- a/loki/types.py
+++ b/loki/types.py
@@ -12,7 +12,7 @@ Collection of classes to represent type information for symbols used throughout
 """
 
 import weakref
-from enum import IntEnum
+from enum import Enum
 from loki.tools import flatten, as_tuple, LazyNodeLookup
 
 
@@ -25,7 +25,7 @@ class DataType:
     """
 
 
-class BasicType(DataType, IntEnum):
+class BasicType(DataType, int, Enum):
     """
     Representation of intrinsic data types, names taken from the FORTRAN convention.
 

--- a/loki/types.py
+++ b/loki/types.py
@@ -24,13 +24,6 @@ class DataType:
     Base class for data types a symbol may have
     """
 
-    def __init__(self, *args): # pylint:disable=unused-argument
-        # Make sure we always instantiate one of the subclasses
-        # Note that we cannot use ABC for that as this would cause a
-        # metaclass clash with IntEnum, which is used to represent
-        # intrinsic types in BasicType
-        assert self.__class__ is not DataType
-
 
 class BasicType(DataType, IntEnum):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ license_file = LICENSE
 
 [options]
 packages = find:
-python_requires = >=3.8,<3.11
+python_requires = >=3.8,<3.12
 install_requires =
     numpy<1.24  # essential for tests, loop transformations and other dependencies
     pymbolic>=2022.1  # essential for expression tree


### PR DESCRIPTION
A small change to achieve compatibility with Python 3.11. Reason is that since 3.11, Enum values do get the type of all mixin base classes and because of the composing nature how this is done, the assertion we had there triggered.
See also https://discuss.python.org/t/inconsistent-behavior-with-python-3-11-enum-mixin-class-behavior/24613/4

I had to also use a plain `Enum` with `int` datatype instead of `IntEnum` to retain the original `str`-behaviour. (Changed with PEP 663)

Testing has been expanded to include Python 3.11