### PR TITLE
Make derived argument flattening optional in loki_transform convert

### DIFF
--- a/cmake/loki_transform.cmake
+++ b/cmake/loki_transform.cmake
@@ -182,7 +182,7 @@ endmacro()
 #       [OMNI_INCLUDE <omni-inc1> [<omni-inc2> ...]]
 #       [XMOD <xmod-dir1> [<xmod-dir2> ...]]
 #       [REMOVE_OPENMP] [DATA_OFFLOAD] [GLOBAL_VAR_OFFLOAD]
-#       [TRIM_VECTOR_SECTIONS]
+#       [TRIM_VECTOR_SECTIONS] [NO_REMOVE_DERIVED_ARGS]
 #   )
 #
 # Call ``loki-transform.py convert ...`` with the provided arguments.
@@ -199,7 +199,7 @@ endmacro()
 
 function( loki_transform_convert )
 
-    set( options CPP DATA_OFFLOAD REMOVE_OPENMP GLOBAL_VAR_OFFLOAD TRIM_VECTOR_SECTIONS )
+    set( options CPP DATA_OFFLOAD REMOVE_OPENMP GLOBAL_VAR_OFFLOAD TRIM_VECTOR_SECTIONS NO_REMOVE_DERIVED_ARGS )
     set( oneValueArgs MODE DIRECTIVE FRONTEND CONFIG PATH OUTPATH )
     set( multiValueArgs OUTPUT DEPENDS INCLUDES INCLUDE HEADERS HEADER DEFINITIONS DEFINE OMNI_INCLUDE XMOD )
 
@@ -242,6 +242,10 @@ function( loki_transform_convert )
 
     if( ${_PAR_TRIM_VECTOR_SECTIONS} )
         list( APPEND _ARGS --trim-vector-sections )
+    endif()
+
+    if( ${_PAR_NO_REMOVE_DERIVED_ARGS} )
+        list( APPEND _ARGS --no-remove-derived-args )
     endif()
 
     _loki_transform_env_setup()

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -148,8 +148,13 @@ def cli(debug):
               help='Trim vector loops in SCC transform to exclude scalar assignments.')
 @click.option('--global-var-offload', is_flag=True, default=False,
               help="Generate offload instructions for global vars imported via 'USE' statements.")
-def convert(out_path, path, header, cpp, directive, include, define, omni_include, xmod,
-            data_offload, remove_openmp, mode, frontend, config, trim_vector_sections, global_var_offload):
+@click.option('--remove-derived-args/--no-remove-derived-args', default=True,
+              help="Remove derived-type arguments and replace with canonical arguments")
+def convert(
+        out_path, path, header, cpp, directive, include, define, omni_include, xmod,
+        data_offload, remove_openmp, mode, frontend, config, trim_vector_sections,
+        global_var_offload, remove_derived_args
+):
     """
     Single Column Abstraction (SCA): Convert kernel into single-column
     format and adjust driver to apply it over in a horizontal loop.
@@ -191,7 +196,8 @@ def convert(out_path, path, header, cpp, directive, include, define, omni_includ
                           definitions=definitions, **build_args)
 
     # First, remove all derived-type arguments; caller first!
-    scheduler.process(transformation=DerivedTypeArgumentsTransformation())
+    if remove_derived_args:
+        scheduler.process(transformation=DerivedTypeArgumentsTransformation())
 
     # Remove DR_HOOK and other utility calls first, so they don't interfere with SCC loop hoisting
     if 'scc' in mode:


### PR DESCRIPTION
Unlike the `ecphys` entry point, `loki_transform.py convert` always applies the `DerivedTypeArgumentTransformation`. This PR adds a switch to allow overriding this behaviour (default `True`, as before), and extends the CMake API with a similar override option. 