### PR TITLE
Extend SCC transformation to loops in driver

### DIFF
--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -426,8 +426,8 @@ def test_scc_hoist_multiple_kernels_loops(frontend, horizontal, vertical, blocki
 
     tmp = 0.0
 
+    !$loki driver-loop
     do b=1, nb
-      !$loki driver-loop
       end = nlon - nb
       !$loki separator
       do jk = 2, nz
@@ -458,8 +458,8 @@ def test_scc_hoist_multiple_kernels_loops(frontend, horizontal, vertical, blocki
       END DO
     end do
 
+    !$loki driver-loop
     do b=3, nb
-      !$loki driver-loop
       end = nlon - nb
       !$loki separator
       do jk = 2, nz

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -5,6 +5,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from shutil import rmtree
+
 import pytest
 
 from loki import (
@@ -498,7 +500,7 @@ CONTAINS
 END MODULE kernel_mod
 """.strip()
 
-    basedir = gettempdir() / 'test_pool_allocator_args_vs_kwargs'
+    basedir = gettempdir() / 'test_scc_hoist_multiple_kernels_loops'
     basedir.mkdir(exist_ok=True)
     (basedir / 'driver.F90').write_text(fcode_driver)
     (basedir / 'kernel.F90').write_text(fcode_kernel)
@@ -593,6 +595,8 @@ END MODULE kernel_mod
     assert driver_loops[9].bounds == 'start:end'
     assert driver_loops[10].variable == 'jk'
     assert driver_loops[10].bounds == '2:nz'
+
+    rmtree(basedir)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -526,9 +526,9 @@ END MODULE kernel_mod
     transformation += (SCCDevectorTransformation(horizontal=horizontal, trim_vector_sections=False),)
     transformation += (SCCDemoteTransformation(horizontal=horizontal),)
     transformation += (SCCRevectorTransformation(horizontal=horizontal),)
-    transformation += (SCCAnnotateTransformation(horizontal=horizontal, vertical=vertical,
-                                                 directive='openacc', block_dim=blocking,
-                                                 hoist_column_arrays=False),)
+    transformation += (SCCAnnotateTransformation(
+        horizontal=horizontal, vertical=vertical, directive='openacc', block_dim=blocking,
+    ),)
     for transform in transformation:
         scheduler.process(transformation=transform)
 

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -513,7 +513,8 @@ class SCCAnnotateTransformation(Transformation):
         if self.directive == 'openacc':
             self.insert_annotations(routine, self.horizontal, self.vertical)
 
-        # Remove section wrappers
+        # Remove the vector section wrappers
+        # These have been inserted by SCCDevectorTransformation
         section_mapper = {s: s.body for s in FindNodes(ir.Section).visit(routine.body) if s.label == 'vector_section'}
         if section_mapper:
             routine.body = Transformer(section_mapper).visit(routine.body)
@@ -556,6 +557,8 @@ class SCCAnnotateTransformation(Transformation):
                 self.kernel_annotate_sequential_loops_openacc(routine, self.horizontal, self.block_dim,
                                                               ignore=driver_loops)
 
+        # Remove the vector section wrappers
+        # These have been inserted by SCCDevectorTransformation
         section_mapper = {s: s.body for s in FindNodes(ir.Section).visit(routine.body) if s.label == 'vector_section'}
         if section_mapper:
             routine.body = Transformer(section_mapper).visit(routine.body)

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -200,7 +200,7 @@ class SCCBaseTransformation(Transformation):
             routine.variables += as_tuple(loop_variable)
 
     @staticmethod
-    def is_driver_loop(loop, routine, targets):
+    def is_driver_loop(loop, targets):
         """
         Test/check whether a given loop is a *driver loop*.
 
@@ -208,8 +208,6 @@ class SCCBaseTransformation(Transformation):
         ----------
         loop : :any: `Loop`
             The loop to test if it is a *driver loop*.
-        routine : :any:`Subroutine`
-            The subroutine in which to check whether loop is a *driver loop*.
         targets : list or string
             List of subroutines that are to be considered as part of
             the transformation call tree.
@@ -218,7 +216,7 @@ class SCCBaseTransformation(Transformation):
             for pragma in loop.pragma:
                 if pragma.keyword.lower() == "loki" and pragma.content.lower() == "driver-loop":
                     return True
-        for call in FindNodes(ir.CallStatement).visit(routine.body):
+        for call in FindNodes(ir.CallStatement).visit(loop.body):
             if call.name in targets:
                 return True
         return False
@@ -246,7 +244,7 @@ class SCCBaseTransformation(Transformation):
             if loop in nested_driver_loops:
                 continue
 
-            if not cls.is_driver_loop(loop, routine, targets):
+            if not cls.is_driver_loop(loop, targets):
                 continue
 
             driver_loops.append(loop)

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -9,7 +9,7 @@ import re
 from loki.expression import symbols as sym
 from loki.transform import resolve_associates, inline_member_procedures
 from loki import (
-    Transformation, FindNodes, FindScopes, Transformer, info,
+    Transformation, FindNodes, Transformer, info,
     pragmas_attached, as_tuple, flatten, ir, FindExpressions,
     SymbolAttributes, BasicType, SubstituteExpressions, DerivedType,
     FindVariables, CaseInsensitiveDict, pragma_regions_attached,
@@ -198,6 +198,61 @@ class SCCBaseTransformation(Transformation):
         # if loops have been inserted, check if loop variable is declared
         if mapper and loop_variable not in routine.variables:
             routine.variables += as_tuple(loop_variable)
+
+    @staticmethod
+    def is_driver_loop(loop, routine, targets):
+        """
+        Test/check whether a given loop is a *driver loop*.
+
+        Parameters
+        ----------
+        loop : :any: `Loop`
+            The loop to test if it is a *driver loop*.
+        routine : :any:`Subroutine`
+            The subroutine in which to check whether loop is a *driver loop*.
+        targets : list or string
+            List of subroutines that are to be considered as part of
+            the transformation call tree.
+        """
+        if loop.pragma:
+            for pragma in loop.pragma:
+                if pragma.keyword.lower() == "loki" and pragma.content.lower() == "driver-loop":
+                    return True
+        for call in FindNodes(ir.CallStatement).visit(routine.body):
+            if call.name in targets:
+                return True
+        return False
+
+    @classmethod
+    def find_driver_loops(cls, routine, targets):
+        """
+        Find and return all driver loops of a given `routine`.
+
+        A *driver loop* is specified either by a call to a routine within
+        `targets` or by the pragma `!$loki driver-loop`.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The subroutine in which to find the driver loops.
+        targets : list or string
+            List of subroutines that are to be considered as part of
+            the transformation call tree.
+        """
+
+        driver_loops = []
+        nested_driver_loops = []
+        for loop in FindNodes(ir.Loop).visit(routine.body):
+            if loop in nested_driver_loops:
+                continue
+
+            if not cls.is_driver_loop(loop, routine, targets):
+                continue
+
+            driver_loops.append(loop)
+            loops = FindNodes(ir.Loop).visit(loop.body)
+            nested_driver_loops.extend(loops)
+        return driver_loops
 
     def transform_subroutine(self, routine, **kwargs):
         """
@@ -487,51 +542,21 @@ class SCCAnnotateTransformation(Transformation):
                 num_threads = size_expr
                 break
 
-        driver_loops = []
-        ignore = []
         with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
-            for call in FindNodes((ir.CallStatement, ir.Pragma)).visit(routine.body):
-                if isinstance(call, ir.CallStatement):
-                    if call.name not in targets:
-                        continue
-                else:
-                    if "loki" not in call.keyword.lower() or "driver-loop" not in call.content.lower():
-                        continue
-
-                # Find the driver loop by checking the call's heritage
-                ancestors = flatten(FindScopes(call).visit(routine.body))
-                loops = [a for a in ancestors if isinstance(a, ir.Loop)]
-                if not loops:
-                    # Skip if there are no driver loops
-                    continue
-                driver_loop = loops[0]
-                driver_loops.append(driver_loop)
-                ignore.append(driver_loop)
-                kernel_loop = [l for l in loops if l.variable == self.horizontal.index]
-                if kernel_loop:
-                    kernel_loop = kernel_loop[0]
-
-                assert not driver_loop == kernel_loop
-
-                # Mark driver loop as "gang parallel".
+            driver_loops = SCCBaseTransformation.find_driver_loops(routine=routine, targets=targets)
+            for loop in driver_loops:
+                loops = FindNodes(ir.Loop).visit(loop.body)
+                kernel_loops = [l for l in loops if l.variable == self.horizontal.index]
+                if kernel_loops:
+                    assert not loop == kernel_loops[0]
                 self.annotate_driver(
-                    self.directive, driver_loop, kernel_loop, self.block_dim, num_threads
+                    self.directive, loop, kernel_loops, self.block_dim, num_threads
                 )
 
-        if self.directive == 'openacc':
-            # self.insert_annotations(routine, self.horizontal, self.vertical, False)
-            # Mark all non-parallel loops as `!$acc loop seq`
-            self.kernel_annotate_sequential_loops_openacc(routine, self.horizontal, self.block_dim, ignore=ignore)
-            # Mark all parallel vector loops as `!$acc loop vector`
-            # self.kernel_annotate_vector_loops_openacc(routine, self.horizontal, self.vertical, role='driver')
-            with pragmas_attached(routine, ir.Loop):
-                for driver_loop in driver_loops:
-                    for loop in FindNodes(ir.Loop).visit(driver_loop.body):
-                        if loop.variable == self.horizontal.index:
-                            # Construct pragma and wrap entire body in vector loop
-                            private_clause = ''
-                            pragma = ir.Pragma(keyword='acc', content=f'loop vector{private_clause}')
-                            loop._update(pragma=(pragma,))
+            if self.directive == 'openacc':
+                # Mark all non-parallel loops as `!$acc loop seq`
+                self.kernel_annotate_sequential_loops_openacc(routine, self.horizontal, self.block_dim,
+                                                              ignore=driver_loops)
 
         section_mapper = {s: s.body for s in FindNodes(ir.Section).visit(routine.body) if s.label == 'vector_section'}
         if section_mapper:
@@ -559,7 +584,7 @@ class SCCAnnotateTransformation(Transformation):
             routine.body.append((ir.Comment(''), pragma_post, ir.Comment('')))
 
     @classmethod
-    def annotate_driver(cls, directive, driver_loop, kernel_loop, block_dim, num_threads):
+    def annotate_driver(cls, directive, driver_loop, kernel_loops, block_dim, num_threads):
         """
         Annotate driver block loop with ``'openacc'`` pragmas.
 
@@ -570,7 +595,7 @@ class SCCAnnotateTransformation(Transformation):
             ``'openacc'`` or ``None``.
         driver_loop : :any:`Loop`
             Driver ``Loop`` to wrap in ``'opencc'`` pragmas.
-        kernel_loop : :any:`Loop`
+        kernel_loops : list of :any:`Loop`
             Vector ``Loop`` to wrap in ``'opencc'`` pragmas if hoisting is enabled.
         block_dim : :any:`Dimension`
             Optional ``Dimension`` object to define the blocking dimension
@@ -594,10 +619,13 @@ class SCCAnnotateTransformation(Transformation):
             vector_length_clause = '' if not num_threads else f' vector_length({num_threads})'
 
             # Annotate vector loops with OpenACC pragmas
-            if kernel_loop:
-                kernel_loop._update(pragma=ir.Pragma(keyword='acc', content='loop vector'))
+            if kernel_loops:
+                for loop in as_tuple(kernel_loops):
+                    loop._update(pragma=(ir.Pragma(keyword='acc', content='loop vector'),))
 
-            if driver_loop.pragma is None:
+            if driver_loop.pragma is None or (len(driver_loop.pragma) == 1 and
+                                              driver_loop.pragma[0].keyword.lower() == "loki" and
+                                              driver_loop.pragma[0].content.lower() == "driver-loop"):
                 p_content = f'parallel loop gang{private_clause}{vector_length_clause}'
                 driver_loop._update(pragma=(ir.Pragma(keyword='acc', content=p_content),))
                 driver_loop._update(pragma_post=(ir.Pragma(keyword='acc', content='end parallel loop'),))


### PR DESCRIPTION
to apply loop flip, vector and seq annotations at driver level too

* introducing two new Loki pragmas
    * `!$loki separator` - for extract vector sections in order to have assignments in the correct position
    * `!$loki driver-loop` - for recognising a driver loop without a call in it 