### PR TITLE
Performance optimisations for frontend parsing/sanitising

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -31,7 +31,7 @@ from loki.expression.operations import (
     StringConcat, ParenthesisedAdd, ParenthesisedMul, ParenthesisedDiv, ParenthesisedPow
 )
 from loki.expression import ExpressionDimensionsMapper, AttachScopes, AttachScopesMapper
-from loki.logging import debug, info, warning, error
+from loki.logging import debug, perf, info, warning, error
 from loki.tools import as_tuple, flatten, CaseInsensitiveDict, LazyNodeLookup
 from loki.pragma_utils import (
     attach_pragmas, process_dimension_pragmas, detach_pragmas, pragmas_attached
@@ -55,7 +55,7 @@ def parse_fparser_file(filename):
     return parse_fparser_source(source=fcode)
 
 
-@Timer(logger=debug, text=lambda s: f'[Loki::FP] Executed parse_fparser_source in {s:.2f}s')
+@Timer(logger=perf, text=lambda s: f'[Loki::FP] Executed parse_fparser_source in {s:.2f}s')
 def parse_fparser_source(source):
     """
     Generate a parse tree from string
@@ -77,7 +77,7 @@ def parse_fparser_source(source):
     return f2008_parser(reader)
 
 
-@Timer(logger=debug, text=lambda s: f'[Loki::FP] Executed parse_fparser_ast in {s:.2f}s')
+@Timer(logger=perf, text=lambda s: f'[Loki::FP] Executed parse_fparser_ast in {s:.2f}s')
 def parse_fparser_ast(ast, raw_source, pp_info=None, definitions=None, scope=None):
     """
     Generate an internal IR from fparser parse tree

--- a/loki/frontend/source.py
+++ b/loki/frontend/source.py
@@ -519,4 +519,4 @@ def join_source_list(source_list):
             newlines = 0
         string += '\n' * newlines + source.string
         lines[1] = source.lines[1] if source.lines[1] else lines[1] + newlines + source.string.count('\n')
-    return Source(lines, string, source_list[0].file)
+    return Source(tuple(lines), string, source_list[0].file)

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -8,6 +8,7 @@
 from enum import IntEnum
 from pathlib import Path
 import codecs
+from codetiming import Timer
 
 from loki.visitors import NestedTransformer, FindNodes, PatternFinder, SequenceFinder
 from loki.ir import (
@@ -15,7 +16,7 @@ from loki.ir import (
     Loop, Intrinsic, Pragma
 )
 from loki.frontend.source import Source
-from loki.logging import warning
+from loki.logging import warning, perf
 
 __all__ = [
     'Frontend', 'OFP', 'OMNI', 'FP', 'REGEX',
@@ -180,6 +181,7 @@ def combine_multiline_pragmas(ir):
     return NestedTransformer(pragma_mapper, invalidate_source=False).visit(ir)
 
 
+@Timer(logger=perf, text=lambda s: f'[Loki::Frontend] Executed sanitize_ir in {s:.2f}s')
 def sanitize_ir(_ir, frontend, pp_registry=None, pp_info=None):
     """
     Utility function to sanitize internal representation after creating it

--- a/loki/visitors/transform.py
+++ b/loki/visitors/transform.py
@@ -8,10 +8,8 @@
 """
 Visitor classes for transforming the IR
 """
-from more_itertools import replace
-
 from loki.ir import Node, Conditional, ScopedNode
-from loki.tools import flatten, is_iterable, as_tuple
+from loki.tools import flatten, is_iterable, as_tuple, replace_windowed
 from loki.visitors.visitor import Visitor
 
 
@@ -137,11 +135,7 @@ class Transformer(Visitor):
 
         for k, handle in self.mapper.items():
             if is_iterable(k):
-                k = as_tuple(k)
-                pred = lambda *args: args == k
-                o = tuple(replace(
-                    o, pred=pred, substitutes=as_tuple(handle), window_size=len(k)
-                ))
+                o = replace_windowed(o, k, subs=handle)
             if k in o and is_iterable(handle):
                 # Replace k by the iterable that is provided by handle
                 o, i = _inject_handle(o, 0, k, handle)

--- a/loki/visitors/transform.py
+++ b/loki/visitors/transform.py
@@ -8,7 +8,7 @@
 """
 Visitor classes for transforming the IR
 """
-from more_itertools import windowed
+from more_itertools import replace
 
 from loki.ir import Node, Conditional, ScopedNode
 from loki.tools import flatten, is_iterable, as_tuple
@@ -137,10 +137,11 @@ class Transformer(Visitor):
 
         for k, handle in self.mapper.items():
             if is_iterable(k):
-                w = list(windowed(o, len(k)))
-                if k in w:
-                    i = list(w).index(k)
-                    o = o[:i] + as_tuple(handle) + o[i+len(k):]
+                k = as_tuple(k)
+                pred = lambda *args: args == k
+                o = tuple(replace(
+                    o, pred=pred, substitutes=as_tuple(handle), window_size=len(k)
+                ))
             if k in o and is_iterable(handle):
                 # Replace k by the iterable that is provided by handle
                 o, i = _inject_handle(o, 0, k, handle)

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -1686,18 +1686,27 @@ REAL, INTENT(INOUT) :: B
 !$ACC& PRESENT(ZRDG_LCVQ,ZFLU_QSATS,ZRDG_CVGQ) &
 !$ACC& PRIVATE (JBLK) &
 !$ACC& VECTOR_LENGTH (YDCPG_OPTS%KLON)
+!$ACC SEQUENTIAL
 
 END SUBROUTINE TOTO
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
     pragmas = FindNodes(Pragma).visit(routine.body)
-    assert len(pragmas) == 1
+
+    assert len(pragmas) == 2
     assert pragmas[0].keyword == 'ACC'
     assert 'PARALLEL' in pragmas[0].content
     assert 'PRESENT' in pragmas[0].content
     assert 'PRIVATE' in pragmas[0].content
     assert 'VECTOR_LENGTH' in pragmas[0].content
+    assert pragmas[1].content == 'SEQUENTIAL'
+
+    # Check that source object was generated right
+    assert pragmas[0].source
+    assert pragmas[0].source.lines == (8, 8) if frontend == OMNI else (8, 11)
+    assert pragmas[1].source
+    assert pragmas[1].source.lines == (12, 12)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -223,8 +223,8 @@ end module some_module
     (
         [], None
     ),  (
-        [Source([1, 2], 'subroutine my_routine\nimplicit none'), Source([3, None], 'end subroutine my_routine')],
-        Source([1, 3], 'subroutine my_routine\nimplicit none\nend subroutine my_routine')
+        [Source((1, 2), 'subroutine my_routine\nimplicit none'), Source((3, None), 'end subroutine my_routine')],
+        Source((1, 3), 'subroutine my_routine\nimplicit none\nend subroutine my_routine')
     ), (
         [
             Source([1, None], 'subroutine my_routine'),
@@ -235,7 +235,7 @@ end module some_module
             Source([6, 7], '  var_1 = 1._real64\n  var_2 = 2._real64'),
             Source([8, None], 'end subroutine my_routine'),
         ],
-        Source([1, 8], '''
+        Source((1, 8), '''
 subroutine my_routine
   use iso_fortran_env, only: real64
   implicit none
@@ -247,22 +247,22 @@ end subroutine my_routine
         '''.strip())
     ), (
         [
-            Source([5, 5], 'integer ::'),
-            Source([5, None], ' var1,'),
-            Source([5, 5], ' var2')
+            Source((5, 5), 'integer ::'),
+            Source((5, None), ' var1,'),
+            Source((5, 5), ' var2')
         ],
-        Source([5, 5], 'integer :: var1, var2')
+        Source((5, 5), 'integer :: var1, var2')
     ), (
-        [Source([1, 1], 'print *,* "hello world!"')], Source([1, 1], 'print *,* "hello world!"')
+        [Source((1, 1), 'print *,* "hello world!"')], Source((1, 1), 'print *,* "hello world!"')
     ), (
-        [Source([13, 19], '! line with less line breaks than reported'), Source([20, None], '! here')],
-        Source([13, 20], '! line with less line breaks than reported\n! here')
+        [Source((13, 19), '! line with less line breaks than reported'), Source((20, None), '! here')],
+        Source((13, 20), '! line with less line breaks than reported\n! here')
     ), (
-        [Source([7, None], '! Some line'), Source([12, None], '! Some other line')],
-        Source([7, 12], '! Some line\n\n\n\n\n! Some other line')
+        [Source((7, None), '! Some line'), Source([12, None], '! Some other line')],
+        Source((7, 12), '! Some line\n\n\n\n\n! Some other line')
     ), (
-        [Source([3, 4], '! Some line\n! With line break'), Source([6, None], '! Other line\n! And new line')],
-        Source([3, 7], '! Some line\n! With line break\n\n! Other line\n! And new line')
+        [Source((3, 4), '! Some line\n! With line break'), Source([6, None], '! Other line\n! And new line')],
+        Source((3, 7), '! Some line\n! With line break\n\n! Other line\n! And new line')
     )
 ))
 def test_join_source_list(source_list, expected):


### PR DESCRIPTION
Several steps in the frontend utilities have sub-optimal performance scaling with the size of the IR tree being processed, thus inflating frontend parsing times for large files, as flagged in #227 . This PR aims to address this by replacing the expensive "search-and-replace" pattern with an on-the-fly processing of multi-line comments and pragmas.

Importantly, it also introduces a few small utilities to do multi-item sub-sequence finding and replacement in tuples, which makes this much neater and reduces the clutter a bit. One of those new utilities is now also used in the `Transformer` base class itself, and a small fix to `Source` lines was needed to make those hash correctly (we were still using lists! :scream:).

Final note: There probably more to be done for raw processing speed optimisation, as the search-and-replace pattern is very common (and advertised) in many transformations and still used in the frontend sanitisation. More could probably be done by carefully weeding out used of `Transformer`/`NestedTransformer`, but those two already improved the example in #227 by quite a bit.

In more detail:
* Added"perf"-level timers to frontend sanitisation to allow quick-check of overheads
* Added `group_by_class` and `replace_windowed` utilities that allow finding and replacing sub-sequences in tuples
* Rewrote `cluster_comments` and `combine_multiline_pragmas` frontend utilities as in-place `Transformer` classes using new utilities
* Use `replace_windowed` in tuple-injection of `Transformer` base class
* Small fix to `Source` utility: We should always use tuples for `lines` to make the object hashable!
* Respective test additions and fixes for the respective pieces touches