### PR TITLE
Pragma-driven subroutine inlining and associated utilities

### DIFF
--- a/loki/transform/__init__.py
+++ b/loki/transform/__init__.py
@@ -21,3 +21,4 @@ from loki.transform.transform_hoist_variables import * # noqa
 from loki.transform.transform_parametrise import * # noqa
 from loki.transform.transform_extract_contained_procedures import * # noqa
 from loki.transform.transform_sequence_association import * # noqa
+from loki.transform.transform_dead_code import * # noqa

--- a/loki/transform/transform_dead_code.py
+++ b/loki/transform/transform_dead_code.py
@@ -64,5 +64,5 @@ class DeadCodeEliminationTransformer(Transformer):
         if condition == 'False':
             return else_body
 
-        has_elseif = isinstance(else_body, Conditional)
+        has_elseif = o.has_elseif and else_body and isinstance(else_body[0], Conditional)
         return self._rebuild(o, tuple((condition,) + (body,) + (else_body,)), has_elseif=has_elseif)

--- a/loki/transform/transform_dead_code.py
+++ b/loki/transform/transform_dead_code.py
@@ -1,0 +1,66 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Collection of utilities to perform Dead Code Elimination.
+"""
+from loki.visitors import Transformer
+from loki.expression.symbolic import simplify
+from loki.tools import flatten, as_tuple
+
+
+__all__ = ['dead_code_elimination', 'DeadCodeEliminationTransformer']
+
+
+def dead_code_elimination(routine, use_simplify=True):
+    """
+    Perform Dead Code Elimination on the given :any:`Subroutine` object.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine to which to apply dead code elimination.
+    simplify : boolean
+        Use :any:`simplify` when evaluating expressions for branch pruning.
+    """
+
+    transformer = DeadCodeEliminationTransformer(use_simplify=use_simplify)
+    routine.body = transformer.visit(routine.body)
+
+
+class DeadCodeEliminationTransformer(Transformer):
+    """
+    :any:`Transformer` class that removes provably unreachable code paths.
+
+    The pirmary modification performed is to prune individual code branches
+    under :any:`Conditional` nodes.
+
+    Parameters
+    ----------
+    simplify : boolean
+        Use :any:`simplify` when evaluating expressions for branch pruning.
+    """
+
+    def __init__(self, use_simplify=True, **kwargs):
+        super().__init__(**kwargs)
+        self.use_simplify = use_simplify
+
+    def visit_Conditional(self, o, **kwargs):
+        condition = self.visit(o.condition, **kwargs)
+        body = as_tuple(flatten(as_tuple(self.visit(o.body, **kwargs))))
+        else_body = as_tuple(flatten(as_tuple(self.visit(o.else_body, **kwargs))))
+
+        if self.use_simplify:
+            condition = simplify(condition)
+
+        if condition == 'True':
+            return body
+
+        if condition == 'False':
+            return else_body
+
+        return self._rebuild(o, tuple((condition,) + (body,) + (else_body,)))

--- a/loki/transform/transform_dead_code.py
+++ b/loki/transform/transform_dead_code.py
@@ -11,6 +11,7 @@ Collection of utilities to perform Dead Code Elimination.
 from loki.visitors import Transformer
 from loki.expression.symbolic import simplify
 from loki.tools import flatten, as_tuple
+from loki.ir import Conditional
 
 
 __all__ = ['dead_code_elimination', 'DeadCodeEliminationTransformer']
@@ -63,4 +64,5 @@ class DeadCodeEliminationTransformer(Transformer):
         if condition == 'False':
             return else_body
 
-        return self._rebuild(o, tuple((condition,) + (body,) + (else_body,)))
+        has_elseif = isinstance(else_body, Conditional)
+        return self._rebuild(o, tuple((condition,) + (body,) + (else_body,)), has_elseif=has_elseif)

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -327,6 +327,8 @@ def inline_subroutine_calls(routine, calls, callee):
     decls = FindNodes(VariableDeclaration).visit(callee.spec)
     decls = tuple(d for d in decls if all(s.name.lower() not in callee._dummies for s in d.symbols))
     decls = tuple(d for d in decls if all(s not in routine.variables for s in d.symbols))
+    # Rescope the declaration symbols
+    decls = tuple(d.clone(symbols=tuple(s.clone(scope=routine) for s in d.symbols)) for d in decls)
     routine.spec.append(decls)
 
     # Resolve the call by mapping arguments into the called procedure's body

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -326,7 +326,7 @@ def inline_subroutine_calls(routine, calls, callee, allowed_aliases=None):
         if v.name in parent_variables and v.name.lower() not in callee._dummies
     )
     # Filter out allowed aliases to prevent suffixing
-    duplicates = tuple(v for v in duplicates if v.name not in allowed_aliases)
+    duplicates = tuple(v for v in duplicates if v.symbol not in allowed_aliases)
     shadow_mapper = SubstituteExpressions(
         {v: v.clone(name=f'{callee.name}_{v.name}') for v in duplicates}
     )

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -268,6 +268,16 @@ def map_call_to_procedure_body(call, caller):
         else:
             argmap[arg] = val
 
+    # Deal with PRESENT check for optional arguments
+    present_checks = tuple(
+        check for check in FindInlineCalls().visit(callee.body) if check.function == 'PRESENT'
+    )
+    present_map = {
+        check: sym.Literal('.true.') if check.arguments[0] in call.arg_map else sym.Literal('.false.')
+        for check in present_checks
+    }
+    argmap.update(present_map)
+
     # Recursive update of the map in case of nested variables to map
     argmap = recursive_expression_map_update(argmap, max_iterations=10)
 

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -107,6 +107,8 @@ def cli(debug):
               help="Remove derived-type arguments and replace with canonical arguments")
 @click.option('--inline-members/--no-inline-members', default=False,
               help='Inline member functions for SCC-class transformations.')
+@click.option('--inline-marked/--no-inline-marked', default=True,
+              help='Inline pragma-marked subroutines for SCC-class transformations.')
 @click.option('--resolve-sequence-association/--no-resolve-sequence-association', default=False,
               help='Replace array arguments passed as scalars with arrays.')
 @click.option('--derive-argument-array-shape/--no-derive-argument-array-shape', default=False,
@@ -114,8 +116,8 @@ def cli(debug):
 def convert(
         mode, config, build, source, header, cpp, directive, include, define, omni_include, xmod,
         data_offload, remove_openmp, assume_deviceptr, frontend, trim_vector_sections,
-        global_var_offload, remove_derived_args, inline_members, resolve_sequence_association,
-        derive_argument_array_shape
+        global_var_offload, remove_derived_args, inline_members, inline_marked,
+        resolve_sequence_association, derive_argument_array_shape
 ):
     """
     Batch-processing mode for Fortran-to-Fortran transformations that
@@ -210,7 +212,8 @@ def convert(
         # Apply the basic SCC transformation set
         scheduler.process( SCCBaseTransformation(
             horizontal=horizontal, directive=directive,
-            inline_members=inline_members, resolve_sequence_association=resolve_sequence_association
+            inline_members=inline_members, inline_marked=inline_marked,
+            resolve_sequence_association=resolve_sequence_association
         ))
         scheduler.process( SCCDevectorTransformation(
             horizontal=horizontal, trim_vector_sections=trim_vector_sections

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -113,7 +113,7 @@ def cli(debug):
               help='Replace array arguments passed as scalars with arrays.')
 @click.option('--derive-argument-array-shape/--no-derive-argument-array-shape', default=False,
               help="Recursively derive explicit shape dimension for argument arrays")
-@click.option('--eliminate_dead_code/--no-eliminate_dead_code', default=True,
+@click.option('--eliminate-dead-code/--no-eliminate-dead-code', default=True,
               help='Perform dead code elimination, where unreachable branches are trimmed from the code.')
 def convert(
         mode, config, build, source, header, cpp, directive, include, define, omni_include, xmod,

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -113,11 +113,13 @@ def cli(debug):
               help='Replace array arguments passed as scalars with arrays.')
 @click.option('--derive-argument-array-shape/--no-derive-argument-array-shape', default=False,
               help="Recursively derive explicit shape dimension for argument arrays")
+@click.option('--eliminate_dead_code/--no-eliminate_dead_code', default=True,
+              help='Perform dead code elimination, where unreachable branches are trimmed from the code.')
 def convert(
         mode, config, build, source, header, cpp, directive, include, define, omni_include, xmod,
         data_offload, remove_openmp, assume_deviceptr, frontend, trim_vector_sections,
         global_var_offload, remove_derived_args, inline_members, inline_marked,
-        resolve_sequence_association, derive_argument_array_shape
+        resolve_sequence_association, derive_argument_array_shape, eliminate_dead_code
 ):
     """
     Batch-processing mode for Fortran-to-Fortran transformations that
@@ -213,7 +215,8 @@ def convert(
         scheduler.process( SCCBaseTransformation(
             horizontal=horizontal, directive=directive,
             inline_members=inline_members, inline_marked=inline_marked,
-            resolve_sequence_association=resolve_sequence_association
+            resolve_sequence_association=resolve_sequence_association,
+            eliminate_dead_code=eliminate_dead_code
         ))
         scheduler.process( SCCDevectorTransformation(
             horizontal=horizontal, trim_vector_sections=trim_vector_sections

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -188,6 +188,25 @@ def test_simplify_collect_coefficients(source, ref):
 
 @pytest.mark.skipif(not HAVE_FP, reason='Fparser not available')
 @pytest.mark.parametrize('source, ref', [
+    ('1 == 1', 'True'),
+    ('2 == 1', 'False'),
+    ('1 + 1 == 2', '1 + 1 == 2'),  # Not true without integer arithmetic
+    ('.true. .and. .true.', 'True'),
+    ('.true. .and. .false.', 'False'),
+    ('.true. .or. .false.', 'True'),
+    ('.false. .or. .false.', 'False'),
+    ('2 == 1 .and. 1 == 1', 'False'),
+    ('2 == 1 .or. 1 == 1', 'True'),
+])
+def test_simplify_logic_evaluation(source, ref):
+    scope = Scope()
+    expr = parse_fparser_expression(source, scope)
+    expr = simplify(expr, enabled_simplifications=Simplification.LogicEvaluation)
+    assert str(expr) == ref
+
+
+@pytest.mark.skipif(not HAVE_FP, reason='Fparser not available')
+@pytest.mark.parametrize('source, ref', [
     ('5 * (4 + 3 * (2 + 1) )', '65'),
     ('1 - (-1 - (-1 - (-1 - (-1 - 1) - 1) - 1) - 1) - 1', '0'),
     ('5 + a * (3 - b * (2 + c)) * 5 - 4', '1 + 15*a - 10*a*b - 5*a*b*c'),
@@ -201,7 +220,9 @@ def test_simplify_collect_coefficients(source, ref):
     ('1*a*b + 0*a*b', 'a*b'),
     ('n+(((-1)*1)*n)', '0'),
     ('5 + a * (3 - b * (2 + c) / 7) * 5 - 4', '1 + 15*a - 10*a*b / 7 - 5*a*b*c / 7'),
-    ('(5 + 3) * a - 8 * a / 2 + a * ((7 - 1) / 3)', '6*a')
+    ('(5 + 3) * a - 8 * a / 2 + a * ((7 - 1) / 3)', '6*a'),
+    ('(5 + 3) == 8', 'True'),
+    ('42 == 666', 'False'),
 ])
 def test_simplify(source,ref):
     scope = Scope()

--- a/tests/test_transform_dead_code.py
+++ b/tests/test_transform_dead_code.py
@@ -80,22 +80,32 @@ subroutine test_dead_code_conditional(a, b, flag)
   else
     b = a + 3
   end if
+
+  if (a > 2.0) then
+    a = a + 5.0
+  elseif (2 == 3) then
+    a = a + 3.0
+  else
+    a = a + 1.0
+  endif
 end subroutine test_dead_code_conditional
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     # Please note that nested conditionals (elseif) counts as two
-    assert len(FindNodes(Conditional).visit(routine.body)) == 2
-    assert len(FindNodes(Assignment).visit(routine.body)) == 3
+    assert len(FindNodes(Conditional).visit(routine.body)) == 4
+    assert len(FindNodes(Assignment).visit(routine.body)) == 6
 
     dead_code_elimination(routine)
 
     conditionals = FindNodes(Conditional).visit(routine.body)
-    assert len(conditionals) == 1
+    assert len(conditionals) == 2
     assert conditionals[0].condition == 'flag'
+    assert not conditionals[0].has_elseif
+    assert conditionals[1].condition == 'a > 2.0'
+    assert not conditionals[1].has_elseif
     assigns = FindNodes(Assignment).visit(routine.body)
-    assert len(assigns) == 2
+    assert len(assigns) == 4
     assert assigns[0].lhs == 'b' and assigns[0].rhs == 'b + 4'
     assert assigns[1].lhs == 'b' and assigns[1].rhs == 'a + 3'
-
-    # Ensure that the `has_elseif` attribute has been resolved
-    assert not conditionals[0].has_elseif
+    assert assigns[2].lhs == 'a' and assigns[2].rhs == 'a + 5.0'
+    assert assigns[3].lhs == 'a' and assigns[3].rhs == 'a + 1.0'

--- a/tests/test_transform_dead_code.py
+++ b/tests/test_transform_dead_code.py
@@ -8,7 +8,7 @@
 import pytest
 
 from conftest import available_frontends
-from loki import Subroutine, FindNodes, Conditional, Assignment
+from loki import Subroutine, FindNodes, Conditional, Assignment, OMNI
 from loki.transform import dead_code_elimination
 
 
@@ -88,24 +88,42 @@ subroutine test_dead_code_conditional(a, b, flag)
   else
     a = a + 1.0
   endif
+
+  if (a > 2.0) then
+    a = a + 5.0
+  elseif (2 == 3) then
+    a = a + 3.0
+  elseif (a > 1.0) then
+    a = a + 2.0
+  else
+    a = a + 1.0
+  endif
 end subroutine test_dead_code_conditional
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     # Please note that nested conditionals (elseif) counts as two
-    assert len(FindNodes(Conditional).visit(routine.body)) == 4
-    assert len(FindNodes(Assignment).visit(routine.body)) == 6
+    assert len(FindNodes(Conditional).visit(routine.body)) == 7
+    assert len(FindNodes(Assignment).visit(routine.body)) == 10
 
     dead_code_elimination(routine)
 
     conditionals = FindNodes(Conditional).visit(routine.body)
-    assert len(conditionals) == 2
+    assert len(conditionals) == 4
     assert conditionals[0].condition == 'flag'
     assert not conditionals[0].has_elseif
     assert conditionals[1].condition == 'a > 2.0'
     assert not conditionals[1].has_elseif
+    assert conditionals[2].condition == 'a > 2.0'
+    if not frontend == OMNI:  # OMNI does not get elseifs right
+        assert conditionals[2].has_elseif
+    assert conditionals[3].condition == 'a > 1.0'
+    assert not conditionals[3].has_elseif
     assigns = FindNodes(Assignment).visit(routine.body)
-    assert len(assigns) == 4
+    assert len(assigns) == 7
     assert assigns[0].lhs == 'b' and assigns[0].rhs == 'b + 4'
     assert assigns[1].lhs == 'b' and assigns[1].rhs == 'a + 3'
     assert assigns[2].lhs == 'a' and assigns[2].rhs == 'a + 5.0'
     assert assigns[3].lhs == 'a' and assigns[3].rhs == 'a + 1.0'
+    assert assigns[4].lhs == 'a' and assigns[4].rhs == 'a + 5.0'
+    assert assigns[5].lhs == 'a' and assigns[5].rhs == 'a + 2.0'
+    assert assigns[6].lhs == 'a' and assigns[6].rhs == 'a + 1.0'

--- a/tests/test_transform_dead_code.py
+++ b/tests/test_transform_dead_code.py
@@ -1,0 +1,52 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from conftest import available_frontends
+from loki import Subroutine, FindNodes, Conditional, Assignment
+from loki.transform import dead_code_elimination
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_dead_code_conditional(frontend):
+    """
+    Test correct elimination of unreachable conditional branches.
+    """
+    fcode = """
+subroutine test_dead_code_conditional(a, b, flag)
+  real(kind=8), intent(inout) :: a, b
+  logical, intent(in) :: flag
+
+  if (flag) then
+    if (1 == 6) then
+      a = a + b
+    else
+      b = b + 2.0
+    end if
+
+    if (2 == 2) then
+      b = b + a
+    else
+      a = a + 3.0
+    end if
+  end if
+end subroutine test_dead_code_conditional
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert len(FindNodes(Conditional).visit(routine.body)) == 3
+    assert len(FindNodes(Assignment).visit(routine.body)) == 4
+
+    dead_code_elimination(routine)
+
+    conditionals = FindNodes(Conditional).visit(routine.body)
+    assert len(conditionals) == 1
+    assert conditionals[0].condition == 'flag'
+    assigns = FindNodes(Assignment).visit(routine.body)
+    assert len(assigns) == 2
+    assert assigns[0].lhs == 'b' and assigns[0].rhs == 'b + 2.0'
+    assert assigns[1].lhs == 'b' and assigns[1].rhs == 'b + a'

--- a/tests/test_transform_dead_code.py
+++ b/tests/test_transform_dead_code.py
@@ -34,12 +34,58 @@ subroutine test_dead_code_conditional(a, b, flag)
     else
       a = a + 3.0
     end if
+
+    if (1 == 2) then
+      b = b + a
+    elseif (3 == 3) then
+      a = a + b
+    else
+      a = a + 6.0
+    end if
+
   end if
 end subroutine test_dead_code_conditional
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    assert len(FindNodes(Conditional).visit(routine.body)) == 3
-    assert len(FindNodes(Assignment).visit(routine.body)) == 4
+    # Please note that nested conditionals (elseif) counts as two
+    assert len(FindNodes(Conditional).visit(routine.body)) == 5
+    assert len(FindNodes(Assignment).visit(routine.body)) == 7
+
+    dead_code_elimination(routine)
+
+    conditionals = FindNodes(Conditional).visit(routine.body)
+    assert len(conditionals) == 1
+    assert conditionals[0].condition == 'flag'
+    assigns = FindNodes(Assignment).visit(routine.body)
+    assert len(assigns) == 3
+    assert assigns[0].lhs == 'b' and assigns[0].rhs == 'b + 2.0'
+    assert assigns[1].lhs == 'b' and assigns[1].rhs == 'b + a'
+    assert assigns[2].lhs == 'a' and assigns[2].rhs == 'a + b'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_dead_code_conditional_nested(frontend):
+    """
+    Test correct elimination of unreachable branches in nested conditionals.
+    """
+    fcode = """
+subroutine test_dead_code_conditional(a, b, flag)
+  real(kind=8), intent(inout) :: a, b
+  logical, intent(in) :: flag
+
+  if (1 == 2) then
+    a = a + 5
+  elseif (flag) then
+    b = b + 4
+  else
+    b = a + 3
+  end if
+end subroutine test_dead_code_conditional
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    # Please note that nested conditionals (elseif) counts as two
+    assert len(FindNodes(Conditional).visit(routine.body)) == 2
+    assert len(FindNodes(Assignment).visit(routine.body)) == 3
 
     dead_code_elimination(routine)
 
@@ -48,5 +94,8 @@ end subroutine test_dead_code_conditional
     assert conditionals[0].condition == 'flag'
     assigns = FindNodes(Assignment).visit(routine.body)
     assert len(assigns) == 2
-    assert assigns[0].lhs == 'b' and assigns[0].rhs == 'b + 2.0'
-    assert assigns[1].lhs == 'b' and assigns[1].rhs == 'b + a'
+    assert assigns[0].lhs == 'b' and assigns[0].rhs == 'b + 4'
+    assert assigns[1].lhs == 'b' and assigns[1].rhs == 'a + 3'
+
+    # Ensure that the `has_elseif` attribute has been resolved
+    assert not conditionals[0].has_elseif

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -669,7 +669,7 @@ end module util_mod
     assert calls[1].routine == module['add_a_to_b']
     assert calls[2].routine == module['add_one']
 
-    inline_marked_subroutines(routine=driver, allowed_aliases=('i',))
+    inline_marked_subroutines(routine=driver, allowed_aliases=('I',))
 
     # Check inlined loops and assignments
     assert len(FindNodes(Loop).visit(driver.body)) == 3

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -1775,7 +1775,7 @@ def test_single_column_coalesced_inline_and_sequence_association(frontend, horiz
         with pytest.raises(RuntimeError) as e_info:
             scc_transform.apply(routine, role='kernel')
         assert(e_info.exconly() ==
-               'RuntimeError: [Loki::TransformInline] Unable to resolve member subroutine call')
+               'RuntimeError: [Loki::TransformInline] Cannot resolve procedure call to contained_kernel')
 
     #Check that the call is properly modified
     elif (not inline_members and resolve_sequence_association):

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -313,7 +313,9 @@ class SCCBaseTransformation(Transformation):
 
         # Perform full source-inlining for pragma-marked subroutines
         if self.inline_marked:
-            inline_marked_subroutines(routine)
+            # When inlining we allow the horizontal dimension to alias, so that
+            # the de/re-vectorisation captures the shared vector dimension.
+            inline_marked_subroutines(routine, allowed_aliases=(self.horizontal.index,))
 
         # Associates at the highest level, so they don't interfere
         # with the sections we need to do for detecting subroutine calls

--- a/transformations/transformations/single_column_coalesced.py
+++ b/transformations/transformations/single_column_coalesced.py
@@ -314,7 +314,7 @@ class SCCBaseTransformation(Transformation):
 
         # Perform full source-inlining for member subroutines
         if self.inline_members:
-            inline_member_procedures(routine)
+            inline_member_procedures(routine, allowed_aliases=(self.horizontal.index,))
 
         # Perform full source-inlining for pragma-marked subroutines
         if self.inline_marked:


### PR DESCRIPTION
The primary purpose of this PR is to introduce pragma-driven source inlining for Suboutine where `CallStatement` nodes annotated with the `!$loki inline` pragma are replaced by the body of the called routine, with resolved argument mappings. As I developed this on the EC-physics regression suite, I needed to include a few additional utilities that deal with the fallout of the resolution of optional arguments (simplistic logic evaluation in `simplify` and primitive dead code elimination), but these could easily be factored into a separate PR if that is desirable (@reuterbal, please shout!). 

Otherwise, the PR is primarily a refactoring of the procedure inlining utility, where the remapping of a call to the called body is now completely separated from the dealing with local variable declarations (in `inline_subroutine_calls`). This allows us to reuse these entry points between `inline_marked_subroutines` and `inline_internal_procedures`.

The rest of the changes and fixes some more detail:
- Separation of call remapping from declaration/scope management in procedure inlining
- Renaming of `inline_member_subroutines` to the more accurate "internal" and "procedure" (no change in capability though!)
- Dealing with unresolved `optional` arguments after call remapping (resolve the `present(n)` clause, depending on the presence of `n`, to either `.true.` or `.false.`)
-  Simplistic dead code elimination that resolves explicitly unreachable branches of conditionals (eg. from resolving `if (present(arg)) <do_something_with_arg>`. This then avoids dealing with remnant uses of the optional args, in case they were not given to an inlined call.
- Extension of the above dead code elimination by resolving simple constant expressions to logical values, eg. `1 == 6 .or. 2 == 4` to simply `.false.`
- A small fix to vector section-derivation that fixes a corner case of `!$loki separator` prgamas sitting deep in a nested control flow (possibly under tested :hand_over_mouth: )