### PR TITLE
Github actions: Only load SSH_KEY from secrets if available

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -90,6 +90,6 @@ jobs:
           ${{ secrets.BITBUCKET_HOSTKEY }}
           EOF
           eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.ECWAM_REPOSITORY_SSH_KEY }}'
+          [ -n '${{ secrets.ECWAM_REPOSITORY_SSH_KEY }}' ] && ssh-add - <<< '${{ secrets.ECWAM_REPOSITORY_SSH_KEY }}'
           source loki-activate
           pytest --cov=transformations/transformations transformations/tests -k 'cloudsc or ecwam'

--- a/loki/transform/fortran_c_transform.py
+++ b/loki/transform/fortran_c_transform.py
@@ -31,9 +31,9 @@ from loki.subroutine import Subroutine
 from loki.module import Module
 from loki.expression import (
     Variable, InlineCall, RangeIndex, Scalar, Array,
-    ProcedureSymbol, SubstituteExpressions, Dereference
+    ProcedureSymbol, SubstituteExpressions, Dereference,
 )
-from loki.expression import symbols as sym, SubstituteExpressions
+from loki.expression import symbols as sym
 from loki.visitors import Transformer, FindNodes
 from loki.tools import as_tuple, flatten
 from loki.types import BasicType, DerivedType, SymbolAttributes


### PR DESCRIPTION
Nothing more than that. That should allow to run the regression tests (and fail then) even if private repositories are not accessible.