### PR TITLE
FParser: Perform in-place scope attachment during parse

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -413,7 +413,12 @@ class FParser2IR(GenericVisitor):
                 function = var.function.clone(name=f'{parent.name}%{var.function.name}', parent=parent)
                 var = var.clone(function=function)
             else:
-                var = var.clone(name=f'{parent.name}%{var.name}', parent=parent, scope=parent.scope)
+                # Hack: Need to force re-evaluation of the type from parent here via `type=None`
+                # We know there's a parent, but we cannot trust the auto-generation of the type,
+                # since the type lookup via parents can create mismatched DeferredTypeSymbols.
+                var = var.clone(
+                    name=f'{parent.name}%{var.name}', parent=parent, scope=parent.scope, type=None
+                )
         return var
 
     #

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2494,7 +2494,10 @@ class FParser2IR(GenericVisitor):
         if parent:
             scope = parent.scope
         name = self.visit(o.children[2], **kwargs)
-        name = name.clone(name=f'{parent.name}%{name.name}', parent=parent, scope=scope)
+        # Hack: Need to force re-evaluation of the type from parent here via `type=None`
+        # To fix this, we should stop creating symbols in the enclosing scope
+        # when determining the type of drieved type members from their parent.
+        name = name.clone(name=f'{parent.name}%{name.name}', parent=parent, scope=scope, type=None)
         return name
 
     visit_Actual_Arg_Spec_List = visit_List

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2938,7 +2938,7 @@ class FParser2IR(GenericVisitor):
 
         # Special-case: Identify statement functions using our internal symbol table
         symbol_attrs = kwargs['scope'].symbol_attrs
-        if isinstance(lhs, sym.Array) and lhs.name in symbol_attrs:
+        if isinstance(lhs, sym.Array) and not lhs.parent and lhs.name in symbol_attrs:
 
             def _create_stmt_func_type(stmt_func):
                 name = str(stmt_func.variable)
@@ -2951,11 +2951,12 @@ class FParser2IR(GenericVisitor):
                 proc_type = ProcedureType(is_function=True, procedure=procedure, name=name)
                 return SymbolAttributes(dtype=proc_type, is_stmt_func=True)
 
-            if not symbol_attrs[lhs.name].shape and not symbol_attrs[lhs.name].intent:
+            if not lhs.type.shape and not lhs.type.intent:
                 # If the LHS array access is actually declared as a scalar,
                 # we are actually dealing with a statement function!
+                f_symbol = sym.ProcedureSymbol(name=lhs.name, scope=kwargs['scope'])
                 stmt_func = ir.StatementFunction(
-                    variable=lhs.clone(dimensions=None), arguments=lhs.dimensions,
+                    variable=f_symbol, arguments=lhs.dimensions,
                     rhs=rhs, return_type=symbol_attrs[lhs.name],
                     label=kwargs.get('label'), source=kwargs.get('source')
                 )

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1809,7 +1809,7 @@ class FParser2IR(GenericVisitor):
             name=routine.name, args=routine._dummies, docstring=docs, spec=spec,
             body=body, contains=contains, ast=o, prefix=routine.prefix, bind=routine.bind,
             result_name=routine.result_name, is_function=routine.is_function,
-            rescope_symbols=True, source=source, incomplete=False
+            rescope_symbols=False, source=source, incomplete=False
         )
 
         # Once statement functions are in place, we need to update the original declaration so that it
@@ -2048,7 +2048,7 @@ class FParser2IR(GenericVisitor):
         module.__initialize__(
             name=module.name, docstring=docs, spec=spec, contains=contains,
             default_access_spec=module.default_access_spec, public_access_spec=module.public_access_spec,
-            private_access_spec=module.private_access_spec, ast=o, rescope_symbols=True, source=source,
+            private_access_spec=module.private_access_spec, ast=o, rescope_symbols=False, source=source,
             incomplete=False
         )
 

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -766,7 +766,11 @@ class FParser2IR(GenericVisitor):
         * char length (:class:`fparser.two.Fortran2003.Char_Length`)
         * init (:class:`fparser.two.Fortran2003.Initialization`)
         """
-        var = self.visit(o.children[0], **kwargs)
+
+        # Do not pass scope down, as it might alias with previously
+        # created symbols. Instead, let the rescope in the Declaration
+        # assign the right scope, always!
+        var = self.visit(o.children[0])
 
         if o.children[1]:
             dimensions = as_tuple(self.visit(o.children[1], **kwargs))

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -33,7 +33,7 @@ __all__ = [
     'execute', 'CaseInsensitiveDict', 'strip_inline_comments',
     'binary_insertion_sort', 'cached_func', 'optional', 'LazyNodeLookup',
     'yaml_include_constructor', 'auto_post_mortem_debugger', 'set_excepthook',
-    'timeout', 'WeakrefProperty', 'group_by_class', 'replace_windowed'
+    'timeout', 'WeakrefProperty', 'group_by_class', 'replace_windowed', 'dict_override'
 ]
 
 
@@ -669,3 +669,26 @@ def replace_windowed(iterable, group, subs):
         iterable, pred=lambda *args: args == group,
         substitutes=as_tuple(subs), window_size=len(group)
     ))
+
+
+@contextmanager
+def dict_override(base, override):
+    """
+    Contextmanager to temporarily override a set of dictionary values.
+
+    Parameters
+    ----------
+    base : dict
+        The base dictionary in which to overide values
+    replace : dict
+        Replacement mapping to temporarily insert
+    """
+    original_values = tuple((k, base[k]) for k in override.keys() if k in base)
+    added_keys = tuple(k for k in override.keys() if k not in base)
+    base.update(override)
+
+    yield base
+
+    base.update(original_values)
+    for k in added_keys:
+        del base[k]

--- a/tests/test_fgen.py
+++ b/tests/test_fgen.py
@@ -127,6 +127,9 @@ def test_multiline_inline_conditional(frontend):
     """
     fcode = """
 subroutine test_fgen(DIMS, ZSURF_LOCAL)
+  type(DIMENSION_TYPE), intent(in) :: DIMS
+  type(SURFACE_TYPE), intent(inout) :: ZSURF_LOCAL
+  type(STATE_TYPE) :: TENDENCY_LOC
 contains
 subroutine test_inline_multiline(KDIMS, LBUD23)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -26,7 +26,7 @@ except ImportError:
 from conftest import stdchannel_is_captured, stdchannel_redirected
 from loki.tools import (
     JoinableStringList, truncate_string, binary_insertion_sort, is_subset,
-    optional, yaml_include_constructor, execute, timeout
+    optional, yaml_include_constructor, execute, timeout, dict_override
 )
 
 
@@ -341,3 +341,15 @@ def test_timeout():
         stop = perf_counter()
         assert .9 < stop - start < 1.1
         assert "My message" in str(exc.value)
+
+
+def test_dict_override():
+    kwargs = {'rick' : 42, 'dave' : 'yeah'}
+    with dict_override(kwargs, {'dave' : 'nope', 'joe' : 'huh?'}):
+        assert kwargs['dave'] == 'nope'
+        assert kwargs['rick'] == 42
+        assert kwargs['joe'] == 'huh?'
+    assert kwargs['dave'] == 'yeah'
+    assert kwargs['rick'] == 42
+    assert 'joe' not in kwargs
+    assert len(kwargs) == 2


### PR DESCRIPTION
_Note: This is the second part to optimising the performance of the FP frontend, as detailed in PR #234. It contributes significantly to the throughput number presented in #234 ._

The key idea behind this PR is to avoid the costly rescoping pass of the subroutine/module bodies after the initial IR generation. Instead we now use the `scope` argument passed through the AST-to-IR converter whenever possible.

One caveat to this is that we still need to do one `AttachScopes` pass after parsing the `spec`, as we might encounter symbols used in shape declarations out of sequence (yay, Fortran!). I have adjusted one of the tests to capture this accordingly.

There are also a few little tricks involved, and I've added a small utility to temporarily override dict values, as we now need to be careful when and what to pass down the AST parse tree. There is still one hacky workaround left that forces type re-evaluation from scope for ProcedureDesignators, as the recursive lookup for parents still injects, wrongly-typed pseudo-symbols into the scope (via `Symbol.variable_map`). I leave it to a follow-on to fix this correctly.