### PR TITLE
add 'kernel_only=True' to RemoveCallsTransformation

### DIFF
--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -172,7 +172,7 @@ def convert(
     if 'scc' in mode:
         scheduler.process( RemoveCallsTransformation(
             routines=config.default.get('utility_routines', None) or ['DR_HOOK', 'ABOR1', 'WRITE(NULOUT'],
-            include_intrinsics=True
+            include_intrinsics=True, kernel_only=True
         ))
     else:
         scheduler.process( DrHookTransformation(mode=mode, remove=False) )


### PR DESCRIPTION
add `kernel_only=True` to RemoveCallsTransformation to avoid DrHook Calls being removed from driver routines. 

This was part of the `loki_transform.py` `ecphys()` entry point, but not yet part of the `convert()` entry point. Tested with/for ecphys. 