### PR TITLE
C/C++ De/Reference

### DIFF
--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -60,13 +60,10 @@ class CCodeMapper(LokiStringifyMapper):
             self.format('(%s) %s', c_intrinsic_type(_type), expression), enclosing_prec, PREC_CALL)
 
     def map_variable_symbol(self, expr, enclosing_prec, *args, **kwargs):
-        # TODO: Big hack, this is completely agnostic to whether value or address is to be assigned
-        # ptr = '*' if expr.type and expr.type.pointer else ''
-        ptr = ''
         if expr.parent is not None:
-            parent = self.parenthesize(self.rec(expr.parent, PREC_NONE, *args, **kwargs))
-            return self.format('%s%s.%s', ptr, parent, expr.basename)
-        return self.format('%s%s', ptr, expr.name)
+            parent = expr.parent
+            return self.format('%s).%s', parent, expr.basename)
+        return self.format('%s', expr.name)
 
     def map_meta_symbol(self, expr, enclosing_prec, *args, **kwargs):
         return self.rec(expr._symbol, enclosing_prec, *args, **kwargs)
@@ -113,12 +110,11 @@ class CCodeMapper(LokiStringifyMapper):
             enclosing_prec, PREC_NONE)
 
     def map_c_reference(self, expr, enclosing_prec, *args, **kwargs):
-        print(f"HERE map_c_reference: expr {expr} | expr.expression {expr.expression} | type {type(expr.expression)}")
         return self.format(' &%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs)) 
 
     def map_c_dereference(self, expr, enclosing_prec, *args, **kwargs):
-        print(f"HERE map_c_dereference: expr {expr} | expr.expression {expr.expression}")
-        return self.format(' *%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
+        parenthesize = '(' if expr.expression.parent is not None else ''
+        return self.format(' %s*%s', parenthesize, self.rec(expr.expression, PREC_NONE, *args, **kwargs))
 
 
 class CCodegen(Stringifier):

--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -61,8 +61,8 @@ class CCodeMapper(LokiStringifyMapper):
 
     def map_variable_symbol(self, expr, enclosing_prec, *args, **kwargs):
         if expr.parent is not None:
-            parent = expr.parent
-            return self.format('%s).%s', parent, expr.basename)
+            parent = self.parenthesize(self.rec(expr.parent, PREC_NONE, *args, **kwargs))
+            return self.format('%s.%s', parent, expr.basename)
         return self.format('%s', expr.name)
 
     def map_meta_symbol(self, expr, enclosing_prec, *args, **kwargs):
@@ -110,11 +110,10 @@ class CCodeMapper(LokiStringifyMapper):
             enclosing_prec, PREC_NONE)
 
     def map_c_reference(self, expr, enclosing_prec, *args, **kwargs):
-        return self.format(' &%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
+        return self.format(' (&%s)', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
 
     def map_c_dereference(self, expr, enclosing_prec, *args, **kwargs):
-        parenthesize = '(' if expr.expression.parent is not None else ''
-        return self.format(' %s*%s', parenthesize, self.rec(expr.expression, PREC_NONE, *args, **kwargs))
+        return self.format(' (*%s)', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
 
 
 class CCodegen(Stringifier):

--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -61,7 +61,8 @@ class CCodeMapper(LokiStringifyMapper):
 
     def map_variable_symbol(self, expr, enclosing_prec, *args, **kwargs):
         # TODO: Big hack, this is completely agnostic to whether value or address is to be assigned
-        ptr = '*' if expr.type and expr.type.pointer else ''
+        # ptr = '*' if expr.type and expr.type.pointer else ''
+        ptr = ''
         if expr.parent is not None:
             parent = self.parenthesize(self.rec(expr.parent, PREC_NONE, *args, **kwargs))
             return self.format('%s%s.%s', ptr, parent, expr.basename)
@@ -110,6 +111,14 @@ class CCodeMapper(LokiStringifyMapper):
             self.format('pow(%s, %s)', self.rec(expr.base, PREC_NONE, *args, **kwargs),
                         self.rec(expr.exponent, PREC_NONE, *args, **kwargs)),
             enclosing_prec, PREC_NONE)
+
+    def map_c_reference(self, expr, enclosing_prec, *args, **kwargs):
+        print(f"HERE map_c_reference: expr {expr} | expr.expression {expr.expression} | type {type(expr.expression)}")
+        return self.format(' &%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs)) 
+
+    def map_c_dereference(self, expr, enclosing_prec, *args, **kwargs):
+        print(f"HERE map_c_dereference: expr {expr} | expr.expression {expr.expression}")
+        return self.format(' *%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
 
 
 class CCodegen(Stringifier):

--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -110,7 +110,7 @@ class CCodeMapper(LokiStringifyMapper):
             enclosing_prec, PREC_NONE)
 
     def map_c_reference(self, expr, enclosing_prec, *args, **kwargs):
-        return self.format(' &%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs)) 
+        return self.format(' &%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
 
     def map_c_dereference(self, expr, enclosing_prec, *args, **kwargs):
         parenthesize = '(' if expr.expression.parent is not None else ''

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -211,6 +211,12 @@ class LokiStringifyMapper(StringifyMapper):
 
     map_string_subscript = map_array_subscript
 
+    def map_c_reference(self, expr, enclosing_prec, *args, **kwargs):
+        return self.format('%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
+
+    def map_c_dereference(self, expr, enclosing_prec, *args, **kwargs):
+        return self.format('%s', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
+
 
 class LokiWalkMapper(WalkMapper):
     """
@@ -299,6 +305,20 @@ class LokiWalkMapper(WalkMapper):
         self.rec(expr.values, *args, **kwargs)
         self.rec(expr.variable, *args, **kwargs)
         self.rec(expr.bounds, *args, **kwargs)
+        self.post_visit(expr, *args, **kwargs)
+
+    # TODO: necessary?
+    def map_c_reference(self, expr, *args, **kwargs):
+        if not self.visit(expr):
+            return
+        self.rec(expr.expression, *args, **kwargs)
+        self.post_visit(expr, *args, **kwargs)
+
+    # TODO: necessary?
+    def map_c_dereference(self, expr, *args, **kwargs):
+        if not self.visit(expr):
+            return
+        self.rec(expr.expression, *args, **kwargs)
         self.post_visit(expr, *args, **kwargs)
 
 
@@ -696,6 +716,12 @@ class LokiIdentityMapper(IdentityMapper):
         variable = self.rec(expr.variable, *args, **kwargs)
         bounds = self.rec(expr.bounds, *args, **kwargs)
         return expr.__class__(values, variable, bounds)
+
+    def map_c_reference(self, expr, *args, **kwargs):
+        return expr.__class__(self.rec(expr.expression, *args, **kwargs))
+
+    def map_c_dereference(self, expr, *args, **kwargs):
+        return expr.__class__(self.rec(expr.expression, *args, **kwargs))
 
 
 class SubstituteExpressionsMapper(LokiIdentityMapper):

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -307,14 +307,12 @@ class LokiWalkMapper(WalkMapper):
         self.rec(expr.bounds, *args, **kwargs)
         self.post_visit(expr, *args, **kwargs)
 
-    # TODO: necessary?
     def map_c_reference(self, expr, *args, **kwargs):
         if not self.visit(expr):
             return
         self.rec(expr.expression, *args, **kwargs)
         self.post_visit(expr, *args, **kwargs)
 
-    # TODO: necessary?
     def map_c_dereference(self, expr, *args, **kwargs):
         if not self.visit(expr):
             return

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1477,26 +1477,8 @@ class Reference(pmbl.Expression):
         assert isinstance(expression, pmbl.Expression)
         self.expression = expression
 
-    """
-    @property
-    def name(self):
-        return self.expression.name
-
-    @property
-    def type(self):
-        return self.expression.type
-
-    @property
-    def scope(self):
-        return self.expression.scope
-
-    @property
-    def initial(self):
-        return self.expression.initial
-
     mapper_method = intern('map_c_reference')
     make_stringifier = loki_make_stringifier
-    """
 
 
 class Dereference(pmbl.Expression):
@@ -1515,24 +1497,6 @@ class Dereference(pmbl.Expression):
     def __init__(self, expression):
         assert isinstance(expression, pmbl.Expression)
         self.expression = expression
-
-    """
-    @property
-    def name(self):
-        return self.expression.name
-
-    @property
-    def type(self):
-        return self.expression.type
-
-    @property
-    def scope(self):
-        return self.expression.scope
-
-    @property
-    def initial(self):
-        return self.expression.initial
-    """
 
     mapper_method = intern('map_c_dereference')
     make_stringifier = loki_make_stringifier

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1471,7 +1471,7 @@ class Reference(pmbl.Expression):
     init_arg_names = ('expression',)
 
     def __getinitargs__(self):
-        return self.expression,
+        return (self.expression, )
 
     def __init__(self, expression):
         assert isinstance(expression, pmbl.Expression)

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -254,7 +254,8 @@ class TypedSymbol:
 
     @parent.setter
     def parent(self, parent):
-        assert parent is None or isinstance(parent, (TypedSymbol, MetaSymbol))
+        assert parent is None or isinstance(parent, (TypedSymbol, MetaSymbol,
+            Reference, Dereference))
         self._parent = parent
 
     @property
@@ -1464,6 +1465,8 @@ class Reference(pmbl.Expression):
     """
     Internal representation of a Reference.
 
+    .. warning:: Experimental!
+
     **C/C++ only**, no corresponding concept in Fortran.
     Referencing refers to taking the address of an
     existing variable (to set a pointer variable).
@@ -1477,6 +1480,22 @@ class Reference(pmbl.Expression):
         assert isinstance(expression, pmbl.Expression)
         self.expression = expression
 
+    @property
+    def name(self):
+        return self.expression.name
+
+    @property
+    def type(self):
+        return self.expression.type
+
+    @property
+    def scope(self):
+        return self.expression.scope
+
+    @property
+    def initial(self):
+        return self.expression.initial
+
     mapper_method = intern('map_c_reference')
     make_stringifier = loki_make_stringifier
 
@@ -1484,6 +1503,8 @@ class Reference(pmbl.Expression):
 class Dereference(pmbl.Expression):
     """
     Internal representation of a Dereference.
+
+    .. warning:: Experimental!
 
     **C/C++ only**, no corresponding concept in Fortran.
     Dereferencing (a pointer) refers to retrieving the value
@@ -1497,6 +1518,22 @@ class Dereference(pmbl.Expression):
     def __init__(self, expression):
         assert isinstance(expression, pmbl.Expression)
         self.expression = expression
+
+    @property
+    def name(self):
+        return self.expression.name
+
+    @property
+    def type(self):
+        return self.expression.type
+
+    @property
+    def scope(self):
+        return self.expression.scope
+
+    @property
+    def initial(self):
+        return self.expression.initial
 
     mapper_method = intern('map_c_dereference')
     make_stringifier = loki_make_stringifier

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1465,7 +1465,10 @@ class Reference(pmbl.Expression):
     """
     Internal representation of a Reference.
 
-    .. warning:: Experimental!
+    .. warning:: Experimental! Allowing compound
+        ``Reference(Variable(...))`` to appear
+        with behaviour akin to a symbol itself
+        for easier processing in mappers.
 
     **C/C++ only**, no corresponding concept in Fortran.
     Referencing refers to taking the address of an
@@ -1482,18 +1485,34 @@ class Reference(pmbl.Expression):
 
     @property
     def name(self):
+        """
+        Allowing the compound ``Reference(Variable(name))`` to appear 
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
         return self.expression.name
 
     @property
     def type(self):
+        """
+        Allowing the compound ``Reference(Variable(type))`` to appear 
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
         return self.expression.type
 
     @property
     def scope(self):
+        """
+        Allowing the compound ``Reference(Variable(scope))`` to appear 
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
         return self.expression.scope
 
     @property
     def initial(self):
+        """
+        Allowing the compound ``Reference(Variable(initial))`` to appear 
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
         return self.expression.initial
 
     mapper_method = intern('map_c_reference')
@@ -1504,7 +1523,10 @@ class Dereference(pmbl.Expression):
     """
     Internal representation of a Dereference.
 
-    .. warning:: Experimental!
+    .. warning:: Experimental! Allowing compound
+        ``Dereference(Variable(...))`` to appear
+        with behaviour akin to a symbol itself
+        for easier processing in mappers.
 
     **C/C++ only**, no corresponding concept in Fortran.
     Dereferencing (a pointer) refers to retrieving the value
@@ -1521,18 +1543,34 @@ class Dereference(pmbl.Expression):
 
     @property
     def name(self):
+        """
+        Allowing the compound ``Dereference(Variable(name))`` to appear 
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
         return self.expression.name
 
     @property
     def type(self):
+        """
+        Allowing the compound ``Dereference(Variable(type))`` to appear 
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
         return self.expression.type
 
     @property
     def scope(self):
+        """
+        Allowing the compound ``Dereference(Variable(scope))`` to appear 
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
         return self.expression.scope
 
     @property
     def initial(self):
+        """
+        Allowing the compound ``Dereference(Variable(initial))`` to appear 
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
         return self.expression.initial
 
     mapper_method = intern('map_c_dereference')

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -39,6 +39,8 @@ __all__ = [
     'Sum', 'Product', 'Quotient', 'Power', 'Comparison', 'LogicalAnd', 'LogicalOr',
     'LogicalNot', 'InlineCall', 'Cast', 'Range', 'LoopRange', 'RangeIndex', 'ArraySubscript',
     'StringSubscript',
+    # C/C++ concepts
+    'Reference', 'Dereference',
 ]
 
 # pylint: disable=abstract-method,too-many-lines
@@ -1457,3 +1459,80 @@ class StringSubscript(StrCompareMixin, pmbl.Subscript):
     @property
     def symbol(self):
         return self.aggregate
+
+class Reference(pmbl.Expression):
+    """
+    Internal representation of a Reference.
+
+    **C/C++ only**, no corresponding concept in Fortran.
+    Referencing refers to taking the address of an
+    existing variable (to set a pointer variable).
+    """
+    init_arg_names = ('expression',)
+
+    def __getinitargs__(self):
+        return self.expression,
+
+    def __init__(self, expression):
+        assert isinstance(expression, pmbl.Expression)
+        self.expression = expression
+
+    """
+    @property
+    def name(self):
+        return self.expression.name
+
+    @property
+    def type(self):
+        return self.expression.type
+
+    @property
+    def scope(self):
+        return self.expression.scope
+
+    @property
+    def initial(self):
+        return self.expression.initial
+
+    mapper_method = intern('map_c_reference')
+    make_stringifier = loki_make_stringifier
+    """
+
+
+class Dereference(pmbl.Expression):
+    """
+    Internal representation of a Dereference.
+
+    **C/C++ only**, no corresponding concept in Fortran.
+    Dereferencing (a pointer) refers to retrieving the value
+    from a memory address (that is pointed by the pointer).
+    """
+    init_arg_names = ('expression', )
+
+    def __getinitargs__(self):
+        return (self.expression, )
+
+    def __init__(self, expression):
+        assert isinstance(expression, pmbl.Expression)
+        self.expression = expression
+
+    """
+    @property
+    def name(self):
+        return self.expression.name
+
+    @property
+    def type(self):
+        return self.expression.type
+
+    @property
+    def scope(self):
+        return self.expression.scope
+
+    @property
+    def initial(self):
+        return self.expression.initial
+    """
+
+    mapper_method = intern('map_c_dereference')
+    make_stringifier = loki_make_stringifier

--- a/loki/transform/fortran_c_transform.py
+++ b/loki/transform/fortran_c_transform.py
@@ -31,8 +31,7 @@ from loki.subroutine import Subroutine
 from loki.module import Module
 from loki.expression import (
     Variable, InlineCall, RangeIndex, Scalar, Array,
-    ProcedureSymbol, SubstituteExpressions, Dereference,
-    FindVariables
+    ProcedureSymbol, SubstituteExpressions, Dereference
 )
 from loki.visitors import Transformer, FindNodes
 from loki.tools import as_tuple, flatten
@@ -440,16 +439,8 @@ class FortranCTransformation(Transformation):
                     # Lower case type names for derived types
                     typedef = _type.dtype.typedef.clone(name=_type.dtype.typedef.name.lower())
                     _type = _type.clone(dtype=typedef.dtype)
-                else:
-                    var_map[arg] = Dereference(arg)
+                var_map[arg] = Dereference(arg)
                 kernel.symbol_attrs[arg.name] = _type
-        if var_map:
-            routine.body = SubstituteExpressions(var_map).visit(routine.body)
-        variables = FindVariables().visit(kernel.body)
-        var_map = {}
-        for var in variables:
-            if var.parent is not None:
-                var_map[var] = Dereference(var)
         routine.body = SubstituteExpressions(var_map).visit(routine.body)
 
         symbol_map = {'epsilon': 'DBL_EPSILON'}

--- a/loki/transform/fortran_c_transform.py
+++ b/loki/transform/fortran_c_transform.py
@@ -31,7 +31,8 @@ from loki.subroutine import Subroutine
 from loki.module import Module
 from loki.expression import (
     Variable, InlineCall, RangeIndex, Scalar, Array,
-    ProcedureSymbol, SubstituteExpressions, Dereference
+    ProcedureSymbol, SubstituteExpressions, Dereference,
+    FindVariables
 )
 from loki.visitors import Transformer, FindNodes
 from loki.tools import as_tuple, flatten
@@ -439,10 +440,18 @@ class FortranCTransformation(Transformation):
                     # Lower case type names for derived types
                     typedef = _type.dtype.typedef.clone(name=_type.dtype.typedef.name.lower())
                     _type = _type.clone(dtype=typedef.dtype)
-                var_map[arg] = Dereference(arg)
+                else:
+                    var_map[arg] = Dereference(arg)
                 kernel.symbol_attrs[arg.name] = _type
         if var_map:
             routine.body = SubstituteExpressions(var_map).visit(routine.body)
+        variables = FindVariables().visit(kernel.body)
+        var_map = {}
+        for var in variables:
+            if var.parent is not None:
+                var_map[var] = Dereference(var)
+        routine.body = SubstituteExpressions(var_map).visit(routine.body)
+
         symbol_map = {'epsilon': 'DBL_EPSILON'}
         function_map = {'min': 'fmin', 'max': 'fmax', 'abs': 'fabs',
                         'exp': 'exp', 'sqrt': 'sqrt', 'sign': 'copysign'}

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1518,3 +1518,21 @@ end subroutine some_routine
     c_str = cgen(routine).replace(' ', '')
     assert '(&var_reference)=1' in c_str
     assert '(*var_dereference)=2' in c_str
+
+    # now test processing in mappers (by renaming variables being "De/Referenced")
+    var_reference = routine.variable_map['var_reference']
+    var_dereference = routine.variable_map['var_dereference']
+    var_map = {var_reference: var_reference.clone(name='renamed_var_reference'),
+            var_dereference: var_dereference.clone(name='renamed_var_dereference')}
+    routine.spec = SubstituteExpressions(var_map).visit(routine.spec)
+    routine.body = SubstituteExpressions(var_map).visit(routine.body)
+
+    f_str = fgen(routine).replace(' ', '')
+    assert 'renamed_var_reference=1' in f_str
+    assert 'renamed_var_dereference=2' in f_str
+    assert '*' not in f_str
+    assert '&' not in f_str
+
+    c_str = cgen(routine).replace(' ', '')
+    assert '(&renamed_var_reference)=1' in c_str
+    assert '(*renamed_var_dereference)=2' in c_str


### PR DESCRIPTION
Should be `Dereference(<derived_type>%member)`. However, it would be more correct to have `Dereference(<derived_type>)%member`. But, this won't work unless `Reference`/ `Dereference` get e.g., the following methods:

```py
@property
def name(self):
    return self.expression.name

@property
def type(self):
    return self.expression.type

@property
def scope(self):
    return self.expression.scope

@property
def initial(self):
    return self.expression.initial
```

Moreover, the insertion of parentheses is a bit hacky rn ...

**Tested** currently via the *transpile* tests and tested with CLOUDSC Loki C.

___________

**EDIT:**: using the `Dereference(<derived_type>)%member` approach with the above mentioned methods implemented. This seems to be the best solution for now, but it is **experimental** and may be refactored at some point.