### PR TITLE
Call remove call and remove hook  transformations on contained subroutines

### DIFF
--- a/transformations/transformations/utility_routines.py
+++ b/transformations/transformations/utility_routines.py
@@ -66,6 +66,9 @@ class DrHookTransformation(Transformation):
         if role == 'driver':
             return
 
+        for r in routine.members:
+            self.transform_subroutine(r, **kwargs)
+
         mapper = {}
         for call in FindNodes(CallStatement).visit(routine.body):
             # Lazily changing the DrHook label in-place
@@ -121,6 +124,9 @@ class RemoveCallsTransformation(Transformation):
         role = kwargs.get('role', None)
         if role and role == 'driver' and self.kernel_only:
             return
+
+        for r in routine.members:
+            self.transform_subroutine(r, **kwargs)
 
         mapper = {}
 


### PR DESCRIPTION
Main will not call the remove_call and remove_hook on contained routines, resulting in code that does not compile. This PR adds calls on any member routines as well