### PR TITLE
Save attribute (fix #164)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,7 @@
 # Authors and Contributors
 
 - R. Heilemann Myhre (Met Norway)
+- P. Kiepas (École polytechnique/IPSL)
 - M. Lange (ECMWF)
 - J. Legaux (CERFACS)
 - O. Marsden (ECMWF)

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -796,6 +796,8 @@ class FortranCodegen(Stringifier):
 
         if o.external:
             attributes += ['EXTERNAL']
+        if o.save:
+            attributes += ['SAVE']
         if o.allocatable:
             attributes += ['ALLOCATABLE']
         if o.pointer:

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -917,6 +917,10 @@ class OFP2IR(GenericVisitor):
             target = self.visit(o.find('attribute-target'), **kwargs)
             attrs.update((target,))
 
+        if o.find('attribute-save') is not None:
+            save = self.visit(o.find('attribute-save'), **kwargs)
+            attrs.update((save,))
+
         if o.find('access-spec') is not None:
             access_spec = self.visit(o.find('access-spec'), **kwargs)
             attrs.update((access_spec,))

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -830,6 +830,8 @@ class OMNI2IR(GenericVisitor):
             _type.private = True
         if o.get('is_public') == 'true':
             _type.public = True
+        if o.get('is_save') == 'true':
+            _type.save = True
         return _type
 
     def visit_FfunctionType(self, o, **kwargs):

--- a/tests/test_fgen.py
+++ b/tests/test_fgen.py
@@ -146,3 +146,20 @@ end subroutine test_fgen
     out = fgen(routine, linewidth=132)
     for line in out.splitlines():
         assert line.count('&') <= 2
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_fgen_save_attribute(frontend):
+    """
+    Make sure the SAVE attribute on declarations is preserved (#164)
+    """
+    fcode = """
+MODULE test
+    INTEGER, SAVE :: variable
+END MODULE test
+    """.strip()
+    module = Module.from_source(fcode, frontend=frontend)
+    assert module['variable'].type.save is True
+    assert len(module.declarations) == 1
+    assert 'SAVE' in fgen(module.declarations[0])
+    assert 'SAVE' in module.to_fortran()


### PR DESCRIPTION
We only stored the `SAVE` attribute for variables with the FP frontend and didn't output it again via `fgen`. This adds a test and fixes the missing behaviour.

Thanks to @quepas for reporting and providing a reproducer and fix.