### PR TITLE
Allow wildcards in `disable` list for scheduler

### DIFF
--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -6,6 +6,7 @@
 # nor does it submit to any jurisdiction.
 
 from abc import abstractmethod
+from fnmatch import fnmatch
 try:
     from functools import cached_property
 except ImportError:
@@ -326,7 +327,8 @@ class Item:
 
         # Filter out local members and disabled sub-branches
         children = [c for c in children if c not in self.members]
-        children = [c for c in children if c not in disabled]
+        for d in disabled:
+            children = [c for c in children if not fnmatch(c, d)]
 
         # Remove duplicates
         return as_tuple(dict.fromkeys(children))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2190,3 +2190,73 @@ def test_scheduler_unqualified_imports(config):
 
     assert item.enable_imports
     assert item.children == ('other_routine',)
+
+
+def test_scheduler_disable_wildcard(here, config):
+
+    fcode_mod = """
+module field_mod
+  type field2d
+    contains
+    procedure :: init => field_init
+  end type
+
+  type field3d
+    contains
+    procedure :: init => field_init
+  end type
+
+  contains
+    subroutine field_init()
+
+    end subroutine
+end module
+"""
+
+    fcode_driver = """
+subroutine my_driver
+  use field_mod, only: field2d, field3d, field_init
+implicit none
+
+  type(field2d) :: a, b
+  type(field3d) :: c, d
+
+  call a%init()
+  call b%init()
+  call c%init()
+  call field_init(d)
+end subroutine my_driver
+"""
+
+    # Set up the test files
+    dirname = here/'test_scheduler_disable_wildcard'
+    dirname.mkdir(exist_ok=True)
+    modfile = dirname/'field_mod.F90'
+    modfile.write_text(fcode_mod)
+    testfile = dirname/'test.F90'
+    testfile.write_text(fcode_driver)
+
+    config['default']['disable'] = ['*%init']
+
+    scheduler = Scheduler(paths=dirname, seed_routines=['my_driver'], config=config)
+
+    expected_items = [
+        '#my_driver', 'field_mod#field_init',
+    ]
+    expected_dependencies = [
+        ('#my_driver', 'field_mod#field_init'),
+    ]
+
+    assert all(n in scheduler.items for n in expected_items)
+    assert all(e in scheduler.dependencies for e in expected_dependencies)
+
+    assert 'field_mod#field2d%init' not in scheduler.items
+    assert 'field_mod#field3d%init' not in scheduler.items
+
+    # Clean up
+    try:
+        modfile.unlink()
+        testfile.unlink()
+        dirname.rmdir()
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
A very small and pragmatic change that allows us to generically exclude groups of calls from `Scheduler` traversal by using wildcards in the `disable` method. A more robust and generic solution would probably extend wildcard notation to all path/source name resolution mechanisms, but as the `Scheduler` is still being refactored heavily I chose the "quick and easy" option. Opinions and comments very welcome, of course!