### PR TITLE
Fix type update behaviour in expression clones

### DIFF
--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -815,16 +815,10 @@ class Variable:
         scope = kwargs.get('scope')
         _type = kwargs.get('type')
 
-        if scope is not None and (_type is None or _type.dtype is BasicType.DEFERRED):
+        if scope is not None and _type is None:
             # Try to determine stored type information if we have no or only deferred type
-            stored_type = cls._get_type_from_scope(name, scope, kwargs.get('parent'))
-            if _type is None:
-                _type = stored_type
-            elif stored_type is not None:
-                if stored_type.dtype is not BasicType.DEFERRED or not _type.attributes:
-                    # If provided and stored are deferred but attributes given, we use provided
-                    _type = stored_type
-            kwargs['type'] = _type
+            _type = cls._get_type_from_scope(name, scope, kwargs.get('parent'))
+        kwargs['type'] = _type
 
         if _type and isinstance(_type.dtype, ProcedureType):
             # This is the name in a function/subroutine call

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -286,7 +286,7 @@ class TypedSymbol:
             if _type.dtype.typedef is BasicType.DEFERRED:
                 return ()
             return tuple(
-                v.clone(name=f'{self.name}%{v.name}', scope=self.scope, parent=self)
+                v.clone(name=f'{self.name}%{v.name}', scope=self.scope, type=v.type, parent=self)
                 for v in _type.dtype.typedef.variables
             )
         return None
@@ -328,8 +328,12 @@ class TypedSymbol:
             kwargs['name'] = self.name
         if 'scope' not in kwargs and self.scope:
             kwargs['scope'] = self.scope
-        if 'type' not in kwargs and self.type:
-            kwargs['type'] = self.type
+        if 'type' not in kwargs:
+            # If no type is given, check new scope
+            if 'scope' in kwargs and kwargs['scope'] and kwargs['name'] in kwargs['scope'].symbol_attrs:
+                kwargs['type'] = kwargs['scope'].symbol_attrs[kwargs['name']]
+            else:
+                kwargs['type'] = self.type
         if 'parent' not in kwargs and self.parent:
             kwargs['parent'] = self.parent
 

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -820,7 +820,7 @@ class Variable:
         _type = kwargs.get('type')
 
         if scope is not None and _type is None:
-            # Try to determine stored type information if we have no or only deferred type
+            # Determine type information from scope if not provided explicitly
             _type = cls._get_type_from_scope(name, scope, kwargs.get('parent'))
         kwargs['type'] = _type
 

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -30,10 +30,7 @@ import loki.expression.symbols as sym
 from loki.expression.operations import (
     StringConcat, ParenthesisedAdd, ParenthesisedMul, ParenthesisedDiv, ParenthesisedPow
 )
-from loki.expression import (
-    ExpressionDimensionsMapper, FindTypedSymbols,
-    SubstituteExpressions, AttachScopes, AttachScopesMapper
-)
+from loki.expression import ExpressionDimensionsMapper, AttachScopes, AttachScopesMapper
 from loki.logging import debug, info, warning, error
 from loki.tools import as_tuple, flatten, CaseInsensitiveDict
 from loki.pragma_utils import (

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1126,7 +1126,7 @@ def test_variable_rebuild(initype, inireftype, newtype, newreftype):
     (None, symbols.DeferredTypeSymbol, SymbolAttributes(BasicType.INTEGER), symbols.Scalar),
     # From Scalar to other type
     (SymbolAttributes(BasicType.INTEGER), symbols.Scalar,
-     SymbolAttributes(BasicType.DEFERRED), symbols.Scalar),  # Providing DEFERRED doesn't change type
+     SymbolAttributes(BasicType.DEFERRED), symbols.DeferredTypeSymbol),
     (SymbolAttributes(BasicType.INTEGER), symbols.Scalar,
      SymbolAttributes(BasicType.INTEGER, shape=(symbols.Literal(3),)), symbols.Array),
     (SymbolAttributes(BasicType.INTEGER), symbols.Scalar,
@@ -1135,12 +1135,12 @@ def test_variable_rebuild(initype, inireftype, newtype, newreftype):
     (SymbolAttributes(BasicType.INTEGER, shape=(symbols.Literal(4),)), symbols.Array,
      SymbolAttributes(BasicType.INTEGER), symbols.Scalar),
     (SymbolAttributes(BasicType.INTEGER, shape=(symbols.Literal(4),)), symbols.Array,
-     SymbolAttributes(BasicType.DEFERRED), symbols.Array),  # Providing DEFERRED doesn't change type
+     SymbolAttributes(BasicType.DEFERRED), symbols.DeferredTypeSymbol),
     (SymbolAttributes(BasicType.INTEGER, shape=(symbols.Literal(4),)), symbols.Array,
      SymbolAttributes(ProcedureType('foo')), symbols.ProcedureSymbol),
     # From ProcedureSymbol to other type
     (SymbolAttributes(ProcedureType('foo')), symbols.ProcedureSymbol,
-     SymbolAttributes(BasicType.DEFERRED), symbols.ProcedureSymbol),  # Providing DEFERRED doesn't change type
+     SymbolAttributes(BasicType.DEFERRED), symbols.DeferredTypeSymbol),
     (SymbolAttributes(ProcedureType('foo')), symbols.ProcedureSymbol,
      SymbolAttributes(BasicType.INTEGER), symbols.Scalar),
     (SymbolAttributes(ProcedureType('foo')), symbols.ProcedureSymbol,

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1186,7 +1186,7 @@ def test_variable_clone_type(initype, newtype, reftype):
     scope = Scope()
     var = symbols.Variable(name='var', scope=scope, type=initype)
     assert 'var' in scope.symbol_attrs
-    new = var.clone(type=newtype)
+    new = var.clone(type=newtype)  # pylint: disable=no-member
     assert new.type == reftype
 
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1244,12 +1244,12 @@ def test_variable_without_scope():
     assert isinstance(rescoped_var, symbols.Scalar)
     assert rescoped_var.type.dtype is BasicType.REAL
     assert scope.symbol_attrs['var'].dtype is BasicType.REAL
-    # Re-attach the scope (overwrites scope-stored type with local type)
+    # Re-attach the scope (uses scope-stored type over local type)
     var = var.clone(scope=scope)
     assert var.scope is scope
     assert isinstance(var, symbols.Scalar)
-    assert var.type.dtype is BasicType.LOGICAL
-    assert scope.symbol_attrs['var'].dtype is BasicType.LOGICAL
+    assert var.type.dtype is BasicType.REAL
+    assert scope.symbol_attrs['var'].dtype is BasicType.REAL
 
 
 @pytest.mark.skipif(not HAVE_FP, reason='Fparser not available')


### PR DESCRIPTION
_Note the problem this PR intends to fix is the underlying problem to the symptoms reported in #128. Many thanks to @rolfhm for providing the MFE that helped triage this._

This PR adds a test and fixes certain corner cases for type updates of symbols via `symbol.clone(type-<...>)`. The key problem is that there were edge-cases where we would preserve existing type info stored in the associated scope of the symbol, if the new type was deemed inadequate. This PR now simplifies this logic and only ignores the incoming type if it is `None`, as we do not allow `None` type info in the symbol table (`BaseType.DEFERRED` signifies unknown types). 

In addition, a test was added that pins down the intended behaviour for plain scalar symbols. In the future this could be extended to procedures etc., but this felt overkill for the current problem. 

I've also needed to change the scope handling logic in the fparser-based standalone expression parsing utility, where we can never gain type info (no declarations in expressions), but would wipe existing type info by setting it to DEFERRED. We now instead use a dummy to parse expressions and suppress that info in the subsequent rescoping (see inline comments).   