### PR TITLE
Further frontend performance optimisations

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1809,7 +1809,7 @@ class FParser2IR(GenericVisitor):
             name=routine.name, args=routine._dummies, docstring=docs, spec=spec,
             body=body, contains=contains, ast=o, prefix=routine.prefix, bind=routine.bind,
             result_name=routine.result_name, is_function=routine.is_function,
-            rescope_symbols=True, source=source, incomplete=False
+            rescope_symbols=False, source=source, incomplete=False
         )
 
         # Once statement functions are in place, we need to update the original declaration so that it

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -357,8 +357,7 @@ class FParser2IR(GenericVisitor):
         if parent:
             scope = parent.scope
         if scope:
-            symbol_scope = scope.get_symbol_scope(name)
-            scope = symbol_scope if symbol_scope else scope
+            scope = scope.get_symbol_scope(name)
         return sym.Variable(name=name, parent=parent, scope=scope)
 
     def visit_Type_Name(self, o, **kwargs):
@@ -1776,7 +1775,7 @@ class FParser2IR(GenericVisitor):
 
         # As variables may be defined out of sequence, we need to re-generate
         # symbols in the spec part to make them coherent with the symbol table
-        spec = DeferredSymbolTransformer().visit(spec)
+        spec = AttachScopes().visit(spec, scope=routine, recurse_to_declaration_attributes=True)
 
         # Now all declarations are well-defined and we can parse the member routines
         if contains_ast is not None:
@@ -2076,7 +2075,7 @@ class FParser2IR(GenericVisitor):
 
         # As variables may be defined out of sequence, we need to re-generate
         # symbols in the spec part to make them coherent with the symbol table
-        spec = DeferredSymbolTransformer().visit(spec)
+        spec = AttachScopes().visit(spec, scope=module, recurse_to_declaration_attributes=True)
 
         # Now that all declarations are well-defined we can parse the member routines
         if contains_ast is not None:

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -853,7 +853,7 @@ class FParser2IR(GenericVisitor):
         scope = kwargs['scope']
         for var in symbols:
             _type = scope.symbol_attrs.lookup(var.name)
-            if _type is None:
+            if _type is None or _type.dtype == BasicType.DEFERRED:
                 dtype = ProcedureType(var.name, is_function=False)
             else:
                 dtype = _type.dtype
@@ -1342,22 +1342,31 @@ class FParser2IR(GenericVisitor):
         interface = None
         if o.children[0]:
             # Procedure interface provided
+            # (we pass the parent scope down for this)
+            kwargs['scope'] = scope.parent
             interface = self.visit(o.children[0], **kwargs)
-            interface = AttachScopesMapper()(interface, scope=scope)
             bind_names = as_tuple(interface)
             func_names = [interface.name] * len(symbols)
             assert o.children[4] is None
+            kwargs['scope'] = scope
         elif o.children[4]:
+            # we pass the parent scope down for this
+            kwargs['scope'] = scope.parent
             bind_names = as_tuple(self.visit(o.children[4], **kwargs))
-            bind_names = AttachScopesMapper()(bind_names, scope=scope)
             assert len(bind_names) == len(symbols)
             func_names = [i.name for i in bind_names]
+            kwargs['scope'] = scope
         else:
             bind_names = None
             func_names = [s.name for s in symbols]
 
         # Look up the type of the procedure
-        types = [scope.symbol_attrs.lookup(name) or SymbolAttributes(dtype=ProcedureType(name)) for name in func_names]
+        types = [scope.symbol_attrs.lookup(name) for name in func_names]
+        types = [
+            SymbolAttributes(dtype=ProcedureType(name))
+            if not t or t.dtype == BasicType.DEFERRED else t
+            for t, name in zip(types, func_names)
+        ]
 
         # Any declared attributes
         attrs = self.visit(o.children[1], **kwargs) if o.children[1] else ()
@@ -1573,8 +1582,11 @@ class FParser2IR(GenericVisitor):
         elif spec is not None:
             # This has a generic specification (and we might need to update symbol table)
             scope = kwargs['scope']
-            if spec.name not in scope.symbol_attrs:
-                scope.symbol_attrs[spec.name] = SymbolAttributes(ProcedureType(name=spec.name, is_generic=True))
+            spec_type = scope.symbol_attrs.lookup(spec.name)
+            if not spec_type or spec_type.dtype == BasicType.DEFERRED:
+                scope.symbol_attrs[spec.name] = SymbolAttributes(
+                    ProcedureType(name=spec.name, is_generic=True)
+                )
             spec = spec.rescope(scope=scope)
 
         # Traverse the body and build the object
@@ -2053,6 +2065,10 @@ class FParser2IR(GenericVisitor):
         else:
             docs = []
             spec = None
+
+        # As variables may be defined out of sequence, we need to re-generate
+        # symbols in the spec part to make them coherent with the symbol table
+        spec = DeferredSymbolTransformer().visit(spec)
 
         # Now that all declarations are well-defined we can parse the member routines
         if contains_ast is not None:

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2053,7 +2053,7 @@ class FParser2IR(GenericVisitor):
         module.__initialize__(
             name=module.name, docstring=docs, spec=spec, contains=contains,
             default_access_spec=module.default_access_spec, public_access_spec=module.public_access_spec,
-            private_access_spec=module.private_access_spec, ast=o, rescope_symbols=True, source=source,
+            private_access_spec=module.private_access_spec, ast=o, rescope_symbols=False, source=source,
             incomplete=False
         )
 

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2938,7 +2938,7 @@ class FParser2IR(GenericVisitor):
 
         # Special-case: Identify statement functions using our internal symbol table
         symbol_attrs = kwargs['scope'].symbol_attrs
-        if isinstance(lhs, sym.Array) and lhs.name in symbol_attrs:
+        if isinstance(lhs, sym.Array) and not lhs.parent and lhs.name in symbol_attrs:
 
             def _create_stmt_func_type(stmt_func):
                 name = str(stmt_func.variable)
@@ -2951,11 +2951,12 @@ class FParser2IR(GenericVisitor):
                 proc_type = ProcedureType(is_function=True, procedure=procedure, name=name)
                 return SymbolAttributes(dtype=proc_type, is_stmt_func=True)
 
-            if not symbol_attrs[lhs.name].shape and not symbol_attrs[lhs.name].intent:
+            if not lhs.type.shape and not lhs.type.intent:
                 # If the LHS array access is actually declared as a scalar,
                 # we are actually dealing with a statement function!
+                f_symbol = sym.ProcedureSymbol(name=lhs.name, scope=kwargs['scope'])
                 stmt_func = ir.StatementFunction(
-                    variable=lhs.clone(dimensions=None), arguments=lhs.dimensions,
+                    variable=f_symbol, arguments=lhs.dimensions,
                     rhs=rhs, return_type=symbol_attrs[lhs.name],
                     label=kwargs.get('label'), source=kwargs.get('source')
                 )

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -766,7 +766,11 @@ class FParser2IR(GenericVisitor):
         * char length (:class:`fparser.two.Fortran2003.Char_Length`)
         * init (:class:`fparser.two.Fortran2003.Initialization`)
         """
-        var = self.visit(o.children[0], **kwargs)
+
+        # Do not pass scope down, as it might alias with previously
+        # created symbols. Instead, let the rescope in the Declaration
+        # assign the right scope, always!
+        var = self.visit(o.children[0])
 
         if o.children[1]:
             dimensions = as_tuple(self.visit(o.children[1], **kwargs))

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -35,7 +35,9 @@ from loki.expression import (
     DeferredSymbolTransformer
 )
 from loki.logging import debug, perf, info, warning, error
-from loki.tools import as_tuple, flatten, CaseInsensitiveDict, LazyNodeLookup
+from loki.tools import (
+    as_tuple, flatten, CaseInsensitiveDict, LazyNodeLookup, dict_override
+)
 from loki.pragma_utils import (
     attach_pragmas, process_dimension_pragmas, detach_pragmas, pragmas_attached
 )
@@ -350,8 +352,10 @@ class FParser2IR(GenericVisitor):
         :class:`fparser.two.Fortran2003.Name` has no children.
         """
         name = o.tostr()
-        parent = kwargs.get('parent')
         scope = kwargs.get('scope', None)
+        parent = kwargs.get('parent')
+        if parent:
+            scope = parent.scope
         if scope:
             symbol_scope = scope.get_symbol_scope(name)
             scope = symbol_scope if symbol_scope else scope
@@ -377,7 +381,9 @@ class FParser2IR(GenericVisitor):
           subscript (or `None`)
         """
         name = self.visit(o.children[0], **kwargs)
-        dimensions = self.visit(o.children[1], **kwargs)
+        with dict_override(kwargs, {'parent': None}):
+            # Don't pass any parent on to dimension symbols
+            dimensions = self.visit(o.children[1], **kwargs)
         if dimensions:
             name = name.clone(dimensions=dimensions)
 
@@ -403,6 +409,7 @@ class FParser2IR(GenericVisitor):
         var = self.visit(o.children[0], **kwargs)
         for c in o.children[1:]:
             parent = var
+            kwargs['parent'] = parent
             var = self.visit(c, **kwargs)
             if isinstance(var, sym.InlineCall):
                 # This is a function call with a type-bound procedure, so we need to
@@ -774,7 +781,8 @@ class FParser2IR(GenericVisitor):
         # Do not pass scope down, as it might alias with previously
         # created symbols. Instead, let the rescope in the Declaration
         # assign the right scope, always!
-        var = self.visit(o.children[0])
+        with dict_override(kwargs, {'scope': None}):
+            var = self.visit(o.children[0], **kwargs)
 
         if o.children[1]:
             dimensions = as_tuple(self.visit(o.children[1], **kwargs))

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -20,7 +20,7 @@ from loki.ir import (
 )
 from loki.frontend.source import join_source_list
 from loki.logging import warning, perf
-from loki.tools import group_by_class, replace_windowed
+from loki.tools import group_by_class, replace_windowed, as_tuple
 
 
 __all__ = [
@@ -88,7 +88,10 @@ class ClusterCommentTransformer(Transformer):
             o = replace_windowed(o, group, subs=(block,))
 
         # Then recurse over the new nodes
-        return tuple(self.visit(i, **kwargs) for i in o)
+        visited = tuple(self.visit(i, **kwargs) for i in o)
+
+        # Strip empty sublists/subtuples or None entries
+        return tuple(i for i in visited if i is not None and as_tuple(i))
 
     visit_list = visit_tuple
 
@@ -162,7 +165,10 @@ class CombineMultilinePragmasTransformer(Transformer):
                 )
                 o = replace_windowed(o, pragmaset, subs=(new_pragma,))
 
-        return tuple(self.visit(i, **kwargs) for i in o)
+        visited = tuple(self.visit(i, **kwargs) for i in o)
+
+        # Strip empty sublists/subtuples or None entries
+        return tuple(i for i in visited if i is not None and as_tuple(i))
 
 
 @Timer(logger=perf, text=lambda s: f'[Loki::Frontend] Executed sanitize_ir in {s:.2f}s')

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -199,12 +199,12 @@ def sanitize_ir(_ir, frontend, pp_registry=None, pp_info=None):
 
     # Perform some minor sanitation tasks
     _ir = inline_comments(_ir)
-    _ir = ClusterCommentTransformer(invalidate_source=False).visit(_ir)
+    _ir = ClusterCommentTransformer(inplace=True, invalidate_source=False).visit(_ir)
 
     if frontend in (OMNI, OFP):
         _ir = inline_labels(_ir)
 
     if frontend in (FP, OFP):
-        _ir = CombineMultilinePragmasTransformer(invalidate_source=False).visit(_ir)
+        _ir = CombineMultilinePragmasTransformer(inplace=True, invalidate_source=False).visit(_ir)
 
     return _ir

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -33,7 +33,7 @@ __all__ = [
     'execute', 'CaseInsensitiveDict', 'strip_inline_comments',
     'binary_insertion_sort', 'cached_func', 'optional', 'LazyNodeLookup',
     'yaml_include_constructor', 'auto_post_mortem_debugger', 'set_excepthook',
-    'timeout', 'WeakrefProperty', 'group_by_class', 'replace_windowed'
+    'timeout', 'WeakrefProperty', 'group_by_class', 'replace_windowed', 'dict_override'
 ]
 
 
@@ -669,3 +669,26 @@ def replace_windowed(iterable, group, subs):
         iterable, pred=lambda *args: args == group,
         substitutes=as_tuple(subs), window_size=len(group)
     ))
+
+
+@contextmanager
+def dict_override(base, override):
+    """
+    Contextmanager to temporarily override a set of dictionary values.
+
+    Parameters
+    ----------
+    base : dict
+        The base dictionary in which to overide values
+    replace : dict
+        Replacement mapping to temporarily insert
+    """
+    original_values = tuple((k, base[k]) for k in override.keys() if k in base)
+    added_keys = tuple(k for k in override.keys() if k not in base)
+    base.update(override)
+
+    yield base
+
+    base.update(original_values)
+    for k in added_keys:
+        del base[k]

--- a/tests/test_fgen.py
+++ b/tests/test_fgen.py
@@ -127,6 +127,9 @@ def test_multiline_inline_conditional(frontend):
     """
     fcode = """
 subroutine test_fgen(DIMS, ZSURF_LOCAL)
+  type(DIMENSION_TYPE), intent(in) :: DIMS
+  type(SURFACE_TYPE), intent(inout) :: ZSURF_LOCAL
+  type(STATE_TYPE) :: TENDENCY_LOC
 contains
 subroutine test_inline_multiline(KDIMS, LBUD23)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -26,7 +26,7 @@ except ImportError:
 from conftest import stdchannel_is_captured, stdchannel_redirected
 from loki.tools import (
     JoinableStringList, truncate_string, binary_insertion_sort, is_subset,
-    optional, yaml_include_constructor, execute, timeout
+    optional, yaml_include_constructor, execute, timeout, dict_override
 )
 
 
@@ -341,3 +341,15 @@ def test_timeout():
         stop = perf_counter()
         assert .9 < stop - start < 1.1
         assert "My message" in str(exc.value)
+
+
+def test_dict_override():
+    kwargs = {'rick' : 42, 'dave' : 'yeah'}
+    with dict_override(kwargs, {'dave' : 'nope', 'joe' : 'huh?'}):
+        assert kwargs['dave'] == 'nope'
+        assert kwargs['rick'] == 42
+        assert kwargs['joe'] == 'huh?'
+    assert kwargs['dave'] == 'yeah'
+    assert kwargs['rick'] == 42
+    assert 'joe' not in kwargs
+    assert len(kwargs) == 2


### PR DESCRIPTION
Another small round of tricks to improve the performance of the `sanitize_ir` utility and the `FP` frontend to reduce the frontend processing time for large input subroutines. Primarily, this PR focuses on using fast in-place transformers for the necessary IR sanitisation and avoid using the explicit rescoping for the FParser frontend by attaching the scopes on first IR node creation.

In more detail:
* Use an on-the-fly `Transformer to do inline-comment attachment
* Make all transformers used during sanitisation use `inplace=True`
* Avoid calling `rescope_symbols` on the finalised IR when creating subroutines

On the pathological test case we the following improvements:
```
# On main
In [2]: with config_override({'log-level': 'perf'}):
   ...:     Sourcefile.from_file("apl_arpege_parallel.F90")
[Loki::Frontend] Executed sanitize_input in 0.12s
[Loki::FP] Executed parse_fparser_source in 7.41s
[Loki::Frontend] Executed sanitize_ir in 0.25s
[Loki::Frontend] Executed sanitize_ir in 5.70s
[Loki::Frontend] Executed sanitize_ir in 0.94s
[Loki::FP] Executed parse_fparser_ast in 19.30s
[Loki::Sourcefile] Constructed from apl_arpege_parallel.F90 in 26.83s

# with this PR
In [2]: with config_override({'log-level': 'perf'}):
   ...:     Sourcefile.from_file("apl_arpege_parallel.F90")
[Loki::Frontend] Executed sanitize_input in 0.12s
[Loki::FP] Executed parse_fparser_source in 7.76s
[Loki::Frontend] Executed sanitize_ir in 0.09s
[Loki::Frontend] Executed sanitize_ir in 2.13s
[Loki::Frontend] Executed sanitize_ir in 0.47s
[Loki::FP] Executed parse_fparser_ast in 9.32s
[Loki::Sourcefile] Constructed from apl_arpege_parallel.F90 in 17.27s
```

_Integration note: PR is currently passing ECphysics regression, but not local test base. Will attempt to fix local tests ASAP, but filing draft now to trigger test base. Initial bulk-parse in EC-physics also seems to improve with this._