### PR TITLE
Loki: Add a 1% code coverage degradation threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
Filing this as a separate PR to get input on the level of degradation we should allow. I've gone for 1% per PR, which would easily work for most of the maintenance PRs, where this is the biggest issue. Opinions and comments welcome.