### PR TITLE
Codecov: Remove old config, drop threashold, disable patch checking

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,0 @@
-# When modifying this file, please validate using
-# curl -X POST --data-binary @.codecov.yml https://codecov.io/validate

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,18 @@
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+
 coverage:
+  precision: 2
+  round: down
+
   status:
     project:
       default:
+        enabled: yes
         target: auto
-        threshold: 1%
+        threshold: 0.1
+    patch:
+      default:
+        enabled: off


### PR DESCRIPTION
Trialling new code coverage settings that are less permissive, more detailed and disable patch testing. Also removes the previous `.codecov.yml` which probably got conflated with the real one.