### PR TITLE
Generic enrichment process

### DIFF
--- a/example/05_argument_intent_linter.ipynb
+++ b/example/05_argument_intent_linter.ipynb
@@ -113,7 +113,7 @@
     "from loki import Sourcefile\n",
     "\n",
     "source = Sourcefile.from_file('src/intent_test.F90')\n",
-    "print(source.to_fortran())"
+    "print(source.to_fortran())\n"
    ]
   },
   {
@@ -148,7 +148,7 @@
    ],
    "source": [
     "routine = source['intent_test']\n",
-    "print('vars::', ', '.join([str(v) for v in routine.variables]))"
+    "print('vars::', ', '.join([str(v) for v in routine.variables]))\n"
    ]
   },
   {
@@ -179,13 +179,13 @@
     "intent_vars = defaultdict(list)\n",
     "for var in routine.arguments:\n",
     "    intent_vars[var.type.intent].append(var)\n",
-    "    \n",
+    "\n",
     "in_vars = intent_vars['in']\n",
     "out_vars = intent_vars['out']\n",
     "inout_vars = intent_vars['inout']\n",
     "\n",
     "print('in::', ', '.join([str(v) for v in in_vars]), 'out::', ', '.join([str(v) for v in out_vars]), 'inout::', ','.join([str(v) for v in inout_vars]))\n",
-    "assert all([len(in_vars) == 3, len(out_vars) == 2, len(inout_vars) == 1])"
+    "assert all([len(in_vars) == 3, len(out_vars) == 2, len(inout_vars) == 1])\n"
    ]
   },
   {
@@ -223,7 +223,7 @@
     "\n",
     "alloc = FindNodes(Allocation).visit(routine.body)[0]\n",
     "alloc_vars = FindVariables().visit(alloc.variables)\n",
-    "print(', '.join([str(v) for v in alloc_vars]))"
+    "print(', '.join([str(v) for v in alloc_vars]))\n"
    ]
   },
   {
@@ -245,7 +245,7 @@
     "\n",
     "def findvarsnotdims(o, return_vars=True):\n",
     "    \"\"\"Return list of variables excluding any array dimensions.\"\"\"\n",
-    "    \n",
+    "\n",
     "    dims = flatten([FindVariables().visit(var.dimensions) for var in FindVariables().visit(o) if isinstance(var, Array)])\n",
     "\n",
     "#   remove duplicates from dims\n",
@@ -253,9 +253,9 @@
     "\n",
     "    if return_vars:\n",
     "        return [var for var in FindVariables().visit(o) if not var in dims]\n",
-    "    \n",
+    "\n",
     "    return [var.name for var in FindVariables().visit(o) if not var in dims]\n",
-    "                \n",
+    "\n",
     "def finddimsnotvars(o, return_vars=True):\n",
     "    \"\"\"Return list of all array dimensions.\"\"\"\n",
     "\n",
@@ -266,8 +266,8 @@
     "\n",
     "    if return_vars:\n",
     "        return dims\n",
-    "    \n",
-    "    return [var.name for var in dims]"
+    "\n",
+    "    return [var.name for var in dims]\n"
    ]
   },
   {
@@ -298,7 +298,7 @@
     "print(f'dims:{finddimsnotvars(alloc.variables, return_vars=False)}')\n",
     "\n",
     "assert len(findvarsnotdims(alloc.variables)) == 1\n",
-    "assert len(finddimsnotvars(alloc.variables)) == 1"
+    "assert len(finddimsnotvars(alloc.variables)) == 1\n"
    ]
   },
   {
@@ -371,7 +371,7 @@
     "        vmap.update({var: rexpr for var in FindVariables().visit(assoc.body) if lexpr == var})\n",
     "    assoc_map[assoc] = SubstituteExpressions(vmap).visit(assoc.body)\n",
     "routine.body = Transformer(assoc_map).visit(routine.body)\n",
-    "print(fgen(routine.body))"
+    "print(fgen(routine.body))\n"
    ]
   },
   {
@@ -408,23 +408,23 @@
     "class FindPointerRange(FindNodes):\n",
     "    \"\"\"Visitor to find range of nodes over which pointer associations apply.\"\"\"\n",
     "\n",
-    "    \n",
+    "\n",
     "    def __init__(self, match, greedy=False):\n",
-    "        \n",
+    "\n",
     "        super().__init__(match, mode='type', greedy=greedy)\n",
     "        self.rule = lambda match, o: o == match\n",
     "        self.stat = False\n",
-    "    \n",
+    "\n",
     "    def visit_Assignment(self, o, **kwargs):\n",
     "        \"\"\"\n",
-    "        Check for pointer assignment (=>). Also check if pointer is disassociated, \n",
+    "        Check for pointer assignment (=>). Also check if pointer is disassociated,\n",
     "        else add the node to the returned list.\n",
     "        \"\"\"\n",
-    "        \n",
+    "\n",
     "        ret = kwargs.pop('ret', self.default_retval())\n",
     "        if self.rule(self.match, o):\n",
     "            assert not self.stat # we should only visit the pointer assignment node once\n",
-    "            self.stat = True   \n",
+    "            self.stat = True\n",
     "        elif self.match.lhs in findvarsnotdims(o.lhs) and 'null' in [v.name.lower for v in findvarsnotdims(o.rhs)]:\n",
     "            assert self.stat\n",
     "            self.stat = False\n",
@@ -437,7 +437,7 @@
     "        \"\"\"\n",
     "        Check if pointer is disassociated, else add the node to the returned list.\n",
     "        \"\"\"\n",
-    "        \n",
+    "\n",
     "        ret = kwargs.pop('ret', self.default_retval())\n",
     "        if self.match.lhs in findvarsnotdims(o.variables):\n",
     "            assert self.stat\n",
@@ -446,13 +446,13 @@
     "        elif self.stat:\n",
     "            ret.append(o)\n",
     "        return ret or self.default_retval()\n",
-    "    \n",
+    "\n",
     "    def visit_Node(self, o, **kwargs):\n",
     "        \"\"\"\n",
     "        Add the node to the returned list if stat is True and visit\n",
     "        all children.\n",
     "        \"\"\"\n",
-    "        \n",
+    "\n",
     "        ret = kwargs.pop('ret', self.default_retval())\n",
     "        if self.stat:\n",
     "            ret.append(o)\n",
@@ -461,11 +461,11 @@
     "        for i in o.children:\n",
     "            ret = self.visit(i, ret=ret, **kwargs)\n",
     "        return ret or self.default_retval()\n",
-    "    \n",
+    "\n",
     "for assign in [a for a in FindNodes(Assignment).visit(routine.body) if a.ptr]:\n",
     "    nodes = FindPointerRange(assign).visit(routine.body)\n",
     "    for node in nodes[:-1]:\n",
-    "        print(node)"
+    "        print(node)\n"
    ]
   },
   {
@@ -528,7 +528,7 @@
     "        pointer_map[node] = SubstituteExpressions(vmap).visit(node)\n",
     "    pointer_map[nodes[-1]] = None\n",
     "routine.body = Transformer(pointer_map).visit(routine.body)\n",
-    "print(fgen(routine.body))"
+    "print(fgen(routine.body))\n"
    ]
   },
   {
@@ -578,7 +578,7 @@
     "\n",
     "class IntentLinterVisitor(Visitor):\n",
     "    \"\"\"Visitor to check for dummy argument intent violations.\"\"\"\n",
-    "    \n",
+    "\n",
     "    def __init__(self, in_vars, out_vars, inout_vars):  # pylint: disable=redefined-outer-name\n",
     "        \"\"\"Initialise an instance of the intent linter visitor.\"\"\"\n",
     "\n",
@@ -587,17 +587,17 @@
     "        self.out_vars = out_vars\n",
     "        self.inout_vars = inout_vars\n",
     "        self.var_check = {var: True for var in (in_vars + out_vars + inout_vars)}\n",
-    "        \n",
+    "\n",
     "        self.vars_read = set(in_vars + inout_vars)\n",
     "        self.vars_written = set()\n",
     "        self.alloc_vars = set() # set of variables that are allocated\n",
-    "        \n",
+    "\n",
     "    def rule_check(self):\n",
     "        \"\"\"Check rule-status for all variables with declared intent.\"\"\"\n",
-    "        \n",
+    "\n",
     "        for v, s in self.var_check.items():\n",
-    "            assert s, f'intent({v.type.intent}) rule broken for {v.name}'   \n",
-    "        print('All rules satisfied')"
+    "            assert s, f'intent({v.type.intent}) rule broken for {v.name}'\n",
+    "        print('All rules satisfied')\n"
    ]
   },
   {
@@ -622,7 +622,7 @@
     "    Check if loop induction variable has declared intent, update vars_read/vars_written\n",
     "    if variables with declared intent are used in loop bounds and visit any nodes in loop body.\n",
     "    \"\"\"\n",
-    "    \n",
+    "\n",
     "    if o.variable.type.intent:\n",
     "        self.var_check[o.variable] = False\n",
     "        print(f'intent({o.variable.type.intent}) {o.variable.name} used as loop induction variable.')\n",
@@ -634,7 +634,7 @@
     "        self.vars_written.discard(v)\n",
     "    self.visit(o.body, **kwargs)\n",
     "\n",
-    "IntentLinterVisitor.visit_Loop = visit_Loop"
+    "IntentLinterVisitor.visit_Loop = visit_Loop\n"
    ]
   },
   {
@@ -654,23 +654,23 @@
    "source": [
     "def visit_Assignment(self, o):\n",
     "    \"\"\"Check intent rules for assignment statements.\"\"\"\n",
-    "    \n",
+    "\n",
     "    if o.lhs.type.intent == 'in':\n",
     "        print(f'value of intent(in) var {o.lhs.name} modified')\n",
     "        self.var_check[o.lhs] = False\n",
-    "        \n",
+    "\n",
     "    self.vars_written.add(o.lhs)\n",
     "    self.vars_read.discard(o.lhs)\n",
-    "    \n",
+    "\n",
     "    for v in FindVariables().visit(o.rhs):\n",
     "        if v.type.intent == 'out' and v not in self.vars_read | self.vars_written:\n",
     "            print('intent(out) var read from before being written to.')\n",
     "            self.var_check[v] = False\n",
     "        elif v.type.intent:\n",
     "            self.vars_read.add(v)\n",
-    "            self.vars_written.discard(v) \n",
+    "            self.vars_written.discard(v)\n",
     "\n",
-    "IntentLinterVisitor.visit_Assignment = visit_Assignment        "
+    "IntentLinterVisitor.visit_Assignment = visit_Assignment\n"
    ]
   },
   {
@@ -703,7 +703,7 @@
     "    Update set of allocated variables and read/written sets for variables used to define\n",
     "    allocation size.\n",
     "    \"\"\"\n",
-    "    \n",
+    "\n",
     "    self.alloc_vars.update(o.variables)\n",
     "    for v in [v for v in finddimsnotvars(o.variables) if v.type.intent]:\n",
     "        if v not in self.vars_read | self.vars_written:\n",
@@ -712,7 +712,7 @@
     "        self.vars_read.add(v)\n",
     "        self.vars_written.discard(v)\n",
     "\n",
-    "IntentLinterVisitor.visit_Allocation = visit_Allocation"
+    "IntentLinterVisitor.visit_Allocation = visit_Allocation\n"
    ]
   },
   {
@@ -765,7 +765,7 @@
     "from IPython.display import Image\n",
     "\n",
     "fig = Image(filename='gfx/intent_out_map-crop.png')\n",
-    "fig"
+    "fig\n"
    ]
   },
   {
@@ -796,7 +796,7 @@
    ],
    "source": [
     "fig = Image(filename='gfx/intent_inout_map-crop.png')\n",
-    "fig"
+    "fig\n"
    ]
   },
   {
@@ -836,14 +836,14 @@
     "\n",
     "def visit_CallStatement(self, o):\n",
     "    \"\"\"\n",
-    "    Check intent consistency across callstatement and check intent of \n",
+    "    Check intent consistency across callstatement and check intent of\n",
     "    dummy arguments corresponding to allocatables.\n",
     "    \"\"\"\n",
-    "   \n",
+    "\n",
     "    assign_type = {v.name: 'none' for v in self.in_vars + self.out_vars + self.inout_vars}\n",
     "    assign_type.update({v.name: 'lhs' for v in self.vars_written})\n",
     "    assign_type.update({v.name: 'rhs' for v in self.vars_read})\n",
-    "    \n",
+    "\n",
     "    for f, a in o.arg_iter():\n",
     "        if getattr(getattr(a, 'type', None), 'intent', None):\n",
     "            if f.type.intent not in intent_map[a.type.intent][assign_type[a.name]]:\n",
@@ -860,7 +860,7 @@
     "\n",
     "IntentLinterVisitor.intent_map = intent_map\n",
     "IntentLinterVisitor.visit_CallStatement = visit_CallStatement\n",
-    "routine.enrich_calls(source.all_subroutines) # link CallStatements to Subroutines"
+    "routine.enrich(source.all_subroutines) # link CallStatements to Subroutines\n"
    ]
   },
   {
@@ -868,7 +868,7 @@
    "id": "83a0eaa7",
    "metadata": {},
    "source": [
-    "In the final line of the above code-cell, we called the function `enrich_calls`. This uses inter-procedural analysis to link `CallStatement` nodes to the relevant `Subroutine` objects. Also note that in the above code-cell, `intent_map` has been declared as a class-attribute because it will be the same for every instance of `IntentLinterVisitor`. \n",
+    "In the final line of the above code-cell, we called the function `enrich`. This uses inter-procedural analysis to link `CallStatement` nodes to the relevant `Subroutine` objects. Also note that in the above code-cell, `intent_map` has been declared as a class-attribute because it will be the same for every instance of `IntentLinterVisitor`. \n",
     "\n",
     "We can now finally run our intent-linter and check if any rules are broken:"
    ]
@@ -890,7 +890,7 @@
    "source": [
     "intent_linter = IntentLinterVisitor(in_vars, out_vars, inout_vars)\n",
     "intent_linter.visit(routine.body)\n",
-    "intent_linter.rule_check()"
+    "intent_linter.rule_check()\n"
    ]
   }
  ],

--- a/lint_rules/tests/test_debug_rules.py
+++ b/lint_rules/tests/test_debug_rules.py
@@ -82,7 +82,7 @@ end subroutine kernel
 
     driver = driver_source['driver']
     kernel = kernel_source['kernel']
-    driver.enrich_calls([kernel,])
+    driver.enrich([kernel,])
 
     messages = []
     handler = DefaultHandler(target=messages.append)
@@ -155,7 +155,7 @@ end subroutine kernel
 
     driver = driver_source['driver']
     kernel = kernel_source['kernel']
-    driver.enrich_calls([kernel,])
+    driver.enrich([kernel,])
 
     messages = []
     handler = DefaultHandler(target=messages.append)

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -558,7 +558,7 @@ class Scheduler:
             item.source.make_complete(**build_args)
 
 
-    @Timer(logger=perf, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')
+    @Timer(logger=info, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')
     def _enrich(self):
         """
         Enrich subroutine calls for inter-procedural transformations

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -418,7 +418,8 @@ class Scheduler:
             warning(f'Scheduler could not find routine {routine}')
             if self.config.default['strict']:
                 raise RuntimeError(f'Scheduler could not find routine {routine}')
-        elif len(candidates) != 1:
+            return None
+        if len(candidates) != 1:
             warning(f'Scheduler found multiple candidates for routine {routine}: {candidates}')
             if self.config.default['strict']:
                 raise RuntimeError(f'Scheduler found multiple candidates for routine {routine}: {candidates}')

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -266,6 +266,18 @@ class Scheduler:
         return as_tuple(self.item_graph.edges)
 
     @property
+    def definitions(self):
+        """
+        The list of definitions that the source files in the
+        callgraph provide
+        """
+        return tuple(
+            definition
+            for item in self.item_graph
+            for definition in item.source.definitions
+        )
+
+    @property
     def file_graph(self):
         """
         Alternative dependency graph based on relations between source files
@@ -541,35 +553,37 @@ class Scheduler:
         """
         # Force the parsing of the routines
         build_args = self.build_args.copy()
-        build_args['definitions'] = as_tuple(build_args['definitions'])
+        build_args['definitions'] = as_tuple(build_args['definitions']) + self.definitions
         for item in reversed(list(nx.topological_sort(self.item_graph))):
             item.source.make_complete(**build_args)
-            build_args['definitions'] += item.source.definitions
+
 
     @Timer(logger=perf, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')
     def _enrich(self):
         """
         Enrich subroutine calls for inter-procedural transformations
         """
-        # Force the parsing of the routines in the call tree
+        definitions = self.definitions
         for item in self.item_graph:
             if not isinstance(item, SubroutineItem):
                 continue
 
-            # Enrich with all routines in the call tree
-            item.routine.enrich_calls(routines=self.routines)
-            item.routine.enrich_types(typedefs=self.typedefs)
+            # Enrich all modules and subroutines in the source file with
+            # the definitions of the scheduler's graph
+            for node in item.source.modules + item.source.subroutines:
+                node.enrich(definitions, recurse=True)
 
             # Enrich item with meta-info from outside of the callgraph
-            for routine in item.enrich:
-                lookup_name = self.find_routine(routine)
+            for name in as_tuple(item.enrich):
+                lookup_name = self.find_routine(name)
                 if not lookup_name:
-                    warning(f'Scheduler could not find file for enrichment:\n{routine}')
+                    warning(f'Scheduler could not find file for enrichment:\n{name}')
                     if self.config.default['strict']:
-                        raise FileNotFoundError(f'Source path not found for routine {routine}')
+                        raise FileNotFoundError(f'Source path not found for routine {name}')
                     continue
                 self.obj_map[lookup_name].make_complete(**self.build_args)
-                item.routine.enrich_calls(self.obj_map[lookup_name].all_subroutines)
+                for node in item.source.modules + item.source.subroutines:
+                    node.enrich(self.obj_map[lookup_name].definitions, recurse=True)
 
     def item_successors(self, item):
         """

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -978,7 +978,9 @@ class CallPattern(Pattern):
         for cname in name_parts[1:]:
             name = sym.Variable(name=name.name + '%' + cname, parent=name, scope=scope)  # pylint:disable=no-member
 
-        scope.symbol_attrs[call] = scope.symbol_attrs[call].clone(dtype=ProcedureType(name=call, is_function=False))
+        scope.symbol_attrs[call] = scope.symbol_attrs.lookup(call).clone(
+            dtype=ProcedureType(name=call, is_function=False)
+        )
 
         source = reader.source_from_current_line()
         if match['conditional']:

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -332,7 +332,7 @@ def transpile(build, header, source, driver, cpp, include, define, frontend, xmo
                                   frontend=frontend)
     driver = Sourcefile.from_file(driver, xmods=xmod, frontend=frontend)
     # Ensure that the kernel calls have all meta-information
-    driver[driver_name].enrich(routines=kernel[kernel_name])
+    driver[driver_name].enrich(kernel[kernel_name])
 
     kernel_item = SubroutineItem(f'#{kernel_name.lower()}', source=kernel)
     driver_item = SubroutineItem(f'#{driver_name.lower()}', source=driver)

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -332,7 +332,7 @@ def transpile(build, header, source, driver, cpp, include, define, frontend, xmo
                                   frontend=frontend)
     driver = Sourcefile.from_file(driver, xmods=xmod, frontend=frontend)
     # Ensure that the kernel calls have all meta-information
-    driver[driver_name].enrich_calls(routines=kernel[kernel_name])
+    driver[driver_name].enrich(routines=kernel[kernel_name])
 
     kernel_item = SubroutineItem(f'#{kernel_name.lower()}', source=kernel)
     driver_item = SubroutineItem(f'#{driver_name.lower()}', source=driver)

--- a/tests/test_analyse_dataflow.py
+++ b/tests/test_analyse_dataflow.py
@@ -307,7 +307,7 @@ end subroutine test
 
     source = Sourcefile.from_source(fcode, frontend=frontend)
     routine = source['test']
-    routine.enrich_calls(source.all_subroutines)
+    routine.enrich(source.all_subroutines)
     call = FindNodes(CallStatement).visit(routine.body)[0]
 
     with dataflow_analysis_attached(routine):
@@ -443,7 +443,7 @@ end subroutine test
     routine = source['test']
 
     call = FindNodes(CallStatement).visit(routine.body)[0]
-    routine.enrich_calls(source.all_subroutines)
+    routine.enrich(source.all_subroutines)
 
     with dataflow_analysis_attached(routine):
         assert 'n' in call.uses_symbols

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1663,6 +1663,8 @@ end subroutine driver
         assert isinstance(call.name.type.dtype, ProcedureType)
         assert call.name.parent
         assert isinstance(call.name.parent.type.dtype, DerivedType)
+        assert isinstance(call.routine, Subroutine)
+        assert isinstance(call.name.type.dtype.procedure, Subroutine)
 
     assert isinstance(calls[0].name.parent, Scalar)
     assert calls[0].name.parent.type.dtype.name == 'third_type'

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1995,9 +1995,9 @@ end subroutine driver
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_enrich_calls_explicit_interface(frontend):
+def test_enrich_explicit_interface(frontend):
     """
-    Test enrich_calls points to the actual routine and not the symbol declared
+    Test enrich points to the actual routine and not the symbol declared
     in an explicit interface.
     """
 
@@ -2036,7 +2036,7 @@ def test_enrich_calls_explicit_interface(frontend):
     kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
     driver = Subroutine.from_source(fcode_driver, frontend=frontend)
 
-    driver.enrich_calls(routines=(kernel,))
+    driver.enrich(kernel)
 
     # check if call is enriched correctly
     calls = FindNodes(CallStatement).visit(driver.body)

--- a/transformations/tests/test_argument_shape.py
+++ b/transformations/tests/test_argument_shape.py
@@ -49,7 +49,7 @@ def test_argument_shape_simple(frontend):
 
     kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
     driver = Subroutine.from_source(fcode_driver, frontend=frontend)
-    driver.enrich_calls(kernel)  # Attach kernel source to driver call
+    driver.enrich(kernel)  # Attach kernel source to driver call
 
     # Ensure initial call uses implicit argument shapes
     calls = FindNodes(CallStatement).visit(driver.body)
@@ -107,9 +107,9 @@ def test_argument_shape_nested(frontend):
 
     kernel_b = Subroutine.from_source(fcode_kernel_b, frontend=frontend)
     kernel_a = Subroutine.from_source(fcode_kernel_a, frontend=frontend)
-    kernel_a.enrich_calls(kernel_b)  # Attach kernel source to call
+    kernel_a.enrich(kernel_b)  # Attach kernel source to call
     driver = Subroutine.from_source(fcode_driver, frontend=frontend)
-    driver.enrich_calls(kernel_a)  # Attach kernel source to call
+    driver.enrich(kernel_a)  # Attach kernel source to call
 
     # Ensure initial call uses implicit argument shapes
     calls = FindNodes(CallStatement).visit(driver.body)
@@ -204,15 +204,15 @@ def test_argument_shape_multiple(frontend):
 
     kernel_b = Subroutine.from_source(fcode_kernel_b, frontend=frontend)
     kernel_a1 = Subroutine.from_source(fcode_kernel_a1, frontend=frontend)
-    kernel_a1.enrich_calls(kernel_b)  # Attach kernel source to call
+    kernel_a1.enrich(kernel_b)  # Attach kernel source to call
     kernel_a2 = Subroutine.from_source(fcode_kernel_a2, frontend=frontend)
-    kernel_a2.enrich_calls(kernel_b)  # Attach kernel source to call
+    kernel_a2.enrich(kernel_b)  # Attach kernel source to call
     kernel_a3 = Subroutine.from_source(fcode_kernel_a3, frontend=frontend)
-    kernel_a3.enrich_calls(kernel_b)  # Attach kernel source to call
+    kernel_a3.enrich(kernel_b)  # Attach kernel source to call
     driver = Subroutine.from_source(fcode_driver, frontend=frontend)
-    driver.enrich_calls(kernel_a1)  # Attach kernel source to call
-    driver.enrich_calls(kernel_a2)  # Attach kernel source to call
-    driver.enrich_calls(kernel_a3)  # Attach kernel source to call
+    driver.enrich(kernel_a1)  # Attach kernel source to call
+    driver.enrich(kernel_a2)  # Attach kernel source to call
+    driver.enrich(kernel_a3)  # Attach kernel source to call
 
     # Ensure initial call uses implicit argument shapes
     calls = FindNodes(CallStatement).visit(driver.body)
@@ -304,12 +304,12 @@ def test_argument_shape_transformation(frontend):
     # Manually create subroutines and attach call-signature info
     kernel_b = Subroutine.from_source(fcode_kernel_b, frontend=frontend)
     kernel_a1 = Subroutine.from_source(fcode_kernel_a1, frontend=frontend)
-    kernel_a1.enrich_calls(kernel_b)  # Attach kernel source to call
+    kernel_a1.enrich(kernel_b)  # Attach kernel source to call
     kernel_a2 = Subroutine.from_source(fcode_kernel_a2, frontend=frontend)
-    kernel_a2.enrich_calls(kernel_b)  # Attach kernel source to call
+    kernel_a2.enrich(kernel_b)  # Attach kernel source to call
     driver = Subroutine.from_source(fcode_driver, frontend=frontend)
-    driver.enrich_calls(kernel_a1)  # Attach kernel source to call
-    driver.enrich_calls(kernel_a2)  # Attach kernel source to call
+    driver.enrich(kernel_a1)  # Attach kernel source to call
+    driver.enrich(kernel_a2)  # Attach kernel source to call
 
     # Ensure initial call uses implicit argument shapes
     calls = FindNodes(CallStatement).visit(driver.body)

--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -55,7 +55,7 @@ def test_data_offload_region_openacc(frontend, assume_deviceptr):
 """
     driver = Sourcefile.from_source(fcode_driver, frontend=frontend)['driver_routine']
     kernel = Sourcefile.from_source(fcode_kernel, frontend=frontend)['kernel_routine']
-    driver.enrich_calls(kernel)
+    driver.enrich(kernel)
 
     driver.apply(DataOffloadTransformation(assume_deviceptr=assume_deviceptr), role='driver',
                  targets=['kernel_routine'])
@@ -129,7 +129,7 @@ def test_data_offload_region_complex_remove_openmp(frontend):
 """
     driver = Sourcefile.from_source(fcode_driver, frontend=frontend)['driver_routine']
     kernel = Sourcefile.from_source(fcode_kernel, frontend=frontend)['kernel_routine']
-    driver.enrich_calls(kernel)
+    driver.enrich(kernel)
 
     offload_transform = DataOffloadTransformation(remove_openmp=True)
     driver.apply(offload_transform, role='driver', targets=['kernel_routine'])
@@ -200,7 +200,7 @@ def test_data_offload_region_multiple(frontend):
 """
     driver = Sourcefile.from_source(fcode_driver, frontend=frontend)['driver_routine']
     kernel = Sourcefile.from_source(fcode_kernel, frontend=frontend)['kernel_routine']
-    driver.enrich_calls(kernel)
+    driver.enrich(kernel)
 
     driver.apply(DataOffloadTransformation(), role='driver', targets=['kernel_routine'])
 

--- a/transformations/tests/test_single_column.py
+++ b/transformations/tests/test_single_column.py
@@ -147,7 +147,7 @@ def test_extract_sca_nested_level_zero(frontend, horizontal):
   END SUBROUTINE compute_level_zero
 """, frontend=frontend)
 
-    source['compute_column'].enrich_calls(routines=level_zero.all_subroutines)
+    source['compute_column'].enrich(routines=level_zero.all_subroutines)
 
     # Apply single-column extraction trasnformation in topological order
     sca_transform = ExtractSCATransformation(horizontal=horizontal)
@@ -208,7 +208,7 @@ def test_extract_sca_nested_level_one(frontend, horizontal):
   END SUBROUTINE compute_level_one
 """, frontend=frontend)
 
-    source['compute_column'].enrich_calls(routines=level_one.all_subroutines)
+    source['compute_column'].enrich(routines=level_one.all_subroutines)
 
     # Apply single-column extraction trasnformation in topological order
     sca_transform = ExtractSCATransformation(horizontal=horizontal)

--- a/transformations/tests/test_single_column.py
+++ b/transformations/tests/test_single_column.py
@@ -147,7 +147,7 @@ def test_extract_sca_nested_level_zero(frontend, horizontal):
   END SUBROUTINE compute_level_zero
 """, frontend=frontend)
 
-    source['compute_column'].enrich(routines=level_zero.all_subroutines)
+    source['compute_column'].enrich(level_zero.all_subroutines)
 
     # Apply single-column extraction trasnformation in topological order
     sca_transform = ExtractSCATransformation(horizontal=horizontal)
@@ -208,7 +208,7 @@ def test_extract_sca_nested_level_one(frontend, horizontal):
   END SUBROUTINE compute_level_one
 """, frontend=frontend)
 
-    source['compute_column'].enrich(routines=level_one.all_subroutines)
+    source['compute_column'].enrich(level_one.all_subroutines)
 
     # Apply single-column extraction trasnformation in topological order
     sca_transform = ExtractSCATransformation(horizontal=horizontal)

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -347,7 +347,7 @@ def test_scc_hoist_multiple_kernels(frontend, horizontal, vertical, blocking):
     driver_source = Sourcefile.from_source(fcode_driver, frontend=frontend)
     driver = driver_source['column_driver']
     kernel = kernel_source['compute_column']
-    driver.enrich_calls(kernel)  # Attach kernel source to driver call
+    driver.enrich(kernel)  # Attach kernel source to driver call
 
     driver_item = SubroutineItem(name='#column_driver', source=driver_source)
     kernel_item = SubroutineItem(name='#compute_column', source=kernel_source)
@@ -669,7 +669,7 @@ def test_scc_annotate_openacc(frontend, horizontal, vertical, blocking):
 """
     kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
     driver = Subroutine.from_source(fcode_driver, frontend=frontend)
-    driver.enrich_calls(kernel)  # Attach kernel source to driver call
+    driver.enrich(kernel)  # Attach kernel source to driver call
 
     # Test OpenACC annotations on non-hoisted version
     scc_transform = (SCCDevectorTransformation(horizontal=horizontal),)
@@ -766,7 +766,7 @@ def test_single_column_coalesced_hoist_openacc(frontend, horizontal, vertical, b
     driver_source = Sourcefile.from_source(fcode_driver, frontend=frontend)
     driver = driver_source['column_driver']
     kernel = kernel_source['compute_column']
-    driver.enrich_calls(kernel)  # Attach kernel source to driver call
+    driver.enrich(kernel)  # Attach kernel source to driver call
 
     driver_item = SubroutineItem(name='#column_driver', source=driver_source)
     kernel_item = SubroutineItem(name='#compute_column', source=kernel_source)
@@ -893,8 +893,8 @@ def test_single_column_coalesced_nested(frontend, horizontal, vertical, blocking
     outer_kernel = Subroutine.from_source(fcode_outer_kernel, frontend=frontend)
     inner_kernel = Subroutine.from_source(fcode_inner_kernel, frontend=frontend)
     driver = Subroutine.from_source(fcode_driver, frontend=frontend)
-    outer_kernel.enrich_calls(inner_kernel)  # Attach kernel source to driver call
-    driver.enrich_calls(outer_kernel)  # Attach kernel source to driver call
+    outer_kernel.enrich(inner_kernel)  # Attach kernel source to driver call
+    driver.enrich(outer_kernel)  # Attach kernel source to driver call
 
     # Test SCC transform for plain nested kernel
     scc_transform = (SCCBaseTransformation(horizontal=horizontal),)
@@ -1306,7 +1306,7 @@ def test_single_column_coalesced_multiple_acc_pragmas(frontend, horizontal, vert
 
     source = Sourcefile.from_source(fcode, frontend=frontend)
     routine = source['test']
-    routine.enrich_calls(source.all_subroutines)
+    routine.enrich(source.all_subroutines)
 
     data_offload = DataOffloadTransformation(remove_openmp=True)
     data_offload.transform_subroutine(routine, role='driver', targets=['some_kernel',])
@@ -1408,7 +1408,7 @@ def test_single_column_coalesced_vector_inlined_call(frontend, horizontal):
     source = Sourcefile.from_source(fcode, frontend=frontend)
     routine = source['some_kernel']
     inlined_routine = source['some_inlined_kernel']
-    routine.enrich_calls((inlined_routine,))
+    routine.enrich((inlined_routine,))
 
     scc_transform = (SCCDevectorTransformation(horizontal=horizontal),)
     scc_transform += (SCCRevectorTransformation(horizontal=horizontal),)


### PR DESCRIPTION
Another lift of functionality from the Scheduler overhaul.

This one adds a more generic enrichment process. It is anchored on the following concepts:

1. For anything that is imported via a module import (i.e. `USE`), it is sufficient to look at the import nodes and update the symbol table entries of the symbols listed there (or for all symbols from the remote module if no only list is given). This applies to both, modules and subroutines (we haven't done enrichment for the first before) and also gives us typedef and global variable enrichment.
2. For anything that inherits its type from a parent (e.g., import in the parent module, call in the module procedure), we can compare symbol table entries with the parent's symbol table
3. For `Subroutine`s (the only ones where `CallStatements` can appear), we additionally apply the previous enrichment via call statements to
  a. retain the `active` property and
  b. enrich procedure symbols that are made available without an import (i.e., via explicit interface or non-inlined interface block include)
