### PR TITLE
Loki-lint: First 3 rules for new IFS-Arpégé coding standards

### DIFF
--- a/lint_rules/lint_rules/ifs_arpege_coding_standards.py
+++ b/lint_rules/lint_rules/ifs_arpege_coding_standards.py
@@ -28,7 +28,7 @@ import loki.ir as ir
 
 
 __all__ = [
-    'MissingImplicitNoneRule', 'MissingIntfbRule',
+    'MissingImplicitNoneRule', 'OnlyParameterGlobalVarRule', 'MissingIntfbRule',
 ]
 
 
@@ -90,6 +90,26 @@ class MissingImplicitNoneRule(GenericRule):
         if not found_implicit_none:
             # No 'IMPLICIT NONE' intrinsic node was found
             rule_report.add('No `IMPLICIT NONE` found', subroutine)
+
+
+class OnlyParameterGlobalVarRule(GenericRule):
+    """
+    Only parameters to be declared as global variables.
+    """
+
+    type = RuleType.SERIOUS
+
+    docs = {
+        'id': 'L3',
+        'title': 'Only parameters to be declared as global variables.'
+    }
+
+    @classmethod
+    def check_module(cls, module, rule_report, config):
+        for decl in module.declarations:
+            if not decl.symbols[0].type.parameter:
+                msg = f'Global variable(s) declared that are not parameters: {", ".join(s.name for s in decl.symbols)}'
+                rule_report.add(msg, decl)
 
 
 class MissingIntfbRule(GenericRule):

--- a/lint_rules/lint_rules/ifs_arpege_coding_standards.py
+++ b/lint_rules/lint_rules/ifs_arpege_coding_standards.py
@@ -24,7 +24,7 @@ except ImportError:
 from loki import (
     FindInlineCalls, FindNodes, GenericRule, Module, RuleType
 )
-import loki.ir as ir
+from loki import ir
 
 
 __all__ = [

--- a/lint_rules/lint_rules/ifs_arpege_coding_standards.py
+++ b/lint_rules/lint_rules/ifs_arpege_coding_standards.py
@@ -1,0 +1,100 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Implementation of rules from the IFS Arpege coding standards as :any:`GenericRule`
+
+See
+"""
+
+
+from loki import (
+    FindInlineCalls, FindNodes, GenericRule, RuleType
+)
+import loki.ir as ir
+
+
+__all__ = [
+    'MissingIntfbRule',
+]
+
+
+class MissingIntfbRule(GenericRule):
+    """
+    Calls to subroutines and functions that are provided neither by a module
+    nor by a CONTAINS statement, must have a matching explicit interface block.
+    """
+
+    type = RuleType.SERIOUS
+
+    docs = {
+        'id': 'L9',
+        'title': (
+            'Explicit interface blocks required for procedures that are not '
+            'imported or internal subprograms'
+        )
+    }
+
+    @classmethod
+    def _get_external_symbols(cls, program_unit):
+        """
+        Collect all imported symbols in :data:`program_unit` and
+        parent scopes and return as a set of lower-case names
+        """
+        external_symbols = set()
+
+        if program_unit.parent:
+            external_symbols |= cls._get_external_symbols(program_unit.parent)
+
+        # Get imported symbols
+        external_symbols |= {
+            s.name.lower()
+            for import_ in program_unit.imports
+            for s in import_.symbols or ()
+        }
+
+        # Collect all symbols declared via intfb includees
+        external_symbols |= {
+            include.module[:-8].lower()
+            for include in FindNodes(ir.Import).visit(program_unit.ir)
+            if include.c_import and include.module.endswith('intfb.h')
+        }
+
+        # Add locally declared interface symbols
+        external_symbols |= {s.name.lower() for s in program_unit.interface_symbols}
+
+        # Add internal subprograms and module procedures
+        for routine in program_unit.routines:
+            external_symbols.add(routine.name.lower())
+
+        return external_symbols
+
+    @staticmethod
+    def _add_report(rule_report, node, call_name):
+        """
+        Register a missing interface block for a call to :data:`call_name`
+        in the :any:`RuleReport`
+        """
+        msg = f'Missing import or interface block for called procedure {call_name}'
+        rule_report.add(msg, node)
+
+    @classmethod
+    def check_subroutine(cls, subroutine, rule_report, config, **kwargs):
+        """
+        Check all :any:`CallStatement` and :any:`InlineCall` for a matching import
+        or interface block.
+        """
+        external_symbols = cls._get_external_symbols(subroutine)
+
+        for call in FindNodes(ir.CallStatement).visit(subroutine.body):
+            if str(call.name).lower() not in external_symbols:
+                cls._add_report(rule_report, call, call.name)
+
+        for node, calls in FindInlineCalls(with_ir_node=True).visit(subroutine.body):
+            for call in calls:
+                if call.name.lower() not in external_symbols:
+                    cls._add_report(rule_report, node, call.name)

--- a/lint_rules/lint_rules/ifs_coding_standards_2011.py
+++ b/lint_rules/lint_rules/ifs_coding_standards_2011.py
@@ -16,7 +16,7 @@ import re
 from pymbolic.primitives import Expression
 
 from loki import (
-    Visitor, FindNodes, ExpressionFinder, ExpressionRetriever,
+    Visitor, FindNodes, ExpressionFinder, ExpressionRetriever, Node,
     flatten, as_tuple, strip_inline_comments, Module, Subroutine, BasicType, ir
 )
 from loki.lint import GenericRule, RuleType
@@ -507,7 +507,7 @@ class Fortran90OperatorsRule(GenericRule):  # Coding standards 4.15
                     comparisons = self.retriever.retrieve(ch)
                     if comparisons:
                         retval += ((o, ch, comparisons),)
-                elif ch is not None:
+                elif isinstance(ch, Node):
                     retval += self.visit(ch, **kwargs)
             return retval
 

--- a/lint_rules/tests/test_ifs_arpege_coding_standards.py
+++ b/lint_rules/tests/test_ifs_arpege_coding_standards.py
@@ -103,7 +103,7 @@ end module mod_also_not_okay
     source = Sourcefile.from_source(fcode, frontend=frontend)
     messages = []
     handler = DefaultHandler(target=messages.append)
-    _ = run_linter(source, [rules.MissingImplicitNoneRule], handlers=[handler])
+    run_linter(source, [rules.MissingImplicitNoneRule], handlers=[handler])
 
     expected_messages = (
         (['[L1]', 'MissingImplicitNoneRule', '`IMPLICIT NONE`', 'mod_not_okay', '(l. 40)']),
@@ -114,6 +114,42 @@ end module mod_also_not_okay
         (['[L1]', 'MissingImplicitNoneRule', '`IMPLICIT NONE`', 'routine_not_okay', '(l. 28)']),
         (['[L1]', 'MissingImplicitNoneRule', '`IMPLICIT NONE`', 'routine_also_not_okay', '(l. 49)']),
         (['[L1]', 'MissingImplicitNoneRule', '`IMPLICIT NONE`', 'contained_routine_not_okay', '(l. 54)']),
+    )
+
+    assert len(messages) == len(expected_messages)
+    for msg, keywords in zip(messages, expected_messages):
+        for keyword in keywords:
+            assert keyword in msg
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_only_param_global_var_rule(rules, frontend):
+    fcode = """
+module some_mod
+use other_mod, only: some_type
+implicit none
+
+integer, parameter :: param_ok = 123
+integer, parameter :: arr_param_ok(:) = (/ 1, 2, 3 /)
+integer :: var_not_ok
+integer, allocatable :: arr_not_ok(:), other_arr_not_ok(:,:)
+integer, pointer :: ptr_not_ok
+real, parameter :: rparam_ok = -42.
+type(some_type) :: dt_var_not_ok
+type(some_type) :: dt_arr_not_ok(2)
+end module some_mod
+    """
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    messages = []
+    handler = DefaultHandler(target=messages.append)
+    run_linter(source, [rules.OnlyParameterGlobalVarRule], handlers=[handler])
+
+    expected_messages = (
+        (['L3', 'OnlyParameterGlobalVarRule', 'var_not_ok', '(l. 8)']),
+        (['L3', 'OnlyParameterGlobalVarRule', 'arr_not_ok', 'other_arr_not_ok', '(l. 9)']),
+        (['L3', 'OnlyParameterGlobalVarRule', 'ptr_not_ok', '(l. 10)']),
+        (['L3', 'OnlyParameterGlobalVarRule', 'dt_var_not_ok', '(l. 12)']),
+        (['L3', 'OnlyParameterGlobalVarRule', 'dt_arr_not_ok', '(l. 13)']),
     )
 
     assert len(messages) == len(expected_messages)
@@ -154,7 +190,7 @@ end subroutine missing_intfb_rule
     source = Sourcefile.from_source(fcode)
     messages = []
     handler = DefaultHandler(target=messages.append)
-    _ = run_linter(source, [rules.MissingIntfbRule], handlers=[handler])
+    run_linter(source, [rules.MissingIntfbRule], handlers=[handler])
 
     expected_messages = (
         (['[L9]', 'MissingIntfbRule', '`missing_routine`', '(l. 19)']),
@@ -210,7 +246,7 @@ end module missing_intfb_rule_mod
     source = Sourcefile.from_source(fcode)
     messages = []
     handler = DefaultHandler(target=messages.append)
-    _ = run_linter(source, [rules.MissingIntfbRule], handlers=[handler])
+    run_linter(source, [rules.MissingIntfbRule], handlers=[handler])
 
     expected_messages = (
         (['[L9]', 'MissingIntfbRule', '`missing_routine`', '(l. 24)']),

--- a/lint_rules/tests/test_ifs_arpege_coding_standards.py
+++ b/lint_rules/tests/test_ifs_arpege_coding_standards.py
@@ -1,0 +1,120 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import importlib
+import pytest
+
+from conftest import run_linter, available_frontends
+from loki import Sourcefile
+from loki.lint import DefaultHandler
+
+
+pytestmark = pytest.mark.skipif(not available_frontends(),
+                                reason='Suitable frontend not available')
+
+
+@pytest.fixture(scope='module', name='rules')
+def fixture_rules():
+    rules = importlib.import_module('lint_rules.ifs_arpege_coding_standards')
+    return rules
+
+
+def test_missing_intfb_rule_subroutine(rules):
+    fcode = """
+subroutine missing_intfb_rule(a, b)
+    use some_mod, only: imported_routine
+    use other_mod, only: imported_func
+    implicit none
+    integer, intent(in) :: a, b
+#include "included_routine.intfb.h"
+    integer :: local_var
+    interface
+        subroutine local_intf_routine(X)
+            integer, intent(in) :: x
+        end subroutine local_intf_routine
+    end interface
+#include "included_func.intfb.h"
+
+    CALL IMPORTED_ROUTINE(A)
+    CALL INCLUDED_ROUTINE(B)
+    CALL MISSING_ROUTINE(A, B)
+    CALL LOCAL_INTF_ROUTINE(A)
+    LOCAL_VAR = IMPORTED_FUNC(A)
+    LOCAL_VAR = LOCAL_VAR + INCLUDED_FUNC(B)
+    LOCAL_VAR = LOCAL_VAR + MISSING_FUNC(A, B)
+end subroutine missing_intfb_rule
+""".strip()
+    source = Sourcefile.from_source(fcode)
+    messages = []
+    handler = DefaultHandler(target=messages.append)
+    _ = run_linter(source, [rules.MissingIntfbRule], handlers=[handler])
+
+    expected_messages = (
+        (['[L9]', 'MissingIntfbRule', 'MISSING_ROUTINE', '(l. 17)']),
+        # (['[L9]', 'MissingIntfbRule', 'MISSING_FUNC', '(l. 15)']),
+        # NB: The missing function is not discovered because it is syntactically
+        #     indistinguishable from an Array subscript
+    )
+
+    assert len(messages) == len(expected_messages)
+    for msg, keywords in zip(messages, expected_messages):
+        for keyword in keywords:
+            assert keyword in msg
+
+
+def test_missing_intfb_rule_module(rules):
+    fcode = """
+module missing_intfb_rule_mod
+    use external_mod, only: module_imported_routine, module_imported_func
+    implicit none
+    interface
+        function local_intf_func()
+            integer local_intf_func
+        end function local_intf_func
+    end interface
+#include "included_parent.intfb.h"
+contains
+    subroutine missing_intfb_rule(a, b)
+        use some_mod, only: imported_routine
+        use other_mod, only: imported_func
+        implicit none
+        integer, intent(in) :: a, b
+#include "included_routine.intfb.h"
+        integer :: local_var
+#include "included_func.intfb.h"
+
+
+        CALL IMPORTED_ROUTINE(A)
+        CALL INCLUDED_ROUTINE(B)
+        CALL MODULE_IMPORTED_ROUTINE(A, B)
+        CALL MISSING_ROUTINE(A, B)
+        CALL INCLUDED_PARENT(A)
+        LOCAL_VAR = IMPORTED_FUNC(A)
+        LOCAL_VAR = LOCAL_VAR + INCLUDED_FUNC(B)
+        LOCAL_VAR = LOCAL_VAR + MISSING_FUNC(A, KEY=B)
+        LOCAL_VAR = LOCAL_VAR + MODULE_IMPORTED_FUNC(KEY=A)
+        LOCAL_VAR = LOCAL_VAR + LOCAL_INTF_FUNC()
+    end subroutine missing_intfb_rule
+end module missing_intfb_rule_mod
+""".strip()
+    source = Sourcefile.from_source(fcode)
+    messages = []
+    handler = DefaultHandler(target=messages.append)
+    _ = run_linter(source, [rules.MissingIntfbRule], handlers=[handler])
+
+    expected_messages = (
+        (['[L9]', 'MissingIntfbRule', 'MISSING_ROUTINE', '(l. 24)']),
+        (['[L9]', 'MissingIntfbRule', 'MISSING_FUNC', '(l. 28)']),
+        # NB: The missing function is discovered here because
+        #     the use of a keyword-argument makes it syntactically
+        #     clear to be an inline call rather than an Array subscript
+    )
+
+    assert len(messages) == len(expected_messages)
+    for msg, keywords in zip(messages, expected_messages):
+        for keyword in keywords:
+            assert keyword in msg

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -336,7 +336,7 @@ class ExpressionRetriever(LokiWalkMapper):
         given and that should return `True` or `False` depending on whether
         that expression node and its children should be visited.
     """
-    # pylint: disable=abstract-method
+    # pylint: disable=abstract-method,unused-argument
 
     def __init__(self, query, recurse_query=None, **kwargs):
         super().__init__(**kwargs)
@@ -363,7 +363,7 @@ class ExpressionDimensionsMapper(Mapper):
     """
     A visitor for an expression that determines the dimensions of the expression.
     """
-    # pylint: disable=abstract-method
+    # pylint: disable=abstract-method,unused-argument
 
     def map_algebraic_leaf(self, expr, *args, **kwargs):
         # pylint: disable=import-outside-toplevel,cyclic-import
@@ -401,7 +401,7 @@ class ExpressionDimensionsMapper(Mapper):
 
     map_string_subscript = map_algebraic_leaf
 
-    def map_range_index(self, expr, *args, **kwargs):  # pylint: disable=unused-argument
+    def map_range_index(self, expr, *args, **kwargs):
         if expr.lower is None and expr.upper is None:
             # We have the full range
             return as_tuple(expr)

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -379,7 +379,7 @@ class ExpressionDimensionsMapper(Mapper):
     map_scalar = map_algebraic_leaf
 
     def map_deferred_type_symbol(self, expr, *args, **kwargs):
-        raise ValueError(f'Symbol with deferred type encountered: {expr}')
+        return as_tuple(expr)
 
     def map_array(self, expr, *args, **kwargs):
         if not expr.dimensions:

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1486,7 +1486,7 @@ class Reference(pmbl.Expression):
     @property
     def name(self):
         """
-        Allowing the compound ``Reference(Variable(name))`` to appear 
+        Allowing the compound ``Reference(Variable(name))`` to appear
         with behaviour akin to a symbol itself for easier processing in mappers.
         """
         return self.expression.name
@@ -1494,7 +1494,7 @@ class Reference(pmbl.Expression):
     @property
     def type(self):
         """
-        Allowing the compound ``Reference(Variable(type))`` to appear 
+        Allowing the compound ``Reference(Variable(type))`` to appear
         with behaviour akin to a symbol itself for easier processing in mappers.
         """
         return self.expression.type
@@ -1502,7 +1502,7 @@ class Reference(pmbl.Expression):
     @property
     def scope(self):
         """
-        Allowing the compound ``Reference(Variable(scope))`` to appear 
+        Allowing the compound ``Reference(Variable(scope))`` to appear
         with behaviour akin to a symbol itself for easier processing in mappers.
         """
         return self.expression.scope
@@ -1510,7 +1510,7 @@ class Reference(pmbl.Expression):
     @property
     def initial(self):
         """
-        Allowing the compound ``Reference(Variable(initial))`` to appear 
+        Allowing the compound ``Reference(Variable(initial))`` to appear
         with behaviour akin to a symbol itself for easier processing in mappers.
         """
         return self.expression.initial
@@ -1544,7 +1544,7 @@ class Dereference(pmbl.Expression):
     @property
     def name(self):
         """
-        Allowing the compound ``Dereference(Variable(name))`` to appear 
+        Allowing the compound ``Dereference(Variable(name))`` to appear
         with behaviour akin to a symbol itself for easier processing in mappers.
         """
         return self.expression.name
@@ -1552,7 +1552,7 @@ class Dereference(pmbl.Expression):
     @property
     def type(self):
         """
-        Allowing the compound ``Dereference(Variable(type))`` to appear 
+        Allowing the compound ``Dereference(Variable(type))`` to appear
         with behaviour akin to a symbol itself for easier processing in mappers.
         """
         return self.expression.type
@@ -1560,7 +1560,7 @@ class Dereference(pmbl.Expression):
     @property
     def scope(self):
         """
-        Allowing the compound ``Dereference(Variable(scope))`` to appear 
+        Allowing the compound ``Dereference(Variable(scope))`` to appear
         with behaviour akin to a symbol itself for easier processing in mappers.
         """
         return self.expression.scope
@@ -1568,7 +1568,7 @@ class Dereference(pmbl.Expression):
     @property
     def initial(self):
         """
-        Allowing the compound ``Dereference(Variable(initial))`` to appear 
+        Allowing the compound ``Dereference(Variable(initial))`` to appear
         with behaviour akin to a symbol itself for easier processing in mappers.
         """
         return self.expression.initial

--- a/loki/lint/reporter.py
+++ b/loki/lint/reporter.py
@@ -470,7 +470,7 @@ class ViolationFileHandler(GenericHandler):
         """
         Generate the YAML output from the list of reports.
         """
-        self.target('\n'.join(handler_reports))
+        self.target('\n'.join(report for report in handler_reports if report))
 
 
 class JunitXmlHandler(GenericHandler):

--- a/scripts/loki_lint.py
+++ b/scripts/loki_lint.py
@@ -34,7 +34,7 @@ def get_rules(module):
                     'output and automatically attaches a debugger on exceptions.'))
 @click.option('--log', type=click.Path(writable=True),
               help='Write more detailed information to a log file.')
-@click.option('--rules-module', default='ifs_coding_standards_2011', show_default=True,
+@click.option('--rules-module', default='ifs_arpege_coding_standards', show_default=True,
               help='Select Python module with rules in lint_rules.')
 @click.pass_context
 def cli(ctx, debug, log, rules_module):  # pylint:disable=redefined-outer-name


### PR DESCRIPTION
This adds an implementation of the first 3 (arbitrarily chosen) rules from the new coding standards as a new rules module and makes this the default rules module in loki-lint.py.

Piggy-backed is a small fix for the expression dimensions inference, which would fail with an exception when the dimension expression contains deferred type symbols. However, this exception is actually unnecessary and the deferred type symbol should just be used as-is.

The second fix is just in the output formatting for rule violations to a yaml file. So far, even without any violations it would have inserted an empty line for every file, and skips now over empty reports.