### PR TITLE
Minor fixes to frontends and IR nodes

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -916,10 +916,10 @@ class FParser2IR(GenericVisitor):
             interface = return_type.dtype
             _type = SymbolAttributes(BasicType.DEFERRED, **attrs)
 
-        # Make sure any "initial" symbol (i.e. the procedure we're binding to) is in the right scope
-        if _type.initial is not None:
-            initial = AttachScopesMapper()(_type.initial, scope=scope)
-            _type = _type.clone(initial=initial)
+        # Make sure any "bind_names" symbol (i.e. the procedure we're binding to) is in the right scope
+        if _type.bind_names is not None:
+            bind_names = AttachScopesMapper()(_type.bind_names, scope=scope)
+            _type = _type.clone(bind_names=bind_names)
 
         # Update symbol table entries
         if return_type is None:

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1083,12 +1083,20 @@ class OFP2IR(GenericVisitor):
             spec = spec.rescope(scope=scope)
 
         body = []
+        # Sometimes, OFP gets it wrong and puts the declarations inside <declaration>,
+        # on other occasions it puts it inside <specification>...  ¯\_(ツ)_/¯
         grouped_elems = match_tag_sequence(o.find('body/specification/declaration'), [
             ('names', 'procedure-stmt'),
             ('function', ),
             ('subroutine', ),
             ('comment', ),
         ])
+        if not grouped_elems:
+            grouped_elems = match_tag_sequence(o.find('body/specification'), [
+                ('function',),
+                ('subroutine',),
+                ('comment',)
+            ])
 
         for group in grouped_elems:
             if len(group) == 1:
@@ -1365,7 +1373,7 @@ class OFP2IR(GenericVisitor):
                                source=kwargs['source'], status_var=kw_args.get('stat'))
 
     def visit_use(self, o, **kwargs):
-        name, module = self.visit(o.find('use-stmt'), **kwargs)
+        name, module, nature = self.visit(o.find('use-stmt'), **kwargs)
         scope = kwargs['scope']
         if o.find('only') is not None:
             # ONLY list given (import only selected symbols)
@@ -1422,7 +1430,7 @@ class OFP2IR(GenericVisitor):
                 })
             rename_list = tuple(rename_list.items()) if rename_list else None
         return ir.Import(module=name, symbols=symbols, rename_list=rename_list,
-                         label=kwargs['label'], source=kwargs['source'])
+                         nature=nature, label=kwargs['label'], source=kwargs['source'])
 
     def visit_only(self, o, **kwargs):
         count = int(o.find('only-list').get('count'))
@@ -1438,8 +1446,10 @@ class OFP2IR(GenericVisitor):
     def visit_use_stmt(self, o, **kwargs):
         name = o.attrib['id']
         if o.attrib['hasModuleNature'] != 'false':
-            self.warn_or_fail('module nature in USE statement not implemented')
-        return name, self.definitions.get(name)
+            self.warn_or_fail('Module nature in USE statement not implemented. Assuming INTRINSIC')
+            # Do not return module reference for intrinsic modules
+            return name, None, 'intrinsic'
+        return name, self.definitions.get(name), None
 
     def visit_directive(self, o, **kwargs):
         source = kwargs['source']

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -183,22 +183,21 @@ class Pattern:
         filtered_candidates = [
             candidate for candidate in filtered_candidates if candidate.parser_class & parser_classes
         ]
-        if not filtered_candidates:
-            return []
 
         ir_ = []
         last_match = -1
-        for idx, _ in enumerate(reader):
-            for candidate in filtered_candidates:
-                match = candidate.match(reader, parser_classes=parser_classes, scope=scope)
-                if match:
-                    if last_match - idx > 1:
-                        span = (reader.sanitized_spans[last_match + 1], reader.sanitized_spans[idx])
-                        source = reader.source_from_sanitized_span(span)
-                        ir_ += [ir.RawSource(source.string, source=source)]
-                    last_match = idx
-                    ir_ += [match]
-                    break
+        if filtered_candidates:
+            for idx, _ in enumerate(reader):
+                for candidate in filtered_candidates:
+                    match = candidate.match(reader, parser_classes=parser_classes, scope=scope)
+                    if match:
+                        if last_match - idx > 1:
+                            span = (reader.sanitized_spans[last_match + 1], reader.sanitized_spans[idx])
+                            source = reader.source_from_sanitized_span(span)
+                            ir_ += [ir.RawSource(source.string, source=source)]
+                        last_match = idx
+                        ir_ += [match]
+                        break
 
         if head is not None and ir_:
             ir_ = [ir.RawSource(text=head.string, source=head)] + ir_

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -43,11 +43,12 @@ class RegexParserClass(Flag):
     parse time reduced.
     """
     ProgramUnitClass = auto()
+    InterfaceClass = auto()
     ImportClass = auto()
     TypeDefClass = auto()
     DeclarationClass = auto()
     CallClass = auto()
-    AllClasses = ProgramUnitClass | ImportClass | TypeDefClass | DeclarationClass | CallClass  # pylint: disable=unsupported-binary-operation
+    AllClasses = ProgramUnitClass | InterfaceClass | ImportClass | TypeDefClass | DeclarationClass | CallClass  # pylint: disable=unsupported-binary-operation
 
 
 class Pattern:
@@ -446,7 +447,8 @@ class ModulePattern(Pattern):
             contains = None
 
         module.__initialize__(  # pylint: disable=unnecessary-dunder-call
-            name=module.name, spec=spec, contains=contains, source=module.source, incomplete=True
+            name=module.name, spec=spec, contains=contains, source=module.source, incomplete=True,
+            parser_classes=parser_classes
         )
 
         if match.span()[0] > 0:
@@ -537,7 +539,8 @@ class SubroutineFunctionPattern(Pattern):
 
         routine.__initialize__(  # pylint: disable=unnecessary-dunder-call
             name=routine.name, args=routine._dummies, is_function=routine.is_function,
-            prefix=prefix, spec=spec, contains=contains, source=routine.source, incomplete=True
+            prefix=prefix, spec=spec, contains=contains, source=routine.source,
+            incomplete=True, parser_classes=parser_classes
         )
 
         if match.span()[0] > 0:
@@ -552,7 +555,7 @@ class InterfacePattern(Pattern):
     Pattern to match :any:`Interface` objects
     """
 
-    parser_class = RegexParserClass.ProgramUnitClass
+    parser_class = RegexParserClass.InterfaceClass
 
     def __init__(self):
         super().__init__(
@@ -611,7 +614,7 @@ class ProcedureStatementPattern(Pattern):
     Pattern to match procedure statements in interfaces
     """
 
-    parser_class = RegexParserClass.ProgramUnitClass
+    parser_class = RegexParserClass.InterfaceClass
 
     def __init__(self):
         super().__init__(

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -709,6 +709,18 @@ class Interface(InternalNode, _InterfaceBase):
             return (self.spec,) + symbols
         return symbols
 
+    @property
+    def symbol_map(self):
+        """
+        Map symbol name to symbol declared by this interface
+        """
+        return CaseInsensitiveDict(
+            (s.name.lower(), s) for s in self.symbols
+        )
+
+    def __contains__(self, name):
+        return name in self.symbol_map
+
     def __repr__(self):
         symbols = ', '.join(str(var) for var in self.symbols)
         if self.abstract:
@@ -1514,6 +1526,22 @@ class TypeDef(ScopedNode, InternalNode, _TypeDefBase):
         Map of imported symbol names to objects
         """
         return CaseInsensitiveDict((s.name, s) for s in self.imported_symbols)
+
+    def __contains__(self, name):
+        """
+        Check if a symbol with the given name is declared in this type
+        """
+        return name in self.variables
+
+    @property
+    def interface_symbols(self):
+        """
+        Return the list of symbols declared via interfaces in this unit
+
+        This returns always an empty tuple since there are no interface declarations
+        allowed in typedefs.
+        """
+        return ()
 
     @property
     def dtype(self):

--- a/loki/lint/linter.py
+++ b/loki/lint/linter.py
@@ -17,7 +17,7 @@ import shutil
 from codetiming import Timer
 
 from loki.build import workqueue
-from loki.bulk import Scheduler, SchedulerConfig
+from loki.bulk import Scheduler, SchedulerConfig, Item
 from loki.config import config as loki_config
 from loki.lint.reporter import (
     FileReport, RuleReport, Reporter, LazyTextfile,
@@ -250,6 +250,8 @@ class LinterTransformation(Transformation):
 
     # This transformation is applied over the file graph
     traverse_file_graph = True
+
+    item_filter = Item  # Include everything in the dependency tree
 
     def __init__(self, linter, key=None, **kwargs):
         self.linter = linter

--- a/loki/module.py
+++ b/loki/module.py
@@ -301,4 +301,4 @@ class Module(ProgramUnit):
         Returns :any:`Subroutine` and :any:`TypeDef` nodes declared
         in this module
         """
-        return self.subroutines + self.typedefs + self.variables
+        return self.subroutines + self.typedefs + self.variables + self.interfaces

--- a/loki/module.py
+++ b/loki/module.py
@@ -67,13 +67,15 @@ class Module(ProgramUnit):
         Mark the object as incomplete, i.e. only partially parsed. This is
         typically the case when it was instantiated using the :any:`Frontend.REGEX`
         frontend and a full parse using one of the other frontends is pending.
+    parser_classes : :any:`RegexParserClass`, optional
+        Provide the list of parser classes used during incomplete regex parsing
     """
 
     def __init__(
             self, name=None, docstring=None, spec=None, contains=None,
             default_access_spec=None, public_access_spec=None, private_access_spec=None,
             ast=None, source=None, parent=None, symbol_attrs=None, rescope_symbols=False,
-            incomplete=False
+            incomplete=False, parser_classes=None
     ):
         super().__init__(parent=parent)
 
@@ -84,12 +86,12 @@ class Module(ProgramUnit):
             name=name, docstring=docstring, spec=spec, contains=contains,
             default_access_spec=default_access_spec, public_access_spec=public_access_spec,
             private_access_spec=private_access_spec, ast=ast, source=source,
-            rescope_symbols=rescope_symbols, incomplete=incomplete
+            rescope_symbols=rescope_symbols, incomplete=incomplete, parser_classes=parser_classes
         )
 
     def __initialize__(
             self, name=None, docstring=None, spec=None, contains=None,
-            ast=None, source=None, rescope_symbols=False, incomplete=False,
+            ast=None, source=None, rescope_symbols=False, incomplete=False, parser_classes=None,
             default_access_spec=None, public_access_spec=None, private_access_spec=None
     ):
         # Apply dimension pragma annotations to declarations
@@ -110,7 +112,7 @@ class Module(ProgramUnit):
 
         super().__initialize__(
             name=name, docstring=docstring, spec=spec, contains=contains, ast=ast,
-            source=source, rescope_symbols=rescope_symbols, incomplete=incomplete
+            source=source, rescope_symbols=rescope_symbols, incomplete=incomplete, parser_classes=parser_classes
         )
 
     @classmethod

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -9,7 +9,10 @@ from abc import abstractmethod
 
 from loki import ir
 from loki.expression import Variable
-from loki.frontend import Frontend, parse_omni_source, parse_ofp_source, parse_fparser_source
+from loki.frontend import (
+    Frontend, parse_omni_source, parse_ofp_source, parse_fparser_source,
+    RegexParserClass
+)
 from loki.logging import debug
 from loki.scope import Scope
 from loki.tools import CaseInsensitiveDict, as_tuple, flatten
@@ -54,16 +57,20 @@ class ProgramUnit(Scope):
         Mark the object as incomplete, i.e. only partially parsed. This is
         typically the case when it was instantiated using the :any:`Frontend.REGEX`
         frontend and a full parse using one of the other frontends is pending.
+    parser_classes : :any:`RegexParserClass`, optional
+        Provide the list of parser classes used during incomplete regex parsing
     """
 
     def __initialize__(self, name, docstring=None, spec=None, contains=None,
-                       ast=None, source=None, rescope_symbols=False, incomplete=False):
+                       ast=None, source=None, rescope_symbols=False, incomplete=False,
+                       parser_classes=None):
         # Common properties
         assert name and isinstance(name, str)
         self.name = name
         self._ast = ast
         self._source = source
         self._incomplete = incomplete
+        self._parser_classes = parser_classes
 
         # Bring arguments into shape
         if spec is not None and not isinstance(spec, ir.Section):
@@ -237,7 +244,9 @@ class ProgramUnit(Scope):
         frontend = frontend_args.pop('frontend', Frontend.FP)
         definitions = frontend_args.get('definitions')
         xmods = frontend_args.get('xmods')
-        parser_classes = frontend_args.get('parser_classes')
+        parser_classes = frontend_args.get('parser_classes', RegexParserClass.AllClasses)
+        if frontend == Frontend.REGEX and self._parser_classes:
+            parser_classes = parser_classes | self._parser_classes
 
         # If this object does not have a parent, we create a temporary parent scope
         # and make sure the node exists in the parent scope. This way, the existing

--- a/loki/scope.py
+++ b/loki/scope.py
@@ -275,6 +275,22 @@ class Scope:
         """
         return f'Scope<{id(self)}>'
 
+    @property
+    def parents(self):
+        """
+        All parent scopes enclosing the current scope, with the top-level
+        scope at the end of the list
+
+        Returns
+        -------
+        tuple
+            The list of parent scopes
+        """
+        parent = self.parent
+        if parent:
+            return parent.parents + (parent,)
+        return ()
+
     def rescope_symbols(self):
         """
         Make sure all symbols declared and used inside this node belong
@@ -282,6 +298,18 @@ class Scope:
         """
         from loki.expression import AttachScopes  # pylint: disable=import-outside-toplevel,cyclic-import
         AttachScopes().visit(self)
+
+    def make_complete(self, **frontend_args):
+        """
+        Trigger a re-parse of the object if incomplete to produce a full Loki IR
+
+        See :any:`ProgramUnit.make_complete` for more details.
+
+        This method relays the call only to the :attr:`parent`.
+        """
+        if hasattr(super(), 'make_complete'):
+            super().make_complete(**frontend_args)
+        self.parent.make_complete(**frontend_args)
 
     def clone(self, **kwargs):
         """

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -17,7 +17,8 @@ from loki.backend.cufgen import cufgen
 from loki.frontend import (
     OMNI, OFP, FP, REGEX, sanitize_input, Source, read_file, preprocess_cpp,
     parse_omni_source, parse_ofp_source, parse_fparser_source,
-    parse_omni_ast, parse_ofp_ast, parse_fparser_ast, parse_regex_source
+    parse_omni_ast, parse_ofp_ast, parse_fparser_ast, parse_regex_source,
+    RegexParserClass
 
 )
 from loki.ir import Section, RawSource, Comment, PreprocessorDirective
@@ -54,9 +55,11 @@ class Sourcefile:
         Mark the object as incomplete, i.e. only partially parsed. This is
         typically the case when it was instantiated using the :any:`Frontend.REGEX`
         frontend and a full parse using one of the other frontends is pending.
+    parser_classes : :any:`RegexParserClass`, optional
+        Provide the list of parser classes used during incomplete regex parsing
     """
 
-    def __init__(self, path, ir=None, ast=None, source=None, incomplete=False):
+    def __init__(self, path, ir=None, ast=None, source=None, incomplete=False, parser_classes=None):
         self.path = Path(path) if path is not None else path
         if ir is not None and not isinstance(ir, Section):
             ir = Section(body=ir)
@@ -64,6 +67,7 @@ class Sourcefile:
         self._ast = ast
         self._source = source
         self._incomplete = incomplete
+        self._parser_classes = parser_classes
 
     @classmethod
     def from_file(cls, filename, definitions=None, preprocess=False,
@@ -275,10 +279,12 @@ class Sourcefile:
         """
         source, _ = sanitize_input(source=raw_source, frontend=REGEX)
 
+        if parser_classes is None:
+            parser_classes = RegexParserClass.AllClasses
         ir = parse_regex_source(source, parser_classes=parser_classes)
         lines = (1, raw_source.count('\n') + 1)
         source = Source(lines, string=raw_source, file=filepath)
-        return cls(path=filepath, ir=ir, source=source, incomplete=True)
+        return cls(path=filepath, ir=ir, source=source, incomplete=True, parser_classes=parser_classes)
 
     @classmethod
     def from_source(cls, source, xmods=None, definitions=None, parser_classes=None, frontend=FP):
@@ -396,6 +402,11 @@ class Sourcefile:
 
             self.ir._update(body=as_tuple(body))
             self._incomplete = frontend == REGEX
+            if frontend == REGEX:
+                parser_classes = frontend_args.get('parser_classes', RegexParserClass.AllClasses)
+                if self._parser_classes:
+                    parser_classes = self._parser_classes | parser_classes
+                self._parser_classes = parser_classes
 
     @property
     def source(self):
@@ -448,9 +459,9 @@ class Sourcefile:
     @property
     def definitions(self):
         """
-        List of all definitions made in this sourcefile, i.e. modules, subroutines and types
+        List of all definitions made in this sourcefile, i.e. modules and subroutines
         """
-        return self.modules + self.subroutines + self.typedefs
+        return self.modules + self.subroutines
 
     def __getitem__(self, name):
         name = name.lower()

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -463,6 +463,13 @@ class Sourcefile:
         """
         return self.modules + self.subroutines
 
+    def __contains__(self, name):
+        """
+        Check if a module, type, or subroutine with the given name is declared
+        inside this sourcefile
+        """
+        return self[name] is not None
+
     def __getitem__(self, name):
         name = name.lower()
         for module in self.modules:
@@ -477,6 +484,9 @@ class Sourcefile:
             for typedef in module.typedefs:
                 if name == typedef.name.lower():
                     return typedef
+            for interface in module.interfaces:
+                if name in interface.symbols:
+                    return interface
 
         return None
 

--- a/loki/subroutine.py
+++ b/loki/subroutine.py
@@ -70,13 +70,15 @@ class Subroutine(ProgramUnit):
         Mark the object as incomplete, i.e. only partially parsed. This is
         typically the case when it was instantiated using the :any:`Frontend.REGEX`
         frontend and a full parse using one of the other frontends is pending.
+    parser_classes : :any:`RegexParserClass`, optional
+        Provide the list of parser classes used during incomplete regex parsing
     """
 
     def __init__(
             self, name, args=None, docstring=None, spec=None, body=None,
             contains=None, prefix=None, bind=None, result_name=None,
             is_function=False, ast=None, source=None, parent=None,
-            symbol_attrs=None, rescope_symbols=False, incomplete=False
+            symbol_attrs=None, rescope_symbols=False, incomplete=False, parser_classes=None
     ):
         super().__init__(parent=parent)
 
@@ -87,13 +89,13 @@ class Subroutine(ProgramUnit):
             name=name, args=args, docstring=docstring, spec=spec, body=body,
             contains=contains,  prefix=prefix, bind=bind, result_name=result_name,
             is_function=is_function, ast=ast, source=source,
-            rescope_symbols=rescope_symbols, incomplete=incomplete
+            rescope_symbols=rescope_symbols, incomplete=incomplete, parser_classes=parser_classes
         )
 
     def __initialize__(
             self, name, docstring=None, spec=None, contains=None,
-            ast=None, source=None, rescope_symbols=False, incomplete=False,
-            body=None, args=None, prefix=None, bind=None, result_name=None, is_function=False,
+            ast=None, source=None, rescope_symbols=False, incomplete=False, parser_classes=None,
+            body=None, args=None, prefix=None, bind=None, result_name=None, is_function=False
     ):
         # First, store additional Subroutine-specific properties
         self._dummies = as_tuple(a.lower() for a in as_tuple(args))  # Order of dummy arguments
@@ -109,7 +111,8 @@ class Subroutine(ProgramUnit):
 
         super().__initialize__(
             name=name, docstring=docstring, spec=spec, contains=contains,
-            ast=ast, source=source, rescope_symbols=rescope_symbols, incomplete=incomplete
+            ast=ast, source=source, rescope_symbols=rescope_symbols,
+            incomplete=incomplete, parser_classes=parser_classes
         )
 
     def __getstate__(self):

--- a/tests/sources/projTypeBound/typebound_item.F90
+++ b/tests/sources/projTypeBound/typebound_item.F90
@@ -53,9 +53,10 @@ subroutine driver
     use typebound_other, only: other => other_type
     implicit none
 
+    integer, parameter :: constant = 2
     type(some_type), allocatable :: obj(:), obj2(:,:)
     type(header_type) :: header
-    type(other) :: other_obj, derived(2)
+    type(other) :: other_obj, derived(constant)
     real :: x
     integer :: i
 

--- a/tests/sources/projTypeBound/typebound_other.F90
+++ b/tests/sources/projTypeBound/typebound_other.F90
@@ -1,5 +1,5 @@
 module typebound_other
-    use typebound_header, header => header_type
+    use typebound_header, only: header => header_type
 
     implicit none
 
@@ -8,6 +8,12 @@ module typebound_other
     contains
       procedure :: member => other_member
     end type other_type
+
+    type outer_type
+      type(other_type) :: other
+    contains
+      procedure :: nested_call
+    end type outer_type
 
 contains
 
@@ -18,5 +24,12 @@ contains
         call member_routine(m)
         call self%var(i)%member_routine(m)
     end subroutine other_member
+
+    subroutine nested_call(self, m)
+      class(outer_type) :: self
+      integer, intent(in) :: m
+      call self%other%var(1)%member_routine(m)
+      call self%other%var(2)%member_routine(m)
+    end subroutine nested_call
 
 end module typebound_other

--- a/tests/test_derived_types.py
+++ b/tests/test_derived_types.py
@@ -1398,3 +1398,6 @@ end module some_mod
         assert symbol.type.bind_names == (symbol,)
         assert symbol.scope is typedef
         assert symbol.type.bind_names[0].scope is module
+
+    assert typedef.imported_symbols == ()
+    assert not typedef.imported_symbol_map

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -45,6 +45,8 @@ end module interface_spec_mod
     # Make sure basic properties are right
     assert interface.abstract is False
     assert interface.symbols == ('sub',)
+    assert 'sub' in interface
+    assert interface.symbol_map == {'sub': interface.symbols[0]}
 
     # Check the subroutine is there
     assert len(interface.body) == 1
@@ -55,6 +57,8 @@ end module interface_spec_mod
     assert 'interface' in code
     assert 'end interface' in code
     assert 'subroutine sub' in code
+
+    assert repr(interface) == 'Interface:: sub'
 
 
 @pytest.mark.parametrize('frontend', available_frontends(include_regex=True))
@@ -287,6 +291,7 @@ end module interface_generic_spec_mod
     assert intf.spec == 'switch'
     assert intf.spec.type.dtype.is_generic is True
     assert 'INTERFACE SWITCH' in fgen(intf).upper()
+    assert repr(intf).upper() == 'INTERFACE SWITCH:: SWITCH, INT_SWITCH, REAL_SWITCH, COMPLEX_SWITCH'
 
     assert all(s in module.symbols for s in ('switch', 'int_switch', 'real_switch', 'complex_switch'))
 
@@ -462,6 +467,7 @@ end module my_interface_mod
     intf_sim_func = mod.interface_map['sim_func']
     assert intf_sim_func.abstract
     assert intf_sim_func.symbols[0].type.dtype.procedure is intf_sim_func.body[0]
+    assert repr(intf_sim_func).upper() == 'ABSTRACT INTERFACE:: SIM_FUNC'
 
     intf_sub2 = mod.interface_map['sub2']
     assert intf_sub2.symbols[0].type.dtype.procedure is intf_sub2.body[0]

--- a/tests/test_lint/test_linter.py
+++ b/tests/test_lint/test_linter.py
@@ -428,15 +428,15 @@ def test_linter_lint_files_glob(here, rules, counter, exclude, files, max_worker
     target_file_name.unlink(missing_ok=True)
 
 
-@pytest.mark.parametrize('counter,routines,files', [
-    (5, {'driverA': {'role': 'driver'}}, [
+@pytest.mark.parametrize('routines,files', [
+    ({'driverA': {'role': 'driver'}}, [
         'module/driverA_mod.f90',
         'module/kernelA_mod.F90',
         'module/compute_l1_mod.f90',
         'source/another_l1.F90',
         'source/another_l2.F90'
     ]),
-    (3, {
+    ({
         'another_l1': {'role': 'driver'},
         'compute_l1': {'role': 'driver'}
     }, [
@@ -444,14 +444,14 @@ def test_linter_lint_files_glob(here, rules, counter, exclude, files, max_worker
         'module/compute_l1_mod.f90',
         'source/another_l2.F90',
     ]),
-    (2, {
+    ({
         'another_l1': {'role': 'driver'}
     }, [
         'source/another_l1.F90',
         'source/another_l2.F90'
     ]),
 ])
-def test_linter_lint_files_scheduler(here, rules, counter, routines, files):
+def test_linter_lint_files_scheduler(here, rules, routines, files):
     basedir = here.parent/'sources/projA'
 
     class TestHandler(GenericHandler):
@@ -484,6 +484,7 @@ def test_linter_lint_files_scheduler(here, rules, counter, routines, files):
     handler = TestHandler()
     checked = lint_files(rules, config, handlers=[handler])
 
+    counter = len(files)
     assert checked == counter
     assert handler.counter == counter
     assert handler.files == files

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -58,6 +58,7 @@ end subroutine routine_simple
     assert isinstance(routine.spec, Section)
     assert len(routine.docstring) == 1
     assert routine.docstring[0].text == '! This is the docstring'
+    assert routine.definitions == ()
 
     routine_args = [str(arg) for arg in routine.arguments]
     assert routine_args in (['x', 'y', 'scalar', 'vector(x)', 'matrix(x, y)'],

--- a/tests/test_transform_dependency.py
+++ b/tests/test_transform_dependency.py
@@ -51,6 +51,7 @@ MODULE kernel_mod
     INTEGER :: some_const
 CONTAINS
     SUBROUTINE kernel(a, b, c)
+    IMPLICIT NONE
     INTEGER, INTENT(INOUT) :: a, b, c
 
     a = 1
@@ -64,6 +65,7 @@ END MODULE kernel_mod
 SUBROUTINE driver(a, b, c)
     USE kernel_mod, only: kernel
     USE kernel_mod, only: some_const
+    IMPLICIT NONE
     INTEGER, INTENT(INOUT) :: a, b, c
 
     CALL kernel(a, b ,c)


### PR DESCRIPTION
This is intended to be the last maintenance PR of small fixes that are lifted from the Scheduler rewrite. Mostly centered around an improved representation of interfaces and recognizing them as an external-facing declaration in modules, and a consistent representation of procedure bindings in the type information of procedure symbols.

It includes also the stubs to perform partial (i.e., only with a subset of patterns) parsing in the REGEX frontend, including (partial) re-parsing.