### PR TITLE
Global var hoisting

### DIFF
--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -12,11 +12,11 @@ import pytest
 from loki import (
     Sourcefile, FindNodes, Pragma, PragmaRegion, Loop,
     CallStatement, pragma_regions_attached, get_pragma_parameters,
-    gettempdir, Scheduler, OMNI, Import, fgen
+    gettempdir, Scheduler, OMNI, Import
 )
 from conftest import available_frontends
 from transformations import (
-        DataOffloadTransformation, GlobalVariableAnalysis, 
+        DataOffloadTransformation, GlobalVariableAnalysis,
         GlobalVarOffloadTransformation, GlobalVarHoistTransformation
 )
 
@@ -647,9 +647,10 @@ def test_transformation_global_var_import_derived_type(here, config, frontend):
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('hoist_parameters', (False, True))
-def test_transformation_global_var_hoist(here, config, frontend, hoist_parameters):
+@pytest.mark.parametrize('ignore_modules', (None, ('moduleb',)))
+def test_transformation_global_var_hoist(here, config, frontend, hoist_parameters, ignore_modules):
     """
-    Test the generation of offload instructions of global variable imports.
+    Test hoisting of global variable imports.
     """
     config['default']['enable_imports'] = True
     config['routines'] = {
@@ -658,42 +659,85 @@ def test_transformation_global_var_hoist(here, config, frontend, hoist_parameter
 
     scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=config, frontend=frontend)
     scheduler.process(transformation=GlobalVariableAnalysis())
-    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters=hoist_parameters)) # , ignore_modules=('modulec',)))
-
-    print("")
-    print("")
+    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters=hoist_parameters,
+        ignore_modules=ignore_modules))
 
     driver = scheduler['#driver'].routine
     kernel0 = scheduler['#kernel0'].routine
-    kernel1 = scheduler['#kernel1'].routine
-    kernel2 = scheduler['#kernel2'].routine
-    kernel3 = scheduler['#kernel3'].routine
-    moduleA = scheduler['modulea#var0'].scope
-    moduleB = scheduler['moduleb#var2'].scope
-    moduleC = scheduler['modulec#var4'].scope
+    kernel_map = {key: scheduler[f'#{key}'].routine for key in ['kernel1', 'kernel2', 'kernel3']}
 
-    print(fgen(driver))
-    print("----------")
-    print(fgen(kernel0))
-    print("----------")
-    print(fgen(kernel1))
-    print("----------")
-    print(fgen(kernel2))
-    print("----------")
-    print(fgen(kernel3))
-    print("----------")
-    # print(fgen(moduleA))
-    print("----------")
-    # print(fgen(moduleB))
-    print("----------")
-    # print(fgen(moduleC))
+    # symbols within each module
+    expected_symbols = {'modulea': ['var0', 'var1'], 'moduleb': ['var2', 'var3'],
+            'modulec': ['var4', 'var5']}
+    # expected intent of those variables (if hoisted)
+    var_intent_map = {'var0': 'in', 'var1': 'in', 'var2': 'in',
+            'var3': 'in', 'var4': 'inout', 'var5': 'inout', 'tmp': None}
+    # DRIVER
+    imports = FindNodes(Import).visit(driver.spec)
+    import_names = [_import.module.lower() for _import in imports]
+    # check driver imports
+    expected_driver_modules = ['modulec']
+    expected_driver_modules += ['moduleb'] if ignore_modules is None else []
+    if frontend != OMNI:
+        expected_driver_modules += ['modulea'] if hoist_parameters else []
+    assert len(imports) == len(expected_driver_modules)
+    assert sorted(expected_driver_modules) == sorted(import_names)
+    for _import in imports:
+        assert sorted([sym.name for sym in _import.symbols]) == expected_symbols[_import.module.lower()]
+    # check driver call
+    driver_calls = FindNodes(CallStatement).visit(driver.body)
+    expected_args = []
+    for module in expected_driver_modules:
+        expected_args.extend(expected_symbols[module])
+    assert [arg.name for arg in driver_calls[0].arguments] == sorted(expected_args)
+
+    originally = {'kernel1': ['modulea'], 'kernel2': ['moduleb'],
+            'kernel3': ['moduleb', 'modulec']}
+    # KERNEL0
+    assert [arg.name for arg in kernel0.arguments] == sorted(expected_args)
+    assert [arg.name for arg in kernel0.variables] == sorted(expected_args)
+    for var in kernel0.variables:
+        assert kernel0.variable_map[var.name.lower()].type.intent == var_intent_map[var.name.lower()]
+    kernel0_calls = FindNodes(CallStatement).visit(kernel0.body)
+    # KERNEL1 & KERNEL2 & KERNEL3
+    for call in kernel0_calls:
+        expected_args = []
+        expected_imports = []
+        kernel_expected_symbols = []
+        for module in originally[call.routine.name]:
+            # always, since at least 'some_func' is imported
+            if call.routine.name == 'kernel1' and module == 'modulea':
+                expected_imports.append(module)
+                kernel_expected_symbols.append('some_func')
+            if module in expected_driver_modules:
+                expected_args.extend(expected_symbols[module])
+            else:
+                # already added
+                if module != 'modulea':
+                    expected_imports.append(module)
+                kernel_expected_symbols.extend(expected_symbols[module])
+        assert len(expected_args) == len(call.arguments)
+        assert [arg.name for arg in call.arguments] == expected_args
+        assert [arg.name for arg in kernel_map[call.routine.name].arguments] == expected_args
+        for var in kernel_map[call.routine.name].variables:
+            var_intent = kernel_map[call.routine.name].variable_map[var.name.lower()].type.intent
+            assert var_intent == var_intent_map[var.name.lower()]
+        if call.routine.name in ['kernel1', 'kernel2']:
+            expected_args = ['tmp'] + expected_args
+        assert [arg.name for arg in kernel_map[call.routine.name].variables] == expected_args
+        kernel_imports = FindNodes(Import).visit(call.routine.spec)
+        assert sorted([_import.module.lower() for _import in kernel_imports]) == sorted(expected_imports)
+        imported_symbols = [] # _import.symbols for _import in kernel_imports]
+        for _import in kernel_imports:
+            imported_symbols.extend([sym.name.lower() for sym in _import.symbols])
+        assert sorted(imported_symbols) == sorted(kernel_expected_symbols)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('hoist_parameters', (False, True))
 def test_transformation_global_var_derived_type_hoist(here, config, frontend, hoist_parameters):
     """
-    Test the generation of offload instructions of derived-type global variable imports.
+    Test hoisting of derived-type global variable imports.
     """
 
     config['default']['enable_imports'] = True
@@ -707,8 +751,25 @@ def test_transformation_global_var_derived_type_hoist(here, config, frontend, ho
 
     driver = scheduler['#driver_derived_type'].routine
     kernel = scheduler['#kernel_derived_type'].routine
-    module = scheduler['module_derived_type#p'].scope
-    
-    print(fgen(driver))
-    print("--------------------")
-    print(fgen(kernel))
+
+    # DRIVER
+    imports = FindNodes(Import).visit(driver.spec)
+    assert len(imports) == 1
+    assert imports[0].module.lower() == 'module_derived_type'
+    assert sorted([sym.name.lower() for sym in imports[0].symbols]) == sorted(['p', 'p_array', 'p0'])
+    calls = FindNodes(CallStatement).visit(driver.body)
+    assert len(calls) == 1
+    # KERNEL
+    assert [arg.name for arg in calls[0].arguments] == ['p', 'p0', 'p_array']
+    assert [arg.name for arg in kernel.arguments] == ['p', 'p0', 'p_array']
+    kernel_imports = FindNodes(Import).visit(kernel.spec)
+    assert len(kernel_imports) == 1
+    assert [sym.name.lower() for sym in kernel_imports[0].symbols] == ['g']
+    assert sorted([var.name for var in kernel.variables]) == ['i', 'j', 'p', 'p0', 'p_array']
+    assert kernel.variable_map['p_array'].type.allocatable
+    assert kernel.variable_map['p_array'].type.intent == 'inout'
+    assert kernel.variable_map['p_array'].type.dtype.name == 'point'
+    assert kernel.variable_map['p'].type.intent == 'inout'
+    assert kernel.variable_map['p'].type.dtype.name == 'point'
+    assert kernel.variable_map['p0'].type.intent == 'in'
+    assert kernel.variable_map['p0'].type.dtype.name == 'point'

--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -386,11 +386,11 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
     expected_trafo_data = {
         'global_var_analysis_header_mod#nval': {
             'declares': {f'iarr({nfld_dim})', f'rarr({nval_dim}, {nfld_dim})'},
-            'offload': set()
+            'offload': {'nval'}
         },
         'global_var_analysis_header_mod#nfld': {
             'declares': {f'iarr({nfld_dim})', f'rarr({nval_dim}, {nfld_dim})'},
-            'offload': set()
+            'offload': ['nfld']
         },
         'global_var_analysis_header_mod#iarr': {
             'declares': {f'iarr({nfld_dim})', f'rarr({nval_dim}, {nfld_dim})'},
@@ -412,6 +412,8 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         'global_var_analysis_kernel_mod#kernel_a': {
             'defines_symbols': set(),
             'uses_symbols': {
+                ('iarr(nfld)', 'global_var_analysis_header_mod'), ('nfld', 'global_var_analysis_header_mod'),
+                ('nval', 'global_var_analysis_header_mod'),
                 (f'iarr({nfld_dim})', 'global_var_analysis_header_mod'),
                 (f'rarr({nval_dim}, {nfld_dim})', 'global_var_analysis_header_mod')
             }
@@ -419,6 +421,7 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         'global_var_analysis_kernel_mod#kernel_b': {
             'defines_symbols': {('rdata(:, :, :)', 'global_var_analysis_data_mod')},
             'uses_symbols': {
+                ('iarr(nfld)', 'global_var_analysis_header_mod'), ('nfld', 'global_var_analysis_header_mod'),
                 ('rdata(:, :, :)', 'global_var_analysis_data_mod'), ('tt', 'global_var_analysis_data_mod'),
                 ('tt%vals', 'global_var_analysis_data_mod'), (f'iarr({nfld_dim})', 'global_var_analysis_header_mod')
             }
@@ -426,8 +429,10 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         '#driver': {
             'defines_symbols': {('rdata(:, :, :)', 'global_var_analysis_data_mod')},
             'uses_symbols': {
-                ('rdata(:, :, :)', 'global_var_analysis_data_mod'), ('tt', 'global_var_analysis_data_mod'),
-                ('tt%vals', 'global_var_analysis_data_mod'), (f'iarr({nfld_dim})', 'global_var_analysis_header_mod'),
+                ('iarr(nfld)', 'global_var_analysis_header_mod'), ('nfld', 'global_var_analysis_header_mod'),
+                ('nval', 'global_var_analysis_header_mod'), ('rdata(:, :, :)', 'global_var_analysis_data_mod'),
+                ('tt', 'global_var_analysis_data_mod'), ('tt%vals', 'global_var_analysis_data_mod'),
+                (f'iarr({nfld_dim})', 'global_var_analysis_header_mod'),
                 (f'rarr({nval_dim}, {nfld_dim})', 'global_var_analysis_header_mod')
             }
         }
@@ -438,8 +443,7 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         if item == 'global_var_analysis_data_mod#some_type':
             continue
         for trafo_data_key, trafo_data_value in item.trafo_data[key].items():
-            if trafo_data_key not in ('defines_symbols', 'uses_symbols'):
-                continue
+            print(f"item: {item} | trafo_data_key: {trafo_data_key}")
             assert (
                 sorted(
                     tuple(str(vv) for vv in v) if isinstance(v, tuple) else str(v)
@@ -654,7 +658,7 @@ def test_transformation_global_var_hoist(here, config, frontend, hoist_parameter
 
     scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=config, frontend=frontend)
     scheduler.process(transformation=GlobalVariableAnalysis())
-    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters=hoist_parameters, ignore_modules=('modulec',)))
+    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters=hoist_parameters)) # , ignore_modules=('modulec',)))
 
     print("")
     print("")

--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -642,7 +642,8 @@ def test_transformation_global_var_import_derived_type(here, config, frontend):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transformation_global_var_hoist(here, config, frontend):
+@pytest.mark.parametrize('hoist_parameters', (False, True))
+def test_transformation_global_var_hoist(here, config, frontend, hoist_parameters):
     """
     Test the generation of offload instructions of global variable imports.
     """
@@ -653,7 +654,7 @@ def test_transformation_global_var_hoist(here, config, frontend):
 
     scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=config, frontend=frontend)
     scheduler.process(transformation=GlobalVariableAnalysis())
-    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters=False))
+    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters=hoist_parameters))
 
     print("")
     print("")
@@ -682,3 +683,28 @@ def test_transformation_global_var_hoist(here, config, frontend):
     # print(fgen(moduleB))
     print("----------")
     # print(fgen(moduleC))
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('hoist_parameters', (False, True))
+def test_transformation_global_var_derived_type_hoist(here, config, frontend, hoist_parameters):
+    """
+    Test the generation of offload instructions of derived-type global variable imports.
+    """
+
+    config['default']['enable_imports'] = True
+    config['routines'] = {
+        'driver_derived_type': {'role': 'driver'}
+    }
+
+    scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=config, frontend=frontend)
+    scheduler.process(transformation=GlobalVariableAnalysis())
+    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters))
+
+    driver = scheduler['#driver_derived_type'].routine
+    kernel = scheduler['#kernel_derived_type'].routine
+    module = scheduler['module_derived_type#p'].scope
+    
+    print(fgen(driver))
+    print("--------------------")
+    print(fgen(kernel))

--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -386,11 +386,11 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
     expected_trafo_data = {
         'global_var_analysis_header_mod#nval': {
             'declares': {f'iarr({nfld_dim})', f'rarr({nval_dim}, {nfld_dim})'},
-            'offload': {'nval'}
+            'offload': set() if frontend == OMNI else {'nval'}
         },
         'global_var_analysis_header_mod#nfld': {
             'declares': {f'iarr({nfld_dim})', f'rarr({nval_dim}, {nfld_dim})'},
-            'offload': ['nfld']
+            'offload': set() if frontend == OMNI else ['nfld']
         },
         'global_var_analysis_header_mod#iarr': {
             'declares': {f'iarr({nfld_dim})', f'rarr({nval_dim}, {nfld_dim})'},
@@ -412,6 +412,8 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         'global_var_analysis_kernel_mod#kernel_a': {
             'defines_symbols': set(),
             'uses_symbols': {
+                ('iarr(1:3)', 'global_var_analysis_header_mod'), ('rarr(1:5, 1:3)', 'global_var_analysis_header_mod')
+            } if frontend == OMNI else {
                 ('iarr(nfld)', 'global_var_analysis_header_mod'), ('nfld', 'global_var_analysis_header_mod'),
                 ('nval', 'global_var_analysis_header_mod'),
                 (f'iarr({nfld_dim})', 'global_var_analysis_header_mod'),
@@ -421,6 +423,9 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         'global_var_analysis_kernel_mod#kernel_b': {
             'defines_symbols': {('rdata(:, :, :)', 'global_var_analysis_data_mod')},
             'uses_symbols': {
+                ('iarr(1:3)', 'global_var_analysis_header_mod'), ('rdata(:, :, :)', 'global_var_analysis_data_mod'),
+                ('tt', 'global_var_analysis_data_mod'), ('tt%vals', 'global_var_analysis_data_mod')
+                } if frontend == OMNI else {
                 ('iarr(nfld)', 'global_var_analysis_header_mod'), ('nfld', 'global_var_analysis_header_mod'),
                 ('rdata(:, :, :)', 'global_var_analysis_data_mod'), ('tt', 'global_var_analysis_data_mod'),
                 ('tt%vals', 'global_var_analysis_data_mod'), (f'iarr({nfld_dim})', 'global_var_analysis_header_mod')
@@ -429,6 +434,10 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         '#driver': {
             'defines_symbols': {('rdata(:, :, :)', 'global_var_analysis_data_mod')},
             'uses_symbols': {
+                ('iarr(1:3)', 'global_var_analysis_header_mod'), ('rarr(1:5, 1:3)', 'global_var_analysis_header_mod'),
+                ('rdata(:, :, :)', 'global_var_analysis_data_mod'), ('tt', 'global_var_analysis_data_mod'),
+                ('tt%vals', 'global_var_analysis_data_mod')
+            } if frontend == OMNI else {
                 ('iarr(nfld)', 'global_var_analysis_header_mod'), ('nfld', 'global_var_analysis_header_mod'),
                 ('nval', 'global_var_analysis_header_mod'), ('rdata(:, :, :)', 'global_var_analysis_data_mod'),
                 ('tt', 'global_var_analysis_data_mod'), ('tt%vals', 'global_var_analysis_data_mod'),
@@ -443,7 +452,6 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         if item == 'global_var_analysis_data_mod#some_type':
             continue
         for trafo_data_key, trafo_data_value in item.trafo_data[key].items():
-            print(f"item: {item} | trafo_data_key: {trafo_data_key}")
             assert (
                 sorted(
                     tuple(str(vv) for vv in v) if isinstance(v, tuple) else str(v)

--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -654,7 +654,7 @@ def test_transformation_global_var_hoist(here, config, frontend, hoist_parameter
 
     scheduler = Scheduler(paths=here/'sources/projGlobalVarImports', config=config, frontend=frontend)
     scheduler.process(transformation=GlobalVariableAnalysis())
-    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters=hoist_parameters))
+    scheduler.process(transformation=GlobalVarHoistTransformation(hoist_parameters=hoist_parameters, ignore_modules=('modulec',)))
 
     print("")
     print("")

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -802,10 +802,6 @@ class GlobalVarHoistTransformation(Transformation):
         import_map = CaseInsensitiveDict(
                 (s.name, imprt) for imprt in routine.all_imports[::-1] for s in imprt.symbols
                 )
-        scope = routine
-        while scope:
-            import_map.update(scope.import_map)
-            scope = scope.parent
         redundant_imports_map = defaultdict(set)
         for module, variables in symbol_map.items():
             redundant = [var.parent[0] if var.parent else var for var in variables]

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -742,12 +742,8 @@ class GlobalVarHoistTransformation(Transformation):
         self._append_call_arguments(routine, uses_symbols, defines_symbols)
 
         # combine/collect symbols disregarding routine
-        all_defines_symbols = set()
-        all_uses_symbols = set()
-        for _, value in defines_symbols.items():
-            all_defines_symbols |= value
-        for _, value in uses_symbols.items():
-            all_uses_symbols |= value
+        all_defines_symbols = set.union(*defines_symbols.values(), set())
+        all_uses_symbols = set.union(*uses_symbols.values(), set())
         # add imports for symbols hoisted
         symbol_map = defaultdict(set)
         for var, module in chain(all_uses_symbols, all_defines_symbols):
@@ -803,7 +799,9 @@ class GlobalVarHoistTransformation(Transformation):
             if module.lower() in self.ignore_modules:
                 continue
             symbol_map[module].add(var.parents[0] if var.parent else var)
-        import_map = CaseInsensitiveDict()
+        import_map = CaseInsensitiveDict(
+                (s.name, imprt) for imprt in routine.all_imports[::-1] for s in imprt.symbols
+                )
         scope = routine
         while scope:
             import_map.update(scope.import_map)

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -712,10 +712,7 @@ class GlobalVarHoistTransformation(Transformation):
     def __init__(self, hoist_parameters=False, ignore_modules=None, key=None):
         self._key = key or GlobalVariableAnalysis._key
         self.hoist_parameters = hoist_parameters
-        if ignore_modules is None:
-            self.ignore_modules = ()
-        else:
-            self.ignore_modules = [module.lower() for module in ignore_modules]
+        self.ignore_modules = [module.lower() for module in as_tuple(ignore_modules)]
 
     def transform_subroutine(self, routine, **kwargs):
         """


### PR DESCRIPTION
Global/Imported variable hoisting.

Convert e.g., 

```fortran
module moduleB
   real :: var2
   real :: var3
end module moduleB

module moduleC
   real :: var4
   real :: var5
end module moduleC

subroutine driver()
implicit none

call kernel()

end subroutine driver

subroutine kernel()
use moduleB, only: var2,var3
use moduleC, only: var4,var5
implicit none

var4 = var2
var5 = var3

end subroutine kernel
```

to:

```fortran
module moduleB
   real :: var2
   real :: var3
end module moduleB

module moduleC
   real :: var4
   real :: var5
end module moduleC

subroutine driver()
use moduleB, only: var2,var3
use moduleC, only: var4,var5
implicit none

call kernel(var2, var3, var4, var5)

end subroutine driver

subroutine kernel(var2, var3, var4, var5)
implicit none
real, intent(in) :: var2
real, intent(in) :: var3
real, intent(inout) :: var4
real, intent(inout) :: var5

var4 = var2
var5 = var3

end subroutine kernel
```

Tested locally with CLOUDSC Loki C transpilation. However, this requires PR #208.