### PR TITLE
Overwrite frontend options on a per-file basis in Scheduler config

### DIFF
--- a/loki/bulk/configure.py
+++ b/loki/bulk/configure.py
@@ -192,6 +192,22 @@ class SchedulerConfig:
 
         The resulting `dict` contains overwrites that have been provided
         in the :attr:`frontend_args` of the config.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            The file path for which to create the frontend arguments. This
+            can be a fully-qualified path or include :any:`fnmatch`-compatible
+            patterns.
+        default_args : dict
+            The default options to use. Only keys that are explicitly overriden
+            for the file in the scheduler config are updated.
+
+        Returns
+        -------
+        dict
+            The frontend arguments, with file-specific overrides of
+            :data:`default_args` if specified in the Scheduler config.
         """
         path = str(path).lower()
         frontend_args = default_args.copy()

--- a/loki/bulk/configure.py
+++ b/loki/bulk/configure.py
@@ -42,11 +42,15 @@ class SchedulerConfig:
         visualisation. These are intended for utility routines that
         pop up in many routines but can be ignored in terms of program
         control flow, like ``flush`` or ``abort``.
+    transformation_configs : dict
+        Dicts with transformation-specific options
+    frontend_args : dict
+        Dicts with file-specific frontend options
     """
 
     def __init__(
             self, default, routines, disable=None, dimensions=None,
-            transformation_configs=None
+            transformation_configs=None, frontend_args=None
     ):
         self.default = default
         self.disable = as_tuple(disable)
@@ -54,6 +58,7 @@ class SchedulerConfig:
 
         self.routines = CaseInsensitiveDict(routines)
         self.transformation_configs = transformation_configs
+        self.frontend_args = frontend_args
 
         # Resolve the dimensions for trafo configurations
         for cfg in self.transformation_configs.values():
@@ -82,10 +87,11 @@ class SchedulerConfig:
             name: TransformationConfig(name=name, **cfg)
             for name, cfg in transformation_configs.items()
         }
+        frontend_args = config.get('frontend_args', {})
 
         return cls(
             default=default, routines=routines, disable=disable, dimensions=dimensions,
-            transformation_configs=transformation_configs
+            transformation_configs=transformation_configs, frontend_args=frontend_args
         )
 
     @classmethod
@@ -178,6 +184,23 @@ class SchedulerConfig:
         for key in keys:
             item_conf.update(self.routines[key])
         return item_conf
+
+    def create_frontend_args(self, path, default_args):
+        """
+        Create bespoke ``frontend_args`` to pass to the constructor
+        or ``make_complete`` method for a file
+
+        The resulting `dict` contains overwrites that have been provided
+        in the :attr:`frontend_args` of the config.
+        """
+        path = str(path).lower()
+        frontend_args = default_args.copy()
+        for key, args in (self.frontend_args or {}).items():
+            pattern = key.lower() if key[0] == '/' else f'*{key}'.lower()
+            if fnmatch(path, pattern):
+                frontend_args.update(args)
+                return frontend_args
+        return frontend_args
 
     def is_disabled(self, name):
         """

--- a/loki/bulk/item.py
+++ b/loki/bulk/item.py
@@ -1094,6 +1094,8 @@ class ItemFactory:
 
         if not frontend_args:
             frontend_args = {}
+        if config:
+            frontend_args = config.create_frontend_args(path, frontend_args)
 
         source = Sourcefile.from_file(path, **frontend_args)
         item_conf = config.create_item_config(item_name) if config else None

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -138,6 +138,9 @@ class ProgramUnit(Scope):
         parent : :any:`Scope`, optional
             The parent scope this module or subroutine is nested into
         """
+        if isinstance(frontend, str):
+            frontend = Frontend[frontend.upper()]
+
         if preprocess:
             # Trigger CPP-preprocessing explicitly, as includes and
             # defines can also be used by our OMNI frontend
@@ -278,6 +281,8 @@ class ProgramUnit(Scope):
         if not self._incomplete:
             return
         frontend = frontend_args.pop('frontend', Frontend.FP)
+        if isinstance(frontend, str):
+            frontend = Frontend[frontend.upper()]
         definitions = frontend_args.get('definitions')
         xmods = frontend_args.get('xmods')
         parser_classes = frontend_args.get('parser_classes', RegexParserClass.AllClasses)

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -15,7 +15,7 @@ from codetiming import Timer
 from loki.backend.fgen import fgen
 from loki.backend.cufgen import cufgen
 from loki.frontend import (
-    OMNI, OFP, FP, REGEX, sanitize_input, Source, read_file, preprocess_cpp,
+    Frontend, OMNI, OFP, FP, REGEX, sanitize_input, Source, read_file, preprocess_cpp,
     parse_omni_source, parse_ofp_source, parse_fparser_source,
     parse_omni_ast, parse_ofp_ast, parse_fparser_ast, parse_regex_source,
     RegexParserClass
@@ -107,6 +107,8 @@ class Sourcefile:
         frontend : :any:`Frontend`, optional
             Frontend to use for producing the AST (default :any:`FP`).
         """
+        if isinstance(frontend, str):
+            frontend = Frontend[frontend.upper()]
 
         # Log full parses at INFO and regex scans at PERF level
         log = f'[Loki::Sourcefile] Constructed from {filename}' + ' in {:.2f}s'
@@ -323,6 +325,9 @@ class Sourcefile:
         frontend : :any:`Frontend`, optional
             Frontend to use for producing the AST (default :any:`FP`).
         """
+        if isinstance(frontend, str):
+            frontend = Frontend[frontend.upper()]
+
         if preprocess:
             # Trigger CPP-preprocessing explicitly, as includes and
             # defines can also be used by our OMNI frontend
@@ -362,6 +367,8 @@ class Sourcefile:
 
             # Sanitize frontend_args
             frontend = frontend_args.pop('frontend', FP)
+            if isinstance(frontend, str):
+                frontend = Frontend[frontend.upper()]
             if frontend == REGEX:
                 frontend_argnames = ['parser_classes']
             elif frontend == OMNI:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2644,7 +2644,7 @@ end subroutine test_scheduler_frontend_args4
 
     scheduler = Scheduler(
         paths=[workdir], config=config, seed_routines=['test_scheduler_frontend_args1'],
-        frontend=frontend, defines=defines, preprocess=preprocess, xmods=workdir
+        frontend=frontend, defines=defines, preprocess=preprocess, xmods=[workdir]
     )
 
     assert set(scheduler.items) == set(expected_dependencies)
@@ -2654,7 +2654,9 @@ end subroutine test_scheduler_frontend_args4
 
     for item in scheduler.items:
         cpp_directives = FindNodes(PreprocessorDirective).visit(item.ir.ir)
-        assert bool(cpp_directives) == (item in has_cpp_directives)
+        assert bool(cpp_directives) == (item in has_cpp_directives and frontend != OMNI)
+        # NB: OMNI always does preprocessing, therefore we won't find the CPP directives
+        #     after the full parse
 
     rmtree(workdir)
 

--- a/transformations/tests/test_cloudsc.py
+++ b/transformations/tests/test_cloudsc.py
@@ -49,10 +49,7 @@ def fixture_bundle_create(here, local_loki_bundle):
 @pytest.mark.usefixtures('bundle_create')
 @pytest.mark.parametrize('frontend', available_frontends(
     xfail=[(OFP, 'Lack of elemental support makes C-transpilation impossible')],
-    skip=[(OMNI, 'OMNI needs FParser for parsing headers')] if True or not HAVE_FP else None # pylint: disable=condition-evals-to-constant
-    # NB: OMNI has been temporarily disabled until we can provide config-file override of the
-    #     frontend for individual files. This is required for OMNI to parse header files
-    #     with comments in derived types
+    skip=[(OMNI, 'OMNI needs FParser for parsing headers')] if not HAVE_FP else None
 ))
 def test_cloudsc(here, frontend):
     build_cmd = [


### PR DESCRIPTION
This adds the ability to overwrite frontend options on a per-file basis in the Scheduler config. This allows for example to switch on preprocessing for individual files only (e.g., for those that are not valid Fortran without preprocessing), or to overwrite the frontend parser. The latter was the missing piece to successfully run CLOUDSC regression with OMNI.