### PR TITLE
Member inlining utility transform

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,6 +2,7 @@
 
 - R. Heilemann Myhre (Met Norway)
 - M. Lange (ECMWF)
+- J. Legaux (CERFACS)
 - O. Marsden (ECMWF)
 - A. Nawab (ECMWF)
 - B. Reuter (ECMWF)

--- a/cmake/loki_transform.cmake
+++ b/cmake/loki_transform.cmake
@@ -182,7 +182,7 @@ endmacro()
 #       [OMNI_INCLUDE <omni-inc1> [<omni-inc2> ...]]
 #       [XMOD <xmod-dir1> [<xmod-dir2> ...]]
 #       [REMOVE_OPENMP] [DATA_OFFLOAD] [GLOBAL_VAR_OFFLOAD]
-#       [TRIM_VECTOR_SECTIONS] [REMOVE_DERIVED_ARGS]
+#       [TRIM_VECTOR_SECTIONS] [REMOVE_DERIVED_ARGS] [INLINE_MEMBERS]
 #   )
 #
 # Call ``loki-transform.py convert ...`` with the provided arguments.
@@ -199,7 +199,10 @@ endmacro()
 
 function( loki_transform_convert )
 
-    set( options CPP DATA_OFFLOAD REMOVE_OPENMP ASSUME_DEVICEPTR GLOBAL_VAR_OFFLOAD TRIM_VECTOR_SECTIONS REMOVE_DERIVED_ARGS )
+    set(
+        options CPP DATA_OFFLOAD REMOVE_OPENMP ASSUME_DEVICEPTR GLOBAL_VAR_OFFLOAD
+	TRIM_VECTOR_SECTIONS REMOVE_DERIVED_ARGS INLINE_MEMBERS
+    )
     set( oneValueArgs MODE DIRECTIVE FRONTEND CONFIG PATH OUTPATH )
     set( multiValueArgs OUTPUT DEPENDS INCLUDES INCLUDE HEADERS HEADER DEFINITIONS DEFINE OMNI_INCLUDE XMOD )
 
@@ -250,6 +253,10 @@ function( loki_transform_convert )
 
     if( ${_PAR_REMOVE_DERIVED_ARGS} )
         list( APPEND _ARGS --remove-derived-args )
+    endif()
+
+    if( ${_PAR_INLINE_MEMBERS} )
+        list( APPEND _ARGS --inline-members )
     endif()
 
     _loki_transform_env_setup()
@@ -588,6 +595,7 @@ endfunction()
 #       [DIRECTIVE <directive>]
 #       [CPP]
 #       [FRONTEND <frontend>]
+#       [INLINE_MEMBERS]
 #       [BUILDDIR <build-path>]
 #       [SOURCES <source1> [<source2> ...]]
 #       [HEADERS <header1> [<header2> ...]]
@@ -607,7 +615,7 @@ endfunction()
 
 function( loki_transform_command )
 
-    set( options CPP )
+    set( options CPP INLINE_MEMBERS )
     set( oneValueArgs COMMAND MODE DIRECTIVE FRONTEND CONFIG BUILDDIR )
     set( multiValueArgs OUTPUT DEPENDS SOURCES HEADERS )
 
@@ -731,7 +739,7 @@ endfunction()
 
 function( loki_transform_target )
 
-    set( options NO_PLAN_SOURCEDIR COPY_UNMODIFIED CPP CPP_PLAN )
+    set( options NO_PLAN_SOURCEDIR COPY_UNMODIFIED CPP CPP_PLAN INLINE_MEMBERS )
     set( single_value_args TARGET COMMAND MODE DIRECTIVE FRONTEND CONFIG PLAN )
     set( multi_value_args SOURCES HEADERS )
 
@@ -792,6 +800,10 @@ function( loki_transform_target )
         set( _TRANSFORM_OPTIONS "" )
         if( _PAR_CPP )
             list( APPEND _TRANSFORM_OPTIONS CPP )
+        endif()
+
+        if( _PAR_INLINE_MEMBERS )
+            list( APPEND _TRANSFORM_OPTIONS INLINE_MEMBERS )
         endif()
 
         loki_transform_command(

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1069,7 +1069,7 @@ class LogicLiteral(StrCompareMixin, _Literal):
     """
 
     def __init__(self, value, **kwargs):
-        self.value = value.lower() in ('true', '.true.')
+        self.value = str(value).lower() in ('true', '.true.')
         super().__init__(**kwargs)
 
     init_arg_names = ('value', )

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -921,6 +921,14 @@ class CallStatement(LeafNode, _CallStatementBase):
         kwargs = ((r_args[kw], arg) for kw, arg in as_tuple(self.kwarguments))
         return chain(args, kwargs)
 
+    @property
+    def arg_map(self):
+        """
+        A full map of all qualified argument matches from arguments
+        and keyword arguments.
+        """
+        return dict(self.arg_iter())
+
 
 @dataclass_strict(frozen=True)
 class _AllocationBase():

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -233,7 +233,7 @@ def inline_member_routine(routine, member):
     parent_variables = routine.variable_map
     duplicate_locals = tuple(
         v for v in member.variables
-        if v.name in parent_variables and v.name not in member._dummies
+        if v.name in parent_variables and v.name.lower() not in member._dummies
     )
     shadow_mapper = SubstituteExpressions(
         {v: v.clone(name=f'{member.name}_{v.name}') for v in duplicate_locals}
@@ -243,7 +243,7 @@ def inline_member_routine(routine, member):
 
     # Get local variable declarations and hoist them
     decls = FindNodes(VariableDeclaration).visit(member.spec)
-    decls = tuple(d for d in decls if all(s.name not in routine._dummies for s in d.symbols))
+    decls = tuple(d for d in decls if all(s.name.lower() not in routine._dummies for s in d.symbols))
     decls = tuple(d for d in decls if all(s not in routine.variables for s in d.symbols))
     routine.spec.append(decls)
 

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -218,10 +218,19 @@ def inline_member_routine(routine, member):
         For example, mapping the passed array ``m(:,j)`` to the local
         expression ``a(i)`` yields ``m(i,j)``.
         """
-        val_free_dims = tuple(d for d in val.dimensions if isinstance(d, sym.Range))
-        var_bound_dims = tuple(d for d in var.dimensions if not isinstance(d, sym.Range))
-        mapper = SubstituteExpressionsMapper(dict(zip(val_free_dims, var_bound_dims)))
-        return mapper(val)
+        new_dimensions = list(val.dimensions)
+
+        indices = [index for index, dim in enumerate(val.dimensions) if isinstance(dim, sym.Range)]
+
+        for index, dim in enumerate(var.dimensions):
+            new_dimensions[indices[index]] = dim
+
+        original_symbol = sym.ArraySubscript(val.symbol, val.dimensions)
+        new_symbol = sym.ArraySubscript(val.symbol, tuple(new_dimensions) )
+
+        mapper = SubstituteExpressionsMapper({original_symbol:new_symbol})
+
+        return mapper(original_symbol)
 
     # Get local variable declarations and hoist them
     decls = FindNodes(VariableDeclaration).visit(member.spec)

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -241,9 +241,13 @@ def inline_member_routine(routine, member):
                 if isinstance(arg, sym.Array):
                     # Resolve implicit dimension ranges of the passed value,
                     # eg. when passing a two-dimensional array `a` as `call(arg=a)`
-                    qualified_value = val if val.dimensions else val.clone(
-                        dimensions=tuple(sym.Range((None, None)) for _ in arg.shape)
-                    )
+                    # Check if val is a DeferredTypeSymbol, as it does not have a `dimensions` attribute
+                    if not isinstance(val, sym.DeferredTypeSymbol) and val.dimensions:
+                        qualified_value = val
+                    else:
+                        qualified_value = val.clone(
+                            dimensions=tuple(sym.Range((None, None)) for _ in arg.shape)
+                        )
                     arg_vars = tuple(v for v in member_vars if v.name == arg.name)
                     argmap.update((v, _map_unbound_dims(v, qualified_value)) for v in arg_vars)
                 else:

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -14,13 +14,18 @@ from loki.expression import (
     FindVariables, FindInlineCalls, FindLiterals,
     SubstituteExpressions, LokiIdentityMapper
 )
-from loki.ir import Import, Comment, Assignment
+from loki.ir import Import, Comment, Assignment, VariableDeclaration, CallStatement
 from loki.expression import symbols as sym
 from loki.types import BasicType
 from loki.visitors import Transformer, FindNodes
+from loki.tools import as_tuple
+from loki.logging import warning
 
 
-__all__ = ['inline_constant_parameters', 'inline_elemental_functions']
+__all__ = [
+    'inline_constant_parameters', 'inline_elemental_functions',
+    'inline_member_procedures'
+]
 
 
 class InlineSubstitutionMapper(LokiIdentityMapper):
@@ -183,3 +188,67 @@ def inline_elemental_functions(routine):
         if all(hasattr(s, 'type') and s.type.dtype in removed_functions for s in im.symbols):
             import_map[im] = None
     routine.spec = Transformer(import_map).visit(routine.spec)
+
+
+def inline_member_routine(routine, member):
+    """
+    Inline an individual member :any:`Subroutine` at source level.
+
+    This will replace all :any:`Call` objects to the specified
+    subroutine with an adjusted equivalent of the member routines'
+    body. For this, argument matching, including partial dimension
+    matching for array references is performed, and all
+    member-specific declarations are hoisted to the containing
+    :any:`Subroutine`.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine in which to inline all calls to the member routine
+    member : :any:`Subroutine`
+        The contained member subroutine to be inlined in the parent
+    """
+
+    # Get local variable declarations and hoist them
+    decls = FindNodes(VariableDeclaration).visit(member.spec)
+    decls = tuple(d for d in decls if all(not s.type.intent for s in d.symbols))
+    decls = tuple(d for d in decls if all(s not in routine.variables for s in d.symbols))
+    routine.spec.append(decls)
+
+    call_map = {}
+    for call in FindNodes(CallStatement).visit(routine.body):
+        if call.routine == member:
+            # Substitute argument calls into a copy of the body
+            member_body = SubstituteExpressions(call.arg_map).visit(member.body.body)
+
+            # Inline substituted body within a pair of marker comments
+            comment = Comment(f'! [Loki] inlined member subroutine: {member.name}')
+            c_line = Comment('! =========================================')
+            call_map[call] = (comment, c_line) + as_tuple(member_body) + (c_line, )
+
+    # Replace calls to member with the member's body
+    routine.body = Transformer(call_map).visit(routine.body)
+    # Can't use transformer to replace subroutine, so strip it manually
+    contains_body = tuple(n for n in routine.contains.body if not n == member)
+    routine.contains._update(body=contains_body)
+
+
+def inline_member_procedures(routine):
+    """
+    Inline all member subroutines contained in an individual :any:`Subroutine`.
+
+    Please note that member functions are not yet supported!
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine in which to inline all member routines
+    """
+
+    # Run through all members and invoke individual inlining transforms
+    for member in routine.members:
+        if member.is_function:
+            # TODO: Implement for functions!!!
+            warning('[Loki::inline] Inlining member functions is not yet supported, only subroutines!')
+        else:
+            inline_member_routine(routine, member)

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -12,7 +12,7 @@ Collection of utility routines to perform code-level force-inlining.
 """
 from loki.expression import (
     FindVariables, FindInlineCalls, FindLiterals,
-    SubstituteExpressions, LokiIdentityMapper
+    SubstituteExpressions, SubstituteExpressionsMapper, LokiIdentityMapper
 )
 from loki.ir import Import, Comment, Assignment, VariableDeclaration, CallStatement
 from loki.expression import symbols as sym
@@ -209,6 +209,20 @@ def inline_member_routine(routine, member):
         The contained member subroutine to be inlined in the parent
     """
 
+    def _map_unbound_dims(var, val):
+        """
+        Maps all unbound dimension ranges in the passed array value
+        ``val`` with the indices from the local variable ``var``. It
+        returns the re-mapped symbol.
+
+        For example, mapping the passed array ``m(:,j)`` to the local
+        expression ``a(i)`` yields ``m(i,j)``.
+        """
+        val_free_dims = tuple(d for d in val.dimensions if isinstance(d, sym.Range))
+        var_bound_dims = tuple(d for d in var.dimensions if not isinstance(d, sym.Range))
+        mapper = SubstituteExpressionsMapper(dict(zip(val_free_dims, var_bound_dims)))
+        return mapper(val)
+
     # Get local variable declarations and hoist them
     decls = FindNodes(VariableDeclaration).visit(member.spec)
     decls = tuple(d for d in decls if all(not s.type.intent for s in d.symbols))
@@ -218,8 +232,25 @@ def inline_member_routine(routine, member):
     call_map = {}
     for call in FindNodes(CallStatement).visit(routine.body):
         if call.routine == member:
+            argmap = {}
+            member_vars = FindVariables().visit(member.body)
+
+            # Match dimension indexes between the argument and the given value
+            # for all occurences of the argument in the body
+            for arg, val in call.arg_map.items():
+                if isinstance(arg, sym.Array):
+                    # Resolve implicit dimension ranges of the passed value,
+                    # eg. when passing a two-dimensional array `a` as `call(arg=a)`
+                    qualified_value = val if val.dimensions else val.clone(
+                        dimensions=tuple(sym.Range((None, None)) for _ in arg.shape)
+                    )
+                    arg_vars = tuple(v for v in member_vars if v.name == arg.name)
+                    argmap.update((v, _map_unbound_dims(v, qualified_value)) for v in arg_vars)
+                else:
+                    argmap[arg] = val
+
             # Substitute argument calls into a copy of the body
-            member_body = SubstituteExpressions(call.arg_map).visit(member.body.body)
+            member_body = SubstituteExpressions(argmap).visit(member.body.body)
 
             # Inline substituted body within a pair of marker comments
             comment = Comment(f'! [Loki] inlined member subroutine: {member.name}')

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -12,7 +12,7 @@ Collection of utility routines to perform code-level force-inlining.
 """
 from loki.expression import (
     FindVariables, FindInlineCalls, FindLiterals,
-    SubstituteExpressions, SubstituteExpressionsMapper, LokiIdentityMapper
+    SubstituteExpressions, LokiIdentityMapper
 )
 from loki.ir import Import, Comment, Assignment, VariableDeclaration, CallStatement
 from loki.expression import symbols as sym
@@ -20,7 +20,6 @@ from loki.types import BasicType
 from loki.visitors import Transformer, FindNodes
 from loki.tools import as_tuple
 from loki.logging import warning
-from loki.transform import recursive_expression_map_update
 
 
 __all__ = [
@@ -209,6 +208,8 @@ def inline_member_routine(routine, member):
     member : :any:`Subroutine`
         The contained member subroutine to be inlined in the parent
     """
+    # pylint: disable=import-outside-toplevel,cyclic-import
+    from loki.transform import recursive_expression_map_update
 
     def _map_unbound_dims(var, val):
         """

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -226,12 +226,7 @@ def inline_member_routine(routine, member):
         for index, dim in enumerate(var.dimensions):
             new_dimensions[indices[index]] = dim
 
-        original_symbol = sym.ArraySubscript(val.symbol, val.dimensions)
-        new_symbol = sym.ArraySubscript(val.symbol, tuple(new_dimensions) )
-
-        mapper = SubstituteExpressionsMapper({original_symbol:new_symbol})
-
-        return mapper(original_symbol)
+        return val.clone(dimensions=tuple(new_dimensions))
 
     # Prevent shadowing of member variables by renaming them a priori
     parent_variables = routine.variable_map

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -20,6 +20,7 @@ from loki.types import BasicType
 from loki.visitors import Transformer, FindNodes
 from loki.tools import as_tuple
 from loki.logging import warning
+from loki.transform import recursive_expression_map_update
 
 
 __all__ = [
@@ -261,6 +262,9 @@ def inline_member_routine(routine, member):
                     argmap.update((v, _map_unbound_dims(v, qualified_value)) for v in arg_vars)
                 else:
                     argmap[arg] = val
+
+            # Recursive update of the map in case of nested variables to map
+            argmap = recursive_expression_map_update(argmap, max_iterations=10)
 
             # Substitute argument calls into a copy of the body
             member_body = SubstituteExpressions(argmap).visit(member.body.body)

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -225,7 +225,7 @@ def inline_member_routine(routine, member):
 
     # Get local variable declarations and hoist them
     decls = FindNodes(VariableDeclaration).visit(member.spec)
-    decls = tuple(d for d in decls if all(not s.type.intent for s in d.symbols))
+    decls = tuple(d for d in decls if all(s.name not in routine._dummies for s in d.symbols))
     decls = tuple(d for d in decls if all(s not in routine.variables for s in d.symbols))
     routine.spec.append(decls)
 

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -102,10 +102,12 @@ def cli(debug):
               help="Generate offload instructions for global vars imported via 'USE' statements.")
 @click.option('--remove-derived-args/--no-remove-derived-args', default=False,
               help="Remove derived-type arguments and replace with canonical arguments")
+@click.option('--inline-members/--no-inline-members', default=False,
+              help='Inline member functions for SCC-class transformations.')
 def convert(
         mode, config, build, source, header, cpp, directive, include, define, omni_include, xmod,
         data_offload, remove_openmp, assume_deviceptr, frontend, trim_vector_sections,
-        global_var_offload, remove_derived_args
+        global_var_offload, remove_derived_args, inline_members
 ):
     """
     Batch-processing mode for Fortran-to-Fortran transformations that
@@ -190,7 +192,9 @@ def convert(
         horizontal = scheduler.config.dimensions['horizontal']
         vertical = scheduler.config.dimensions['vertical']
         block_dim = scheduler.config.dimensions['block_dim']
-        transformation = (SCCBaseTransformation(horizontal=horizontal, directive=directive),)
+        transformation = (SCCBaseTransformation(
+            horizontal=horizontal, directive=directive, inline_members=inline_members
+        ),)
         transformation += (SCCDevectorTransformation(horizontal=horizontal, trim_vector_sections=trim_vector_sections),)
         transformation += (SCCDemoteTransformation(horizontal=horizontal),)
         if not 'hoist' in mode:

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -988,6 +988,9 @@ def test_string_compare():
     assert symbols.Literal('u') == 'u'
     assert symbols.Literal('u') != 'U'
     assert symbols.Literal('u') != u  # The `Variable(name='u', ...) from above
+    assert symbols.Literal('.TrUe.') == 'true'
+    # Specific test for constructor checks
+    assert symbols.LogicLiteral(value=True) == 'true'
 
 
 @pytest.mark.skipif(not HAVE_FP, reason='Fparser not available')

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -12,13 +12,14 @@ import numpy as np
 from conftest import jit_compile, jit_compile_lib, available_frontends
 from loki import (
     Builder, Module, Subroutine, FindNodes, Import, FindVariables,
-    CallStatement, Loop, symbols as sym, BasicType, DerivedType, OMNI
+    CallStatement, Loop, BasicType, DerivedType, OMNI
 )
 from loki.ir import Assignment
 from loki.transform import (
     inline_elemental_functions, inline_constant_parameters,
     replace_selected_kind, inline_member_procedures
 )
+from loki.expression import symbols as sym
 
 @pytest.fixture(scope='module', name='here')
 def fixture_here():

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -471,15 +471,18 @@ def test_inline_member_routines_variable_shadowing(frontend):
 subroutine outer()
      real :: x = 3 ! 'x' is real in outer.
      real :: tmp = 0
-     call inner(tmp)
+     real :: y
+
+     y = 1.0
+     call inner(tmp, y=y)
      x = x + tmp
 
 contains
     subroutine inner(y)
-        real, intent(inout) :: y
+        real, intent(inout) :: Y
         real :: x(3) ! 'x' is array in inner.
         x = [1, 2, 3]
-        y = sum(x)
+        y = y + sum(x)
     end subroutine inner
 end subroutine outer
     """
@@ -501,7 +504,12 @@ end subroutine outer
     assert isinstance(routine.variable_map['x'], sym.Scalar)
     assert routine.variable_map['x'].type.initial == 3
 
-    # Check inner 'x' was move correctly
+    # Check inner 'x' was moved correctly
     assert routine.variable_map['inner_x'] in ['inner_x(3)', 'inner_x(1:3)']
     assert isinstance(routine.variable_map['inner_x'], sym.Array)
     assert routine.variable_map['inner_x'].type.shape == (3,)
+
+    # Check inner 'y' was substituted, not renamed!
+    assign = FindNodes(Assignment).visit(routine.body)
+    assert routine.variable_map['y'] == 'y'
+    assert assign[2].lhs == 'y' and assign[2].rhs == 'y + sum(x)'

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -357,3 +357,56 @@ end subroutine member_routines
 
     assert (a == [6., 7., 8.]).all()
     assert (b == [3., 3., 3.]).all()
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_inline_member_routines_arg_dimensions(frontend):
+    """
+    Test inlining of member subroutines when sub-arrays of rank less
+    than the formal argument are passed.
+    """
+    fcode = """
+subroutine member_routines_arg_dimensions(matrix, tensor)
+  real(kind=8), intent(inout) :: matrix(3, 3), tensor(3, 3, 4)
+  integer :: i
+  do i=1, 3
+    call add_one(3, matrix(:,i), tensor(1:3,i,:))
+  end do
+  contains
+    subroutine add_one(n, a, b)
+      integer, intent(in) :: n
+      real(kind=8), intent(inout) :: a(3), b(3,1:n)
+      integer :: j
+      do j=1, n
+        a(j) = a(j) + 1
+        b(j,:) = 66.6
+      end do
+    end subroutine
+end subroutine member_routines_arg_dimensions
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    # Ensure initial member arguments
+    assert len(routine.routines) == 1
+    assert routine.routines[0].name == 'add_one'
+    assert len(routine.routines[0].arguments) == 3
+    assert routine.routines[0].arguments[0].name == 'n'
+    assert routine.routines[0].arguments[1].name == 'a'
+    assert routine.routines[0].arguments[2].name == 'b'
+
+    # Now inline the member routines and check again
+    inline_member_procedures(routine=routine)
+
+    # Ensure member has been inlined and arguments adapated
+    assert len(routine.routines) == 0
+    assert len([v for v in FindVariables().visit(routine.body) if v.name == 'a']) == 0
+    assigns = FindNodes(Assignment).visit(routine.body)
+    assert len(assigns) == 2
+    assert assigns[0].lhs == 'matrix(j, i)' and assigns[0].rhs =='matrix(j, i) + 1'
+    assert assigns[1].lhs == 'tensor(j, i, :)'
+
+    # Ensure the `n` in the inner loop bound has been substituted too
+    loops = FindNodes(Loop).visit(routine.body)
+    assert len(loops) == 2
+    assert loops[0].bounds == '1:3'
+    assert loops[1].bounds == '1:3'


### PR DESCRIPTION
_Note: I'm filing this early to enable debugging with external use cases. It is entirely likely that I've missed edge cases and would like to weed these out early, if possible. Interested user should feel free to comment here with edge-cases that break this feature._

This PR brings in an initial implementation of an internally supported source-level member subroutine inlining utility that substitutes a call to a member routine (subroutine contained within another subroutine with a shared variable declaration space) with its body. This is then exposed to the SCC-style family of transformations via an option `inline_members`, both via the CMake interfaces and the general `loki_transform.py` head script ("convert" and "ecphys" mode).  

This will perform matching of sub-array argument references and map them to the corresponding partial local array indices; for example passing a sub-array to a one-dimensional array argument (`call routine(a=b(:, j)`) will map the local expression `a(i)` to `b(i, j)` in the substituted subroutine body.

The current implementation is limited to subroutines only (no functions, yet!) and only to members, although we are planning to extend this to more a generic source-inlining utility for generic subroutine calls soon.  