### PR TITLE
Fix cudafor import in driver for SCC CUF

### DIFF
--- a/transformations/tests/test_scc_cuf.py
+++ b/transformations/tests/test_scc_cuf.py
@@ -60,6 +60,9 @@ def fixture_config():
 
 
 def check_subroutine_driver(routine, blocking, disable=()):
+    # use of "use cudafor"
+    imports = [_import.module.lower() for _import in FindNodes(Import).visit(routine.spec)]
+    assert "cudafor" in imports
     # device arrays
     # device arrays: declaration
     arrays = [var for var in routine.variables if isinstance(var, sym.Array)]

--- a/transformations/transformations/scc_cuf.py
+++ b/transformations/transformations/scc_cuf.py
@@ -671,13 +671,6 @@ class SccCufTransformation(Transformation):
             self.derived_types = [_.upper() for _ in derived_types]
         self.derived_type_variables = ()
 
-    def transform_module(self, module, **kwargs):
-
-        role = kwargs.get('role')
-
-        if role == 'driver':
-            module.spec.prepend(ir.Import(module="cudafor"))
-
     def transform_subroutine(self, routine, **kwargs):
 
         item = kwargs.get('item', None)
@@ -696,8 +689,7 @@ class SccCufTransformation(Transformation):
         single_variable_declaration(routine=routine, group_by_shape=True)
         device_subroutine_prefix(routine, depth)
 
-        if depth > 0:
-            routine.spec.prepend(ir.Import(module="cudafor"))
+        routine.spec.prepend(ir.Import(module="cudafor"))
 
         if role == 'driver':
             self.process_routine_driver(routine, targets=targets)


### PR DESCRIPTION
Hotfix for failing transformation of CLOUDSC (see https://github.com/ecmwf-ifs/dwarf-p-cloudsc/actions/runs/6275881222/job/17044373035)

This is fallout from the recent removal of Transformation recursion, where previously the import was injected into the driver module. No tests had been verifying this. Now it is instead added to the driver subroutine and checked in the tests.