### PR TITLE
Static Transformation properties (manifest)

### DIFF
--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -614,7 +614,7 @@ class Scheduler:
                 successors += [self.item_map[child.name]] + self.item_successors(child)
         return successors
 
-    def process(self, transformation, item_filter=SubroutineItem):
+    def process(self, transformation):
         """
         Process all :attr:`items` in the scheduler's graph
 
@@ -638,11 +638,11 @@ class Scheduler:
         log = f'[Loki::Scheduler] Applied transformation <{trafo_name}>' + ' in {:.2f}s'
         with Timer(logger=info, text=log):
 
-            if transformation.traverse_file_graph:
-                graph = self.file_graph
-            else:
-                graph = self.item_graph
+            # Extract the graph iteration properties from the transformation
+            graph = self.file_graph if transformation.traverse_file_graph else self.item_graph
+            item_filter = as_tuple(transformation.item_filter)
 
+            # Construct the actual graph to traverse
             traversal = nx.topological_sort(graph)
             if transformation.reverse_traversal:
                 traversal = reversed(list(traversal))

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -657,10 +657,7 @@ class Scheduler:
                             continue
 
                     _item = items[0]
-                    transformation.apply(
-                        items[0].source, role=_item.role, mode=_item.mode,
-                        item=_item, items=items, targets=_item.targets,
-                    )
+                    transformation.apply(items[0].source, items=items)
             else:
                 for item in traversal:
                     if item_filter and not isinstance(item, item_filter):

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -614,7 +614,7 @@ class Scheduler:
                 successors += [self.item_map[child.name]] + self.item_successors(child)
         return successors
 
-    def process(self, transformation, reverse=False, item_filter=SubroutineItem, use_file_graph=False):
+    def process(self, transformation, item_filter=SubroutineItem, use_file_graph=False):
         """
         Process all :attr:`items` in the scheduler's graph
 
@@ -644,7 +644,7 @@ class Scheduler:
                 graph = self.item_graph
 
             traversal = nx.topological_sort(graph)
-            if reverse:
+            if transformation.reverse_traversal:
                 traversal = reversed(list(traversal))
 
             if use_file_graph:

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -656,7 +656,11 @@ class Scheduler:
                         if not items:
                             continue
 
-                    transformation.apply(items[0].source, items=items)
+                    _item = items[0]
+                    transformation.apply(
+                        items[0].source, role=_item.role, mode=_item.mode,
+                        item=_item, items=items, targets=_item.targets,
+                    )
             else:
                 for item in traversal:
                     if item_filter and not isinstance(item, item_filter):

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -614,7 +614,7 @@ class Scheduler:
                 successors += [self.item_map[child.name]] + self.item_successors(child)
         return successors
 
-    def process(self, transformation, item_filter=SubroutineItem, use_file_graph=False):
+    def process(self, transformation, item_filter=SubroutineItem):
         """
         Process all :attr:`items` in the scheduler's graph
 
@@ -638,7 +638,7 @@ class Scheduler:
         log = f'[Loki::Scheduler] Applied transformation <{trafo_name}>' + ' in {:.2f}s'
         with Timer(logger=info, text=log):
 
-            if use_file_graph:
+            if transformation.traverse_file_graph:
                 graph = self.file_graph
             else:
                 graph = self.item_graph
@@ -647,7 +647,7 @@ class Scheduler:
             if transformation.reverse_traversal:
                 traversal = reversed(list(traversal))
 
-            if use_file_graph:
+            if transformation.traverse_file_graph:
                 for node in traversal:
                     items = graph.nodes[node]['items']
 

--- a/loki/lint/linter.py
+++ b/loki/lint/linter.py
@@ -248,6 +248,9 @@ class LinterTransformation(Transformation):
 
     _key = 'LinterTransformation'
 
+    # This transformation is applied over the file graph
+    traverse_file_graph = True
+
     def __init__(self, linter, key=None, **kwargs):
         self.linter = linter
         self.counter = 0
@@ -272,7 +275,7 @@ def lint_files_scheduler(linter, basedir, config):
     """
     scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config))
     transformation = LinterTransformation(linter=linter)
-    scheduler.process(transformation=transformation, use_file_graph=True)
+    scheduler.process(transformation=transformation)
     return transformation.counter
 
 

--- a/loki/transform/build_system_transform.py
+++ b/loki/transform/build_system_transform.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from loki.logging import info
 from loki.transform.transformation import Transformation
+from loki.bulk.item import SubroutineItem, GlobalVarImportItem
 
 __all__ = ['CMakePlanner', 'FileWriteTransformation']
 
@@ -129,16 +130,33 @@ class FileWriteTransformation(Transformation):
         omitted, it will preserve the original file type.
     cuf : bool, optional
         Use CUF (CUDA Fortran) backend instead of Fortran backend.
+    include_module_var_imports : bool, optional
+        Flag to force the :any:`Scheduler` traversal graph to recognise
+        module variable imports and write the modified module files.
     """
 
     # This transformation is applied over the file graph
     traverse_file_graph = True
 
-    def __init__(self, builddir=None, mode='loki', suffix=None, cuf=False):
+    def __init__(
+            self, builddir=None, mode='loki', suffix=None, cuf=False,
+            include_module_var_imports=False
+    ):
         self.builddir = Path(builddir)
         self.mode = mode
         self.suffix = suffix
         self.cuf = cuf
+        self.include_module_var_imports = include_module_var_imports
+
+    @property
+    def item_filter(self):
+        """
+        Override ``item_filter`` to configure whether module variable
+        imports are honoured in the :any:`Scheduler` traversal.
+        """
+        if self.include_module_var_imports:
+            return (SubroutineItem, GlobalVarImportItem)
+        return SubroutineItem
 
     def transform_file(self, sourcefile, **kwargs):
         item = kwargs.get('item', None)

--- a/loki/transform/build_system_transform.py
+++ b/loki/transform/build_system_transform.py
@@ -130,6 +130,10 @@ class FileWriteTransformation(Transformation):
     cuf : bool, optional
         Use CUF (CUDA Fortran) backend instead of Fortran backend.
     """
+
+    # This transformation is applied over the file graph
+    traverse_file_graph = True
+
     def __init__(self, builddir=None, mode='loki', suffix=None, cuf=False):
         self.builddir = Path(builddir)
         self.mode = mode

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -65,6 +65,12 @@ class DependencyTransformation(Transformation):
     # This transformation is applied over the file graph
     traverse_file_graph = True
 
+    # This transformation recurses from the Sourcefile down
+    recurse_to_modules = True
+    recurse_to_subroutines = True
+    recurse_to_contained_procedures = False
+
+
     def __init__(self, suffix, mode='module', module_suffix=None, include_path=None,
                  replace_ignore_items=True):
         self.suffix = suffix
@@ -153,18 +159,6 @@ class DependencyTransformation(Transformation):
 
         if role == 'kernel' and self.mode == 'module':
             self.module_wrap(sourcefile, **kwargs)
-
-        for module in sourcefile.modules:
-            # Recursion into contained modules using the sourcefile's "role"
-            self.transform_module(module, role=role, targets=targets, **kwargs)
-
-        if items:
-            # Recursion into all subroutine items in the current file
-            for item in items:
-                self.transform_subroutine(item.routine, item=item, role=item.role, targets=item.targets, **kwargs)
-        else:
-            for routine in sourcefile.all_subroutines:
-                self.transform_subroutine(routine, role=role, targets=targets, **kwargs)
 
     def rename_calls(self, routine, **kwargs):
         """

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -67,8 +67,8 @@ class DependencyTransformation(Transformation):
 
     # This transformation recurses from the Sourcefile down
     recurse_to_modules = True
-    recurse_to_subroutines = True
-    recurse_to_contained_procedures = False
+    recurse_to_procedures = True
+    recurse_to_internal_procedures = False
 
 
     def __init__(self, suffix, mode='module', module_suffix=None, include_path=None,

--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -62,6 +62,9 @@ class DependencyTransformation(Transformation):
         in the ``ignore``. Default is ``True``.
     """
 
+    # This transformation is applied over the file graph
+    traverse_file_graph = True
+
     def __init__(self, suffix, mode='module', module_suffix=None, include_path=None,
                  replace_ignore_items=True):
         self.suffix = suffix

--- a/loki/transform/transform_hoist_variables.py
+++ b/loki/transform/transform_hoist_variables.py
@@ -46,7 +46,7 @@ using
 .. code-block:: python
 
     # Transformation: Analysis
-    scheduler.process(transformation=HoistTemporaryArraysAnalysis(), reverse=True)
+    scheduler.process(transformation=HoistTemporaryArraysAnalysis())
     # Transformation: Synthesis
     scheduler.process(transformation=HoistVariablesTransformation())
 
@@ -73,10 +73,10 @@ are provided to create derived classes for specialisation of the actual hoisting
     .. code-block:: python
 
         key = "UniqueKey"
-        scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('b',), key=key), reverse=True)
+        scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('b',), key=key))
         scheduler.process(transformation=HoistTemporaryArraysTransformation(key=key))
         key = "AnotherUniqueKey"
-        scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('a',), key=key), reverse=True)
+        scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('a',), key=key))
         scheduler.process(transformation=HoistTemporaryArraysTransformationAllocatable(key=key))
 """
 from loki.expression import FindVariables, SubstituteExpressions
@@ -100,9 +100,6 @@ class HoistVariablesAnalysis(Transformation):
     Create a derived class and override :func:`find_variables<HoistVariablesAnalysis.find_variables>`
     to define which variables to be hoisted.
 
-    .. note::
-        To be applied **reversed**, in order to recursively find all variables to be hoisted.
-
     Parameters
     ----------
     key : str
@@ -111,6 +108,9 @@ class HoistVariablesAnalysis(Transformation):
     """
 
     _key = 'HoistVariablesTransformation'
+
+    # Apply in reverse order to recursively find all variables to be hoisted.
+    reverse_traversal = True
 
     def __init__(self, key=None):
         if key is not None:
@@ -324,6 +324,9 @@ class HoistTemporaryArraysAnalysis(HoistVariablesAnalysis):
         Variables to be within the dimensions of the arrays to be hoisted. If not provided, no checks will be done
         for the array dimensions.
     """
+
+    # Apply in reverse order to recursively find all variables to be hoisted.
+    reverse_traversal = True
 
     def __init__(self, key=None, dim_vars=None, **kwargs):
         super().__init__(key=key, **kwargs)

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -11,6 +11,7 @@ Base class definition for :ref:`transformations`.
 from loki.module import Module
 from loki.sourcefile import Sourcefile
 from loki.subroutine import Subroutine
+from loki.bulk.item import SubroutineItem
 
 
 __all__ = ['Transformation']
@@ -49,6 +50,7 @@ class Transformation:
     # TODO: All these traversal options will eventually superseded by SGraph options
     traverse_file_graph = False
 
+    item_filter = SubroutineItem  # This can also be a tuple of types
 
     def transform_subroutine(self, routine, **kwargs):
         """

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -38,30 +38,32 @@ class Transformation:
     traversed before standalone :any:`Subroutine` objects.
 
     Classes inheriting from :any:`Transformation` may configure the
-    invocation and behaviour batch processing via a predefined set of
-    class attributes. These flags determine the underlying
+    invocation and behaviour during batch processing via a predefined
+    set of class attributes. These flags determine the underlying
     graph traversal when processing complex call trees and determine
     how the transformations are invoked for a given type of scheduler
     :any:`Item`.
 
-    * ``reverse_traversal`` :
+    Attributes
+    ----------
+    reverse_traversal : bool
         Forces scheduler traversal in reverse order from the leaf
         nodes upwards (default: ``False``).
-    * ``traverse_file_graph`` :
+    traverse_file_graph : bool
          Apply :any:`Transformation` to the :any:`Sourcefile` object
          corresponding to the :any:`Item` being processed, instead of
          the program unit in question (default: ``False``).
-    * ``item_filter`` :
+    item_filter : bool
         Filter by graph node types to prune the graph and change connectivity.
         By default, only calls to :any:`Subroutine` items are used to construct
         the graph.
-    * ``recurse_to_modules`` :
+    recurse_to_modules : bool
         Apply transformation to all :any:`Module` objects when processing
         a :any:`Sourcefile` (default ``False``)
-    * ``recurse_to_subroutines`` :
+    recurse_to_procedures : bool
         Apply transformation to all :any:`Subroutine` objects when processing
         :any:`Sourcefile` or :any:``Module`` objects (default ``False``)
-    * ``recurse_to_contained_procedures`` :
+    recurse_to_internal_procedures : bool
         Apply transformation to all internal :any:`Subroutine` objects
         when processing :any:`Subroutine` objects (default ``False``)
     """
@@ -77,8 +79,8 @@ class Transformation:
 
     # Recursion behaviour when invoking transformations via ``trafo.apply()``
     recurse_to_modules = False  # Recurse from Sourcefile to Module
-    recurse_to_subroutines = False  # Recurse from Sourcefile/Module to Subroutine
-    recurse_to_contained_procedures = False  # Recurse to subroutines in ``contains`` clause
+    recurse_to_procedures = False  # Recurse from Sourcefile/Module to subroutines and functions
+    recurse_to_internal_procedures = False  # Recurse to subroutines in ``contains`` clause
 
 
     def transform_subroutine(self, routine, **kwargs):
@@ -167,7 +169,7 @@ class Transformation:
         If the :attr:`recurse_to_modules` class property is set, it
         will also invoke :meth:`apply` on all :any:`Module` objects in
         this :any:`Sourcefile`. Likewise, if
-        :attr:`recurse_to_subroutines` is set, it will invoke
+        :attr:`recurse_to_procedures` is set, it will invoke
         :meth:`apply` on all free :any:`Subroutine` objects in this
         :any:`Sourcefile`.
 
@@ -211,8 +213,8 @@ class Transformation:
             for module in sourcefile.modules:
                 self.transform_module(module, item=item, role=role, targets=targets, items=items, **kwargs)
 
-        # Recurse into subroutine, if configured
-        if self.recurse_to_subroutines:
+        # Recurse into procedures, if configured
+        if self.recurse_to_procedures:
             if items:
                 # Recursion into all subroutine items in the current file
                 for item in items:
@@ -250,8 +252,8 @@ class Transformation:
         # Apply the actual transformation for subroutines
         self.transform_subroutine(subroutine, **kwargs)
 
-        # Recurse to contained member subroutines
-        if self.recurse_to_contained_procedures:
+        # Recurse to internal procedures
+        if self.recurse_to_internal_procedures:
             for routine in subroutine.subroutines:
                 self.apply_subroutine(routine, **kwargs)
 
@@ -261,7 +263,7 @@ class Transformation:
 
         This calls :meth:`transform_module`.
 
-        If the :attr:`recurse_to_subroutines` class property is set,
+        If the :attr:`recurse_to_procedures` class property is set,
         it will also invoke :meth:`apply` on all :any:`Subroutine`
         objects in the ``contains`` clause of this :any:`Module`.
 
@@ -281,8 +283,8 @@ class Transformation:
         # Apply the actual transformation for modules
         self.transform_module(module, **kwargs)
 
-        # Recurse to subroutines contained in this module
-        if self.recurse_to_subroutines:
+        # Recurse to procedures contained in this module
+        if self.recurse_to_procedures:
             for routine in module.subroutines:
                 self.apply_subroutine(routine, **kwargs)
 

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -42,6 +42,14 @@ class Transformation:
     # Forces scheduler traversal in reverse order from the leaf nodes upwards
     reverse_traversal = False
 
+    # The following options configure the iteration space of the
+    # Scheduler traversal; it configures which graph-type is used and
+    # which nodes are traversed when applying the Transformation.
+    #
+    # TODO: All these traversal options will eventually superseded by SGraph options
+    traverse_file_graph = False
+
+
     def transform_subroutine(self, routine, **kwargs):
         """
         Defines the transformation to apply to :any:`Subroutine` items.

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -36,20 +36,43 @@ class Transformation:
 
     Note that in :any:`Sourcefile` objects, all :any:`Module` members will be
     traversed before standalone :any:`Subroutine` objects.
-    """
 
-    # Below is a set of flags that consfigure the corresponding Scheduler behaviour
+    Classes inheriting from :any:`Transformation` may configure the
+    invocation and behaviour batch processing via a predefined set of
+    class attributes. These flags determine the underlying
+    graph traversal when processing complex call trees and determine
+    how the transformations are invoked for a given type of scheduler
+    :any:`Item`.
+
+    * ``reverse_traversal`` :
+        Forces scheduler traversal in reverse order from the leaf
+        nodes upwards (default: ``False``).
+    * ``traverse_file_graph`` :
+         Apply :any:`Transformation` to the :any:`Sourcefile` object
+         corresponding to the :any:`Item` being processed, instead of
+         the program unit in question (default: ``False``).
+    * ``item_filter`` :
+        Filter by graph node types to prune the graph and change connectivity.
+        By default, only calls to :any:`Subroutine` items are used to construct
+        the graph.
+    * ``recurse_to_modules`` :
+        Apply transformation to all :any:`Module` objects when processing
+        a :any:`Sourcefile` (default ``False``)
+    * ``recurse_to_subroutines`` :
+        Apply transformation to all :any:`Subroutine` objects when processing
+        :any:`Sourcefile` or :any:``Module`` objects (default ``False``)
+    * ``recurse_to_contained_procedures`` :
+        Apply transformation to all internal :any:`Subroutine` objects
+        when processing :any:`Subroutine` objects (default ``False``)
+    """
 
     # Forces scheduler traversal in reverse order from the leaf nodes upwards
     reverse_traversal = False
 
-    # The following options configure the iteration space of the
-    # Scheduler traversal; it configures which graph-type is used and
-    # which nodes are traversed when applying the Transformation.
-    #
-    # TODO: All these traversal options will eventually superseded by SGraph options
+    # Traverse a graph of Sourcefile options corresponding to scheduler items
     traverse_file_graph = False
 
+    # Filter certain graph nodes to prune the graph and change connectivity
     item_filter = SubroutineItem  # This can also be a tuple of types
 
     # Recursion behaviour when invoking transformations via ``trafo.apply()``

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -191,15 +191,14 @@ class Transformation:
         role = kwargs.pop('role', None)
         targets = kwargs.pop('targets', None)
 
-        if 'items' in kwargs:
+        if items:
             # TODO: This special logic is required for the
             # DependencyTransformation to capture certain corner
             # cases. Once the module wrapping is split into its
             # own transformation, we can probably simplify this.
 
             # We consider the sourcefile to be a "kernel" file if all items are kernels
-            if all(item.role == 'kernel' for item in items):
-                role = 'kernel'
+            role = 'kernel' if all(item.role == 'kernel' for item in items) else 'driver'
 
             if targets is None:
                 # We collect the targets for file/module-level imports from all items

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -37,6 +37,11 @@ class Transformation:
     traversed before standalone :any:`Subroutine` objects.
     """
 
+    # Below is a set of flags that consfigure the corresponding Scheduler behaviour
+
+    # Forces scheduler traversal in reverse order from the leaf nodes upwards
+    reverse_traversal = False
+
     def transform_subroutine(self, routine, **kwargs):
         """
         Defines the transformation to apply to :any:`Subroutine` items.

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -238,8 +238,7 @@ def convert(
         ))
 
     if global_var_offload:
-        scheduler.process(transformation=GlobalVarOffloadTransformation(),
-                          item_filter=(SubroutineItem, GlobalVarImportItem))
+        scheduler.process(transformation=GlobalVarOffloadTransformation())
 
     if mode in ['idem-stack', 'scc-stack']:
         if frontend == Frontend.OMNI:
@@ -272,14 +271,10 @@ def convert(
     scheduler.process(transformation=dependency)
 
     # Write out all modified source files into the build directory
-    if global_var_offload:
-        item_filter = (SubroutineItem, GlobalVarImportItem)
-    else:
-        item_filter = SubroutineItem
-    scheduler.process(
-        transformation=FileWriteTransformation(builddir=build, mode=mode, cuf='cuf' in mode),
-        item_filter=item_filter
-    )
+    scheduler.process(transformation=FileWriteTransformation(
+        builddir=build, mode=mode, cuf='cuf' in mode,
+        include_module_var_imports=global_var_offload
+    ))
 
 
 @cli.command()

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -269,7 +269,7 @@ def convert(
     dependency = DependencyTransformation(
         suffix=f'_{mode.upper()}', mode='module', module_suffix='_MOD'
     )
-    scheduler.process(transformation=dependency, use_file_graph=True)
+    scheduler.process(transformation=dependency)
 
     # Write out all modified source files into the build directory
     if global_var_offload:
@@ -278,7 +278,7 @@ def convert(
         item_filter = SubroutineItem
     scheduler.process(
         transformation=FileWriteTransformation(builddir=build, mode=mode, cuf='cuf' in mode),
-        use_file_graph=True, item_filter=item_filter
+        item_filter=item_filter
     )
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1491,6 +1491,8 @@ def test_scheduler_traversal_order(here, config, frontend, use_file_graph, rever
 
         reverse_traversal = reverse
 
+        traverse_file_graph = use_file_graph
+
         def __init__(self):
             self.record = []
 
@@ -1507,7 +1509,7 @@ def test_scheduler_traversal_order(here, config, frontend, use_file_graph, rever
             self.record += [kwargs['item'].name + '::' + routine.name]
 
     transformation = LoggingTransformation()
-    scheduler.process(transformation=transformation, use_file_graph=use_file_graph)
+    scheduler.process(transformation=transformation)
 
     if reverse:
         assert transformation.record == flatten(expected[::-1])
@@ -1555,6 +1557,8 @@ end module member_mod
 
         reverse_traversal = reverse
 
+        traverse_file_graph = use_file_graph
+
         def __init__(self):
             self.record = []
 
@@ -1571,7 +1575,7 @@ end module member_mod
             self.record += [kwargs['item'].name + '::' + routine.name]
 
     transformation = LoggingTransformation()
-    scheduler.process(transformation=transformation, use_file_graph=use_file_graph)
+    scheduler.process(transformation=transformation)
 
     if use_file_graph:
         expected = ['member_mod.F90']

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1489,6 +1489,8 @@ def test_scheduler_traversal_order(here, config, frontend, use_file_graph, rever
 
     class LoggingTransformation(Transformation):
 
+        reverse_traversal = reverse
+
         def __init__(self):
             self.record = []
 
@@ -1505,9 +1507,7 @@ def test_scheduler_traversal_order(here, config, frontend, use_file_graph, rever
             self.record += [kwargs['item'].name + '::' + routine.name]
 
     transformation = LoggingTransformation()
-    scheduler.process(
-        transformation=transformation, reverse=reverse, use_file_graph=use_file_graph
-    )
+    scheduler.process(transformation=transformation, use_file_graph=use_file_graph)
 
     if reverse:
         assert transformation.record == flatten(expected[::-1])
@@ -1553,6 +1553,8 @@ end module member_mod
 
     class LoggingTransformation(Transformation):
 
+        reverse_traversal = reverse
+
         def __init__(self):
             self.record = []
 
@@ -1569,9 +1571,7 @@ end module member_mod
             self.record += [kwargs['item'].name + '::' + routine.name]
 
     transformation = LoggingTransformation()
-    scheduler.process(
-        transformation=transformation, reverse=reverse, use_file_graph=use_file_graph,
-    )
+    scheduler.process(transformation=transformation, use_file_graph=use_file_graph)
 
     if use_file_graph:
         expected = ['member_mod.F90']

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1497,10 +1497,7 @@ def test_scheduler_traversal_order(here, config, frontend, use_file_graph, rever
             self.record = []
 
         def transform_file(self, sourcefile, **kwargs):
-            if 'item' in kwargs:
-                self.record += [kwargs['item'].name + '::' + sourcefile.path.name]
-            else:
-                self.record += [sourcefile.path.name]
+            self.record += [sourcefile.path.name]
 
         def transform_module(self, module, **kwargs):
             self.record += [kwargs['item'].name + '::' + module.name]
@@ -1563,10 +1560,7 @@ end module member_mod
             self.record = []
 
         def transform_file(self, sourcefile, **kwargs):
-            if 'item' in kwargs:
-                self.record += [kwargs['item'].name + '::' + sourcefile.path.name]
-            else:
-                self.record += [sourcefile.path.name]
+            self.record += [sourcefile.path.name]
 
         def transform_module(self, module, **kwargs):
             self.record += [kwargs['item'].name + '::' + module.name]

--- a/tests/test_transform_dependency.py
+++ b/tests/test_transform_dependency.py
@@ -77,7 +77,7 @@ END SUBROUTINE driver
         (tempdir/'kernel_mod.F90').write_text(kernel_fcode)
         (tempdir/'driver.F90').write_text(driver_fcode)
         scheduler = Scheduler(paths=[tempdir], config=SchedulerConfig.from_dict(config), frontend=frontend)
-        scheduler.process(transformation, use_file_graph=True)
+        scheduler.process(transformation)
 
         kernel = scheduler['kernel_mod#kernel'].source
         driver = scheduler['#driver'].source
@@ -149,7 +149,7 @@ END MODULE DRIVER_MOD
         (tempdir/'kernel_mod.F90').write_text(kernel_fcode)
         (tempdir/'driver_mod.F90').write_text(driver_fcode)
         scheduler = Scheduler(paths=[tempdir], config=SchedulerConfig.from_dict(config), frontend=frontend)
-        scheduler.process(transformation, use_file_graph=True)
+        scheduler.process(transformation)
 
         kernel = scheduler['kernel_mod#kernel'].source
         driver = scheduler['driver_mod#driver'].source
@@ -272,7 +272,7 @@ END SUBROUTINE kernel
         (tempdir/'kernel.F90').write_text(kernel_fcode)
         (tempdir/'driver.F90').write_text(driver_fcode)
         scheduler = Scheduler(paths=[tempdir], config=SchedulerConfig.from_dict(config), frontend=frontend)
-        scheduler.process(transformation, use_file_graph=True)
+        scheduler.process(transformation)
 
         kernel = scheduler['#kernel'].source
         driver = scheduler['#driver'].source
@@ -348,7 +348,7 @@ END SUBROUTINE kernel
         (tempdir/'kernel.F90').write_text(kernel_fcode)
         (tempdir/'driver.F90').write_text(driver_fcode)
         scheduler = Scheduler(paths=[tempdir], config=SchedulerConfig.from_dict(config), frontend=frontend)
-        scheduler.process(transformation, use_file_graph=True)
+        scheduler.process(transformation)
 
         kernel = scheduler['#kernel'].source
         driver = scheduler['#driver'].source
@@ -576,7 +576,7 @@ END SUBROUTINE driver
         (tempdir/'kernel_mod.F90').write_text(kernel_fcode)
         (tempdir/'driver.F90').write_text(driver_fcode)
         scheduler = Scheduler(paths=[tempdir], config=SchedulerConfig.from_dict(config), frontend=frontend)
-        scheduler.process(transformation, use_file_graph=True)
+        scheduler.process(transformation)
 
         kernel = scheduler['kernel_mod#kernel'].source
         driver = scheduler['#driver'].source
@@ -668,7 +668,7 @@ END MODULE header_mod
     assert 'header_mod#header_var' in scheduler.items
 
     transformation = DependencyTransformation(suffix='_test', mode='module', module_suffix='_mod')
-    scheduler.process(transformation, use_file_graph=True)
+    scheduler.process(transformation)
 
     kernel = scheduler['kernel_mod#kernel'].source
     header = scheduler['header_mod#header_var'].source

--- a/tests/test_transform_hoist_variables.py
+++ b/tests/test_transform_hoist_variables.py
@@ -133,7 +133,7 @@ def test_hoist(here, frontend, config):
     compile_and_test(scheduler=scheduler, here=here, frontend=frontend, a=(5, 10, 100), test_name="source")
 
     # Transformation: Analysis
-    scheduler.process(transformation=HoistVariablesAnalysis(), reverse=True)
+    scheduler.process(transformation=HoistVariablesAnalysis())
     # Transformation: Synthesis
     scheduler.process(transformation=HoistVariablesTransformation())
 
@@ -172,7 +172,7 @@ def test_hoist_disable(here, frontend, config):
     scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
 
     # Transformation: Analysis
-    scheduler.process(transformation=HoistVariablesAnalysis(), reverse=True)
+    scheduler.process(transformation=HoistVariablesAnalysis())
     # Transformation: Synthesis
     scheduler.process(transformation=HoistVariablesTransformation())
 
@@ -214,7 +214,7 @@ def test_hoist_arrays(here, frontend, config):
     scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
 
     # Transformation: Analysis
-    scheduler.process(transformation=HoistTemporaryArraysAnalysis(), reverse=True)
+    scheduler.process(transformation=HoistTemporaryArraysAnalysis())
     # Transformation: Synthesis
     scheduler.process(transformation=HoistVariablesTransformation())
 
@@ -250,7 +250,7 @@ def test_hoist_specific_variables(here, frontend, config):
     scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
 
     # Transformation: Analysis
-    scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('a', 'a1', 'a2')), reverse=True)
+    scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('a', 'a1', 'a2')))
     # Transformation: Synthesis
     scheduler.process(transformation=HoistVariablesTransformation())
 
@@ -303,7 +303,7 @@ def test_hoist_allocatable(here, frontend, config):
 
     key = "HoistVariablesAllocatable"
     # Transformation: Analysis
-    scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('a', 'a1', 'a2'), key=key), reverse=True)
+    scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('a', 'a1', 'a2'), key=key))
     # Transformation: Synthesis
     scheduler.process(transformation=HoistTemporaryArraysTransformationAllocatable(key=key))
 
@@ -411,7 +411,7 @@ end module kernel_mod
         for item in scheduler.items:
             normalize_range_indexing(item.routine)
 
-    scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('klev',)), reverse=True)
+    scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('klev',)))
     scheduler.process(transformation=HoistTemporaryArraysTransformationAllocatable())
 
     driver_variables = (

--- a/transformations/tests/test_argument_shape.py
+++ b/transformations/tests/test_argument_shape.py
@@ -386,7 +386,7 @@ def test_argument_shape_transformation_import(frontend, here):
     scheduler = Scheduler(paths=here/'sources/projArgShape', config=config, frontend=frontend,
                           definitions=definitions)
     scheduler.process(transformation=ArgumentArrayShapeAnalysis())
-    scheduler.process(transformation=ExplicitArgumentArrayShapeTransformation(), reverse=True)
+    scheduler.process(transformation=ExplicitArgumentArrayShapeTransformation())
 
     item_map = {item.name: item for item in scheduler.items}
     driver = item_map['driver_mod#driver'].source['driver']

--- a/transformations/tests/test_global_var_offload.py
+++ b/transformations/tests/test_global_var_offload.py
@@ -51,7 +51,7 @@ def test_transformation_global_var_import(here, config, frontend):
 
     scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=my_config, frontend=frontend)
     scheduler.process(transformation=GlobalVarOffloadTransformation(),
-                      item_filter=(SubroutineItem, GlobalVarImportItem), reverse=True)
+                      item_filter=(SubroutineItem, GlobalVarImportItem))
 
     item_map = {item.name: item for item in scheduler.items}
     driver_item = item_map['#driver']
@@ -129,7 +129,7 @@ def test_transformation_global_var_import_derived_type(here, config, frontend):
 
     scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=my_config, frontend=frontend)
     scheduler.process(transformation=GlobalVarOffloadTransformation(),
-                      item_filter=(SubroutineItem, GlobalVarImportItem), reverse=True)
+                      item_filter=(SubroutineItem, GlobalVarImportItem))
 
     item_map = {item.name: item for item in scheduler.items}
     driver_item = item_map['#driver_derived_type']

--- a/transformations/tests/test_global_var_offload.py
+++ b/transformations/tests/test_global_var_offload.py
@@ -9,9 +9,7 @@ from pathlib import Path
 import pytest
 
 from conftest import available_frontends
-from loki import (
-    Scheduler, FindNodes, Pragma, Import, SubroutineItem, GlobalVarImportItem
-)
+from loki import Scheduler, FindNodes, Pragma, Import
 
 from transformations import GlobalVarOffloadTransformation
 
@@ -50,8 +48,7 @@ def test_transformation_global_var_import(here, config, frontend):
     ]
 
     scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=my_config, frontend=frontend)
-    scheduler.process(transformation=GlobalVarOffloadTransformation(),
-                      item_filter=(SubroutineItem, GlobalVarImportItem))
+    scheduler.process(transformation=GlobalVarOffloadTransformation())
 
     item_map = {item.name: item for item in scheduler.items}
     driver_item = item_map['#driver']
@@ -128,8 +125,7 @@ def test_transformation_global_var_import_derived_type(here, config, frontend):
     ]
 
     scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=my_config, frontend=frontend)
-    scheduler.process(transformation=GlobalVarOffloadTransformation(),
-                      item_filter=(SubroutineItem, GlobalVarImportItem))
+    scheduler.process(transformation=GlobalVarOffloadTransformation())
 
     item_map = {item.name: item for item in scheduler.items}
     driver_item = item_map['#driver_derived_type']

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -217,7 +217,7 @@ end module kernel_mod
     transformation = TemporariesPoolAllocatorTransformation(
         block_dim=block_dim, check_bounds=check_bounds
     )
-    scheduler.process(transformation=transformation, reverse=True)
+    scheduler.process(transformation=transformation)
     kernel_item = scheduler['kernel_mod#kernel']
 
     assert transformation._key in kernel_item.trafo_data
@@ -501,7 +501,7 @@ end module kernel_mod
             normalize_range_indexing(item.routine)
 
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim, directive=directive, key='some_key')
-    scheduler.process(transformation=transformation, reverse=True)
+    scheduler.process(transformation=transformation)
     kernel_item = scheduler['kernel_mod#kernel']
     kernel2_item = scheduler['kernel_mod#kernel2']
 
@@ -779,7 +779,7 @@ end module kernel_mod
             normalize_range_indexing(item.routine)
 
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim, directive=directive)
-    scheduler.process(transformation=transformation, reverse=True)
+    scheduler.process(transformation=transformation)
     kernel_item = scheduler['kernel_mod#kernel']
     kernel2_item = scheduler['kernel_mod#kernel2']
 
@@ -998,7 +998,7 @@ def test_pool_allocator_more_call_checks(frontend, block_dim, caplog):
             normalize_range_indexing(item.routine)
 
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
-    scheduler.process(transformation=transformation, reverse=True)
+    scheduler.process(transformation=transformation)
     item = scheduler['kernel_mod#kernel']
     kernel = item.routine
 

--- a/transformations/tests/test_scc_cuf.py
+++ b/transformations/tests/test_scc_cuf.py
@@ -297,7 +297,7 @@ def test_scc_cuf_hoist(here, frontend, config, horizontal, vertical, blocking):
     scheduler.process(transformation=cuf_transform)
 
     # Transformation: Analysis
-    scheduler.process(transformation=HoistTemporaryArraysAnalysis(), reverse=True)
+    scheduler.process(transformation=HoistTemporaryArraysAnalysis())
     # Transformation: Synthesis
     scheduler.process(transformation=HoistTemporaryArraysDeviceAllocatableTransformation())
 

--- a/transformations/transformations/argument_shape.py
+++ b/transformations/transformations/argument_shape.py
@@ -111,6 +111,10 @@ class ExplicitArgumentArrayShapeTransformation(Transformation):
     in reverse order via ``Scheduler.process(..., reverse=True)``.
     """
 
+    # We need to traverse call tree in reverse to ensure called
+    # procedures are updated before callers.
+    reverse_traversal = True
+
     def transform_subroutine(self, routine, **kwargs):  # pylint: disable=arguments-differ
 
         # First, replace assumed array shapes with concrete shapes for

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -8,7 +8,7 @@
 from loki import (
     pragma_regions_attached, PragmaRegion, Transformation, FindNodes,
     CallStatement, Pragma, Array, as_tuple, Transformer, warning, BasicType,
-    GlobalVarImportItem, dataflow_analysis_attached, Import,
+    SubroutineItem, GlobalVarImportItem, dataflow_analysis_attached, Import,
     Comment, Variable, flatten, DerivedType, get_pragma_parameters, CaseInsensitiveDict
 )
 
@@ -289,6 +289,10 @@ class GlobalVarOffloadTransformation(Transformation):
 
     # Traverse call tree in reverse when using Scheduler
     reverse_traversal = True
+
+    # Include module variable imports in the underlying graph
+    # connectivity for traversal with the Scheduler
+    item_filter = (SubroutineItem, GlobalVarImportItem)
 
     def __init__(self, key=None):
         if key:

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -287,6 +287,9 @@ class GlobalVarOffloadTransformation(Transformation):
 
     _key = 'GlobalVarOffloadTransformation'
 
+    # Traverse call tree in reverse when using Scheduler
+    reverse_traversal = True
+
     def __init__(self, key=None):
         if key:
             self._key = key

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -103,6 +103,9 @@ class TemporariesPoolAllocatorTransformation(Transformation):
 
     _key = 'TemporariesPoolAllocatorTransformation'
 
+    # Traverse call tree in reverse when using Scheduler
+    reverse_traversal = True
+
     def __init__(self, block_dim,
                  stack_module_name='STACK_MOD', stack_type_name='STACK', stack_ptr_name='L',
                  stack_end_name='U', stack_size_name='ISTSZ', stack_storage_name='ZSTACK',


### PR DESCRIPTION
This PR changes the way we configure the `Scheduler` behaviour for individual `Transformation` passes. Up until now, we rely on the user of a transformation to hand any special iteration properties (reverse graph traversal, program unit recursion, etc.) as run time argument to the scheduler, with no safeguards if the wrong behaviour is requested. 

This PR now changes this, so that `Transformation` objects carry a set of specific flags as class properties (the manifest) that can be overridden in the class definition. So far, this change only moves scheduler traversal behaviour and behaviour specific to `apply(...)` to the manifest, but it can easily be extended to capture other static meta-information, etc. 

In more detail:
* Moved `reverse_traversal`, `traverse_file_graph` and `item_filter` properties to the static class manifest. @reuterbal Please note that these are the main "graph traversal" configuration options that should eventually be implemented via the planned `SGraph` mechanisms. 
* Move the "program unit recursion" properties to the manifest, with fine-grained configuration behaviour over which recursion is required. Please note that this includes a few mechanisms specific to the `DependencyTransformation`, which we can hopefully simplify once that transformation is streamlined and/or we have the SGraph (@reuterbal )
* Fixes to various tests, and use of new configuration mechanism in `DependencyTransformation` and `GlobalVarTransformation` 