### PR TITLE
InlineMember: rename duplicate locals in the body

### DIFF
--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -239,7 +239,12 @@ def inline_member_routine(routine, member):
         {v: v.clone(name=f'{member.name}_{v.name}') for v in duplicate_locals}
     )
     member.spec = shadow_mapper.visit(member.spec)
-    member.body = shadow_mapper.visit(member.body)
+
+    var_map = {}
+    for v in FindVariables(unique=False).visit(member.body):
+        if v.name in [dl.name for dl in duplicate_locals]:
+            var_map[v] = v.clone(name=f'{member.name}_{v.name}')
+    member.body = SubstituteExpressions(var_map).visit(member.body)
 
     # Get local variable declarations and hoist them
     decls = FindNodes(VariableDeclaration).visit(member.spec)

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -473,12 +473,11 @@ def test_inline_member_routines_variable_shadowing(frontend):
     fcode = """
 subroutine outer()
      real :: x = 3 ! 'x' is real in outer.
-     real :: tmp = 0
      real :: y
 
      y = 1.0
-     call inner(tmp, y=y)
-     x = x + tmp
+     call inner(y)
+     x = x + y
 
 contains
     subroutine inner(y)
@@ -515,7 +514,7 @@ end subroutine outer
     # Check inner 'y' was substituted, not renamed!
     assign = FindNodes(Assignment).visit(routine.body)
     assert routine.variable_map['y'] == 'y'
-    assert assign[2].lhs == 'y' and assign[2].rhs == 'y + sum(x)'
+    assert assign[2].lhs == 'y' and assign[2].rhs == 'y + sum(inner_x)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
The shadow mapper will only find variables in the declaration and leaves the body unchanged.

I do not understand the need for the `[dl.name for dl in duplicate_locals]` construct though. I would have thought that a `v in duplicate_locals` or `v.name in duplicate_locals` would be sufficient.