### PR TITLE
bugfix : symbols from the inlined member's dummies were hoisted in the calling routine

### DIFF
--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -243,7 +243,7 @@ def inline_member_routine(routine, member):
 
     # Get local variable declarations and hoist them
     decls = FindNodes(VariableDeclaration).visit(member.spec)
-    decls = tuple(d for d in decls if all(s.name.lower() not in routine._dummies for s in d.symbols))
+    decls = tuple(d for d in decls if all(s.name.lower() not in member._dummies for s in d.symbols))
     decls = tuple(d for d in decls if all(s not in routine.variables for s in d.symbols))
     routine.spec.append(decls)
 

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -401,6 +401,9 @@ end subroutine member_routines_arg_dimensions
     # Ensure member has been inlined and arguments adapated
     assert len(routine.routines) == 0
     assert len([v for v in FindVariables().visit(routine.body) if v.name == 'a']) == 0
+    assert len([v for v in FindVariables().visit(routine.body) if v.name == 'b']) == 0
+    assert len([v for v in FindVariables().visit(routine.spec) if v.name == 'a']) == 0
+    assert len([v for v in FindVariables().visit(routine.spec) if v.name == 'b']) == 0
     assigns = FindNodes(Assignment).visit(routine.body)
     assert len(assigns) == 2
     assert assigns[0].lhs == 'matrix(j, i)' and assigns[0].rhs =='matrix(j, i) + 1'


### PR DESCRIPTION
We want to eliminate the symbols from dummies variables when hoisting the local variables from an inlined member routine to its caller.
The check eliminated symbols from the routine._dummies list, but we rather want the list of memeber._dummies