### PR TITLE
Bugfix: Memory error in Statement functions test

### DIFF
--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1415,7 +1415,7 @@ END SUBROUTINE DOT_PROD_SP_2D
     assert 'dot_product_ecv' in routine.variables
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=(OFP, 'No support for prefix implemented')))
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'No support for prefix implemented')]))
 def test_regex_prefix(frontend):
     fcode = """
 module some_mod

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1501,7 +1501,7 @@ subroutine subroutine_stmt_func(a, b)
     integer :: tmp
     mult(i, j) = i * j
 
-    array(i) = i
+    array(a) = a
     tmp = plus(a, 5)
     tmp = minus(tmp, 1)
     b = mult(2, tmp)


### PR DESCRIPTION
We had seen random failures of CI tests with a segfault, which typically went away when re-running the test. I have tracked this down to the statement functions test, where an uninitialised value was used for the index when writing to an array.

The test has been fixed and the problem hasn't resurfaced so far, hoping this was the root cause.