### PR TITLE
`GlobalVarHoistTransformation`: fix for functions/inline calls

### DIFF
--- a/transformations/tests/sources/projGlobalVarImports/functions.F90
+++ b/transformations/tests/sources/projGlobalVarImports/functions.F90
@@ -5,7 +5,6 @@ contains
   real function some_func()
     use moduleB, only: var2
     implicit none
-    real some_func
     some_func = var2
   end function some_func
 

--- a/transformations/tests/sources/projGlobalVarImports/functions.F90
+++ b/transformations/tests/sources/projGlobalVarImports/functions.F90
@@ -1,0 +1,12 @@
+module func_mod
+implicit none
+contains
+
+  real function some_func()
+    use moduleB, only: var2
+    implicit none
+    real some_func
+    some_func = var2
+  end function some_func
+
+end module func_mod

--- a/transformations/tests/sources/projGlobalVarImports/kernels.F90
+++ b/transformations/tests/sources/projGlobalVarImports/kernels.F90
@@ -1,10 +1,12 @@
 subroutine kernel0()
+use func_mod, only: some_func
 implicit none
-
+  real a
   call kernel1()
   call kernel2()
   call kernel3()
-
+  ! print *, "result: ", some_func()
+  a = some_func()
 end subroutine kernel0
 
 subroutine kernel1()
@@ -34,3 +36,10 @@ var4 = var2
 var5 = var3
 
 end subroutine kernel3
+
+! real function some_func()
+! use moduleB, only: var2
+! implicit none
+! real some_func
+! some_func = var2
+! end function some_func

--- a/transformations/tests/sources/projGlobalVarImports/kernels.F90
+++ b/transformations/tests/sources/projGlobalVarImports/kernels.F90
@@ -5,7 +5,6 @@ implicit none
   call kernel1()
   call kernel2()
   call kernel3()
-  ! print *, "result: ", some_func()
   a = some_func()
 end subroutine kernel0
 
@@ -36,10 +35,3 @@ var4 = var2
 var5 = var3
 
 end subroutine kernel3
-
-! real function some_func()
-! use moduleB, only: var2
-! implicit none
-! real some_func
-! some_func = var2
-! end function some_func


### PR DESCRIPTION
This adds proper handling of functions/inline calls for the `GlobalVarHoistTransformation` transformation. 
Problem was related to *arguments*/*parameters* missing in the inline call signature ...