### PR TITLE
Expression mappers: Remove recurse_to_parent option and recurse by default

### DIFF
--- a/docs/source/visitors.rst
+++ b/docs/source/visitors.rst
@@ -187,7 +187,6 @@ visitors exist that apply :any:`ExpressionRetriever` to all expression trees.
    loki.expression.expr_visitors.FindVariables
    loki.expression.expr_visitors.FindInlineCalls
    loki.expression.expr_visitors.FindLiterals
-   loki.expression.expr_visitors.FindExpressionRoot
 
 For example, the following finds all function calls embedded in expressions
 (:any:`InlineCall`, as opposed to subroutine calls in :any:`CallStatement`):

--- a/lint_rules/tests/test_ifs_coding_standards_2011.py
+++ b/lint_rules/tests/test_ifs_coding_standards_2011.py
@@ -724,12 +724,20 @@ end subroutine test_routine
     keywords = ('Fortran90OperatorsRule', '[4.15]', 'Use Fortran 90 comparison operator')
     assert all(all(keyword in msg for keyword in keywords) for msg in messages)
 
-    f77_f90_line = (('.ne.', '/=', '7'), ('.eq.', '==', '7'),
-                    ('.lt.', '<', '6'), ('.gt.', '>', '6'),
-                    ('.le.', '<=', '5'), ('.ge.', '>=', '5'),
-                    ('.gt.', '>', '26'), ('.gt.', '>', '32'),
-                    ('.eq.', '==', '29'), ('.gt.', '>', '25'),
-                    ('.le.', '<=', '23'))
+    # Check that violations are reported in the right order
+    f77_f90_line = (
+        ('.le.', '<=', '5'),
+        ('.ge.', '>=', '5'),
+        ('.lt.', '<', '6'),
+        ('.gt.', '>', '6'),
+        ('.ne.', '/=', '7'),
+        ('.eq.', '==', '7'),
+        ('.le.', '<=', '23'),
+        ('.gt.', '>', '25'),
+        ('.gt.', '>', '26'),
+        ('.eq.', '==', '29'),
+        ('.gt.', '>', '32'),
+    )
 
     for keywords, message in zip(f77_f90_line, messages):
         assert all(str(keyword) in message for keyword in keywords)

--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -22,8 +22,7 @@ from loki.expression.symbols import (
 
 __all__ = [
     'FindExpressions', 'FindVariables', 'FindTypedSymbols', 'FindInlineCalls',
-    'FindLiterals', 'FindExpressionRoot', 'SubstituteExpressions',
-    'ExpressionFinder', 'AttachScopes'
+    'FindLiterals', 'SubstituteExpressions', 'ExpressionFinder', 'AttachScopes'
 ]
 
 
@@ -204,24 +203,6 @@ class FindLiterals(ExpressionFinder):
         literal_types = (FloatLiteral, IntLiteral, LogicLiteral, StringLiteral, IntrinsicLiteral)
         self._retriever = ExpressionRetriever(lambda e: isinstance(e, literal_types))
         super().__init__(retrieve=self._retriever.retrieve, **kwargs)
-
-
-class FindExpressionRoot(ExpressionFinder):
-    """
-    A visitor to obtain the root node of the expression tree in which a given
-    :class:`pymbolic.primitives.Expression` is located.
-
-    Parameters
-    ----------
-    expr : :any:`pymbolic.primitives.Expression`
-        The expression for which to find the root node
-    """
-    def __init__(self, expr, **kwargs):
-        self._retriever = ExpressionRetriever(lambda e: e is expr)
-        if kwargs.get('unique'):
-            raise ValueError('FindExpressionRoot requires unique=False')
-        kwargs['unique'] = False
-        super().__init__(retrieve=lambda e: e if self._retriever.retrieve(e) else (), **kwargs)
 
 
 class SubstituteExpressions(Transformer):

--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -149,17 +149,10 @@ class FindExpressions(ExpressionFinder):
     (i.e., :class:`pymbolic.primitives.Expression`) in an IR tree.
 
     See :any:`ExpressionFinder`
-
-    Parameters
-    ----------
-    recurse_to_parent : bool, optional
-        For symbols that belong to a derived type, recurse also to the
-        ``parent`` of that symbol (default: `True`)
     """
 
-    def __init__(self, recurse_to_parent=True, **kwargs):
-        self._retriever = ExpressionRetriever(lambda e: isinstance(e, Expression),
-                                              recurse_to_parent=recurse_to_parent)
+    def __init__(self, **kwargs):
+        self._retriever = ExpressionRetriever(lambda e: isinstance(e, Expression))
         super().__init__(retrieve=self._retriever.retrieve, **kwargs)
 
 
@@ -168,16 +161,9 @@ class FindTypedSymbols(ExpressionFinder):
     A visitor to collect all :any:`TypedSymbol` used in an IR tree.
 
     See :any:`ExpressionFinder`
-
-    Parameters
-    ----------
-    recurse_to_parent : bool, optional
-        For symbols that belong to a derived type, recurse also to the
-        ``parent`` of that symbol (default: `True`)
     """
-    def __init__(self, recurse_to_parent=True, **kwargs):
-        self._retriever = ExpressionRetriever(lambda e: isinstance(e, TypedSymbol),
-                                              recurse_to_parent=recurse_to_parent)
+    def __init__(self, **kwargs):
+        self._retriever = ExpressionRetriever(lambda e: isinstance(e, TypedSymbol))
         super().__init__(retrieve=self._retriever.retrieve, **kwargs)
 
 
@@ -189,16 +175,9 @@ class FindVariables(ExpressionFinder):
     :any:`DeferredTypeSymbol`.
 
     See :class:`ExpressionFinder` for further details
-
-    Parameters
-    ----------
-    recurse_to_parent : bool, optional
-        For symbols that belong to a derived type, recurse also to the
-        ``parent`` of that symbol (default: `True`)
     """
-    def __init__(self, recurse_to_parent=True, **kwargs):
-        self._retriever = ExpressionRetriever(lambda e: isinstance(e, (Scalar, Array, DeferredTypeSymbol)),
-                                              recurse_to_parent=recurse_to_parent)
+    def __init__(self, **kwargs):
+        self._retriever = ExpressionRetriever(lambda e: isinstance(e, (Scalar, Array, DeferredTypeSymbol)))
         super().__init__(retrieve=self._retriever.retrieve, **kwargs)
 
 
@@ -207,16 +186,9 @@ class FindInlineCalls(ExpressionFinder):
     A visitor to collect all :any:`InlineCall` symbols used in an IR tree.
 
     See :class:`ExpressionFinder`
-
-    Parameters
-    ----------
-    recurse_to_parent : bool, optional
-        For symbols that belong to a derived type, recurse also to the
-        ``parent`` of that symbol (default: `True`)
     """
-    def __init__(self, recurse_to_parent=True, **kwargs):
-        self._retriever = ExpressionRetriever(lambda e: isinstance(e, InlineCall),
-                                              recurse_to_parent=recurse_to_parent)
+    def __init__(self, **kwargs):
+        self._retriever = ExpressionRetriever(lambda e: isinstance(e, InlineCall))
         super().__init__(retrieve=self._retriever.retrieve, **kwargs)
 
 
@@ -227,17 +199,10 @@ class FindLiterals(ExpressionFinder):
     and :any:`IntrinsicLiteral`) used in an IR tree.
 
     See :class:`ExpressionFinder`
-
-    Parameters
-    ----------
-    recurse_to_parent : bool, optional
-        For symbols that belong to a derived type, recurse also to the
-        ``parent`` of that symbol (default: `True`)
     """
-    def __init__(self, recurse_to_parent=True, **kwargs):
+    def __init__(self, **kwargs):
         literal_types = (FloatLiteral, IntLiteral, LogicLiteral, StringLiteral, IntrinsicLiteral)
-        self._retriever = ExpressionRetriever(lambda e: isinstance(e, literal_types),
-                                              recurse_to_parent=recurse_to_parent)
+        self._retriever = ExpressionRetriever(lambda e: isinstance(e, literal_types))
         super().__init__(retrieve=self._retriever.retrieve, **kwargs)
 
 
@@ -250,12 +215,9 @@ class FindExpressionRoot(ExpressionFinder):
     ----------
     expr : :any:`pymbolic.primitives.Expression`
         The expression for which to find the root node
-    recurse_to_parent : bool, optional
-        For symbols that belong to a derived type, recurse also to the
-        ``parent`` of that symbol (default: `True`)
     """
-    def __init__(self, expr, recurse_to_parent=True, **kwargs):
-        self._retriever = ExpressionRetriever(lambda e: e is expr, recurse_to_parent=recurse_to_parent)
+    def __init__(self, expr, **kwargs):
+        self._retriever = ExpressionRetriever(lambda e: e is expr)
         if kwargs.get('unique'):
             raise ValueError('FindExpressionRoot requires unique=False')
         kwargs['unique'] = False

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -419,6 +419,9 @@ class ExpressionCallbackMapper(CombineMapper):
         self.callback = callback
         self.combine = combine
 
+    def retrieve(self, expr, *args, **kwargs):
+        return self(expr, *args, **kwargs)
+
     def map_constant(self, expr, *args, **kwargs):
         return self.callback(expr, *args, **kwargs)
 

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -216,23 +216,13 @@ class LokiWalkMapper(WalkMapper):
     """
     A mapper that traverses the expression tree and calls :meth:`visit`
     for each visited node.
-
-    Parameters
-    ----------
-    recurse_to_parent : bool, optional
-        For symbols that belong to a derived type, recurse also to the
-        ``parent`` of that symbol (default: `True`)
     """
     # pylint: disable=abstract-method
-
-    def __init__(self, recurse_to_parent=True):
-        super().__init__()
-        self.recurse_to_parent = recurse_to_parent
 
     def map_variable_symbol(self, expr, *args, **kwargs):
         if not self.visit(expr):
             return
-        if self.recurse_to_parent and expr.parent:
+        if expr.parent:
             self.rec(expr.parent, *args, **kwargs)
         self.post_visit(expr, *args, **kwargs)
 

--- a/loki/transform/transform_utilities.py
+++ b/loki/transform/transform_utilities.py
@@ -200,9 +200,7 @@ def find_and_eliminate_unused_imports(routine):
     # We need a custom expression retriever that does not return symbols used in Imports
     class SymbolRetriever(ExpressionFinder):
 
-        def __init__(self):
-            self._retriever = ExpressionRetriever(lambda e: isinstance(e, (TypedSymbol, MetaSymbol)))
-            super().__init__(retrieve=self._retriever.retrieve)
+        retriever = ExpressionRetriever(lambda e: isinstance(e, (TypedSymbol, MetaSymbol)))
 
         def visit_Import(self, o, **kwargs):  # pylint: disable=unused-argument
             return ()

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -244,7 +244,6 @@ END ASSOCIATE
 END SUBROUTINE
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    assert len(FindVariables(recurse_to_parent=False).visit(routine.body)) == 3
     variables = {v.name: v for v in FindVariables().visit(routine.body)}
     assert len(variables) == 4
     some_var = variables['SOME_VAR']

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -1266,7 +1266,7 @@ end module attach_scopes_associates_mod
     assert len(associates) == 2
     assignment = FindNodes(Assignment).visit(routine.body)
     assert len(assignment) == 1
-    assert len(FindVariables(recurse_to_parent=False).visit(assignment)) == 2
+    assert len(FindVariables().visit(assignment)) == 3
     var_map = {str(var): var for var in FindVariables().visit(assignment)}
     assert len(var_map) == 3
     assert associates[1].parent is associates[0]

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -12,8 +12,8 @@ from conftest import available_frontends
 from loki import (
     OMNI,
     Module, Subroutine, Section, Loop, Assignment, Conditional, Sum, Associate,
-    Array, ArraySubscript, LoopRange, IntLiteral, FloatLiteral, LogicLiteral, Comparison, Cast,
-    FindNodes, FindExpressions, FindVariables, ExpressionFinder, FindExpressionRoot,
+    Array, ArraySubscript, LoopRange, IntLiteral, FloatLiteral, LogicLiteral,
+    FindNodes, FindVariables, ExpressionFinder,
     ExpressionCallbackMapper, ExpressionRetriever, Stringifier, Transformer,
     NestedTransformer, MaskedTransformer, NestedMaskedTransformer, SubstituteExpressions,
     is_parent_of, is_child_of, fgen, FindScopes, Intrinsic
@@ -327,87 +327,6 @@ end subroutine routine_simple
     else:
         assert len(literals) == 2
         assert sorted([str(l) for l in literals]) == ['1.', '2']
-
-
-@pytest.mark.parametrize('frontend', available_frontends())
-def test_find_expression_root(frontend):
-    """
-    Test basic functionality of FindExpressionRoot.
-    """
-    fcode = """
-subroutine routine_simple (x, y, scalar, vector, matrix)
-  integer, parameter :: jprb = selected_real_kind(13,300)
-  integer, intent(in) :: x, y
-  real(kind=jprb), intent(in) :: scalar
-  real(kind=jprb), intent(inout) :: vector(x), matrix(x, y)
-  integer :: i, j
-
-  do i=1, x
-    vector(i) = vector(i) + scalar
-    do j=1, y
-      if (j > i) then
-        matrix(i, j) = real(i * j, kind=jprb) + 1.
-      else
-        matrix(i, j) = i * vector(j)
-      end if
-    end do
-  end do
-end subroutine routine_simple
-"""
-
-    # Test the internals of the subroutine
-    routine = Subroutine.from_source(fcode, frontend=frontend)
-
-    exprs = FindExpressions().visit(routine.body)
-    assert len(exprs) == (33 if frontend == OMNI else 31)  # OMNI substitutes jprb in the Cast
-
-    # Test ability to find root if searching for root
-    comps = [e for e in exprs if isinstance(e, Comparison)]
-    assert len(comps) == 1
-    comp_root = FindExpressionRoot(comps[0]).visit(routine.body)
-    assert len(comp_root) == 1
-    assert comp_root[0] is comps[0]
-
-    # Test ability to find root if searching for intermediate expression
-    casts = [e for e in exprs if isinstance(e, Cast)]
-    assert len(casts) == 1
-    cast_root = FindExpressionRoot(casts[0]).visit(routine.body)
-    assert len(cast_root) == 1
-    cond = FindNodes(Conditional).visit(routine.body).pop()
-    assert cast_root[0] is cond.body[0].rhs
-
-    # Test ability to find root if searching for a leaf expression
-    retriever = ExpressionRetriever(lambda e: isinstance(e, FloatLiteral))
-    literals = ExpressionFinder(retrieve=retriever.retrieve, with_ir_node=True).visit(routine.body)
-    assert len(literals) == 1
-    assert isinstance(literals[0][0], Assignment) and literals[0][0].source.lines == (13, 13)
-
-    literal_root = FindExpressionRoot(literals[0][1].pop()).visit(literals[0][0])
-    assert literal_root[0] is cast_root[0]
-
-
-@pytest.mark.parametrize('frontend', available_frontends())
-def test_find_expression_root_constructor_args(frontend):
-    """
-    Test correct handling for various constructor arguments
-    """
-    fcode = """
-subroutine my_routine
-    implicit none
-    integer :: i
-    i = 1 + 1
-end subroutine my_routine
-    """.strip()
-
-    routine = Subroutine.from_source(fcode, frontend=frontend)
-    exprs = FindExpressions().visit(routine.body)
-    some_expr = [expr for expr in exprs if isinstance(expr, IntLiteral)][0]
-
-    with pytest.raises(ValueError):
-        FindExpressionRoot(some_expr, unique=True).visit(routine.body)
-
-    expr_root = FindExpressionRoot(some_expr, unique=False).visit(routine.body)
-    assert expr_root == (routine.body.body[0].rhs,)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
This fixes the symptom described in #133.

The retrieval function for IR visitors that recurse into expression trees is defined as a static method on the class of each such visitor. While the current way how this is being installed is debatable, it is conceptually correct. However, a later addition allowed to parameterize this retrieval function by providing the option to not recurse to "parents" of expression nodes (the `recurse_to_parent` option). This causes problems, because multiple instances of the same class may then use different variations and consequently change the behaviour of existing objects.

This option relates to the used of derived type member variables, where e.g., a lookup of symbols would then yield, say `a%b%c`, `a%b` and `a` - but return only `a%b%c` if that recursion is switched off.

The option has only been switched off in very few places and there wasn't a hard dependency on it's functionality (only true use case was in the derived type flattening where the filtering can be done post-visitor as well). Therefore, I removed the option and made recursion the default behaviour.