### PR TITLE
Add ExternalItem to allow building dependency graph with missing nodes

### DIFF
--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -316,7 +316,7 @@ class Scheduler:
                 if item.name not in renamed_keys and item.name not in item.source:
                     # The module was in a file (likely with something else) and has been deleted
                     deleted_keys.add(key)
-            else:
+            elif not isinstance(item, ExternalItem):
                 if not item.scope_name:
                     # IR node without a scope (i.e., a Procedure without a module)
                     if item.local_name not in item.source:

--- a/tests/sources/projA/module/kernelB_mod.F90
+++ b/tests/sources/projA/module/kernelB_mod.F90
@@ -1,7 +1,9 @@
 module kernelB_mod
   use header_mod, only: jprb
   use compute_l1_mod, only: compute_l1
+#ifdef HAVE_EXT_DRIVER_MODULE
   use ext_driver_mod, only: ext_driver
+#endif
 
   implicit none
 
@@ -10,6 +12,10 @@ contains
   subroutine kernelB(vector, matrix)
     real(kind=jprb), intent(inout) :: vector(:)
     real(kind=jprb), intent(inout) :: matrix(:)
+
+#ifndef HAVE_EXT_DRIVER_MODULE
+#include "ext_driver.intfb.h"
+#endif
 
     call compute_l1(vector)
 

--- a/tests/sources/projB/external/ext_driver_mod.f90
+++ b/tests/sources/projB/external/ext_driver_mod.f90
@@ -1,13 +1,19 @@
+#ifdef HAVE_EXT_DRIVER_MODULE
 module ext_driver_mod
-  use ext_kernel_mod, only: jprb, ext_kernel
+  implicit none
 
 contains
+#endif
 
   subroutine ext_driver(vector, matrix)
+    use ext_kernel_mod, only: jprb, ext_kernel
+    implicit none
     real(kind=jprb), intent(inout) :: vector(:)
     real(kind=jprb), intent(inout) :: matrix(:, :)
 
     call ext_kernel(vector, matrix)
   end subroutine ext_driver
 
+#ifdef HAVE_EXT_DRIVER_MODULE
 end module ext_driver_mod
+#endif

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -49,13 +49,11 @@ def fixture_default_config():
 def fixture_comp1_expected_dependencies():
     return {
         '#comp1': ('header_mod', 't_mod', 't_mod#t', '#comp2', 't_mod#t%proc', 't_mod#t%no%way'),
-        '#comp2': ('header_mod', 't_mod', 't_mod#t', 'a_mod', 'a_mod#a', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
-        'a_mod': (),
+        '#comp2': ('header_mod', 't_mod#t', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc'),
         'a_mod#a': ('header_mod',),
-        'b_mod': ('header_mod',),
         'b_mod#b': (),
-        't_mod': ('a_mod', 'a_mod#a', 'tt_mod', 'tt_mod#tt'),
-        't_mod#t': ('tt_mod', 'tt_mod#tt', 't_mod#t1'),
+        't_mod': ('tt_mod#tt',),
+        't_mod#t': ('tt_mod#tt', 't_mod#t1'),
         't_mod#t1': (),
         't_mod#t%proc': ('t_mod#t_proc',),
         't_mod#t_proc': ('t_mod#t', 'a_mod#a', 't_mod#t%yay%proc'),
@@ -63,7 +61,6 @@ def fixture_comp1_expected_dependencies():
         't_mod#t%yay%proc': ('tt_mod#tt%proc',),
         't_mod#t1%way': ('t_mod#my_way',),
         't_mod#my_way': ('t_mod#t1',),
-        'tt_mod': ('header_mod',),
         'tt_mod#tt': (),
         'tt_mod#tt%proc': ('tt_mod#proc',),
         'tt_mod#proc': ('tt_mod#tt',),
@@ -74,12 +71,10 @@ def fixture_comp1_expected_dependencies():
 @pytest.fixture(name='mod_proc_expected_dependencies')
 def fixture_mod_proc_expected_dependencies():
     return {
-        'other_mod#mod_proc': ('tt_mod', 'tt_mod#tt', 'tt_mod#tt%proc', 'b_mod#b'),
-        'tt_mod': ('header_mod',),
+        'other_mod#mod_proc': ('tt_mod#tt', 'tt_mod#tt%proc', 'b_mod#b'),
         'tt_mod#tt': (),
         'tt_mod#tt%proc': ('tt_mod#proc',),
         'tt_mod#proc': ('tt_mod#tt',),
-        'header_mod': (),
         'b_mod#b': ()
     }
 
@@ -115,15 +110,11 @@ def fixture_file_dependencies():
             'module/tt_mod.F90',
             'module/a_mod.F90',
         ),
-        'module/tt_mod.F90': (
-            'headers/header_mod.F90',
-        ),
+        'module/tt_mod.F90': (),
         'module/a_mod.F90': (
             'headers/header_mod.F90',
         ),
-        'module/b_mod.F90': (
-            'headers/header_mod.F90',
-        ),
+        'module/b_mod.F90': (),
         'headers/header_mod.F90': ()
     }
 
@@ -456,10 +447,7 @@ def test_procedure_item2(here):
         ]
     })
     items = item.create_dependency_items(item_factory=item_factory)
-    assert items == (
-        't_mod', 't_mod#t', 'header_mod', 'a_mod', 'a_mod#a',
-        'b_mod', 'b_mod#b', 't_mod#t%yay%proc'
-    )
+    assert items == ('t_mod#t', 'header_mod', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc')
 
     # Does it still work if we call it again?
     assert items == item.create_dependency_items(item_factory=item_factory)
@@ -488,9 +476,7 @@ def test_procedure_item3(here):
         'tt_mod': get_item(ModuleItem, proj/'module/tt_mod.F90', 'tt_mod', RegexParserClass.ProgramUnitClass),
         'b_mod': get_item(ModuleItem, proj/'module/b_mod.F90', 'b_mod', RegexParserClass.ProgramUnitClass)
     })
-    assert item.create_dependency_items(item_factory=item_factory) == (
-        'tt_mod', 'tt_mod#tt', 'tt_mod#tt%proc', 'b_mod#b'
-    )
+    assert item.create_dependency_items(item_factory=item_factory) == ('tt_mod#tt', 'tt_mod#tt%proc', 'b_mod#b')
 
 
 def test_procedure_item4(here):
@@ -519,57 +505,62 @@ def test_procedure_item4(here):
 @pytest.mark.parametrize('config,expected_dependencies,expected_targets', [
     (
         {},
-        ('t_mod', 't_mod#t', 'header_mod', 'a_mod', 'a_mod#a', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
+        ('t_mod#t', 'header_mod', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc'),
         ('t_mod', 't', 'header_mod', 'k', 'a_mod', 'a', 'b_mod', 'b', 'arg%yay%proc')
     ),
     (
         {'default': {'disable': ['#a']}},
-        ('t_mod', 't_mod#t', 'header_mod', 'a_mod', 'a_mod#a', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
+        ('t_mod#t', 'header_mod', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc'),
         ('t_mod', 't', 'header_mod', 'k', 'a_mod', 'a', 'b_mod', 'b', 'arg%yay%proc')
     ),
     (
         {'default': {'disable': ['a']}},
-        ('t_mod', 't_mod#t', 'header_mod', 'a_mod', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
+        ('t_mod#t', 'header_mod', 'b_mod#b', 't_mod#t%yay%proc'),
         ('t_mod', 't', 'header_mod', 'k', 'a_mod', 'b_mod', 'b', 'arg%yay%proc')
     ),
     (
         {'default': {'disable': ['a', 'a_mod']}},
-        ('t_mod', 't_mod#t', 'header_mod', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
+        ('t_mod#t', 'header_mod', 'b_mod#b', 't_mod#t%yay%proc'),
         ('t_mod', 't', 'header_mod', 'k', 'b_mod', 'b', 'arg%yay%proc'),
     ),
     (
         {'default': {'disable': ['a_mod#a']}},
-        ('t_mod', 't_mod#t', 'header_mod', 'a_mod', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
+        ('t_mod#t', 'header_mod', 'b_mod#b', 't_mod#t%yay%proc'),
         ('t_mod', 't', 'header_mod', 'k', 'a_mod', 'b_mod', 'b', 'arg%yay%proc')
     ),
     (
         {'default': {'disable': ['a_mod']}},
-        ('t_mod', 't_mod#t', 'header_mod', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
+        ('t_mod#t', 'header_mod', 'b_mod#b', 't_mod#t%yay%proc'),
         ('t_mod', 't', 'header_mod', 'k', 'b_mod', 'b', 'arg%yay%proc')
     ),
     (
+        {'default': {'disable': ['t%yay%proc']}},
+        ('t_mod#t', 'header_mod', 'a_mod#a', 'b_mod#b'),
+        ('t_mod', 't', 'header_mod', 'k', 'a_mod', 'a', 'b_mod', 'b')
+    ),
+    (
         {'default': {'disable': ['t_mod#t%yay%proc']}},
-        ('t_mod', 't_mod#t', 'header_mod', 'a_mod', 'a_mod#a', 'b_mod', 'b_mod#b'),
+        ('t_mod#t', 'header_mod', 'a_mod#a', 'b_mod#b'),
         ('t_mod', 't', 'header_mod', 'k', 'a_mod', 'a', 'b_mod', 'b')
     ),
     (
         {'default': {'disable': ['t_mod#t']}},
-        ('t_mod', 'header_mod', 'a_mod', 'a_mod#a', 'b_mod', 'b_mod#b'),
+        ('header_mod', 'a_mod#a', 'b_mod#b'),
         ('t_mod', 'header_mod', 'k', 'a_mod', 'a', 'b_mod', 'b')
     ),
     (
         {'default': {'disable': ['t_mod']}},
-        ('header_mod', 'a_mod', 'a_mod#a', 'b_mod', 'b_mod#b'),
+        ('header_mod', 'a_mod#a', 'b_mod#b'),
         ('header_mod', 'k', 'a_mod', 'a', 'b_mod', 'b')
     ),
     (
         {'default': {'disable': ['header_mod']}},
-        ('t_mod', 't_mod#t', 'a_mod', 'a_mod#a', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
+        ('t_mod#t', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc'),
         ('t_mod', 't', 'a_mod', 'a', 'b_mod', 'b', 'arg%yay%proc')
     ),
     (
         {'default': {'disable': ['k']}},
-        ('t_mod', 't_mod#t', 'header_mod', 'a_mod', 'a_mod#a', 'b_mod', 'b_mod#b', 't_mod#t%yay%proc'),
+        ('t_mod#t', 'a_mod#a', 'b_mod#b', 't_mod#t%yay%proc'),
         ('t_mod', 't', 'header_mod', 'a_mod', 'a', 'b_mod', 'b', 'arg%yay%proc')
     ),
 ])
@@ -670,9 +661,7 @@ def test_typedef_item(here):
     items = item.create_dependency_items(item_factory=item_factory)
     assert 'tt_mod#tt' in item_factory.item_cache
     assert 't_mod#t1' in item_factory.item_cache
-    assert items == (
-        item_factory.item_cache['tt_mod'], item_factory.item_cache['tt_mod#tt'], item_factory.item_cache['t_mod#t1']
-    )
+    assert items == (item_factory.item_cache['tt_mod#tt'], item_factory.item_cache['t_mod#t1'])
     assert all(isinstance(i, TypeDefItem) for i in items[1:])
     assert not items[1].dependencies
 
@@ -1012,20 +1001,20 @@ def test_sgraph_from_seed(here, default_config, seed, dependencies_fixture, requ
     ('#comp1', ('comp2', 'a'), (
         '#comp1', 't_mod', 't_mod#t', 'header_mod', 't_mod#t%proc', 't_mod#t%no%way',
         't_mod#t_proc', 't_mod#t%yay%proc', 'tt_mod#tt%proc', 'tt_mod#proc',
-        't_mod#t1%way', 't_mod#my_way', 'tt_mod', 'tt_mod#tt', 't_mod#t1', 'a_mod'
+        't_mod#t1%way', 't_mod#my_way', 'tt_mod#tt', 't_mod#t1'
     )),
     ('#comp1', ('comp2', 'a', 't_mod#t%no%way'), (
         '#comp1', 't_mod', 't_mod#t', 'header_mod', 't_mod#t%proc',
         't_mod#t_proc', 't_mod#t%yay%proc', 'tt_mod#tt%proc', 'tt_mod#proc',
-        'tt_mod', 'tt_mod#tt', 't_mod#t1', 'a_mod',
+        'tt_mod#tt', 't_mod#t1'
     )),
     ('#comp1', ('#comp2', 't1%way'), (
         '#comp1', 't_mod', 't_mod#t', 'header_mod', 't_mod#t%proc', 't_mod#t%no%way',
         't_mod#t_proc', 't_mod#t%yay%proc', 'tt_mod#tt%proc', 'tt_mod#proc',
-        'tt_mod', 'tt_mod#tt', 't_mod#t1', 'a_mod', 'a_mod#a'
+        'tt_mod#tt', 't_mod#t1', 'a_mod#a'
     )),
     ('t_mod#t_proc', ('t_mod#t1', 'proc'), (
-        't_mod#t_proc', 't_mod#t', 'tt_mod', 'tt_mod#tt', 'a_mod#a', 'header_mod',
+        't_mod#t_proc', 't_mod#t', 'tt_mod#tt', 'a_mod#a', 'header_mod',
         't_mod#t%yay%proc', 'tt_mod#tt%proc'
     ))
 ])
@@ -1079,9 +1068,8 @@ def test_sgraph_disable(here, default_config, expected_dependencies, seed, disab
             'comp2': {'block': ['a', 'b']},
             't_mod': {'block': ['a']}
         }, (
-            '#comp2', 't_mod', 't_mod#t', 'header_mod', 't_mod#t%yay%proc',
-            'tt_mod', 'tt_mod#tt', 't_mod#t1', 'tt_mod#tt%proc', 'tt_mod#proc',
-            'a_mod', 'b_mod'
+            '#comp2', 't_mod#t', 'header_mod', 't_mod#t%yay%proc',
+            'tt_mod#tt', 't_mod#t1', 'tt_mod#tt%proc', 'tt_mod#proc'
         )
     ),
     (
@@ -1089,9 +1077,9 @@ def test_sgraph_disable(here, default_config, expected_dependencies, seed, disab
             'comp2': {'ignore': ['a'], 'block': ['b']},
             't_mod': {'ignore': ['a']}
         }, (
-            '#comp2', 't_mod', 't_mod#t', 'header_mod', 't_mod#t%yay%proc',
-            'tt_mod', 'tt_mod#tt', 't_mod#t1', 'tt_mod#tt%proc', 'tt_mod#proc',
-            'a_mod', 'a_mod#a', 'b_mod'
+            '#comp2', 't_mod#t', 'header_mod', 't_mod#t%yay%proc',
+            'tt_mod#tt', 't_mod#t1', 'tt_mod#tt%proc', 'tt_mod#proc',
+            'a_mod#a'
         )
     ),
 ])
@@ -1141,7 +1129,7 @@ def test_sgraph_routines(here, default_config, expected_dependencies, seed, rout
     if seed == '#comp1':
         targets += ['nt1']
     if seed == '#comp2':
-        targets += ['k']
+        targets += ['t_mod', 'b_mod', 'a_mod', 'k']
 
     if 'block' in routines[seed[1:]]:
         targets = [t for t in targets if t not in routines[seed[1:]]['block']]
@@ -1281,7 +1269,6 @@ def discover_proj_typebound_item_factory(here, scheduler_config):
         (
             'typebound_item',
             'typebound_header',
-            'typebound_other',
             'typebound_other#other_type',
             'typebound_item#some_type%other_routine',
             'typebound_item#some_type%some_routine',
@@ -1459,7 +1446,7 @@ def discover_proj_typebound_item_factory(here, scheduler_config):
             'calls': (),
             'targets': ('typebound_header', 'header')
         },
-        ('typebound_header', 'typebound_header#header_type',),
+        ('typebound_header#header_type',),
     ),
 ])
 def test_batch_typebound_item(
@@ -1504,9 +1491,8 @@ def test_batch_typebound_nested_item(here, default_config):
     # dependency items
     assert 'typebound_other#other_type%var%member_routine' not in item_factory
     assert item.create_dependency_items(item_factory, scheduler_config) == (
-        'typebound_header',
-        'typebound_header#header_member_routine',
         'typebound_other#other_type',
+        'typebound_header#header_member_routine',
         'typebound_other#other_type%var%member_routine',
     )
     assert 'typebound_other#other_type%var%member_routine' in item_factory

--- a/tests/test_transform_dependency.py
+++ b/tests/test_transform_dependency.py
@@ -82,8 +82,8 @@ END SUBROUTINE driver
         scheduler.process(transformation)
 
         # Check that both, old and new module exist now in the scheduler graph
-        assert 'kernel_test_mod' in scheduler.items
-        assert 'kernel_mod' in scheduler.items
+        assert 'kernel_test_mod#kernel_test' in scheduler.items  # for the subroutine
+        assert 'kernel_mod' in scheduler.items  # for the global variable
 
         kernel = scheduler['kernel_test_mod#kernel_test'].source
         driver = scheduler['#driver'].source
@@ -834,11 +834,9 @@ end subroutine test_dependency_transformation_filter_items_driver
     # Only the driver and mod1 are in the Sgraph
     expected_dependencies = {
         '#test_dependency_transformation_filter_items_driver': {
-            'test_dependency_transformation_filter_items1_mod',
             'test_dependency_transformation_filter_items1_mod#proc1',
             'test_dependency_transformation_filter_items3_mod'
         },
-        'test_dependency_transformation_filter_items1_mod': set(),
         'test_dependency_transformation_filter_items1_mod#proc1': set(),
         'test_dependency_transformation_filter_items3_mod': set()
     }
@@ -868,11 +866,9 @@ end subroutine test_dependency_transformation_filter_items_driver
 
     expected_dependencies = {
         '#test_dependency_transformation_filter_items_driver': {
-            'test_dependency_transformation_filter_items1_foo_mod',
             'test_dependency_transformation_filter_items1_foo_mod#proc1_foo',
             'test_dependency_transformation_filter_items3_mod'
         },
-        'test_dependency_transformation_filter_items1_foo_mod': set(),
         'test_dependency_transformation_filter_items1_foo_mod#proc1_foo': set(),
         'test_dependency_transformation_filter_items3_mod': set()
     }

--- a/tests/test_transform_inline.py
+++ b/tests/test_transform_inline.py
@@ -6,7 +6,6 @@
 # nor does it submit to any jurisdiction.
 
 from pathlib import Path
-from itertools import product
 import pytest
 import numpy as np
 
@@ -698,9 +697,8 @@ end subroutine acraneb_transt
     assert len(assocs) == 2
 
 
-@pytest.mark.parametrize(
-    'frontend,remove_imports', product(available_frontends(), (True, False))
-)
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('remove_imports', [True, False])
 def test_inline_marked_subroutines(frontend, remove_imports):
     """ Test subroutine inlining via marker pragmas. """
 
@@ -783,9 +781,8 @@ end module util_mod
         assert imports[0].symbols == ('add_one', 'add_a_to_b')
 
 
-@pytest.mark.parametrize(
-    'frontend,remove_imports', product(available_frontends(), (True, False))
-)
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('remove_imports', [True, False])
 def test_inline_marked_routine_with_optionals(frontend, remove_imports):
     """ Test subroutine inlining via marker pragmas with omitted optionals. """
 

--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -407,7 +407,6 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
             'offload': {'rdata(:, :, :)', 'tt', 'tt%vals'}
         },
         'global_var_analysis_data_mod#some_routine': {'defines_symbols': set(), 'uses_symbols': set()},
-        'global_var_analysis_kernel_mod': {'declares': set(), 'offload': set()},
         'global_var_analysis_kernel_mod#kernel_a': {
             'defines_symbols': set(),
             'uses_symbols': nval_data | nfld_data | {


### PR DESCRIPTION
This adds the missing `ExternalItem` item type for the new Scheduler, that allows to parse incomplete source trees and adds missing dependencies as `ExternalItem`. 

The missing dependency's type (i.e., the Item type that we would have created if the respective source file was available) is stored as `origin_cls` on the `ExternalItem`.

`SFilter` has been amended to ignore externals or include those externals that would have matched the `item_filter`. That allows to identify missing items with the `strict` config option during processing.
