### PR TITLE
Fix deep-cloning of subroutiens and modules (fix #174)

### DIFF
--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -290,12 +290,13 @@ class ProgramUnit(Scope):
         kwargs.setdefault('incomplete', self._incomplete)
 
         # Rebuild IRs
+        rebuild = Transformer({}, rebuild_scopes=True)
         if 'docstring' in kwargs:
-            kwargs['docstring'] = Transformer({}).visit(kwargs['docstring'])
+            kwargs['docstring'] = rebuild.visit(kwargs['docstring'])
         if 'spec' in kwargs:
-            kwargs['spec'] = Transformer({}).visit(kwargs['spec'])
+            kwargs['spec'] = rebuild.visit(kwargs['spec'])
         if 'contains' in kwargs:
-            kwargs['contains'] = Transformer({}).visit(kwargs['contains'])
+            kwargs['contains'] = rebuild.visit(kwargs['contains'])
 
         # Rescope symbols if not explicitly disabled
         kwargs.setdefault('rescope_symbols', True)

--- a/loki/subroutine.py
+++ b/loki/subroutine.py
@@ -288,7 +288,7 @@ class Subroutine(ProgramUnit):
 
         # Rebuild body (other IR components are taken care of in super class)
         if 'body' in kwargs:
-            kwargs['body'] = Transformer({}).visit(kwargs['body'])
+            kwargs['body'] = Transformer({}, rebuild_scopes=True).visit(kwargs['body'])
 
         # Escalate to parent class
         return super().clone(**kwargs)


### PR DESCRIPTION
As the title implies, we were indeed not rebuilding nested `ScopedNode` objects in the duplication `Transformer` used for deep-copying (cloning) of  `Subroutine`/`Module` objects. This PR fixes this and adds tests that include nested `ScopedNode` objects (`Associate` for subroutine and `TypeDef` for modules) in the duplicated IR. 

This should fix issue #174.

Many thanks to @JoeffreyLegaux for reporting and providing the reproducer for the subroutine case. I've slightly shortened the example code, but in essence it's the same problem. :wink: Please do confirm that this fixes things as you'd expect.