### PR TITLE
ECPhys: Add a "kernel-only" option to remove calls

### DIFF
--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -468,7 +468,7 @@ def ecphys(mode, config, header, source, build, cpp, directive, frontend):
     # Remove DR_HOOK and other utility calls first, so they don't interfere with SCC loop hoisting
     if 'scc' in mode:
         scheduler.process(transformation=RemoveCallsTransformation(
-            routines=['DR_HOOK', 'ABOR1', 'WRITE(NULOUT'], include_intrinsics=True
+            routines=['DR_HOOK', 'ABOR1', 'WRITE(NULOUT'], include_intrinsics=True, kernel_only=True
         ))
     else:
         scheduler.process(transformation=DrHookTransformation(mode=mode, remove=False))

--- a/transformations/transformations/utility_routines.py
+++ b/transformations/transformations/utility_routines.py
@@ -104,15 +104,22 @@ class RemoveCallsTransformation(Transformation):
         Option to extend searches to :any:`Intrinsic` nodes to
         capture print/write statements
     """
-    def __init__(self, routines, include_intrinsics=False, **kwargs):
+    def __init__(self, routines, include_intrinsics=False, kernel_only=False, **kwargs):
         self.routines = as_tuple(routines)
         self.include_intrinsics = include_intrinsics
+        self.kernel_only = kernel_only
         super().__init__(**kwargs)
 
     def transform_subroutine(self, routine, **kwargs):
         """
         Apply transformation to subroutine object
         """
+
+        # Skip driver layer if requested
+        role = kwargs.get('role', None)
+        if role and role == 'driver' and self.kernel_only:
+            return
+
         mapper = {}
 
         # First remove inline conditionals with calls to specified routines or intrinsics

--- a/transformations/transformations/utility_routines.py
+++ b/transformations/transformations/utility_routines.py
@@ -103,6 +103,8 @@ class RemoveCallsTransformation(Transformation):
     include_intrinsics : bool
         Option to extend searches to :any:`Intrinsic` nodes to
         capture print/write statements
+    kernel_only : bool
+        Option to only remove calls in routines marked as "kernel"; default: ``False``
     """
     def __init__(self, routines, include_intrinsics=False, kernel_only=False, **kwargs):
         self.routines = as_tuple(routines)


### PR DESCRIPTION
This avoids the removal of DrHook calls in the driver layer, which we actually want for benchmarking.