### PR TITLE
Member inlining extended

### DIFF
--- a/cmake/loki_transform.cmake
+++ b/cmake/loki_transform.cmake
@@ -182,7 +182,7 @@ endmacro()
 #       [OMNI_INCLUDE <omni-inc1> [<omni-inc2> ...]]
 #       [XMOD <xmod-dir1> [<xmod-dir2> ...]]
 #       [REMOVE_OPENMP] [DATA_OFFLOAD] [GLOBAL_VAR_OFFLOAD]
-#       [TRIM_VECTOR_SECTIONS]
+#       [TRIM_VECTOR_SECTIONS] [INLINE_MEMBERS]
 #   )
 #
 # Call ``loki-transform.py convert ...`` with the provided arguments.
@@ -199,7 +199,7 @@ endmacro()
 
 function( loki_transform_convert )
 
-    set( options CPP DATA_OFFLOAD REMOVE_OPENMP GLOBAL_VAR_OFFLOAD TRIM_VECTOR_SECTIONS )
+    set( options CPP DATA_OFFLOAD REMOVE_OPENMP GLOBAL_VAR_OFFLOAD TRIM_VECTOR_SECTIONS INLINE_MEMBERS )
     set( oneValueArgs MODE DIRECTIVE FRONTEND CONFIG PATH OUTPATH )
     set( multiValueArgs OUTPUT DEPENDS INCLUDES INCLUDE HEADERS HEADER DEFINITIONS DEFINE OMNI_INCLUDE XMOD )
 
@@ -242,6 +242,10 @@ function( loki_transform_convert )
 
     if( ${_PAR_TRIM_VECTOR_SECTIONS} )
         list( APPEND _ARGS --trim-vector-sections )
+    endif()
+
+    if( ${_PAR_INLINE_MEMBERS} )
+        list( APPEND _ARGS --inline-members )
     endif()
 
     _loki_transform_env_setup()
@@ -580,6 +584,7 @@ endfunction()
 #       [DIRECTIVE <directive>]
 #       [CPP]
 #       [FRONTEND <frontend>]
+#       [INLINE_MEMBERS]
 #       [BUILDDIR <build-path>]
 #       [SOURCES <source1> [<source2> ...]]
 #       [HEADERS <header1> [<header2> ...]]
@@ -599,7 +604,7 @@ endfunction()
 
 function( loki_transform_command )
 
-    set( options CPP )
+    set( options CPP INLINE_MEMBERS )
     set( oneValueArgs COMMAND MODE DIRECTIVE FRONTEND CONFIG BUILDDIR )
     set( multiValueArgs OUTPUT DEPENDS SOURCES HEADERS )
 
@@ -723,7 +728,7 @@ endfunction()
 
 function( loki_transform_target )
 
-    set( options NO_PLAN_SOURCEDIR COPY_UNMODIFIED CPP CPP_PLAN )
+    set( options NO_PLAN_SOURCEDIR COPY_UNMODIFIED CPP CPP_PLAN INLINE_MEMBERS )
     set( single_value_args TARGET COMMAND MODE DIRECTIVE FRONTEND CONFIG PLAN )
     set( multi_value_args SOURCES HEADERS )
 
@@ -784,6 +789,10 @@ function( loki_transform_target )
         set( _TRANSFORM_OPTIONS "" )
         if( _PAR_CPP )
             list( APPEND _TRANSFORM_OPTIONS CPP )
+        endif()
+
+        if( _PAR_INLINE_MEMBERS )
+            list( APPEND _TRANSFORM_OPTIONS INLINE_MEMBERS )
         endif()
 
         loki_transform_command(

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -912,6 +912,14 @@ class CallStatement(LeafNode, _CallStatementBase):
         kwargs = ((r_args[kw], arg) for kw, arg in as_tuple(self.kwarguments))
         return chain(args, kwargs)
 
+    @property
+    def argument_map(self):
+        """
+        A full map of all qualified argument matches from arguments
+        and keyword arguments.
+        """
+        return dict(self.arg_iter())
+
 
 @dataclass_strict(frozen=True)
 class _AllocationBase():

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -14,13 +14,18 @@ from loki.expression import (
     FindVariables, FindInlineCalls, FindLiterals,
     SubstituteExpressions, LokiIdentityMapper
 )
-from loki.ir import Import, Comment, Assignment
+from loki.ir import Import, Comment, Assignment, VariableDeclaration, CallStatement
 from loki.expression import symbols as sym
 from loki.types import BasicType
 from loki.visitors import Transformer, FindNodes
+from loki.subroutine import Subroutine
+from loki.tools import as_tuple
 
 
-__all__ = ['inline_constant_parameters', 'inline_elemental_functions']
+__all__ = [
+    'inline_constant_parameters', 'inline_elemental_functions',
+    'inline_member_procedures'
+]
 
 
 class InlineSubstitutionMapper(LokiIdentityMapper):
@@ -183,3 +188,62 @@ def inline_elemental_functions(routine):
         if all(hasattr(s, 'type') and s.type.dtype in removed_functions for s in im.symbols):
             import_map[im] = None
     routine.spec = Transformer(import_map).visit(routine.spec)
+
+
+def inline_member_routine(routine, member):
+    """
+    Inline an individual member :any:`Subroutine` at source level.
+
+    This will replace all :any:`Call` objects to the specified
+    subroutine with an adjusted equivalent of the member routines'
+    body. For this, argument matching, including partial dimension
+    matching for array references is performed, and all
+    member-specific declarations are hoisted to the containing
+    :any:`Subroutine`.
+
+    routine : :any:`Subroutine`
+        The subroutine in which to inline all calls to the member routine
+    member : :any:`Subroutine`
+        The contained member subroutine to be inlined in the parent
+    """
+
+    # Get local variable declarations and hoist them
+    decls = FindNodes(VariableDeclaration).visit(member.spec)
+    decls = tuple(d for d in decls if all(not s.type.intent for s in d.symbols))
+    decls = tuple(d for d in decls if all(s not in routine.variables for s in d.symbols))
+    routine.spec.append(decls)
+
+    call_map = {}
+    for call in FindNodes(CallStatement).visit(routine.body):
+        if call.routine == member:
+            # Substitute argument calls into a copy of the body
+            member_body = SubstituteExpressions(call.argument_map).visit(member.body.body)
+
+            # Inline substituted body within a pair of marker comments
+            comment = Comment(f'! [Loki] inlined member subroutine: {member.name}')
+            c_line = Comment('! =========================================')
+            call_map[call] = (comment, c_line) + as_tuple(member_body) + (c_line, )
+
+    # Replace calls to member with the member's body
+    routine.body = Transformer(call_map).visit(routine.body)
+    # Can't use transformer to replace subroutine, so strip it manually
+    contains_body = tuple(n for n in routine.contains.body if not n == member)
+    routine.contains._update(body=contains_body)
+
+
+def inline_member_procedures(routine):
+    """
+    Inline all member subroutines contained in an individual :any:`Subroutine`.
+
+    Please note that member functions are not yet supported!
+
+    routine : :any:`Subroutine`
+        The subroutine in which to inline all member routines
+    """
+
+    # Run through all members and invoke individual inlining transforms
+    for member in routine.members:
+        if isinstance(member, Subroutine):
+            inline_member_routine(routine, member)
+
+    # TODO: Implement for functions!!!

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -12,7 +12,7 @@ Collection of utility routines to perform code-level force-inlining.
 """
 from loki.expression import (
     FindVariables, FindInlineCalls, FindLiterals,
-    SubstituteExpressions, LokiIdentityMapper
+    SubstituteExpressions, SubstituteExpressionsMapper, LokiIdentityMapper
 )
 from loki.ir import Import, Comment, Assignment, VariableDeclaration, CallStatement
 from loki.expression import symbols as sym
@@ -207,6 +207,19 @@ def inline_member_routine(routine, member):
         The contained member subroutine to be inlined in the parent
     """
 
+    def _map_unbound_dims(var, val):
+        """
+        Maps all unbound dimension ranges in the passed array value `val` with the
+        indices from the local variable `var`. It returns the re-mapped symbol.
+
+        For example, mapping the passed array `m(:,j)` to the local
+        expression `a(i)` yields `m(i,j)`.
+        """
+        val_free_dims = tuple(d for d in val.dimensions if isinstance(d, sym.Range))
+        var_bound_dims = tuple(d for d in var.dimensions if not isinstance(d, sym.Range))
+        mapper = SubstituteExpressionsMapper(dict(zip(val_free_dims, var_bound_dims)))
+        return mapper(val)
+
     # Get local variable declarations and hoist them
     decls = FindNodes(VariableDeclaration).visit(member.spec)
     decls = tuple(d for d in decls if all(not s.type.intent for s in d.symbols))
@@ -216,8 +229,25 @@ def inline_member_routine(routine, member):
     call_map = {}
     for call in FindNodes(CallStatement).visit(routine.body):
         if call.routine == member:
+            argmap = {}
+            member_vars = FindVariables().visit(member.body)
+
+            # Match dimension indexes between the argument and the given value
+            # for all occurences of the argument in the body
+            for arg, val in call.argument_map.items():
+                if isinstance(arg, sym.Array):
+                    # Resolve implicit dimension ranges of the passed value,
+                    # eg. when passing a two-dimensional array `a` as `call(arg=a)`
+                    qualified_value = val if val.dimensions else val.clone(
+                        dimensions=tuple(sym.Range((None, None)) for _ in arg.shape)
+                    )
+                    arg_vars = tuple(v for v in member_vars if v.name == arg.name)
+                    argmap.update((v, _map_unbound_dims(v, qualified_value)) for v in arg_vars)
+                else:
+                    argmap[arg] = val
+
             # Substitute argument calls into a copy of the body
-            member_body = SubstituteExpressions(call.argument_map).visit(member.body.body)
+            member_body = SubstituteExpressions(argmap).visit(member.body.body)
 
             # Inline substituted body within a pair of marker comments
             comment = Comment(f'! [Loki] inlined member subroutine: {member.name}')

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -10,9 +10,10 @@ Collection of utility routines to perform code-level force-inlining.
 
 
 """
+import sys
 from loki.expression import (
     FindVariables, FindInlineCalls, FindLiterals,
-    SubstituteExpressions, SubstituteExpressionsMapper, LokiIdentityMapper
+    SubstituteExpressions, LokiIdentityMapper
 )
 from loki.ir import Import, Comment, Assignment, VariableDeclaration, CallStatement
 from loki.expression import symbols as sym
@@ -22,7 +23,6 @@ from loki.subroutine import Subroutine
 from loki.tools import as_tuple
 from loki.logging import error
 
-import sys
 
 
 __all__ = [
@@ -267,12 +267,12 @@ def inline_member_routine(routine, member):
             test = True
             arg_names = [a.name for a in argmap]
             depth = 0
-            while(test) :
+            while test :
                 depth += 1
                 test = False
                 for var in FindVariables().visit(member_body):
                     if var.name in arg_names:
-                        test=True                   
+                        test=True
                 if test:
                     member_body = SubstituteExpressions(argmap).visit(member_body)
 

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -238,9 +238,13 @@ def inline_member_routine(routine, member):
                 if isinstance(arg, sym.Array):
                     # Resolve implicit dimension ranges of the passed value,
                     # eg. when passing a two-dimensional array `a` as `call(arg=a)`
-                    qualified_value = val if val.dimensions else val.clone(
-                        dimensions=tuple(sym.Range((None, None)) for _ in arg.shape)
-                    )
+                    # Check if val is a DeferredTypeSymbol, as it does not have a `dimensions` attribute
+                    if not isinstance(val, sym.DeferredTypeSymbol) and val.dimensions:
+                        qualified_value = val
+                    else:
+                        qualified_value = val.clone(
+                            dimensions=tuple(sym.Range((None, None)) for _ in arg.shape)
+                        )
                     arg_vars = tuple(v for v in member_vars if v.name == arg.name)
                     argmap.update((v, _map_unbound_dims(v, qualified_value)) for v in arg_vars)
                 else:

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -10,7 +10,6 @@ Collection of utility routines to perform code-level force-inlining.
 
 
 """
-import sys
 from loki.expression import (
     FindVariables, FindInlineCalls, FindLiterals,
     SubstituteExpressions, SubstituteExpressionsMapper, LokiIdentityMapper
@@ -21,7 +20,6 @@ from loki.types import BasicType
 from loki.visitors import Transformer, FindNodes
 from loki.subroutine import Subroutine
 from loki.tools import as_tuple
-from loki.logging import error
 from loki.transform import recursive_expression_map_update
 
 

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -357,3 +357,56 @@ end subroutine member_routines
 
     assert (a == [6., 7., 8.]).all()
     assert (b == [3., 3., 3.]).all()
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_inline_member_routines_arg_dimensions(frontend):
+    """
+    Test inlining of member subroutines when sub-arrays of rank less
+    than the formal argument are passed.
+    """
+    fcode = """
+subroutine member_routines_arg_dimensions(matrix, tensor)
+  real(kind=8), intent(inout) :: matrix(3, 3), tensor(3, 3, 4)
+  integer :: i
+  do i=1, 3
+    call add_one(3, matrix(:,i), tensor(1:3,i,:))
+  end do
+  contains
+    subroutine add_one(n, a, b)
+      integer, intent(in) :: n
+      real(kind=8), intent(inout) :: a(3), b(3,1:n)
+      integer :: j
+      do j=1, n
+        a(j) = a(j) + 1
+        b(j,:) = 66.6
+      end do
+    end subroutine
+end subroutine member_routines_arg_dimensions
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    # Ensure initial member arguments
+    assert len(routine.routines) == 1
+    assert routine.routines[0].name == 'add_one'
+    assert len(routine.routines[0].arguments) == 3
+    assert routine.routines[0].arguments[0].name == 'n'
+    assert routine.routines[0].arguments[1].name == 'a'
+    assert routine.routines[0].arguments[2].name == 'b'
+
+    # Now inline the member routines and check again
+    inline_member_procedures(routine=routine)
+
+    # Ensure member has been inlined and arguments adapated
+    assert len(routine.routines) == 0
+    assert len([v for v in FindVariables().visit(routine.body) if v.name == 'a']) == 0
+    assigns = FindNodes(Assignment).visit(routine.body)
+    assert len(assigns) == 2
+    assert assigns[0].lhs == 'matrix(j, i)' and assigns[0].rhs =='matrix(j, i) + 1'
+    assert assigns[1].lhs == 'tensor(j, i, :)'
+
+    # Ensure the `n` in the inner loop bound has been substituted too
+    loops = FindNodes(Loop).visit(routine.body)
+    assert len(loops) == 2
+    assert loops[0].bounds == '1:3'
+    assert loops[1].bounds == '1:3'


### PR DESCRIPTION
This extends PR #130 to circumvent some limitations.

The first commit solves the issue when a derived type argument has to be matched to an array inside the inlined subroutine. This led to a crash since a DeferredTypeSymbol does not have a 'dimensions' attribute.

The second commit revamps the management of dimensions mapping. This was done originally by creating a mapper that would map the relevant argument dimensions to the variable dimensions, however when the argument has several assumed-size dimensions they would end up being mapped to the same single dimension. I solved this by making _map_unbound_dims replace the dimensions with awareness of their respective positions, and return the tuple of new dimensions, then create a clone of the argument with the new dimensions to replace the variable instance.

The third commit treats the cases where there are multiple arguments to variables conversions nested in the same expression.
I solved this through a recursive process that re-applies the expression substitution until all the variables names from the argument-to-variables list have been eliminated. This is a straightforward approach but I guess there are probably more elegant solutions to this.