### PR TITLE
Remove `ExprMetadataMixin`

### DIFF
--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -33,7 +33,7 @@ class DataflowAnalysisAttacher(Transformer):
     _mem_property_queries = ('size', 'lbound', 'ubound', 'present')
 
     def __init__(self, **kwargs):
-        super().__init__(inplace=True, **kwargs)
+        super().__init__(inplace=True, invalidate_source=False, **kwargs)
 
     # Utility routines
 
@@ -277,7 +277,7 @@ class DataflowAnalysisDetacher(Transformer):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(inplace=True, **kwargs)
+        super().__init__(inplace=True, invalidate_source=False, **kwargs)
 
     def visit_Node(self, o, **kwargs):
         o._update(_live_symbols=None, _defines_symbols=None, _uses_symbols=None)

--- a/loki/expression/operations.py
+++ b/loki/expression/operations.py
@@ -15,7 +15,7 @@ from sys import intern
 import pymbolic.primitives as pmbl
 
 from loki.expression.symbols import (
-    StringLiteral, ExprMetadataMixin, Sum, Product, Quotient, Power,
+    StringLiteral, Sum, Product, Quotient, Power,
     loki_make_stringifier
 )
 
@@ -60,7 +60,7 @@ class ParenthesisedPow(Power):
     make_stringifier = loki_make_stringifier
 
 
-class StringConcat(ExprMetadataMixin, pmbl._MultiChildExpression):
+class StringConcat(pmbl._MultiChildExpression):
     """
     Implements string concatenation in a way similar to :class:`Sum`.
     """

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -345,7 +345,7 @@ class FParser2IR(GenericVisitor):
 
         :class:`fparser.two.Fortran2003.Name` has no children.
         """
-        return sym.Variable(name=o.tostr(), parent=kwargs.get('parent'), source=kwargs.get('source'))
+        return sym.Variable(name=o.tostr(), parent=kwargs.get('parent'))
 
     def visit_Type_Name(self, o, **kwargs):
         """
@@ -377,7 +377,7 @@ class FParser2IR(GenericVisitor):
         _type = kwargs['scope'].symbol_attrs.lookup(name.name)
         if _type and isinstance(_type.dtype, ProcedureType):
             name = name.clone(dimensions=None)
-            call = sym.InlineCall(name, parameters=dimensions, kw_parameters=(), source=kwargs.get('source'))
+            call = sym.InlineCall(name, parameters=dimensions, kw_parameters=())
             return call
         return name
 
@@ -795,7 +795,7 @@ class FParser2IR(GenericVisitor):
         source = kwargs.get('source')
         if source:
             source = source.clone_with_string(o.string)
-        return sym.RangeIndex((lower_bound, upper_bound), source=source)
+        return sym.RangeIndex((lower_bound, upper_bound))
 
     visit_Explicit_Shape_Spec_List = visit_List
     visit_Assumed_Shape_Spec = visit_Explicit_Shape_Spec
@@ -984,7 +984,7 @@ class FParser2IR(GenericVisitor):
             values, dtype = self.visit(o.children[1], **kwargs)
         else:
             values, dtype = self.visit(o.children[1], **kwargs), None
-        return sym.LiteralList(values=values, dtype=dtype, source=source)
+        return sym.LiteralList(values=values, dtype=dtype)
 
     def visit_Ac_Spec(self, o, **kwargs):
         """
@@ -1017,7 +1017,7 @@ class FParser2IR(GenericVisitor):
         source = kwargs.get('source')
         if source:
             source = source.clone_with_string(o.string)
-        return sym.InlineDo(values, variable, bounds, source=source)
+        return sym.InlineDo(values, variable, bounds)
 
     def visit_Ac_Implied_Do_Control(self, o, **kwargs):
         """
@@ -1083,7 +1083,7 @@ class FParser2IR(GenericVisitor):
             return constant
 
         repeat = self.visit(o.children[0], **kwargs)
-        return self.create_operation('*', (repeat, constant), kwargs.get('source'))
+        return self.create_operation('*', (repeat, constant))
 
     #
     # Subscripts
@@ -1107,7 +1107,7 @@ class FParser2IR(GenericVisitor):
         source = kwargs.get('source')
         if source:
             source = source.clone_with_string(o.string)
-        return sym.RangeIndex((start, stop, stride), source=source)
+        return sym.RangeIndex((start, stop, stride))
 
     def visit_Array_Section(self, o, **kwargs):
         """
@@ -1127,7 +1127,7 @@ class FParser2IR(GenericVisitor):
         if o.children[1] is None:
             return name
         substring = self.visit(o.children[1], **kwargs)
-        return sym.StringSubscript(name, substring, source=kwargs.get('source'))
+        return sym.StringSubscript(name, substring)
 
     def visit_Substring_Range(self, o, **kwargs):
         """
@@ -1140,7 +1140,7 @@ class FParser2IR(GenericVisitor):
         """
         start = self.visit(o.children[0], **kwargs) if o.children[0] is not None else None
         stop = self.visit(o.children[1], **kwargs) if o.children[1] is not None else None
-        return sym.RangeIndex((start, stop), source=kwargs.get('source'))
+        return sym.RangeIndex((start, stop))
 
     def visit_Stride(self, o, **kwargs):
         # TODO: Implement Stride
@@ -1606,7 +1606,7 @@ class FParser2IR(GenericVisitor):
         * ``'ASSIGNMENT'`` (`str`) followed by
         * ``'='`` (`str`)
         """
-        return sym.Variable(name=str(o), source=kwargs.get('source'))
+        return sym.Variable(name=str(o))
 
     def visit_Procedure_Stmt(self, o, **kwargs):
         """
@@ -2285,7 +2285,7 @@ class FParser2IR(GenericVisitor):
         source = kwargs.get('source')
         if source:
             source = source.clone_with_string(o.string)
-        return sym.RangeIndex((start, stop), source=source)
+        return sym.RangeIndex((start, stop))
 
     visit_Case_Value_Range_List = visit_List
 
@@ -2473,8 +2473,8 @@ class FParser2IR(GenericVisitor):
             arguments = tuple(arg for arg in arguments if not isinstance(arg, tuple))
         else:
             arguments, kwarguments = (), ()
-        return sym.InlineCall(name, parameters=arguments, kw_parameters=kwarguments,
-                              source=kwargs.get('source'))
+        return sym.InlineCall(name, parameters=arguments, kw_parameters=kwarguments)
+
 
     def visit_Intrinsic_Function_Reference(self, o, **kwargs):
         name = self.visit(o.children[0], **kwargs)
@@ -2494,9 +2494,8 @@ class FParser2IR(GenericVisitor):
                 kind = kwarguments[0][1]
             else:
                 kind = arguments[1] if len(arguments) > 1 else None
-            return sym.Cast(name, expr, kind=kind, source=kwargs.get('source'))
-        return sym.InlineCall(name, parameters=arguments, kw_parameters=kwarguments,
-                              source=kwargs.get('source'))
+            return sym.Cast(name, expr, kind=kind)
+        return sym.InlineCall(name, parameters=arguments, kw_parameters=kwarguments)
 
     visit_Intrinsic_Name = visit_Name
 
@@ -2519,7 +2518,7 @@ class FParser2IR(GenericVisitor):
 
         # `name` is a DerivedType but we represent a constructor call as InlineCall for
         # which we need ProcedureSymbol
-        name = sym.Variable(name=name.name, source=self.get_source(o.children[0], kwargs.get('source')))
+        name = sym.Variable(name=name.name)
 
         if o.children[1] is not None:
             arguments = self.visit(o.children[1], **kwargs)
@@ -2528,7 +2527,7 @@ class FParser2IR(GenericVisitor):
         else:
             arguments, kwarguments = (), ()
 
-        return sym.InlineCall(name, parameters=arguments, kw_parameters=kwarguments, source=kwargs.get('source'))
+        return sym.InlineCall(name, parameters=arguments, kw_parameters=kwarguments)
 
     visit_Component_Spec = visit_Actual_Arg_Spec
     visit_Component_Spec_List = visit_List
@@ -2769,11 +2768,11 @@ class FParser2IR(GenericVisitor):
             val = o.items[0]
         if kind is not None:
             if kind.isdigit():
-                kind = sym.Literal(value=int(kind), source=source)
+                kind = sym.Literal(value=int(kind))
             else:
-                kind = AttachScopesMapper()(sym.Variable(name=kind, source=source), scope=kwargs['scope'])
-            return sym.Literal(value=val, type=_type, kind=kind, source=source)
-        return sym.Literal(value=val, type=_type, source=source)
+                kind = AttachScopesMapper()(sym.Variable(name=kind), scope=kwargs['scope'])
+            return sym.Literal(value=val, type=_type, kind=kind)
+        return sym.Literal(value=val, type=_type)
 
     def visit_Char_Literal_Constant(self, o, **kwargs):
         return self.visit_literal(o, BasicType.CHARACTER, **kwargs)
@@ -2800,7 +2799,7 @@ class FParser2IR(GenericVisitor):
             val = source.string
         else:
             val = o.string
-        return sym.IntrinsicLiteral(value=val, source=source)
+        return sym.IntrinsicLiteral(value=val)
 
     visit_Binary_Constant = visit_Complex_Literal_Constant
     visit_Octal_Constant = visit_Complex_Literal_Constant
@@ -2907,12 +2906,7 @@ class FParser2IR(GenericVisitor):
             return self.visit(o.items[0], **kwargs), None
         variable = self.visit(o.items[1][0], **kwargs)
         bounds = as_tuple(flatten(self.visit(a, **kwargs) for a in as_tuple(o.items[1][1])))
-        source = kwargs.get('source')
-        if source:
-            variable_source = source.clone_with_string(o.string[:o.string.find('=')])
-            variable = variable.clone(source=variable_source)
-            source = source.clone_with_string(o.string[o.string.find('=')+1:])
-        return variable, sym.LoopRange(bounds, source=source)
+        return variable, sym.LoopRange(bounds)
 
     def visit_Assignment_Stmt(self, o, **kwargs):
         ptr = isinstance(o, Fortran2003.Pointer_Assignment_Stmt)
@@ -2923,51 +2917,51 @@ class FParser2IR(GenericVisitor):
 
     visit_Pointer_Assignment_Stmt = visit_Assignment_Stmt
 
-    def create_operation(self, op, exprs, source):
+    def create_operation(self, op, exprs):
         """
         Construct expressions from individual operations.
         """
         exprs = as_tuple(exprs)
         if op == '*':
-            return sym.Product(exprs, source=source)
+            return sym.Product(exprs)
         if op == '/':
-            return sym.Quotient(numerator=exprs[0], denominator=exprs[1], source=source)
+            return sym.Quotient(numerator=exprs[0], denominator=exprs[1])
         if op == '+':
-            return sym.Sum(exprs, source=source)
+            return sym.Sum(exprs)
         if op == '-':
             if len(exprs) > 1:
                 # Binary minus
-                return sym.Sum((exprs[0], sym.Product((-1, exprs[1]))), source=source)
+                return sym.Sum((exprs[0], sym.Product((-1, exprs[1]))))
             # Unary minus
-            return sym.Product((-1, exprs[0]), source=source)
+            return sym.Product((-1, exprs[0]))
         if op == '**':
-            return sym.Power(base=exprs[0], exponent=exprs[1], source=source)
+            return sym.Power(base=exprs[0], exponent=exprs[1])
         if op.lower() == '.and.':
-            return sym.LogicalAnd(exprs, source=source)
+            return sym.LogicalAnd(exprs)
         if op.lower() == '.or.':
-            return sym.LogicalOr(exprs, source=source)
+            return sym.LogicalOr(exprs)
         if op.lower() in ('==', '.eq.'):
-            return sym.Comparison(exprs[0], '==', exprs[1], source=source)
+            return sym.Comparison(exprs[0], '==', exprs[1])
         if op.lower() in ('/=', '.ne.'):
-            return sym.Comparison(exprs[0], '!=', exprs[1], source=source)
+            return sym.Comparison(exprs[0], '!=', exprs[1])
         if op.lower() in ('>', '.gt.'):
-            return sym.Comparison(exprs[0], '>', exprs[1], source=source)
+            return sym.Comparison(exprs[0], '>', exprs[1])
         if op.lower() in ('<', '.lt.'):
-            return sym.Comparison(exprs[0], '<', exprs[1], source=source)
+            return sym.Comparison(exprs[0], '<', exprs[1])
         if op.lower() in ('>=', '.ge.'):
-            return sym.Comparison(exprs[0], '>=', exprs[1], source=source)
+            return sym.Comparison(exprs[0], '>=', exprs[1])
         if op.lower() in ('<=', '.le.'):
-            return sym.Comparison(exprs[0], '<=', exprs[1], source=source)
+            return sym.Comparison(exprs[0], '<=', exprs[1])
         if op.lower() == '.not.':
-            return sym.LogicalNot(exprs[0], source=source)
+            return sym.LogicalNot(exprs[0])
         if op.lower() == '.eqv.':
-            return sym.LogicalOr((sym.LogicalAnd(exprs, source=source),
-                                  sym.LogicalNot(sym.LogicalOr(exprs, source=source))), source=source)
+            return sym.LogicalOr((sym.LogicalAnd(exprs),
+                                  sym.LogicalNot(sym.LogicalOr(exprs))))
         if op.lower() == '.neqv.':
-            return sym.LogicalAnd((sym.LogicalNot(sym.LogicalAnd(exprs, source=source)),
-                                   sym.LogicalOr(exprs, source=source)), source=source)
+            return sym.LogicalAnd((sym.LogicalNot(sym.LogicalAnd(exprs)),
+                                   sym.LogicalOr(exprs)))
         if op == '//':
-            return StringConcat(exprs, source=source)
+            return StringConcat(exprs)
         raise RuntimeError('FParser: Error parsing generic expression')
 
     def visit_Add_Operand(self, o, **kwargs):
@@ -2978,10 +2972,10 @@ class FParser2IR(GenericVisitor):
             # Binary operand
             exprs = [self.visit(o.items[0], **kwargs)]
             exprs += [self.visit(o.items[2], **kwargs)]
-            return self.create_operation(op=o.items[1], exprs=exprs, source=source)
+            return self.create_operation(op=o.items[1], exprs=exprs)
         # Unary operand
         exprs = [self.visit(o.items[1], **kwargs)]
-        return self.create_operation(op=o.items[0], exprs=exprs, source=source)
+        return self.create_operation(op=o.items[0], exprs=exprs)
 
     visit_Mult_Operand = visit_Add_Operand
     visit_And_Operand = visit_Add_Operand
@@ -2994,14 +2988,14 @@ class FParser2IR(GenericVisitor):
             source = source.clone_with_string(o.string)
         e1 = self.visit(o.items[0], **kwargs)
         e2 = self.visit(o.items[2], **kwargs)
-        return self.create_operation(op=o.items[1], exprs=(e1, e2), source=source)
+        return self.create_operation(op=o.items[1], exprs=(e1, e2))
 
     def visit_Level_2_Unary_Expr(self, o, **kwargs):
         source = kwargs.get('source')
         if source:
             source = source.clone_with_string(o.string)
         exprs = as_tuple(self.visit(o.items[1], **kwargs))
-        return self.create_operation(op=o.items[0], exprs=exprs, source=source)
+        return self.create_operation(op=o.items[0], exprs=exprs)
 
     visit_Level_3_Expr = visit_Level_2_Expr
     visit_Level_4_Expr = visit_Level_2_Expr
@@ -3013,13 +3007,13 @@ class FParser2IR(GenericVisitor):
         if source:
             source = source.clone_with_string(o.string)
         if isinstance(expression, sym.Sum):
-            expression = ParenthesisedAdd(expression.children, source=source)
+            expression = ParenthesisedAdd(expression.children)
         if isinstance(expression, sym.Product):
-            expression = ParenthesisedMul(expression.children, source=source)
+            expression = ParenthesisedMul(expression.children)
         if isinstance(expression, sym.Quotient):
-            expression = ParenthesisedDiv(expression.numerator, expression.denominator, source=source)
+            expression = ParenthesisedDiv(expression.numerator, expression.denominator)
         if isinstance(expression, sym.Power):
-            expression = ParenthesisedPow(expression.base, expression.exponent, source=source)
+            expression = ParenthesisedPow(expression.base, expression.exponent)
         return expression
 
     visit_Format_Stmt = visit_Intrinsic_Stmt

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -275,8 +275,8 @@ class OMNI2IR(GenericVisitor):
                 name = f'OPERATOR({name})'
 
         if o.attrib.get('local_name'):
-            return (name, sym.Variable(name=o.attrib['local_name'], source=kwargs['source']))
-        return sym.Variable(name=name, source=kwargs['source'])
+            return (name, sym.Variable(name=o.attrib['local_name']))
+        return sym.Variable(name=name)
 
     visit_rename = visit_renamable
 
@@ -1014,7 +1014,7 @@ class OMNI2IR(GenericVisitor):
         step = self.visit(o.find('indexRange/step'), **kwargs)
         # Drop OMNI's `:1` step counting for ranges in the name of consistency
         step = None if step == '1' else step
-        bounds = sym.LoopRange((lower, upper, step), source=kwargs['source'])
+        bounds = sym.LoopRange((lower, upper, step))
         return ir.Loop(variable=variable, body=body, bounds=bounds, source=kwargs['source'])
 
     def visit_FdoLoop(self, o, **kwargs):
@@ -1024,9 +1024,9 @@ class OMNI2IR(GenericVisitor):
         step = self.visit(o.find('indexRange/step'), **kwargs)
         # Drop OMNI's `:1` step counting for ranges in the name of consistency
         step = None if step == '1' else step
-        bounds = sym.LoopRange((lower, upper, step), source=kwargs['source'])
+        bounds = sym.LoopRange((lower, upper, step))
         values = as_tuple(self.visit(o.find('value'), **kwargs))
-        return sym.InlineDo(values, variable, bounds, source=kwargs['source'])
+        return sym.InlineDo(values, variable, bounds)
 
     def visit_FifStatement(self, o, **kwargs):
         condition = self.visit(o.find('condition'), **kwargs)
@@ -1097,7 +1097,7 @@ class OMNI2IR(GenericVisitor):
         return variable
 
     def visit_name(self, o, **kwargs):
-        return sym.Variable(name=o.text, source=kwargs.get('source'))
+        return sym.Variable(name=o.text)
 
     visit_Var = visit_name
 
@@ -1122,7 +1122,7 @@ class OMNI2IR(GenericVisitor):
         step = self.visit(st, **kwargs) if st is not None else None
         # Drop OMNI's `:1` step counting for ranges in the name of consistency
         step = None if step == '1' else step
-        return sym.RangeIndex((lower, upper, step), source=kwargs['source'])
+        return sym.RangeIndex((lower, upper, step))
 
     def visit_FcharacterRef(self, o, **kwargs):
         var = self.visit(o.find('varRef'), **kwargs)
@@ -1138,24 +1138,24 @@ class OMNI2IR(GenericVisitor):
     def visit_FrealConstant(self, o, **kwargs):
         if 'kind' in o.attrib and not 'd' in o.text.lower():
             _type = self.visit(self.type_map[o.attrib.get('type')], **kwargs)
-            return sym.Literal(value=o.text, type=BasicType.REAL, kind=_type.kind, source=kwargs['source'])
-        return sym.Literal(value=o.text, type=BasicType.REAL, source=kwargs['source'])
+            return sym.Literal(value=o.text, type=BasicType.REAL, kind=_type.kind)
+        return sym.Literal(value=o.text, type=BasicType.REAL)
 
     def visit_FlogicalConstant(self, o, **kwargs):
-        return sym.Literal(value=o.text, type=BasicType.LOGICAL, source=kwargs['source'])
+        return sym.Literal(value=o.text, type=BasicType.LOGICAL)
 
     def visit_FcharacterConstant(self, o, **kwargs):
-        return sym.Literal(value=f'"{o.text}"', type=BasicType.CHARACTER, source=kwargs['source'])
+        return sym.Literal(value=f'"{o.text}"', type=BasicType.CHARACTER)
 
     def visit_FintConstant(self, o, **kwargs):
         if 'kind' in o.attrib:
             _type = self.visit(self.type_map[o.attrib.get('type')], **kwargs)
-            return sym.Literal(value=int(o.text), type=BasicType.INTEGER, kind=_type.kind, source=kwargs['source'])
-        return sym.Literal(value=int(o.text), type=BasicType.INTEGER, source=kwargs['source'])
+            return sym.Literal(value=int(o.text), type=BasicType.INTEGER, kind=_type.kind)
+        return sym.Literal(value=int(o.text), type=BasicType.INTEGER)
 
     def visit_FcomplexConstant(self, o, **kwargs):
         value = ', '.join(f'{self.visit(v, **kwargs)}' for v in list(o))
-        return sym.IntrinsicLiteral(value=f'({value})', source=kwargs['source'])
+        return sym.IntrinsicLiteral(value=f'({value})')
 
     def visit_FarrayConstructor(self, o, **kwargs):
         values = as_tuple(self.visit(v, **kwargs) for v in o)
@@ -1195,9 +1195,9 @@ class OMNI2IR(GenericVisitor):
                 kind = kw_args[0][1]
             else:
                 kind = args[1] if len(args) > 1 else None
-            return sym.Cast(name, expr, kind=kind, source=kwargs['source'])
+            return sym.Cast(name, expr, kind=kind)
 
-        return sym.InlineCall(name, parameters=args, kw_parameters=kw_args, source=kwargs['source'])
+        return sym.InlineCall(name, parameters=args, kw_parameters=kw_args)
 
     def visit_FstructConstructor(self, o, **kwargs):
         _type = self.type_from_type_attrib(o.attrib['type'], **kwargs)
@@ -1210,7 +1210,7 @@ class OMNI2IR(GenericVisitor):
         kw_args = as_tuple(arg for arg in args if isinstance(arg, tuple))
         args = as_tuple(arg for arg in args if not isinstance(arg, tuple))
 
-        return sym.InlineCall(name, parameters=args, kw_parameters=kw_args, source=kwargs['source'])
+        return sym.InlineCall(name, parameters=args, kw_parameters=kw_args)
 
     def visit_FcycleStatement(self, o, **kwargs):
         # TODO: do-construct-name is not preserved
@@ -1273,104 +1273,104 @@ class OMNI2IR(GenericVisitor):
         # Note: this will result in an abundance of trivial/unnecessary parenthesis!
         if enclosing_cls in (sym.Product, sym.Quotient):
             if isinstance(expr, sym.Product):
-                return op.ParenthesisedMul(expr.children, source=expr.source)
+                return op.ParenthesisedMul(expr.children)
             if isinstance(expr, sym.Quotient):
-                return op.ParenthesisedDiv(expr.numerator, expr.denominator, source=expr.source)
+                return op.ParenthesisedDiv(expr.numerator, expr.denominator)
             if isinstance(expr, sym.Sum):
-                return op.ParenthesisedAdd(expr.children, source=expr.source)
+                return op.ParenthesisedAdd(expr.children)
             if isinstance(expr, sym.Power):
-                return op.ParenthesisedPow(expr.base, expr.exponent, source=expr.source)
+                return op.ParenthesisedPow(expr.base, expr.exponent)
         return expr
 
     def visit_plusExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Sum(exprs, source=kwargs['source'])
+        return sym.Sum(exprs)
 
     def visit_minusExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Sum((exprs[0], sym.Product((-1, exprs[1]))), source=kwargs['source'])
+        return sym.Sum((exprs[0], sym.Product((-1, exprs[1]))))
 
     def visit_mulExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
         exprs = tuple(self.parenthesize_if_needed(c, sym.Product) for c in exprs)
-        return sym.Product(exprs, source=kwargs['source'])
+        return sym.Product(exprs)
 
     def visit_divExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
         exprs = tuple(self.parenthesize_if_needed(c, sym.Quotient) for c in exprs)
-        return sym.Quotient(*exprs, source=kwargs['source'])
+        return sym.Quotient(*exprs)
 
     def visit_FpowerExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Power(base=exprs[0], exponent=exprs[1], source=kwargs['source'])
+        return sym.Power(base=exprs[0], exponent=exprs[1])
 
     def visit_unaryMinusExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 1
-        return sym.Product((-1, exprs[0]), source=kwargs['source'])
+        return sym.Product((-1, exprs[0]))
 
     def visit_logOrExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
-        return sym.LogicalOr(exprs, source=kwargs['source'])
+        return sym.LogicalOr(exprs)
 
     def visit_logAndExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
-        return sym.LogicalAnd(exprs, source=kwargs['source'])
+        return sym.LogicalAnd(exprs)
 
     def visit_logNotExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 1
-        return sym.LogicalNot(exprs[0], source=kwargs['source'])
+        return sym.LogicalNot(exprs[0])
 
     def visit_logLTExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Comparison(exprs[0], '<', exprs[1], source=kwargs['source'])
+        return sym.Comparison(exprs[0], '<', exprs[1])
 
     def visit_logLEExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Comparison(exprs[0], '<=', exprs[1], source=kwargs['source'])
+        return sym.Comparison(exprs[0], '<=', exprs[1])
 
     def visit_logGTExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Comparison(exprs[0], '>', exprs[1], source=kwargs['source'])
+        return sym.Comparison(exprs[0], '>', exprs[1])
 
     def visit_logGEExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Comparison(exprs[0], '>=', exprs[1], source=kwargs['source'])
+        return sym.Comparison(exprs[0], '>=', exprs[1])
 
     def visit_logEQExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Comparison(exprs[0], '==', exprs[1], source=kwargs['source'])
+        return sym.Comparison(exprs[0], '==', exprs[1])
 
     def visit_logNEQExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.Comparison(exprs[0], '!=', exprs[1], source=kwargs['source'])
+        return sym.Comparison(exprs[0], '!=', exprs[1])
 
     def visit_logEQVExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.LogicalOr((sym.LogicalAnd(exprs), sym.LogicalNot(sym.LogicalOr(exprs))), source=kwargs['source'])
+        return sym.LogicalOr((sym.LogicalAnd(exprs), sym.LogicalNot(sym.LogicalOr(exprs))))
 
     def visit_logNEQVExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return sym.LogicalAnd((sym.LogicalNot(sym.LogicalAnd(exprs)), sym.LogicalOr(exprs)), source=kwargs['source'])
+        return sym.LogicalAnd((sym.LogicalNot(sym.LogicalAnd(exprs)), sym.LogicalOr(exprs)))
 
     def visit_FconcatExpr(self, o, **kwargs):
         exprs = tuple(self.visit(c, **kwargs) for c in o)
         assert len(exprs) == 2
-        return StringConcat(exprs, source=kwargs['source'])
+        return StringConcat(exprs)
 
     def visit_gotoStatement(self, o, **kwargs):
         label = int(o.attrib['label_name'])

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -254,8 +254,7 @@ def inject_statement_functions(routine):
                 if isinstance(variable, Array):
                     parameters = variable.dimensions
                     expr_map_spec[variable] = InlineCall(
-                        variable.clone(dimensions=None), parameters=parameters, source=variable.source
-                    )
+                        variable.clone(dimensions=None), parameters=parameters)
                 elif not isinstance(variable, ProcedureSymbol):
                     expr_map_spec[variable] = variable.clone()
         expr_map_body = {}
@@ -264,8 +263,7 @@ def inject_statement_functions(routine):
                 if isinstance(variable, Array):
                     parameters = variable.dimensions
                     expr_map_body[variable] = InlineCall(
-                        variable.clone(dimensions=None), parameters=parameters, source=variable.source
-                    )
+                        variable.clone(dimensions=None), parameters=parameters)
                 elif not isinstance(variable, ProcedureSymbol):
                     expr_map_body[variable] = variable.clone()
 

--- a/loki/visitors/transform.py
+++ b/loki/visitors/transform.py
@@ -106,9 +106,10 @@ class Transformer(Visitor):
         args_frozen = o.args_frozen
         args_frozen.update(args)
         if self.invalidate_source and 'source' in args_frozen:
-            child_has_no_source = [getattr(i, 'source', None) is None for i in flatten(children)]
-            if any(child_has_no_source) or len(child_has_no_source) != len(flatten(o.children)):
-                return self._rebuild_without_source(o, children, **args_frozen)
+            if any(isinstance(child, Node) for child in flatten(children)):
+                child_has_no_source = [getattr(i, 'source', None) is None for i in flatten(children)]
+                if any(child_has_no_source) or len(child_has_no_source) != len(flatten(o.children)):
+                    return self._rebuild_without_source(o, children, **args_frozen)
 
         if self.inplace:
             # Updated nodes in place, if requested

--- a/tests/test_source_identity.py
+++ b/tests/test_source_identity.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 from conftest import clean_test, available_frontends
 from loki import (
-  Sourcefile, Subroutine, OMNI, fgen, FindNodes, as_tuple, ir
+  Sourcefile, Subroutine, OMNI, fgen, FindNodes, ir
 )
 
 
@@ -136,9 +136,6 @@ end subroutine routine_raw_source_cond
     for node in FindNodes(ir.Conditional).visit(routine.ir):
         assert node.source is not None
         assert node.source.lines in cond_lines
-        # Make sure that conditionals have source information
-        assert node.condition.source.lines[0] == node.condition.source.lines[0]
-        assert node.condition.source.lines[0] == node.source.lines[0]
         # Verify that source string is subset of the relevant lines in the original source
         assert node.source.string in ('\n'.join(fcode[start-1:end]) for start, end in cond_lines)
         if node.name:
@@ -193,15 +190,9 @@ end subroutine routine_raw_source_multicond
     # Check the conditional
     cond_name_found = 0
     cond_lines = ((4, 11),)
-    conditions = {4: (5, 7)}
     for node in FindNodes(ir.MultiConditional).visit(routine.ir):
         assert node.source is not None
         assert node.source.lines in cond_lines
-        # Make sure that cases have source information
-        for value in node.values:
-            assert all(val.source.lines[0] == val.source.lines[1] and
-                       val.source.lines[0] in conditions[node.source.lines[0]]
-                       for val in as_tuple(value))
         # Verify that source string is subset of the relevant lines in the original source
         assert node.source.string in ('\n'.join(fcode[start-1:end]) for start, end in cond_lines)
         if node.name:

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -10,7 +10,7 @@ from pymbolic.primitives import Expression
 
 from conftest import available_frontends
 from loki import (
-    OMNI, FP,
+    OMNI,
     Module, Subroutine, Section, Loop, Assignment, Conditional, Sum, Associate,
     Array, ArraySubscript, LoopRange, IntLiteral, FloatLiteral, LogicLiteral, Comparison, Cast,
     FindNodes, FindExpressions, FindVariables, ExpressionFinder, FindExpressionRoot,
@@ -385,11 +385,6 @@ end subroutine routine_simple
     literal_root = FindExpressionRoot(literals[0][1].pop()).visit(literals[0][0])
     assert literal_root[0] is cast_root[0]
 
-    # Check source properties of expressions (for FP only)
-    if frontend == FP:
-        assert comp_root[0].source.lines == (12, 12)
-        assert cast_root[0].source.lines == (13, 13)
-
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_find_expression_root_constructor_args(frontend):
@@ -735,7 +730,7 @@ end subroutine routine_simple
     # Find the conditional in new bodies and check that source is untouched
     assert cond.source is not None
     cond_without_src = get_conditional(body_without_source)
-    assert cond_without_src.source == cond.source
+    assert cond_without_src.source is None
     cond_with_src = get_conditional(body_with_source)
     assert cond_with_src.source == cond.source
 


### PR DESCRIPTION
Expression nodes have a `source` attribute, and the smallest unit of source is a source line. Strictly speaking, the `source` property of an expression should be just the expression itself, i.e. smaller than a full-line.

In many instances, the control-flow node `source` can be invalidated but `Expression.source` will still be intact, e.g. after a `Transformer` pass. This can then cause problems when running `fgen` in `conservative=True` mode. When the `fgen` visitor arrives at the `Expression` node in question and finds the `source` property intact, it will simply print `Expression.source` rather than generating Fortran code. Because `Expression.source` points to a full source-code line, incorrect code is generated.

@reuterbal suggested that because we cannot correctly parse the source for `Expression` nodes, they should not have a `source` property at all. So one solution to the above problem is to remove the `source` property from `Expression` nodes. Since the only purpose of `ExprMetaDataMixin` was to add a `source` property to expression nodes, this PR tries to remove `ExprMetaDataMixin`.

As this was a change to the IR, it also affected many ostensibly unrelated parts of the code. Small fixes and updates to tests were thus also required.

NB: These changes have been regression tested against ecWam.