### PR TITLE
kwargs utilities

### DIFF
--- a/loki/ir.py
+++ b/loki/ir.py
@@ -953,10 +953,17 @@ class CallStatement(LeafNode, _CallStatementBase):
         new_kwarguments = tuple((arg_name, kwargs[arg_name]) for arg_name in r_arg_names)
         return new_kwarguments
 
+    def check_kwarguments_order(self):
+        """
+        Check whether kwarguments are correctly ordered
+        in respect to the arguments (``self.routine.arguments``).
+        """
+        return self.kwarguments == self._sort_kwarguments()
+
     def sort_kwarguments(self):
         """
         Sort and update the kwarguments according to the order of the
-        arguments (``self.routine.arguments``)`.
+        arguments (``self.routine.arguments``).
         """
         new_kwarguments = self._sort_kwarguments()
         self._update(kwarguments=new_kwarguments)

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -948,7 +948,7 @@ class CallStatement(LeafNode, _CallStatementBase):
         """
         routine = self.routine
         assert routine is not BasicType.DEFERRED
-        kwargs = CaseInsensitiveDict(self.kwarguments) # [kwarg[0] for kwarg in self.kwarguments]
+        kwargs = CaseInsensitiveDict(self.kwarguments)
         r_arg_names = [arg.name for arg in routine.arguments if arg.name in kwargs]
         new_kwarguments = tuple((arg_name, kwargs[arg_name]) for arg_name in r_arg_names)
         return new_kwarguments
@@ -968,7 +968,7 @@ class CallStatement(LeafNode, _CallStatementBase):
         new_kwarguments = self._sort_kwarguments()
         self._update(kwarguments=new_kwarguments)
 
-    def kwargs_to_args(self):
+    def convert_kwargs_to_args(self):
         """
         Convert all kwarguments to arguments and update the call accordingly.
         """

--- a/loki/ir.py
+++ b/loki/ir.py
@@ -941,6 +941,34 @@ class CallStatement(LeafNode, _CallStatementBase):
         """
         return dict(self.arg_iter())
 
+    def _sort_kwarguments(self):
+        """
+        Helper routine to sort the kwarguments according to the order of the
+        arguments (``self.routine.arguments``)`.
+        """
+        routine = self.routine
+        assert routine is not BasicType.DEFERRED
+        kwargs = CaseInsensitiveDict(self.kwarguments) # [kwarg[0] for kwarg in self.kwarguments]
+        r_arg_names = [arg.name for arg in routine.arguments if arg.name in kwargs]
+        new_kwarguments = tuple((arg_name, kwargs[arg_name]) for arg_name in r_arg_names)
+        return new_kwarguments
+
+    def sort_kwarguments(self):
+        """
+        Sort and update the kwarguments according to the order of the
+        arguments (``self.routine.arguments``)`.
+        """
+        new_kwarguments = self._sort_kwarguments()
+        self._update(kwarguments=new_kwarguments)
+
+    def kwargs_to_args(self):
+        """
+        Convert all kwarguments to arguments and update the call accordingly.
+        """
+        new_kwarguments = self._sort_kwarguments()
+        new_args = tuple(arg[1] for arg in new_kwarguments)
+        self._update(arguments=self.arguments + new_args, kwarguments=())
+
 
 @dataclass_strict(frozen=True)
 class _AllocationBase():

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -2169,7 +2169,7 @@ def test_call_args_kwargs_conversion(frontend):
 
     # kwarg to arg conversion
     for call in FindNodes(CallStatement).visit(driver.body):
-        call.kwargs_to_args()
+        call.convert_kwargs_to_args()
 
     # check calls with kwargs converted to args
     for call in FindNodes(CallStatement).visit(driver.body):

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -2104,3 +2104,74 @@ end subroutine myroutine
     # Ensure that the original copy of the routine remains unaffected
     assert len(FindNodes(Assignment).visit(routine.body)) == 3
     assert len(FindNodes(Assignment).visit(new_routine.body)) == 0
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_call_args_kwargs_conversion(frontend):
+
+    fcode_kernel = """
+    subroutine kernel(a,b,c,d,e,f,g)
+    implicit none
+    integer, intent(inout) :: a
+    integer, intent(out) :: b
+    integer, intent(in) :: c, d, e, f, g
+
+
+    a = a + 1
+    b = a + c + d + e + f + g
+
+    end subroutine kernel
+    """
+
+    fcode_driver = """
+    subroutine driver()
+    implicit none
+
+    integer :: a
+    integer :: b
+    integer :: driver_c
+    integer :: driver_d
+    integer :: driver_ze
+    integer :: driver_f
+    integer :: driver_g
+
+    a = 0
+
+    call kernel(a, b, driver_c, driver_d, driver_ze, driver_f, driver_g)
+    call kernel(a=a, b=b, c=driver_c, d=driver_d, e=driver_ze, f=driver_f, g=driver_g)
+    call kernel(b=b, e=driver_ze, c=driver_c, d=driver_d, f=driver_f, g=driver_g, a=a)
+    ! this is NOT allowed in Fortran
+    ! call kernel(driver_c, driver_d, driver_ze, driver_f, driver_g, a=a, b=b)
+    call kernel(a,b,driver_c, driver_d, driver_ze, g=driver_g, f=driver_f)
+
+    end subroutine driver
+    """
+
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    driver.enrich(kernel)
+
+    # already correct ordered kwarguments?
+    kwargs_in_order = [True, True, False, False]
+    # expected (kw)arguments in calls, 'driver_ze' to break alphabetical order
+    call_args = ('a', 'b', 'driver_c', 'driver_d', 'driver_ze', 'driver_f', 'driver_g')
+    # expected amount of kwargs for the corresponding calls
+    len_kwargs = (0, 7, 7, 2)
+
+    # sort kwargs
+    for i_call, call in enumerate(FindNodes(CallStatement).visit(driver.body)):
+        assert call.check_kwarguments_order() == kwargs_in_order[i_call]
+        call.sort_kwarguments()
+
+    # check calls with sorted kwargs
+    for i_call, call in enumerate(FindNodes(CallStatement).visit(driver.body)):
+        assert tuple(arg[1].name for arg in call.arg_iter()) == call_args
+        assert len(call.kwarguments) == len_kwargs[i_call]
+
+    # kwarg to arg conversion
+    for call in FindNodes(CallStatement).visit(driver.body):
+        call.kwargs_to_args()
+
+    # check calls with kwargs converted to args
+    for call in FindNodes(CallStatement).visit(driver.body):
+        assert tuple(arg.name for arg in call.arguments) == call_args
+        assert call.kwarguments == ()


### PR DESCRIPTION
Utilities for `CallStatement`s

* check whether `kwargs` are correctly ordered
* sort `kwargs`
* convert `kwargs` to args

necessary for e.g., F2C transpilation