### PR TITLE
Enabling SCC-Stack for EC-physics, part 2

### DIFF
--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -606,7 +606,7 @@ class FortranCodegen(Stringifier):
             # No indentation and only a single body node
             cond = self.visit(o.condition, **kwargs)
             body = self.visit(o.body, **kwargs)
-            line = self.format_line(f'IF ({cond}) ') + body.lstrip()
+            line = self.format_line(f'IF ({cond}) {body.lstrip()}')
             # Ensure we run multi-line formatter, in case the body is complex
             return self.join_lines(line)
 

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -605,10 +605,13 @@ class FortranCodegen(Stringifier):
         if o.inline:
             # No indentation and only a single body node
             cond = self.visit(o.condition, **kwargs)
+            d = self.depth
+            self.depth = 0
             body = self.visit(o.body, **kwargs)
-            line = self.format_line(f'IF ({cond}) {body.lstrip()}')
-            # Ensure we run multi-line formatter, in case the body is complex
-            return self.join_lines(line)
+            self.depth = d
+            # Undo the indentation, so that we may re-format and re-indent
+            line = f'IF ({cond}) ' + ''.join(body.lstrip().split('&\n&'))
+            return self.format_line(line)
 
         name = kwargs.pop('name', f' {o.name}' if o.name else '')
         is_elseif = kwargs.pop('is_elseif', False)

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -97,6 +97,8 @@ class Item:
         self.config = config or {}
         self.trafo_data = {}
 
+        self.ignored = False
+
     def __repr__(self):
         return f'loki.bulk.Item<{self.name}>'
 

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -97,7 +97,7 @@ class Item:
         self.config = config or {}
         self.trafo_data = {}
 
-        self.ignored = False
+        self.is_ignored = False
 
     def __repr__(self):
         return f'loki.bulk.Item<{self.name}>'

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -372,8 +372,8 @@ class Scheduler:
                 # Mark children as "ignored", which means they may be
                 # used for certain analysis passes, but are not part
                 # of the injected changes for this batch-transformation
-                if item.ignored or child.local_name in item.ignore:
-                    child.ignored = True
+                if item.is_ignored or child.local_name in item.ignore:
+                    child.is_ignored = True
 
                 if child not in self.item_map:
                     new_items += [child]
@@ -574,13 +574,13 @@ class Scheduler:
                             continue
 
                     _item = items[0]
-                    if _item.ignored and not transformation.process_ignored_items:
+                    if _item.is_ignored and not transformation.process_ignored_items:
                         continue
 
                     transformation.apply(items[0].source, items=items)
             else:
                 for item in traversal:
-                    if item.ignored and not transformation.process_ignored_items:
+                    if item.is_ignored and not transformation.process_ignored_items:
                         continue
 
                     if item_filter and not isinstance(item, item_filter):
@@ -714,7 +714,7 @@ class Scheduler:
         sources_to_transform = []
 
         for item in self.items:
-            if item.ignored:
+            if item.is_ignored:
                 continue
 
             sourcepath = item.path.resolve()

--- a/loki/transform/build_system_transform.py
+++ b/loki/transform/build_system_transform.py
@@ -11,108 +11,10 @@ Transformations to be used in build-system level tasks
 
 from pathlib import Path
 
-from loki.logging import info
 from loki.transform.transformation import Transformation
 from loki.bulk.item import SubroutineItem, GlobalVarImportItem
 
-__all__ = ['CMakePlanner', 'FileWriteTransformation']
-
-
-class CMakePlanner(Transformation):
-    """
-    Generates a list of files to add, remove or replace in a CMake
-    target's list of sources
-
-    This is intended to be used in a :any:`Scheduler` traversal triggered
-    during the configuration phase of a build (e.g., using ``execute_process``)
-    to generate a CMake plan file (using :meth:`write_planfile`).
-    This file set variables ``LOKI_SOURCES_TO_TRANSFORM``,
-    ``LOKI_SOURCES_TO_APPEND``, and ``LOKI_SOURCES_TO_REMOVE`` that can then
-    be used to update a target's ``SOURCES`` property via
-    ``get_target_property`` and ``set_property``.
-
-    Attributes
-    ----------
-    sources_to_append : list of str
-        Newly generated source files that need to be added to the target
-    sources_to_remove : list of str
-        The source files that are replaced and must be removed from the target
-    sources_to_transform : list of str
-        The source files that are going to be transformed by Loki
-        transformations
-
-    Parameters
-    ----------
-    rootpath : :any:`pathlib.Path` or str
-        The base directory of the source tree
-    mode : str
-        The name of the transformation mode (which is going to be inserted
-        into the file name of new source files)
-    build : :any:`pathlib.Path` or str
-        The target directory for generate source files
-    """
-
-    def __init__(self, rootpath, mode, build=None):
-        self.build = None if build is None else Path(build)
-        self.mode = mode
-
-        self.rootpath = Path(rootpath).resolve()
-        self.sources_to_append = []
-        self.sources_to_remove = []
-        self.sources_to_transform = []
-
-    def transform_subroutine(self, routine, **kwargs):
-        """
-        Insert the current subroutine into the lists of source files to
-        process, add and remove, if part of the plan
-
-        Parameters
-        ----------
-        routine : :any:`Subroutine`
-            The subroutine object to process
-        item : :any:`Item`
-            The corresponding work item from the :any:`Scheduler`
-        role : str
-            The routine's role
-        """
-        item = kwargs['item']
-        role = kwargs.get('role')
-
-        sourcepath = item.path.resolve()
-        newsource = sourcepath.with_suffix(f'.{self.mode.lower()}.F90')
-        if self.build is not None:
-            newsource = self.build/newsource.name
-
-        # Make new CMake paths relative to source again
-        sourcepath = sourcepath.relative_to(self.rootpath)
-
-        info(f'Planning:: {routine.name} (role={role}, mode={self.mode})')
-
-        self.sources_to_transform += [sourcepath]
-
-        # Inject new object into the final binary libs
-        if item.replicate:
-            # Add new source file next to the old one
-            self.sources_to_append += [newsource]
-        else:
-            # Replace old source file to avoid ghosting
-            self.sources_to_append += [newsource]
-            self.sources_to_remove += [sourcepath]
-
-    def write_planfile(self, filepath):
-        """
-        Write the CMake plan file at :data:`filepath`
-        """
-        info(f'[Loki] CMakePlanner writing plan: {filepath}')
-        with Path(filepath).open('w') as f:
-            s_transform = '\n'.join(f'    {s}' for s in self.sources_to_transform)
-            f.write(f'set( LOKI_SOURCES_TO_TRANSFORM \n{s_transform}\n   )\n')
-
-            s_append = '\n'.join(f'    {s}' for s in self.sources_to_append)
-            f.write(f'set( LOKI_SOURCES_TO_APPEND \n{s_append}\n   )\n')
-
-            s_remove = '\n'.join(f'    {s}' for s in self.sources_to_remove)
-            f.write(f'set( LOKI_SOURCES_TO_REMOVE \n{s_remove}\n   )\n')
+__all__ = ['FileWriteTransformation']
 
 
 class FileWriteTransformation(Transformation):

--- a/loki/transform/transform_hoist_variables.py
+++ b/loki/transform/transform_hoist_variables.py
@@ -113,6 +113,8 @@ class HoistVariablesAnalysis(Transformation):
     # Apply in reverse order to recursively find all variables to be hoisted.
     reverse_traversal = True
 
+    process_ignored_items = True
+
     def __init__(self, key=None):
         if key is not None:
             self._key = key

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -66,6 +66,10 @@ class Transformation:
     recurse_to_internal_procedures : bool
         Apply transformation to all internal :any:`Subroutine` objects
         when processing :any:`Subroutine` objects (default ``False``)
+    process_ignored_items : bool
+        Apply transformation to "ignored" :any:`Item` objects for analysis.
+        This might be needed if IPO-information needs to be passed across
+        library boundaries.
     """
 
     # Forces scheduler traversal in reverse order from the leaf nodes upwards
@@ -82,6 +86,8 @@ class Transformation:
     recurse_to_procedures = False  # Recurse from Sourcefile/Module to subroutines and functions
     recurse_to_internal_procedures = False  # Recurse to subroutines in ``contains`` clause
 
+    # Option to process "ignored" items for analysis
+    process_ignored_items = False
 
     def transform_subroutine(self, routine, **kwargs):
         """

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -320,7 +320,7 @@ def convert(
 
 @cli.command('plan')
 @click.option('--mode', '-m', default='sca',
-              type=click.Choice(['idem', 'sca', 'claw', 'scc', 'scc-hoist']))
+              type=click.Choice(['idem', 'sca', 'claw', 'scc', 'scc-hoist', 'scc-stack']))
 @click.option('--config', '-c', type=click.Path(),
               help='Path to configuration file.')
 @click.option('--header', '-I', type=click.Path(), multiple=True,
@@ -353,6 +353,8 @@ def plan(mode, config, header, source, build, root, cpp, directive, frontend, ca
     paths = [Path(s).resolve() for s in source]
     paths += [Path(h).resolve().parent for h in header]
     scheduler = Scheduler(paths=paths, config=config, frontend=frontend, full_parse=False, preprocess=cpp)
+
+    mode = mode.replace('-', '_')  # Sanitize mode string
 
     # Construct the transformation plan as a set of CMake lists of source files
     scheduler.write_cmake_plan(filepath=plan_file, mode=mode, buildpath=build, rootpath=root)

--- a/tests/test_fgen.py
+++ b/tests/test_fgen.py
@@ -146,6 +146,8 @@ end subroutine test_fgen
     out = fgen(routine, linewidth=132)
     for line in out.splitlines():
         assert line.count('&') <= 2
+        if line.count('&') == 2:
+            assert len(line.split('&')[1]) > 60
 
 
 @pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Loki likes only valid code')]))

--- a/tests/test_fgen.py
+++ b/tests/test_fgen.py
@@ -148,6 +148,28 @@ end subroutine test_fgen
         assert line.count('&') <= 2
 
 
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Loki likes only valid code')]))
+def test_multiline_inline_conditional_long(frontend):
+    """
+    Test correct formatting of an inline :any:`Conditional` that
+    that creates a particularly long line.
+    """
+    fcode = """
+subroutine test_inline_multiline_long(array, flag)
+  real, intent(inout) :: array
+  logical, intent(in) :: flag
+
+  if (flag) call a_subroutine_with_an_exquisitely_loong_and_expertly_chosen_name_and_a_few_keyword_arguments(my_favourite_array=array)
+end subroutine test_inline_multiline_long
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    out = fgen(routine, linewidth=132)
+    for line in out.splitlines():
+        assert len(line) < 132
+        assert line.count('&') <= 2
+
+
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_fgen_save_attribute(frontend):
     """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -829,8 +829,8 @@ def test_scheduler_dependencies_ignore(here, frontend):
     ])
     assert 'ext_driver_mod#ext_driver' in schedulerA.items
     assert 'ext_kernel_mod#ext_kernel' in schedulerA.items
-    assert schedulerA['ext_driver_mod#ext_driver'].ignored
-    assert schedulerA['ext_kernel_mod#ext_kernel'].ignored
+    assert schedulerA['ext_driver_mod#ext_driver'].is_ignored
+    assert schedulerA['ext_kernel_mod#ext_kernel'].is_ignored
 
     assert all(n in schedulerB.items for n in ['ext_driver_mod#ext_driver', 'ext_kernel_mod#ext_kernel'])
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -827,8 +827,10 @@ def test_scheduler_dependencies_ignore(here, frontend):
         'driverB_mod#driverB', 'kernelB_mod#kernelB',
         'compute_l1_mod#compute_l1', 'compute_l2_mod#compute_l2'
     ])
-    assert 'ext_driver_mod#ext_driver' not in schedulerA.items
-    assert 'ext_kernel_mod#ext_kernel' not in schedulerA.items
+    assert 'ext_driver_mod#ext_driver' in schedulerA.items
+    assert 'ext_kernel_mod#ext_kernel' in schedulerA.items
+    assert schedulerA['ext_driver_mod#ext_driver'].ignored
+    assert schedulerA['ext_kernel_mod#ext_kernel'].ignored
 
     assert all(n in schedulerB.items for n in ['ext_driver_mod#ext_driver', 'ext_kernel_mod#ext_kernel'])
 
@@ -843,7 +845,9 @@ def test_scheduler_dependencies_ignore(here, frontend):
     assert schedulerA.items[0].source.all_subroutines[0].name == 'driverB'
     assert schedulerA.items[1].source.all_subroutines[0].name == 'kernelB_test'
     assert schedulerA.items[2].source.all_subroutines[0].name == 'compute_l1_test'
-    assert schedulerA.items[3].source.all_subroutines[0].name == 'compute_l2_test'
+    assert schedulerA.items[3].source.all_subroutines[0].name == 'ext_driver'
+    assert schedulerA.items[4].source.all_subroutines[0].name == 'compute_l2_test'
+    assert schedulerA.items[5].source.all_subroutines[0].name == 'ext_kernel'
 
     # For the second target lib, we want the driver to be converted
     for transformation in transformations:

--- a/tests/test_transform_hoist_variables.py
+++ b/tests/test_transform_hoist_variables.py
@@ -165,9 +165,11 @@ def test_hoist_disable(here, frontend, config):
     """
 
     disable = ("device1", "device2")
-    config['routines']['kernel2'] = {'role': 'kernel', 'ignore': disable}
+    config['routines']['kernel2'] = {'role': 'kernel', 'block': disable}
     proj = here/'sources/projHoist'
-    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend)
+    scheduler = Scheduler(
+        paths=[proj], config=config, seed_routines=['driver', 'another_driver'], frontend=frontend
+    )
 
     # Transformation: Analysis
     scheduler.process(transformation=HoistVariablesAnalysis())

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -297,19 +297,15 @@ end module kernel_mod
     calls = FindNodes(CallStatement).visit(driver.body)
     assert len(calls) == 1
     if nclv_param:
-        if check_bounds:
-            expected_args = ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack_l', 'ylstack_u')
-            assert calls[0].arguments == expected_args
-        else:
-            expected_args = ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack_l')
-            assert calls[0].arguments == expected_args
+        expected_args = ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)')
     else:
-        if check_bounds:
-            expected_args = ('1', 'nlon', 'nlon', 'nz', '2', 'field1(:,b)', 'field2(:,:,b)', 'ylstack_l', 'ylstack_u')
-            assert calls[0].arguments == expected_args
-        else:
-            expected_args = ('1', 'nlon', 'nlon', 'nz', '2', 'field1(:,b)', 'field2(:,:,b)', 'ylstack_l')
-            assert calls[0].arguments == expected_args
+        expected_args = ('1', 'nlon', 'nlon', 'nz', '2', 'field1(:,b)', 'field2(:,:,b)')
+    if check_bounds:
+        expected_kwargs = (('YDSTACK_L', 'ylstack_l'), ('YDSTACK_U', 'ylstack_u'))
+    else:
+        expected_kwargs = (('YDSTACK_L', 'ylstack_l'),)
+    assert calls[0].arguments == expected_args
+    assert calls[0].kwarguments == expected_kwargs
 
     if generate_driver_stack:
         check_stack_created_in_driver(driver, stack_size, calls[0], 1, generate_driver_stack, check_bounds=check_bounds)
@@ -591,8 +587,10 @@ end module kernel_mod
     # Has the stack been added to the call statements?
     calls = FindNodes(CallStatement).visit(driver.body)
     assert len(calls) == 2
-    assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack_l', 'ylstack_u')
-    assert calls[1].arguments == ('1', 'nlon', 'nlon', 'nz', 'field2(:,:,b)', 'ylstack_l', 'ylstack_u')
+    assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)')
+    assert calls[0].kwarguments == (('YDSTACK_L', 'ylstack_l'), ('YDSTACK_U', 'ylstack_U'))
+    assert calls[1].arguments == ('1', 'nlon', 'nlon', 'nz', 'field2(:,:,b)')
+    assert calls[1].kwarguments == (('YDSTACK_L', 'ylstack_l'), ('YDSTACK_U', 'ylstack_U'))
 
     stack_size = f'max({tsize_real}*nlon + {tsize_real}*nlon*nz + '
     stack_size += f'2*{tsize_int}*nlon + {tsize_log}*nz,'
@@ -870,7 +868,8 @@ end module kernel_mod
     # Has the stack been added to the call statements?
     calls = FindNodes(CallStatement).visit(driver.body)
     assert len(calls) == 1
-    assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack_l', 'ylstack_u')
+    assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)')
+    assert calls[0].kwarguments == (('YDSTACK_L', 'ylstack_l'), ('YDSTACK_U', 'ylstack_u'))
 
     stack_size = f'{tsize_real}*nlon/max(c_sizeof(real(1, kind=jwrb)), 8) +'
     stack_size += f'4*{tsize_real}*nlon*nz/max(c_sizeof(real(1, kind=jwrb)), 8) +'
@@ -913,7 +912,8 @@ end module kernel_mod
     #
     calls = FindNodes(CallStatement).visit(kernel_item.routine.body)
     assert len(calls) == 1
-    assert calls[0].arguments == ('start', 'end', 'klon', 'klev', 'field2', 'ylstack_l', 'ylstack_u')
+    assert calls[0].arguments == ('start', 'end', 'klon', 'klev', 'field2')
+    assert calls[0].kwarguments == (('YDSTACK_L', 'ylstack_l'), ('YDSTACK_U', 'ylstack_u'))
 
     for count, item in enumerate([kernel_item, kernel2_item]):
         kernel = item.routine

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -1075,7 +1075,8 @@ def test_pool_allocator_more_call_checks(frontend, block_dim, caplog):
         # Now repeat the checks for the inline call
         calls = [i for i in FindInlineCalls().visit(kernel.body) if not i.name.lower() in ('max', 'c_sizeof', 'real')]
         assert len(calls) == 1
-        assert calls[0].parameters == ('jl', 'ylstack_l', 'ylstack_u')
+        assert calls[0].arguments == ('jl',)
+        assert calls[0].kwarguments == (('YDSTACK_L', 'ylstack_l'), ('YDSTACK_U', 'ylstack_u'))
 
     assert 'Derived-type vars in Subroutine:: kernel not supported in pool allocator' in caplog.text
     rmtree(basedir)

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -29,8 +29,10 @@ def check_c_sizeof_import(routine):
     assert 'c_sizeof' in routine.imported_symbols
 
 
-def check_stack_created_in_driver(driver, stack_size, first_kernel_call, num_block_loops,
-                                  generate_driver_stack=True, kind_real='jprb', check_bounds=True):
+def check_stack_created_in_driver(
+        driver, stack_size, first_kernel_call, num_block_loops,
+        generate_driver_stack=True, kind_real='jprb', check_bounds=True, simplify_stmt=True
+):
     # Are stack size, storage and stack derived type declared?
     assert 'istsz' in driver.variables
     assert 'zstack(:,:)' in driver.variables
@@ -46,7 +48,11 @@ def check_stack_created_in_driver(driver, stack_size, first_kernel_call, num_blo
     assignments = FindNodes(Assignment).visit(driver.body)
     for assignment in assignments:
         if assignment.lhs == 'istsz':
-            assert str(simplify(assignment.rhs)).lower().replace(' ', '') == str(stack_size).lower().replace(' ', '')
+            if simplify_stmt:
+                assert str(simplify(assignment.rhs)).lower().replace(' ', '') \
+                           == str(stack_size).lower().replace(' ', '')
+            else:
+                assert str(assignment.rhs).lower().replace(' ', '') == str(stack_size).lower().replace(' ', '')
             break
 
     # Check for stack assignment inside loop
@@ -59,10 +65,10 @@ def check_stack_created_in_driver(driver, stack_size, first_kernel_call, num_blo
     if check_bounds:
         if generate_driver_stack:
             assert assignments[1].lhs == 'ylstack_u' and (
-                    assignments[1].rhs == f'ylstack_l + istsz * c_sizeof(real(1, kind={kind_real}))')
+                   assignments[1].rhs == f'ylstack_l + istsz * max(c_sizeof(real(1, kind={kind_real})), 8)')
         else:
             assert assignments[1].lhs == 'ylstack_u' and (
-                    assignments[1].rhs == f'ylstack_l + c_sizeof(real(1, kind={kind_real}))*istsz')
+                   assignments[1].rhs == f'ylstack_l + max(c_sizeof(real(1, kind={kind_real})), 8)*istsz')
 
     # Check that stack assignment happens before kernel call
     assert all(loops[0].body.index(a) < loops[0].body.index(first_kernel_call) for a in assignments)
@@ -94,7 +100,7 @@ END MODULE
         integer(kind=8) :: ylstack_l
         integer(kind=8) :: ylstack_u
 
-        {'istsz = 3*c_sizeof(real(1,kind=jprb))*nlon/c_sizeof(real(1,kind=jprb))+c_sizeof(real(1,kind=jprb))*nlon*nz/c_sizeof(real(1,kind=jprb))' if nclv_param else 'istsz = 3*c_sizeof(real(1,kind=jprb))*nlon/c_sizeof(real(1,kind=jprb))+c_sizeof(real(1,kind=jprb))*nlon*nz/c_sizeof(real(1,kind=jprb))+2*c_sizeof(real(1,kind=jprb))/c_sizeof(real(1,kind=jprb))'}
+        {'istsz = 3*max(c_sizeof(real(1,kind=jprb)), 8)*nlon/max(c_sizeof(real(1,kind=jprb)), 8)+max(c_sizeof(real(1,kind=jprb)), 8)*nlon*nz/max(c_sizeof(real(1,kind=jprb)), 8)' if nclv_param else 'istsz = 3*max(c_sizeof(real(1,kind=jprb)), 8)*nlon/max(c_sizeof(real(1,kind=jprb)), 8)+max(c_sizeof(real(1,kind=jprb)), 8)*nlon*nz/max(c_sizeof(real(1,kind=jprb)), 8)+2*max(c_sizeof(real(1,kind=jprb)), 8)/max(c_sizeof(real(1,kind=jprb)), 8)'}
         ALLOCATE(ZSTACK(ISTSZ, nb))
         """
     else:
@@ -104,13 +110,13 @@ END MODULE
         integer(kind=8) :: ylstack_l
         {'integer(kind=8) :: ylstack_u' if check_bounds else ''}
 
-        {'istsz = c_sizeof(real(1,kind=jprb))*nlon/c_sizeof(real(1,kind=jprb))+c_sizeof(real(1,kind=jprb))*nlon*nz/c_sizeof(real(1,kind=jprb))+c_sizeof(real(1,kind=jprb))*nclv*nlon/c_sizeof(real(1,kind=jprb))' if nclv_param else 'istsz = 3*c_sizeof(real(1,kind=jprb))*nlon/c_sizeof(real(1,kind=jprb))+c_sizeof(real(1,kind=jprb))*nlon*nz/c_sizeof(real(1,kind=jprb))+2*c_sizeof(real(1,kind=jprb))/c_sizeof(real(1,kind=jprb))'}
+        {'istsz = max(c_sizeof(real(1,kind=jprb)), 8)*nlon/max(c_sizeof(real(1,kind=jprb)), 8)+max(c_sizeof(real(1,kind=jprb)), 8)*nlon*nz/max(c_sizeof(real(1,kind=jprb)), 8)+max(c_sizeof(real(1,kind=jprb)), 8)*nclv*nlon/max(c_sizeof(real(1,kind=jprb)), 8)' if nclv_param else 'istsz = 3*max(c_sizeof(real(1,kind=jprb)), 8)*nlon/max(c_sizeof(real(1,kind=jprb)), 8)+max(c_sizeof(real(1,kind=jprb)), 8)*nlon*nz/max(c_sizeof(real(1,kind=jprb)), 8)+2*max(c_sizeof(real(1,kind=jprb)), 8)/max(c_sizeof(real(1,kind=jprb)), 8)'}
         ALLOCATE(ZSTACK(ISTSZ, nb))
         """
 
     fcode_stack_assign = """
         ylstack_l = loc(zstack(1, b))
-        ylstack_u = ylstack_l + c_sizeof(real(1, kind=jprb)) * istsz
+        ylstack_u = ylstack_l + max(c_sizeof(real(1, kind=jprb)), 8) * istsz
     """
     fcode_stack_dealloc = "DEALLOCATE(ZSTACK)"
 
@@ -227,37 +233,53 @@ end module kernel_mod
     if nclv_param:
         if frontend == OMNI:
             # pylint: disable-next=line-too-long
-            trafo_data_compare = f'3 * c_sizeof(real(1, kind={kind_real})) * klon + c_sizeof(real(1, kind={kind_real})) * klev * klon'
+            trafo_data_compare = f'3 * max(c_sizeof(real(1, kind={kind_real})), 8) * klon + ' \
+                                 f'max(c_sizeof(real(1, kind={kind_real})), 8) * klev * klon'
 
             if generate_driver_stack:
-                stack_size = f'3 * c_sizeof(real(1, kind={kind_real})) * nlon / c_sizeof(real(1, kind=jprb))'
-                stack_size += f'+ c_sizeof(real(1, kind={kind_real})) * nlon * nz / c_sizeof(real(1, kind=jprb))'
+                stack_size = f'3 * max(c_sizeof(real(1, kind={kind_real})), 8) * nlon / ' \
+                             f'max(c_sizeof(real(1, kind=jprb)), 8)'
+                stack_size += f'+ max(c_sizeof(real(1, kind={kind_real})), 8) * nlon * nz / ' \
+                              f'max(c_sizeof(real(1, kind=jprb)), 8)'
             else:
-                stack_size = f'3 * c_sizeof(real(1, kind={kind_real})) * nlon / c_sizeof(real(1, kind={kind_real}))'
-                stack_size += f'+ c_sizeof(real(1, kind={kind_real})) * nlon * nz / c_sizeof(real(1, kind={kind_real}))'
+                stack_size = f'3 * max(c_sizeof(real(1, kind={kind_real})), 8) * nlon / ' \
+                             f'max(c_sizeof(real(1, kind={kind_real})), 8)'
+                stack_size += f'+ max(c_sizeof(real(1, kind={kind_real})), 8) * nlon * nz / ' \
+                              f'max(c_sizeof(real(1, kind={kind_real})), 8)'
         else:
             # pylint: disable-next=line-too-long
-            trafo_data_compare = f'c_sizeof(real(1, kind={kind_real})) * klon + c_sizeof(real(1, kind={kind_real})) * klev * klon'
-            trafo_data_compare += f'+ c_sizeof(real(1, kind={kind_real})) * klon * nclv'
+            trafo_data_compare = f'max(c_sizeof(real(1, kind={kind_real})), 8) * klon + ' \
+                                 f'max(c_sizeof(real(1, kind={kind_real})), 8) * klev * klon'
+            trafo_data_compare += f'+ max(c_sizeof(real(1, kind={kind_real})), 8) * klon * nclv'
 
-            stack_size = f'c_sizeof(real(1, kind={kind_real})) * nlon / c_sizeof(real(1, kind=jprb))'
-            stack_size += f'+ c_sizeof(real(1, kind={kind_real})) * nlon * nz / c_sizeof(real(1, kind=jprb))'
-            stack_size += f'+ c_sizeof(real(1, kind={kind_real})) * nclv * nlon / c_sizeof(real(1, kind=jprb))'
+            stack_size = f'max(c_sizeof(real(1, kind={kind_real})), 8) * nlon / max(c_sizeof(real(1, kind=jprb)), 8)'
+            stack_size += f'+ max(c_sizeof(real(1, kind={kind_real})), 8) * nlon * nz / ' \
+                          f'max(c_sizeof(real(1, kind=jprb)), 8)'
+            stack_size += f'+ max(c_sizeof(real(1, kind={kind_real})), 8) * nclv * nlon / ' \
+                          f'max(c_sizeof(real(1, kind=jprb)), 8)'
 
     else:
         # pylint: disable-next=line-too-long
-        trafo_data_compare = f'c_sizeof(real(1, kind={kind_real})) * klon + c_sizeof(real(1, kind={kind_real})) * klev * klon'
+        trafo_data_compare = f'max(c_sizeof(real(1, kind={kind_real})), 8) * klon + ' \
+                             f'max(c_sizeof(real(1, kind={kind_real})), 8) * klev * klon'
         # pylint: disable-next=line-too-long
-        trafo_data_compare += f'+ c_sizeof(real(1, kind={kind_real})) * nclv + c_sizeof(real(1, kind={kind_real})) * klon * nclv'
+        trafo_data_compare += f'+ max(c_sizeof(real(1, kind={kind_real})), 8) * nclv + ' \
+                              f'max(c_sizeof(real(1, kind={kind_real})), 8) * klon * nclv'
 
         if generate_driver_stack:
-            stack_size = f'3 * c_sizeof(real(1, kind={kind_real})) * nlon / c_sizeof(real(1, kind=jprb))'
-            stack_size += f'+ c_sizeof(real(1, kind={kind_real})) * nlon * nz / c_sizeof(real(1, kind=jprb))'
-            stack_size += f'+ 2 * c_sizeof(real(1, kind={kind_real})) / c_sizeof(real(1, kind=jprb))'
+            stack_size = f'3 * max(c_sizeof(real(1, kind={kind_real})), 8) * nlon / ' \
+                         f'max(c_sizeof(real(1, kind=jprb)), 8)'
+            stack_size += f'+ max(c_sizeof(real(1, kind={kind_real})), 8) * nlon * nz / ' \
+                          f'max(c_sizeof(real(1, kind=jprb)), 8)'
+            stack_size += f'+ 2 * max(c_sizeof(real(1, kind={kind_real})), 8) / ' \
+                          f'max(c_sizeof(real(1, kind=jprb)), 8)'
         else:
-            stack_size = f'3 * c_sizeof(real(1, kind={kind_real})) * nlon / c_sizeof(real(1, kind={kind_real}))'
-            stack_size += f'+ c_sizeof(real(1, kind={kind_real})) * nlon * nz / c_sizeof(real(1, kind={kind_real}))'
-            stack_size += f'+ 2 * c_sizeof(real(1, kind={kind_real})) / c_sizeof(real(1, kind={kind_real}))'
+            stack_size = f'3 * max(c_sizeof(real(1, kind={kind_real})), 8) * nlon / ' \
+                         f'max(c_sizeof(real(1, kind={kind_real})), 8)'
+            stack_size += f'+ max(c_sizeof(real(1, kind={kind_real})), 8) * nlon * nz / ' \
+                          f'max(c_sizeof(real(1, kind={kind_real})), 8)'
+            stack_size += f'+ 2 * max(c_sizeof(real(1, kind={kind_real})), 8) / ' \
+                          f'max(c_sizeof(real(1, kind={kind_real})), 8)'
 
     assert kernel_item.trafo_data[transformation._key]['stack_size'] == trafo_data_compare
     assert all(v.scope is None for v in
@@ -331,7 +353,7 @@ end module kernel_mod
                 if f'ip_tmp{tmp_index}' == assign.lhs:
                     assign_idx[f'tmp{tmp_index}_ptr_assign'] = idx
         elif assign.lhs == 'ylstack_l' and 'ylstack_l' in assign.rhs and 'c_sizeof' in assign.rhs:
-            _size = str(assign.rhs).lower().replace(f'*c_sizeof(real(1, kind={kind_real}))', '')
+            _size = str(assign.rhs).lower().replace(f'*max(c_sizeof(real(1, kind={kind_real})), 8)', '')
             _size = _size.replace('ylstack_l + ', '')
 
             # Stack increment for tmp1, tmp2, tmp5 (and tmp3, tmp4 if no alloc_dims provided)
@@ -369,7 +391,8 @@ end module kernel_mod
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('directive', [None, 'openmp', 'openacc'])
-def test_pool_allocator_temporaries_kernel_sequence(frontend, block_dim, directive):
+@pytest.mark.parametrize('stack_insert_pragma', [False, True])
+def test_pool_allocator_temporaries_kernel_sequence(frontend, block_dim, directive, stack_insert_pragma):
     if directive == 'openmp':
         driver_loop_pragma1 = '!$omp parallel default(shared) private(b) firstprivate(a)\n    !$omp do'
         driver_end_loop_pragma1 = '!$omp end do\n    !$omp end parallel'
@@ -389,6 +412,12 @@ def test_pool_allocator_temporaries_kernel_sequence(frontend, block_dim, directi
         driver_end_loop_pragma2 = ''
         kernel_pragma = ''
 
+    if stack_insert_pragma:
+        stack_size_location_pragma = '!$loki stack-insert'
+    else:
+        stack_size_location_pragma = ''
+
+
     fcode_parkind_mod = """
 module parkind1
 implicit none
@@ -407,6 +436,10 @@ subroutine driver(NLON, NZ, NB, FIELD1, FIELD2)
     real(kind=jprb), intent(inout) :: field1(nlon, nb)
     real(kind=jprb), intent(inout) :: field2(nlon, nz, nb)
     integer :: a,b
+
+    ! a = 1, necessary to check loki stack-insert pragma
+    a = 1
+    {stack_size_location_pragma}
 
     {driver_loop_pragma1}
     do b=1,nb
@@ -520,21 +553,33 @@ end module kernel_mod
         kind_int = 'jpim'
         kind_log = 'jplm'
 
+    tsize_real = f'max(c_sizeof(real(1, kind={kind_real})), 8)'
+    tsize_int = f'max(c_sizeof(int(1, kind={kind_int})), 8)'
+    tsize_log = f'max(c_sizeof(logical(true, kind={kind_log})), 8)'
+
     assert transformation._key == 'some_key'
     assert transformation._key in kernel_item.trafo_data
-    # pylint: disable-next=line-too-long
-    assert kernel_item.trafo_data[transformation._key]['stack_size'] == f'c_sizeof(real(1, kind={kind_real}))*klon + c_sizeof(real(1, kind={kind_real}))*klev*klon + 2*c_sizeof(int(1, kind={kind_int}))*klon + c_sizeof(logical(true, kind={kind_log}))*klev'
-    # pylint: disable-next=line-too-long
-    assert kernel2_item.trafo_data[transformation._key]['stack_size'] == f'3*c_sizeof(real(1, kind={kind_real}))*klev*klon + c_sizeof(real(1, kind={kind_real}))*klon'
-    assert all(v.scope is None for v in
-                               FindVariables().visit(kernel_item.trafo_data[transformation._key]['stack_size']))
-    assert all(v.scope is None for v in
-                               FindVariables().visit(kernel2_item.trafo_data[transformation._key]['stack_size']))
+    exp_stack_size = f'{tsize_real}*klon + {tsize_real}*klev*klon + 2*{tsize_int}*klon + {tsize_log}*klev'
+    assert kernel_item.trafo_data[transformation._key]['stack_size'] == exp_stack_size
+    exp_stack_size = f'3*{tsize_real}*klev*klon + {tsize_real}*klon'
+    assert kernel2_item.trafo_data[transformation._key]['stack_size'] == exp_stack_size
+    assert all(v.scope is None for v in FindVariables().visit(
+        kernel_item.trafo_data[transformation._key]['stack_size'])
+    )
+    assert all(v.scope is None for v in FindVariables().visit(
+        kernel2_item.trafo_data[transformation._key]['stack_size'])
+    )
 
     #
     # A few checks on the driver
     #
     driver = scheduler['#driver'].routine
+
+    stack_order = FindNodes(Assignment).visit(driver.body)
+    if stack_insert_pragma:
+        assert stack_order[0].lhs == "a"
+    else:
+        assert stack_order[0].lhs == "ISTSZ"
 
     # Check if allocation type symbols have been imported
     if frontend != OMNI:
@@ -549,10 +594,10 @@ end module kernel_mod
     assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack_l', 'ylstack_u')
     assert calls[1].arguments == ('1', 'nlon', 'nlon', 'nz', 'field2(:,:,b)', 'ylstack_l', 'ylstack_u')
 
-    stack_size = f'max(c_sizeof(real(1, kind={kind_real}))*nlon + c_sizeof(real(1, kind={kind_real}))*nlon*nz + '
-    stack_size += f'2*c_sizeof(int(1, kind={kind_int}))*nlon + c_sizeof(logical(true, kind={kind_log}))*nz,'
-    stack_size += f'3*c_sizeof(real(1, kind={kind_real}))*nlon*nz + '
-    stack_size += f'c_sizeof(real(1, kind={kind_real}))*nlon)/c_sizeof(real(1, kind=jprb))'
+    stack_size = f'max({tsize_real}*nlon + {tsize_real}*nlon*nz + '
+    stack_size += f'2*{tsize_int}*nlon + {tsize_log}*nz,'
+    stack_size += f'3*{tsize_real}*nlon*nz + {tsize_real}*nlon)/' \
+                  f'max(c_sizeof(real(1, kind=jprb)), 8)'
     check_stack_created_in_driver(driver, stack_size, calls[0], 2)
 
     # Has the data sharing been updated?
@@ -602,9 +647,9 @@ end module kernel_mod
         # Let's check for the relevant "allocations" happening in the right order
         assign_idx = {}
         for idx, ass in enumerate(FindNodes(Assignment).visit(kernel.body)):
-            _size = str(ass.rhs).lower().replace(f'*c_sizeof(real(1, kind={kind_real}))', '')
-            _size = _size.replace(f'*c_sizeof(int(1, kind={kind_int}))', '')
-            _size = _size.replace(f'*c_sizeof(logical(.true., kind={kind_log}))', '')
+            _size = str(ass.rhs).lower().replace(f'*max(c_sizeof(real(1, kind={kind_real})), 8)', '')
+            _size = _size.replace(f'*max(c_sizeof(int(1, kind={kind_int})), 8)', '')
+            _size = _size.replace(f'*max(c_sizeof(logical(.true., kind={kind_log})), 8)', '')
             _size = _size.replace('ylstack_l + ', '')
 
             if ass.lhs == 'ylstack_l' and ass.rhs == 'ydstack_l':
@@ -796,15 +841,20 @@ end module kernel_mod
         kind_int = 'jpim'
         kind_log = 'jplm'
 
+    tsize_real = f'max(c_sizeof(real(1, kind={kind_real})), 8)'
+    tsize_int = f'max(c_sizeof(int(1, kind={kind_int})), 8)'
+    tsize_log = f'max(c_sizeof(logical(true, kind={kind_log})), 8)'
+
     assert transformation._key in kernel_item.trafo_data
-    # pylint: disable-next=line-too-long
-    assert kernel_item.trafo_data[transformation._key]['stack_size'] == f'c_sizeof(real(1, kind={kind_real}))*klon + 4*c_sizeof(real(1, kind={kind_real}))*klev*klon + 2*c_sizeof(int(1, kind={kind_int}))*klon + c_sizeof(logical(true, kind={kind_log}))*klev'
-    # pylint: disable-next=line-too-long
-    assert kernel2_item.trafo_data[transformation._key]['stack_size'] == f'3*c_sizeof(real(1, kind={kind_real}))*columns*levels'
-    assert all(v.scope is None for v in
-                               FindVariables().visit(kernel_item.trafo_data[transformation._key]['stack_size']))
-    assert all(v.scope is None for v in
-                               FindVariables().visit(kernel2_item.trafo_data[transformation._key]['stack_size']))
+    exp_stack_size = f'{tsize_real}*klon + 4*{tsize_real}*klev*klon + 2*{tsize_int}*klon + {tsize_log}*klev'
+    assert kernel_item.trafo_data[transformation._key]['stack_size'] == exp_stack_size
+    assert kernel2_item.trafo_data[transformation._key]['stack_size'] == f'3*{tsize_real}*columns*levels'
+    assert all(v.scope is None for v in FindVariables().visit(
+        kernel_item.trafo_data[transformation._key]['stack_size']
+    ))
+    assert all(v.scope is None for v in FindVariables().visit(
+        kernel2_item.trafo_data[transformation._key]['stack_size']
+    ))
 
     #
     # A few checks on the driver
@@ -822,11 +872,13 @@ end module kernel_mod
     assert len(calls) == 1
     assert calls[0].arguments == ('1', 'nlon', 'nlon', 'nz', 'field1(:,b)', 'field2(:,:,b)', 'ylstack_l', 'ylstack_u')
 
-    stack_size = f'c_sizeof(real(1, kind={kind_real}))*nlon/c_sizeof(real(1, kind=jwrb)) +'
-    stack_size += f'4*c_sizeof(real(1, kind={kind_real}))*nlon*nz/c_sizeof(real(1, kind=jwrb)) +'
-    stack_size += f'2*c_sizeof(int(1, kind={kind_int}))*nlon/c_sizeof(real(1, kind=jwrb)) +'
-    stack_size += f'c_sizeof(logical(true, kind={kind_log}))*nz/c_sizeof(real(1, kind=jwrb))'
-    check_stack_created_in_driver(driver, stack_size, calls[0], 1, kind_real='jwrb')
+    stack_size = f'{tsize_real}*nlon/max(c_sizeof(real(1, kind=jwrb)), 8) +'
+    stack_size += f'4*{tsize_real}*nlon*nz/max(c_sizeof(real(1, kind=jwrb)), 8) +'
+    stack_size += f'2*{tsize_int}*nlon/max(c_sizeof(real(1, kind=jwrb)), 8) +'
+    stack_size += f'{tsize_log}*nz/max(c_sizeof(real(1, kind=jwrb)), 8)'
+    check_stack_created_in_driver(
+        driver, stack_size, calls[0], 1, kind_real='jwrb', simplify_stmt=True
+    )
 
     # check if stack allocatable in the driver has the correct kind parameter
     if not frontend == OMNI:
@@ -884,9 +936,9 @@ end module kernel_mod
         # Let's check for the relevant "allocations" happening in the right order
         assign_idx = {}
         for idx, ass in enumerate(FindNodes(Assignment).visit(kernel.body)):
-            _size = str(ass.rhs).lower().replace(f'*c_sizeof(real(1, kind={kind_real}))', '')
-            _size = _size.replace(f'*c_sizeof(int(1, kind={kind_int}))', '')
-            _size = _size.replace(f'*c_sizeof(logical(.true., kind={kind_log}))', '')
+            _size = str(ass.rhs).lower().replace(f'*max(c_sizeof(real(1, kind={kind_real})), 8)', '')
+            _size = _size.replace(f'*max(c_sizeof(int(1, kind={kind_int})), 8)', '')
+            _size = _size.replace(f'*max(c_sizeof(logical(.true., kind={kind_log})), 8)', '')
             _size = _size.replace('ylstack_l + ', '')
 
             if ass.lhs == 'ylstack_l' and ass.rhs == 'ydstack_l':
@@ -1016,13 +1068,151 @@ def test_pool_allocator_more_call_checks(frontend, block_dim, caplog):
     # Has the stack been added to the call statement at the correct location?
     calls = FindNodes(CallStatement).visit(kernel.body)
     assert len(calls) == 1
-    assert calls[0].arguments == ('klon', 'temp1', 'ylstack_l', 'ylstack_u', 'temp2')
+    assert calls[0].arguments == ('klon', 'temp1', 'temp2')
+    assert calls[0].kwarguments == (('YDSTACK_L', 'ylstack_l'), ('YDSTACK_U', 'ylstack_u'))
 
     if not frontend == OFP:
         # Now repeat the checks for the inline call
-        calls = [i for i in FindInlineCalls().visit(kernel.body) if not i.name.lower() in ('c_sizeof', 'real')]
+        calls = [i for i in FindInlineCalls().visit(kernel.body) if not i.name.lower() in ('max', 'c_sizeof', 'real')]
         assert len(calls) == 1
         assert calls[0].parameters == ('jl', 'ylstack_l', 'ylstack_u')
 
     assert 'Derived-type vars in Subroutine:: kernel not supported in pool allocator' in caplog.text
+    rmtree(basedir)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_pool_allocator_args_vs_kwargs(frontend, block_dim):
+    fcode_driver = """
+subroutine driver(NLON, NZ, NB, FIELD1, FIELD2)
+    use kernel_mod, only: kernel, kernel2
+    use parkind1, only : jpim
+    implicit none
+    INTEGER, PARAMETER :: JWRB = SELECTED_REAL_KIND(13,300)
+    INTEGER, INTENT(IN) :: NLON, NZ, NB
+    real(kind=jwrb), intent(inout) :: field1(nlon, nb)
+    real(kind=jwrb), intent(inout) :: field2(nlon, nz, nb)
+    integer :: b
+    real(kind=jwrb) :: opt
+    do b=1,nb
+        call KERNEL(start=1, end=nlon, klon=nlon, klev=nz, field1=field1(:,b), field2=field2(:,:,b))
+        call KERNEL2(1, nlon, nlon, nz, field2=field2(:,:,b))
+        call KERNEL2(1, nlon, nlon, nz, field2(:,:,b))
+        call KERNEL2(1, nlon, nlon, nz, field2=field2(:,:,b), opt_arg=opt)
+        call KERNEL2(1, nlon, nlon, nz, field2(:,:,b), opt)
+    end do
+end subroutine driver
+    """.strip()
+
+    fcode_kernel = """
+module kernel_mod
+    implicit none
+contains
+    subroutine kernel(start, end, klon, klev, field1, field2)
+        use parkind1, only : jpim, jplm
+        implicit none
+        integer, parameter :: jwrb = selected_real_kind(13,300)
+        integer, intent(in) :: start, end, klon, klev
+        real(kind=jwrb), intent(inout) :: field1(klon)
+        real(kind=jwrb), intent(inout) :: field2(klon,klev)
+        real(kind=jwrb) :: tmp1(klon)
+        real(kind=jwrb) :: tmp2(klon, klev)
+        integer(kind=jpim) :: tmp3(klon*2)
+        logical(kind=jplm) :: tmp4(klev)
+        integer :: jk, jl
+
+        do jk=1,klev
+            tmp1(jl) = 0.0_jwrb
+            do jl=start,end
+                tmp2(jl, jk) = field2(jl, jk)
+                tmp1(jl) = field2(jl, jk)
+            end do
+            field1(jl) = tmp1(jl)
+            tmp4(jk) = .true.
+        end do
+
+        do jl=start,end
+           tmp3(jl) = 1_jpim
+           tmp3(jl+klon) = 1_jpim
+        enddo
+
+        call kernel2(start, end, klon, klev, field2)
+    end subroutine kernel
+    subroutine kernel2(start, end, columns, levels, field2, opt_arg)
+        implicit none
+        integer, parameter :: jwrb = selected_real_kind(13,300)
+        integer, intent(in) :: start, end, columns, levels
+        real(kind=jwrb), intent(inout) :: field2(columns,levels)
+        real(kind=jwrb) :: tmp1(2*columns, levels), tmp2(columns, levels)
+        real(kind=jwrb), optional :: opt_arg
+        integer :: jk, jl
+
+        do jk=1,levels
+            do jl=start,end
+                tmp1(jl, jk) = field2(jl, jk)
+                tmp1(jl+columns, jk) = field2(jl, jk)*2._jwrb
+                tmp2(jl, jk) = tmp1(jl, jk) + 1._jwrb
+                field2(jl, jk) = tmp2(jl, jk)
+            end do
+        end do
+    end subroutine kernel2
+
+end module kernel_mod
+    """.strip()
+
+    basedir = gettempdir() / 'test_pool_allocator_args_vs_kwargs'
+    basedir.mkdir(exist_ok=True)
+    (basedir / 'driver.F90').write_text(fcode_driver)
+    (basedir / 'kernel.F90').write_text(fcode_kernel)
+
+    config = {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True
+        },
+        'routines': {
+            'driver': {'role': 'driver'}
+        }
+    }
+    scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config), frontend=frontend)
+
+    if frontend == OMNI:
+        for item in scheduler.items:
+            normalize_range_indexing(item.routine)
+
+    transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
+    scheduler.process(transformation=transformation)
+
+    kernel = scheduler['kernel_mod#kernel'].routine
+    kernel2 = scheduler['kernel_mod#kernel2'].routine
+    driver = scheduler['#driver'].routine
+
+    assert 'ydstack_l' in kernel.arguments
+    assert 'ydstack_u' in kernel.arguments
+    assert 'ydstack_l' in kernel2.arguments
+    assert 'ydstack_u' in kernel2.arguments
+
+    calls = FindNodes(CallStatement).visit(driver.body)
+    assert calls[0].arguments == ()
+    assert calls[0].kwarguments == (
+        ('start', 1), ('end', 'nlon'), ('klon', 'nlon'), ('klev', 'nz'),
+        ('field1', 'field1(:, b)'), ('field2', 'field2(:, :, b)'),
+        ('YDSTACK_L', 'YLSTACK_L'), ('YDSTACK_U', 'YLSTACK_U')
+    )
+    assert calls[1].arguments == ('1', 'nlon', 'nlon', 'nz')
+    assert calls[1].kwarguments == (
+        ('field2', 'field2(:, :, b)'), ('YDSTACK_L', 'YLSTACK_L'), ('YDSTACK_U', 'YLSTACK_U')
+    )
+    assert calls[2].arguments == ('1', 'nlon', 'nlon', 'nz', 'field2(:, :, b)')
+    assert calls[2].kwarguments == (('YDSTACK_L', 'YLSTACK_L'), ('YDSTACK_U', 'YLSTACK_U'))
+    assert calls[3].arguments == ('1', 'nlon', 'nlon', 'nz')
+    assert calls[3].kwarguments == (
+        ('field2', 'field2(:, :, b)'), ('opt_arg', 'opt'),
+        ('YDSTACK_L', 'YLSTACK_L'), ('YDSTACK_U', 'YLSTACK_U')
+    )
+    assert calls[4].arguments == ('1', 'nlon', 'nlon', 'nz', 'field2(:, :, b)', 'opt')
+    assert calls[4].kwarguments == (('YDSTACK_L', 'YLSTACK_L'), ('YDSTACK_U', 'YLSTACK_U'))
+
     rmtree(basedir)

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -759,8 +759,9 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         call_map = {}
         for call in FindInlineCalls().visit(routine.body):
             if call.name.lower() in [t.lower() for t in targets]:
-                parameters = call.parameters
-                call_map[call] = call.clone(kw_parameters=as_tuple(call.kw_parameters) + new_kwarguments)
+                call_map[call] = call.clone(
+                    kw_parameters=as_tuple(call.kw_parameters) + new_kwarguments
+                )
 
         if call_map:
             routine.body = SubstituteExpressions(call_map).visit(routine.body)

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -92,6 +92,8 @@ class TemporariesPoolAllocatorTransformation(Transformation):
     # Traverse call tree in reverse when using Scheduler
     reverse_traversal = True
 
+    process_ignored_items = True
+
     def __init__(self, block_dim, stack_ptr_name='L', stack_end_name='U', stack_size_name='ISTSZ',
                  stack_storage_name='ZSTACK', stack_argument_name='YDSTACK', stack_local_var_name='YLSTACK',
                  local_ptr_var_name_pattern='IP_{name}', stack_int_type_kind=IntLiteral(8), directive=None,

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -133,7 +133,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         role = kwargs['role']
         item = kwargs.get('item', None)
         ignore = item.ignore if item else ()
-        targets = kwargs.get('targets', None)
+        targets = as_tuple(kwargs.get('targets', None))
 
         self.stack_type_kind = 'JPRB'
         if item:

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -734,13 +734,11 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         # inject a delaration which the driver cannot do!
         stack_var = self._get_local_stack_var(routine)
         stack_arg_name = f'{self.stack_argument_name}_{self.stack_ptr_name}'
-        new_arguments = (stack_var,)
         new_kwarguments = ((stack_arg_name, stack_var),)
 
         if self.check_bounds:
             stack_var_end = self._get_local_stack_var_end(routine)
             stack_arg_end_name = f'{self.stack_argument_name}_{self.stack_end_name}'
-            new_arguments += (stack_var_end,)
             new_kwarguments += ((stack_arg_end_name, stack_var_end),)
 
         for call in FindNodes(CallStatement).visit(routine.body):
@@ -764,7 +762,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         for call in FindInlineCalls().visit(routine.body):
             if call.name.lower() in [t.lower() for t in targets]:
                 parameters = call.parameters
-                call_map[call] = call.clone(parameters=parameters + new_arguments)
+                call_map[call] = call.clone(kw_parameters=as_tuple(call.kw_parameters) + new_kwarguments)
 
         if call_map:
             routine.body = SubstituteExpressions(call_map).visit(routine.body)

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -7,13 +7,23 @@
 
 import re
 from collections import  defaultdict
+
+from loki.expression import (
+    Quotient, IntLiteral, LogicLiteral, Variable, Array, Sum, Literal,
+    Product, InlineCall, Comparison, RangeIndex, Cast,
+    ProcedureSymbol, LogicalNot, simplify,
+)
+from loki.ir import (
+    Intrinsic, Assignment, Conditional, CallStatement, Import,
+    Allocation, Deallocation, Loop, Pragma
+)
 from loki import (
-    as_tuple, warning, debug, simplify, recursive_expression_map_update, get_pragma_parameters,
-    Transformation, FindNodes, FindVariables, Transformer, SubstituteExpressions, DetachScopesMapper,
-    SymbolAttributes, BasicType, DerivedType, Quotient, IntLiteral, LogicLiteral,
-    Variable, Array, Sum, Literal, Product, InlineCall, Comparison, RangeIndex, Cast,
-    Intrinsic, Assignment, Conditional, CallStatement, Import, Allocation, Deallocation, is_dimension_constant,
-    Loop, Pragma, FindInlineCalls, Interface, ProcedureSymbol, LogicalNot, dataflow_analysis_attached
+    as_tuple, warning, debug, Transformation, FindNodes,
+    FindVariables, Transformer, SubstituteExpressions,
+    DetachScopesMapper, SymbolAttributes, BasicType, DerivedType,
+    is_dimension_constant, recursive_expression_map_update,
+    get_pragma_parameters, FindInlineCalls, Interface,
+    dataflow_analysis_attached
 )
 
 __all__ = ['TemporariesPoolAllocatorTransformation']

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -512,8 +512,6 @@ class TemporariesPoolAllocatorTransformation(Transformation):
 
         # Build expression for array size in bytes
         dim = arr.dimensions[0]
-        if isinstance(dim, RangeIndex):
-            dim = Sum((dim.upper, Product((-1, dim.lower)), 1))
         for d in arr.dimensions[1:]:
             _dim = d
             if isinstance(_dim, RangeIndex):


### PR DESCRIPTION
_Please note that this is a replay of some of the changes in Loki #135 , brought together with an alternative solution for determining stack-size across mulitple libs. A lot of the credit for this excellent work goes to @MichaelSt98 (sorry, in the rebase I dropped the commit authorship when separating the individual steps)._

The main purpose of the PR is to apply the remaining fixes to the `PoolAllocatorTransformation` in unison and enable it as the "scc-stack" mode in the `loki_transform.py convert`. With this, the PR enables the SCC-stack transformation for the current EC-physics demonstrator via three types of changes:
* Enabling the SCC-Stack transformation as a "mode" in convert (bug fix to deal with hyphens in "mode")
* Allowing the analysis part of SCC-stack to run past "ignore" items in the scheduler by changing the filtering rules
* Bringing forward a few of the fixes to the `PoolAllocatorTransformation` that were part of the original PR

The scheduler changes are probably temporary in nature, as we can likely do this better after the rewrite. For now, we change the behaviour to instead of stopping parsing one level below "ignore" items, we keep extending but keep inheriting the "ignored" property. These items are then available for transformations with the explicit property `process_ignored_items`, so that inter-procedural analysis passes may reach the leaves to gather and agglomerate the necessary information. 

The various changes to the pool allocator bug-fixes, changes to the argument insertion (strictly via keyword-arguments now) and enforcing alignment. I've also tried to tidy up the test and imports a tiny bit in the process.

In a little more detail:
* Enabling the SCC-Stack transformation as a "mode" in convert (bug fix to deal with hyphens in "mode")
* Allow "ignore" items to be processed by marked analysis passes and use for `TemporariesPoolAllocatorAnalysis`
* Bug-fix for type handling in base expression mapper
* Adjusting stack size derivation to enforce alignment via `(max(c_sizeof<...>, 8)` and according test adjustments(!)
* Insertion of stack-size at a fixed location in the driver that is marked via `!$loki stack-size` - this is planned to be done more generally at a later stage)
* Strictly use keyword-argument passing for the stack variables to avoid cross-fire with the array-shape adjustment trafo 

Due to the partial replay nature of the PR, the test updates are done in bulk towards the end. @MichaelSt98 please check if the original features and intentions of your fixes are still fine.