### PR TITLE
Small parsing fixes

### DIFF
--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -332,13 +332,13 @@ class FortranCodegen(Stringifier):
         _var_types = [t.dtype.return_type.dtype if isinstance(t.dtype, ProcedureType) else t.dtype for t in types]
         _procedure_types = [t for t in types if isinstance(t.dtype, ProcedureType)]
 
-        if len(_procedure_types) > 0:
+        if _procedure_types:
             # Statement functions are the only symbol with ProcedureType that should appear
             # in a VariableDeclaration as all other forms of procedure declarations (bindings,
             # pointers, EXTERNAL statements) are handled by ProcedureDeclaration.
             # However, the fact that statement function declarations can appear mixed with actual
             # variable declarations forbids this in this case.
-            assert _procedure_types[0].is_stmt_func
+            assert all(t.is_stmt_func for t in _procedure_types)
             # TODO: We can't fully compare statement functions, yet but we can make at least sure
             # other declared attributes are compatible and that all have the same return type
             ignore += ['dtype']

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1812,11 +1812,12 @@ class FParser2IR(GenericVisitor):
             rescope_symbols=True, source=source, incomplete=False
         )
 
-        # Once statement functions are in place, we need to update the original declaration symbol
+        # Once statement functions are in place, we need to update the original declaration so that it
+        # contains ProcedureSymbols rather than Scalars
         for decl in FindNodes(ir.VariableDeclaration).visit(spec):
             if any(routine.symbol_attrs[s.name].is_stmt_func for s in decl.symbols):
-                assert all(routine.symbol_attrs[s.name].is_stmt_func for s in decl.symbols)
-                decl._update(symbols=tuple(s.clone() for s in decl.symbols))
+                decl._update(symbols=tuple(s.clone() if routine.symbol_attrs[s.name].is_stmt_func else s
+                                           for s in decl.symbols))
 
         # Big, but necessary hack:
         # For deferred array dimensions on allocatables, we infer the conceptual

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -468,8 +468,8 @@ class SubroutineFunctionPattern(Pattern):
             r'^(?P<prefix>[ \t\w()=]*)?(?P<keyword>subroutine|function)[ \t]+(?P<name>\w+)\b.*?$'
             r'(?P<spec>(?:.*?(?:^(?:abstract[ \t]+)?interface\b.*?^end[ \t]+interface)?)+)'
             r'(?P<contains>^contains\n(?:'
-            r'(?:[ \t\w()]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
-            r'(?:[ \t\w()]*?function.*?^end[ \t]*function\b(?:[ \t]\w+)?\n)|'
+            r'(?:[ \t\w()=]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
+            r'(?:[ \t\w()=]*?function.*?^end[ \t]*function\b(?:[ \t]\w+)?\n)|'
             r'(?:^#\w+.*?\n)'
             r')*)?'
             r'^end[ \t]*(?P=keyword)\b(?:[ \t](?P=name))?',

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -381,6 +381,7 @@ subroutine routine_b(
     ! arg2
     j
 )
+    use parkind1, only : jpim
     implicit none
     integer, intent(in) :: i, j
     integer b
@@ -391,16 +392,17 @@ subroutine routine_b(
     call routine_a()
 contains
 !abc ^$^**
+    integer(kind=jpim) function contained_e(i)
+        integer, intent(in) :: i
+        contained_e = i
+    end function
+
     subroutine contained_c(i)
         integer, intent(in) :: i
         integer c
         c = 5
     end subroutine contained_c
     ! cc£$^£$^
-    integer function contained_e(i)
-        integer, intent(in) :: i
-        contained_e = i
-    end function
 
     subroutine contained_d(i)
         integer, intent(in) :: i
@@ -415,7 +417,7 @@ end subroutine routine_b
     assert not routine.is_function
     assert routine.arguments == ()
     assert routine.argnames == []
-    assert [r.name for r in routine.subroutines] == ['contained_c', 'contained_e', 'contained_d']
+    assert [r.name for r in routine.subroutines] == ['contained_e', 'contained_c', 'contained_d']
 
     contained_c = routine['contained_c']
     assert contained_c.name == 'contained_c'
@@ -1487,7 +1489,7 @@ end module fypp_mod
 
 
 @pytest.mark.parametrize(
-    'frontend', 
+    'frontend',
     available_frontends(include_regex=True, xfail=[(OMNI, 'OMNI may segfault on empty files')])
 )
 @pytest.mark.parametrize('fcode', ['', '\n', '\n\n\n\n'])

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -1493,8 +1493,7 @@ subroutine subroutine_stmt_func(a, b)
     integer, intent(in) :: a
     integer, intent(out) :: b
     integer :: array(a)
-    integer :: i, j
-    integer :: plus, minus
+    integer :: i, j, plus, minus
     plus(i, j) = i + j
     minus(i, j) = i - j
     integer :: mult


### PR DESCRIPTION
This PR adds two small parsing fixes:
- The REGEX frontend can now parse member functions where the result variable has a specified kind
- Statement function result variables are now allowed to share a declaration with other variables

With these changes, Loki can successfully parse the refactored `LAPINEA/LAPINEB` kernels. 