### PR TITLE
Frontend: Fix bug for multi-line pragmas and add short test

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2833,7 +2833,7 @@ class FParser2IR(GenericVisitor):
                             source=kwargs.get('source'), label=kwargs.get('label'))
 
     # TODO: Deal with line-continuation pragmas!
-    _re_pragma = re.compile(r'^\s*\!\$(?P<keyword>\w+)\s+(?P<content>.*)', re.IGNORECASE)
+    _re_pragma = re.compile(r'^\s*\!\$(?P<keyword>\w+)\s*(?P<content>.*)', re.IGNORECASE)
 
     def visit_Comment(self, o, **kwargs):
         source = kwargs.get('source', None)

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -314,7 +314,7 @@ class OFP2IR(GenericVisitor):
         return as_tuple(value) or None, as_tuple(body)
 
     # TODO: Deal with line-continuation pragmas!
-    _re_pragma = re.compile(r'^\s*\!\$(?P<keyword>\w+)\s+(?P<content>.*)', re.IGNORECASE)
+    _re_pragma = re.compile(r'^\s*\!\$(?P<keyword>\w+)\s*(?P<content>.*)', re.IGNORECASE)
 
     def visit_comment(self, o, **kwargs):
         match_pragma = self._re_pragma.search(kwargs['source'].string)

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# pylint: disable=too-many-lines
+
 """
 Verify correct frontend behaviour and correct parsing of certain Fortran
 language features.

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1498,3 +1498,33 @@ def test_frontend_empty_file(frontend, fcode):
     source = Sourcefile.from_source(fcode, frontend=frontend)
     assert isinstance(source.ir, Section)
     assert not source.to_fortran().strip()
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_pragma_line_continuation(frontend):
+    """
+    Test that multi-line pragmas are parsed and dealt with correctly.
+    """
+    fcode = """
+SUBROUTINE TOTO(A,B)
+
+IMPLICIT NONE
+REAL, INTENT(IN) :: A
+REAL, INTENT(INOUT) :: B
+
+!$ACC PARALLEL LOOP GANG &
+!$ACC& PRESENT(ZRDG_LCVQ,ZFLU_QSATS,ZRDG_CVGQ) &
+!$ACC& PRIVATE (JBLK) &
+!$ACC& VECTOR_LENGTH (YDCPG_OPTS%KLON)
+
+END SUBROUTINE TOTO
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    pragmas = FindNodes(Pragma).visit(routine.body)
+    assert len(pragmas) == 1
+    assert pragmas[0].keyword == 'ACC'
+    assert 'PARALLEL' in pragmas[0].content
+    assert 'PRESENT' in pragmas[0].content
+    assert 'PRIVATE' in pragmas[0].content
+    assert 'VECTOR_LENGTH' in pragmas[0].content


### PR DESCRIPTION
Small bug-fix and test to fix erroneous parsing of multi-line pragmas with missing whitespaces after the keyword. Many thanks for @ecossevin for reporting this (see issue #216).