### PR TITLE
Array shadowing bugfix for inliner

### DIFF
--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -569,6 +569,41 @@ end subroutine outer
     assert assigns[3].lhs == 'jg' and assigns[3].rhs == '2'
     assert assigns[4].lhs == 'z' and assigns[4].rhs == 'jlon + jg'
 
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_inline_member_routines_indexing_of_shadowed_array(frontend):
+    """
+    Test special case of inlining of member subroutines when inlined routine contains
+    shadowed array and array indices. 
+    In particular, this test checks that also the variables indexing
+    the array in the inlined result get renamed correctly.
+    """
+    fcode = """
+    subroutine outer(klon)
+        integer :: jg, jlon
+        integer :: arr(3, 3)
+
+        jg = 70000
+        call inner2()
+
+        contains
+
+        subroutine inner2()
+            integer :: jlon, jg 
+            integer :: arr(3, 3)
+            do jg=1,3
+                do jlon=1,3
+                   arr(jlon, jg) = 11 
+                end do
+            end do
+        end subroutine inner2
+
+    end subroutine outer
+    """
+    routine = Subroutine.from_source(fcode)
+    inline_member_procedures(routine)
+    innerloop = FindNodes(Loop).visit(routine.body)[1]
+    innerloopvars = FindVariables().visit(innerloop)
+    assert 'inner2_arr(inner2_jlon,inner2_jg)' in innerloopvars
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_inline_member_routines_sequence_assoc(frontend):

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -599,7 +599,7 @@ def test_inline_member_routines_indexing_of_shadowed_array(frontend):
 
     end subroutine outer
     """
-    routine = Subroutine.from_source(fcode)
+    routine = Subroutine.from_source(fcode, frontend=frontend)
     inline_member_procedures(routine)
     innerloop = FindNodes(Loop).visit(routine.body)[1]
     innerloopvars = FindVariables().visit(innerloop)


### PR DESCRIPTION
Hello.

This PR fixes a bug in `inline_subroutine_calls`.
Consider the following example (here demonstrating with `inline_member_procedures`, which eventually calls the above):
```
from loki import Sourcefile
from loki.transform import (
    inline_member_procedures
)
fcode = """
    subroutine outer(klon)
        integer :: jg, jlon
        integer :: arr(3, 3)

        jg = 70000
        call inner2()

        contains

        subroutine inner2()
            integer :: jlon, jg 
            integer :: arr(3, 3)
            do jg=1,3
                do jlon=1,3
                   arr(jlon, jg) = 11 
                end do
            end do
        end subroutine inner2

    end subroutine outer
"""
src = Sourcefile.from_source(fcode)
routine = src.routines[0]
inline_member_procedures(routine)
print(routine.to_fortran())
```

On the main branch, this prints:
```
SUBROUTINE outer (klon)
  INTEGER :: jg, jlon
  INTEGER :: arr(3, 3)
  INTEGER :: inner2_jlon, inner2_jg
  INTEGER :: inner2_arr(3, 3)

  jg = 70000
  ! [Loki] inlined child subroutine: inner2
  ! =========================================
  DO inner2_jg=1,3
    DO inner2_jlon=1,3
      inner2_arr(jlon, jg) = 11 ! Wrong 'jlon' and 'jg'
    END DO
  END DO
  ! =========================================

  CONTAINS

END SUBROUTINE outer
```
Inside the double loop, note the wrong `jlon` and `jg`. 
This occurs because the inliner renames shadowing variables only by "name", i.e `arr(jlon, jg)` is transformed only to `inner_arr(jlon, jg)` even though `jlon` and `jg` should also be renamed as they are shadowed as well.
This occurs here (`var_map` only changes name):
https://github.com/ecmwf-ifs/loki/blob/556db2ea0ae5d8475bfa64eb2d935265dba4aeb8/loki/transform/transform_inline.py#L337-L342

This PR fixes the above issue by first building a transformation map for renaming nonarray variables, and then a transformation map for renaming array variables. In the construction of the latter, the `dimensions` attribute is transformed using the transformation map for nonarray variables. There may be a more elegant way to achieve this.

There is also a new test to check that this remains fixed.