### PR TITLE
Statement function parsing on-the-fly

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1811,6 +1811,12 @@ class FParser2IR(GenericVisitor):
             rescope_symbols=True, source=source, incomplete=False
         )
 
+        # Once statement functions are in place, we need to update the original declaration symbol
+        for decl in FindNodes(ir.VariableDeclaration).visit(spec):
+            if any(routine.symbol_attrs[s.name].is_stmt_func for s in decl.symbols):
+                assert all(routine.symbol_attrs[s.name].is_stmt_func for s in decl.symbols)
+                decl._update(symbols=tuple(s.clone() for s in decl.symbols))
+
         # Big, but necessary hack:
         # For deferred array dimensions on allocatables, we infer the conceptual
         # dimension by finding any `allocate(var(<dims>))` statements.

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -24,7 +24,7 @@ except ImportError:
 from loki.visitors import GenericVisitor, Transformer, FindNodes
 from loki.frontend.source import Source
 from loki.frontend.preprocessing import sanitize_registry
-from loki.frontend.util import read_file, FP, inject_statement_functions, sanitize_ir
+from loki.frontend.util import read_file, FP, sanitize_ir
 from loki import ir
 import loki.expression.symbols as sym
 from loki.expression.operations import (
@@ -34,7 +34,7 @@ from loki.expression import (
     ExpressionDimensionsMapper, FindTypedSymbols, SubstituteExpressions, AttachScopesMapper
 )
 from loki.logging import debug, info, warning, error
-from loki.tools import as_tuple, flatten, CaseInsensitiveDict
+from loki.tools import as_tuple, flatten, CaseInsensitiveDict, LazyNodeLookup
 from loki.pragma_utils import (
     attach_pragmas, process_dimension_pragmas, detach_pragmas, pragmas_attached
 )
@@ -1811,9 +1811,6 @@ class FParser2IR(GenericVisitor):
         with pragmas_attached(routine, ir.VariableDeclaration):
             routine.spec = process_dimension_pragmas(routine.spec)
 
-        # Inject statement function definitions
-        inject_statement_functions(routine)
-
         if isinstance(o, Fortran2003.Subroutine_Body):
             # Return the subroutine object along with any clutter before it for interface declarations
             return (*pre, routine)
@@ -2912,8 +2909,39 @@ class FParser2IR(GenericVisitor):
         ptr = isinstance(o, Fortran2003.Pointer_Assignment_Stmt)
         lhs = self.visit(o.items[0], **kwargs)
         rhs = self.visit(o.items[2], **kwargs)
-        return ir.Assignment(lhs=lhs, rhs=rhs, ptr=ptr,
-                             label=kwargs.get('label'), source=kwargs.get('source'))
+
+        # Special-case: Identify statement functions using our internal symbol table
+        symbol_attrs = kwargs['scope'].symbol_attrs
+        if isinstance(lhs, sym.Array) and lhs.name in symbol_attrs:
+
+            def _create_stmt_func_type(stmt_func):
+                name = str(stmt_func.variable)
+                procedure = LazyNodeLookup(
+                    anchor=kwargs['scope'],
+                    query=lambda x: [
+                        f for f in FindNodes(ir.StatementFunction).visit(x.spec) if f.variable == name
+                    ][0]
+                )
+                proc_type = ProcedureType(is_function=True, procedure=procedure, name=name)
+                return SymbolAttributes(dtype=proc_type, is_stmt_func=True)
+
+            if not symbol_attrs[lhs.name].shape and not symbol_attrs[lhs.name].intent:
+                # If the LHS array access is actually declared as a scalar,
+                # we are actually dealing with a statement function!
+                stmt_func = ir.StatementFunction(
+                    variable=lhs.clone(dimensions=None), arguments=lhs.dimensions,
+                    rhs=rhs, return_type=symbol_attrs[lhs.name],
+                    label=kwargs.get('label'), source=kwargs.get('source')
+                )
+
+                # Update the type in the local scope and return stmt func node
+                symbol_attrs[str(stmt_func.variable)] = _create_stmt_func_type(stmt_func)
+                return stmt_func
+
+        # Return Assignment node if we don't have to deal with the stupid side of Fortran!
+        return ir.Assignment(
+            lhs=lhs, rhs=rhs, ptr=ptr, label=kwargs.get('label'), source=kwargs.get('source')
+        )
 
     visit_Pointer_Assignment_Stmt = visit_Assignment_Stmt
 

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -9,23 +9,18 @@ from enum import IntEnum
 from pathlib import Path
 import codecs
 
-from loki.visitors import (
-    Transformer, NestedTransformer, FindNodes, PatternFinder, SequenceFinder
-)
+from loki.visitors import NestedTransformer, FindNodes, PatternFinder, SequenceFinder
 from loki.ir import (
     Assignment, Comment, CommentBlock, VariableDeclaration, ProcedureDeclaration,
-    Loop, Intrinsic, Pragma, StatementFunction
+    Loop, Intrinsic, Pragma
 )
-from loki.expression import SubstituteExpressions, Scalar, Array, InlineCall, FindVariables, ProcedureSymbol
-from loki.types import ProcedureType, SymbolAttributes
-from loki.tools import LazyNodeLookup
 from loki.frontend.source import Source
 from loki.logging import warning
 
 __all__ = [
     'Frontend', 'OFP', 'OMNI', 'FP', 'REGEX',
     'inline_comments', 'cluster_comments', 'read_file',
-    'combine_multiline_pragmas', 'inject_statement_functions', 'sanitize_ir'
+    'combine_multiline_pragmas', 'sanitize_ir'
 ]
 
 
@@ -183,108 +178,6 @@ def combine_multiline_pragmas(ir):
                     collected_pragmas = []
 
     return NestedTransformer(pragma_mapper, invalidate_source=False).visit(ir)
-
-
-def inject_statement_functions(routine):
-    """
-    Identify statement function definitions and correct their
-    representation in the IR
-
-    Fparser misinterprets statement function definitions as array
-    assignments and may put them into the subroutine's body instead of
-    the spec. This function tries to identify them, correct the type of
-    the symbol_attrs representing statement functions (as :any:`ProcedureSymbol`)
-    and store their definition as :any:`StatementFunction`.
-
-    Parameters
-    ----------
-    routine : :any:`Subroutine`
-        The subroutine object for which statement functions should be
-        injected
-    """
-    def create_stmt_func(assignment):
-        arguments = assignment.lhs.dimensions
-        variable = assignment.lhs.clone(dimensions=None)
-        return StatementFunction(variable, arguments, assignment.rhs, variable.type, source=assignment.source)
-
-    def create_type(stmt_func):
-        name = str(stmt_func.variable)
-        procedure = LazyNodeLookup(
-            anchor=routine,
-            query=lambda x: [f for f in FindNodes(StatementFunction).visit(x.spec) if f.variable == name][0]
-        )
-        proc_type = ProcedureType(is_function=True, procedure=procedure, name=name)
-        return SymbolAttributes(dtype=proc_type, is_stmt_func=True)
-
-    # Only locally declared scalar variables are potential candidates
-    candidates = [str(v).lower() for v in routine.variables if isinstance(v, Scalar)]
-
-    # First suspects: Array assignments in the spec
-    spec_map = {}
-    for assignment in FindNodes(Assignment).visit(routine.spec):
-        if isinstance(assignment.lhs, Array) and assignment.lhs.name.lower() in candidates:
-            stmt_func = create_stmt_func(assignment)
-            spec_map[assignment] = stmt_func
-            routine.symbol_attrs[str(stmt_func.variable)] = create_type(stmt_func)
-
-    # Other suspects: Array assignments at the beginning of the body
-    spec_appendix = []
-    body_map = {}
-    for node in routine.body.body:
-        if isinstance(node, (Comment, CommentBlock)):
-            spec_appendix += [node]
-        if isinstance(node, Assignment) and isinstance(node.lhs, Array) and node.lhs.name.lower() in candidates:
-            stmt_func = create_stmt_func(node)
-            spec_appendix += [stmt_func]
-            body_map[node] = None
-            routine.symbol_attrs[str(stmt_func.variable)] = create_type(stmt_func)
-        else:
-            break
-
-    if spec_map or body_map:
-        # All statement functions
-        stmt_funcs = {node.lhs.name.lower() for node in spec_map}
-        stmt_funcs |= {node.lhs.name.lower() for node in body_map}
-
-        # Find any use of the statement functions in the body and replace
-        # them with function calls
-        expr_map_spec = {}
-        for variable in FindVariables().visit(routine.spec):
-            if variable.name.lower() in stmt_funcs:
-                if isinstance(variable, Array):
-                    parameters = variable.dimensions
-                    expr_map_spec[variable] = InlineCall(
-                        variable.clone(dimensions=None), parameters=parameters)
-                elif not isinstance(variable, ProcedureSymbol):
-                    expr_map_spec[variable] = variable.clone()
-        expr_map_body = {}
-        for variable in FindVariables().visit(routine.body):
-            if variable.name.lower() in stmt_funcs:
-                if isinstance(variable, Array):
-                    parameters = variable.dimensions
-                    expr_map_body[variable] = InlineCall(
-                        variable.clone(dimensions=None), parameters=parameters)
-                elif not isinstance(variable, ProcedureSymbol):
-                    expr_map_body[variable] = variable.clone()
-
-        # Make sure we remove comments from the body if we append them to spec
-        if any(isinstance(node, StatementFunction) for node in spec_appendix):
-            body_map.update({node: None for node in spec_appendix if isinstance(node, (Comment, CommentBlock))})
-
-        # Apply transformer with the built maps
-        if spec_map:
-            routine.spec = Transformer(spec_map, invalidate_source=False).visit(routine.spec)
-        if body_map:
-            routine.body = Transformer(body_map, invalidate_source=False).visit(routine.body)
-            if spec_appendix:
-                routine.spec.append(spec_appendix)
-        if expr_map_spec:
-            routine.spec = SubstituteExpressions(expr_map_spec, invalidate_source=False).visit(routine.spec)
-        if expr_map_body:
-            routine.body = SubstituteExpressions(expr_map_body, invalidate_source=False).visit(routine.body)
-
-        # And make sure all symbols have the right type
-        routine.rescope_symbols()
 
 
 def sanitize_ir(_ir, frontend, pp_registry=None, pp_info=None):

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1308,7 +1308,7 @@ contains
   subroutine nested_routine(a, n)
     use some_mod, only: ext2
     integer, parameter :: jpim = selected_int_kind(4)
-    integer, intent(inout) :: a
+    integer, intent(inout) :: a(n)
     integer, intent(in) :: n
     integer(kind=jpim) :: j
 
@@ -1418,7 +1418,7 @@ contains
 
   subroutine nested_routine(a, n)
     use some_mod, only: ext2
-    integer, intent(inout) :: a
+    integer, intent(inout) :: a(n)
     integer, intent(in) :: n
     integer :: j
 

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1492,14 +1492,16 @@ subroutine subroutine_stmt_func(a, b)
     implicit none
     integer, intent(in) :: a
     integer, intent(out) :: b
+    integer :: array(a)
     integer :: i, j
     integer :: plus, minus
     plus(i, j) = i + j
     minus(i, j) = i - j
     integer :: mult
-    mult(i, j) = i * j
     integer :: tmp
+    mult(i, j) = i * j
 
+    array(i) = i
     tmp = plus(a, 5)
     tmp = minus(tmp, 1)
     b = mult(2, tmp)


### PR DESCRIPTION
Previously, statement functions (on of the true beauties of the Fortran standard!) have been retro-fitted to the IR after an initial parse, since the FParser frontend cannot distinguish them from regular array accesses without type information. As pointer out in issue #104, the Loki FP frontend can also fall into the trap of getting this wrong by preprending the last stmt function to the subroutine body instead of appending it to the spec.

This PR now fixes the statement function detection by using our internal symbol table to detect them on-the-fly and thus construct them as part of the original parse. This avoids some very(!) costly IR transformations (rebuilds) that we otherwise perform routinely. Since the StmtFunc objects are already in the partial IRs for spec and body, re-shuffling the mismatch between body and spec is not much easier and can be done before creating the final `Subroutine` object.

This PR now does:
* Detect StmtFuncs in FP frontend by looking for explicitly defined scalars that are used with notation on the LHS of an assignment
* Before finalising the `Subroutine`, look for stray StmtFuncs at the beginning of the body
* Update the original Scalar declaration symbol after the subroutine is finalized; this is needed as the `NodeLazyLookup` requires all declarations to be attached to the spec
* Adjust the existing StmtFunction test to capture the corner-case in issue #104.
* Remove the now obsolete retro-fitting utility

The PR seems to drop the full-parsing time of CLOUDSC (dwarf version) by about 25%, which is a nice side-effect, and has been verified with EC-physics regression.

One final note (@reuterbal), it might make sense to create a dedicated `Procedure` => `Subroutine` | `Function` | StmtFunction` set of classes, with Procedure an ACB, to fully capture the specific procedure types. This would then allow the explicit "nesting" of StmtFuncs in the IR without the use of the `LazyNodeLookup`, as it would create a StmtFunc as a scope in its own right. But that's just meant as food for thought. :wink: 