### PR TITLE
SCC: Support for bounds aliases and derived type members as bounds

### DIFF
--- a/loki/dimension.py
+++ b/loki/dimension.py
@@ -31,14 +31,26 @@ class Dimension:
         String representations of alternative size variables that are
         used to define arrays shapes of this dimension (eg. alternative
         names used in "driver" subroutines).
+    bounds_aliases : list or tuple of strings
+        String representations of alternative bounds variables that are
+        used to define loop ranges.
     """
 
-    def __init__(self, name=None, index=None, bounds=None, size=None, aliases=None):
+    def __init__(self, name=None, index=None, bounds=None, size=None, aliases=None,
+                 bounds_aliases=None):
         self.name = name
         self._index = index
         self._bounds = as_tuple(bounds)
         self._size = size
         self._aliases = as_tuple(aliases)
+
+        if bounds_aliases:
+            if len(bounds_aliases) != 2:
+                raise RuntimeError(f'Start and end both needed for horizontal bounds aliases in {self.name}')
+            if bounds_aliases[0].split('%')[0] != bounds_aliases[1].split('%')[0]:
+                raise RuntimeError(f'Inconsistent root name for horizontal bounds aliases in {self.name}')
+
+        self._bounds_aliases = as_tuple(bounds_aliases)
 
     def __repr__(self):
         """ Pretty-print dimension details """

--- a/loki/dimension.py
+++ b/loki/dimension.py
@@ -106,3 +106,15 @@ class Dimension:
         if self._bounds:
             exprs += (f'{self._bounds[1]} - {self._bounds[0]} + 1', )
         return exprs
+
+    @property
+    def bounds_expressions(self):
+        """
+        A list of all expression strings representing the bounds of a data space.
+        """
+
+        exprs = [(b,) for b in self.bounds]
+        if self._bounds_aliases:
+            exprs = [expr + (b,) for expr, b in zip(exprs, self._bounds_aliases)]
+
+        return as_tuple(exprs)

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -1647,6 +1647,8 @@ end module typebound_resolution_type_info_mod
     for var_name in var_tt_to_try:
         assert f'var_tt%{var_name}' not in sub.symbol_attrs
 
+    assert 'var_c%c_b%b_a%a' == sub.resolve_typebound_var('var_c%c_b%b_a%a')
+
     # Create each derived type member and verify its type
     for var_name, dtype in var_c_to_try.items():
         var = var_c.get_derived_type_member(var_name)

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -798,3 +798,23 @@ class ProgramUnit(Scope):
         """
         # TODO: Should type-check for an `Operation` object here
         op.apply(self, **kwargs)
+
+    def resolve_typebound_var(self, name, variable_map=None):
+        """
+        A small convenience utility to resolve type-bound variables.
+
+        Parameters
+        ----------
+        name : str
+            The full name of the variable to be resolved, e.g., a%b%c%d.
+        variable_map : dict
+            A map of the variables defined in the current scope.
+        """
+
+        if not (_variable_map := variable_map):
+            _variable_map = self.variable_map
+
+        name_parts = name.split('%', maxsplit=1)
+        if (var := _variable_map.get(name_parts[0], None)) and len(name_parts) > 1:
+            var = var.get_derived_type_member(name_parts[1])
+        return var

--- a/loki/tests/test_dimension.py
+++ b/loki/tests/test_dimension.py
@@ -64,3 +64,10 @@ end subroutine test_dimension_index
     assert FindNodes(Loop).visit(routine.body)[0].bounds == dim.range
     assert FindNodes(Loop).visit(routine.body)[0].bounds.lower == dim.bounds[0]
     assert FindNodes(Loop).visit(routine.body)[0].bounds.upper == dim.bounds[1]
+
+    # Test the correct creation of horizontal dim with aliased bounds vars
+    _ = Dimension('test_dim_alias', bounds_aliases=('bnds%start', 'bnds%end'))
+    with pytest.raises(RuntimeError):
+        _ = Dimension('test_dim_alias', bounds_aliases=('bnds%start',))
+    with pytest.raises(RuntimeError):
+        _ = Dimension('test_dim_alias', bounds_aliases=('bnds%start', 'some_other_bnds%end'))

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -812,4 +812,3 @@ def resolve_typebound_var(name, variable_map):
     if (var := variable_map.get(name_parts[0], None)) and len(name_parts) > 1:
         var = var.get_derived_type_member(name_parts[1])
     return var
-

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -38,7 +38,7 @@ __all__ = [
     'auto_post_mortem_debugger', 'set_excepthook', 'timeout',
     'WeakrefProperty', 'group_by_class', 'replace_windowed',
     'dict_override', 'stdchannel_redirected',
-    'stdchannel_is_captured', 'graphviz_present'
+    'stdchannel_is_captured', 'graphviz_present', 'resolve_typebound_var'
 ]
 
 
@@ -794,3 +794,22 @@ def graphviz_present():
         return False
 
     return True
+
+
+def resolve_typebound_var(name, variable_map):
+    """
+    A small convenience utility to resolve type-bound variables.
+
+    Parameters
+    ----------
+    name : str
+        The full name of the variable to be resolved, e.g., a%b%c%d.
+    variable_map : dict
+        A map of the variables defined in the current scope.
+    """
+
+    name_parts = name.split('%', maxsplit=1)
+    if (var := variable_map.get(name_parts[0], None)) and len(name_parts) > 1:
+        var = var.get_derived_type_member(name_parts[1])
+    return var
+

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -38,7 +38,7 @@ __all__ = [
     'auto_post_mortem_debugger', 'set_excepthook', 'timeout',
     'WeakrefProperty', 'group_by_class', 'replace_windowed',
     'dict_override', 'stdchannel_redirected',
-    'stdchannel_is_captured', 'graphviz_present', 'resolve_typebound_var'
+    'stdchannel_is_captured', 'graphviz_present'
 ]
 
 
@@ -794,21 +794,3 @@ def graphviz_present():
         return False
 
     return True
-
-
-def resolve_typebound_var(name, variable_map):
-    """
-    A small convenience utility to resolve type-bound variables.
-
-    Parameters
-    ----------
-    name : str
-        The full name of the variable to be resolved, e.g., a%b%c%d.
-    variable_map : dict
-        A map of the variables defined in the current scope.
-    """
-
-    name_parts = name.split('%', maxsplit=1)
-    if (var := variable_map.get(name_parts[0], None)) and len(name_parts) > 1:
-        var = var.get_derived_type_member(name_parts[1])
-    return var

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -1862,7 +1862,7 @@ def test_scc_base_horizontal_bounds_checks(frontend, horizontal, horizontal_boun
     routine = Subroutine.from_source(fcode, frontend=frontend)
     no_start = Subroutine.from_source(fcode_no_start, frontend=frontend)
     no_end = Subroutine.from_source(fcode_no_end, frontend=frontend)
-    alias = Sourcefile.from_source(fcode_alias, frontend=frontend)
+    alias = Sourcefile.from_source(fcode_alias, frontend=frontend).subroutines[0]
 
     transform = SCCBaseTransformation(horizontal=horizontal)
     with pytest.raises(RuntimeError):

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -341,12 +341,13 @@ def test_scc_demote_transformation(frontend, horizontal):
     """
 
     fcode_kernel = """
-  SUBROUTINE compute_column(start, end, nlon, nz, q)
+  SUBROUTINE compute_column(start, end, nlon, nproma, nz, q)
     INTEGER, INTENT(IN) :: start, end  ! Iteration indices
     INTEGER, INTENT(IN) :: nlon, nz    ! Size of the horizontal and vertical
+    INTEGER, INTENT(IN) :: nproma      ! Horizontal size alias
     REAL, INTENT(INOUT) :: q(nlon,nz)
     REAL :: t(nlon,nz)
-    REAL :: a(nlon)
+    REAL :: a(nproma)
     REAL :: b(nlon,psize)
     REAL :: unused(nlon)
     INTEGER, PARAMETER :: psize = 3

--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -1877,11 +1877,11 @@ def test_scc_base_horizontal_bounds_checks(frontend, horizontal, horizontal_boun
     transform = SCCBaseTransformation(horizontal=horizontal_bounds_aliases)
     transform.apply(alias, role='kernel')
 
-    bounds = SCCBaseTransformation.check_horizontal_var(routine, horizontal_bounds_aliases)
+    bounds = SCCBaseTransformation.get_horizontal_loop_bounds(routine, horizontal_bounds_aliases)
     assert bounds[0] == 'start'
     assert bounds[1] == 'end'
 
-    bounds = SCCBaseTransformation.check_horizontal_var(alias, horizontal_bounds_aliases)
+    bounds = SCCBaseTransformation.get_horizontal_loop_bounds(alias, horizontal_bounds_aliases)
     assert bounds[0] == 'bnds%start'
     assert bounds[1] == 'bnds%end'
 

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -23,7 +23,7 @@ from loki import (
     DetachScopesMapper, SymbolAttributes, BasicType, DerivedType,
     is_dimension_constant, recursive_expression_map_update,
     get_pragma_parameters, FindInlineCalls, Interface,
-    dataflow_analysis_attached
+    dataflow_analysis_attached, resolve_typebound_var
 )
 
 __all__ = ['TemporariesPoolAllocatorTransformation']
@@ -435,11 +435,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             )
             variables_append += [stack_storage]
 
-            name_parts = self.block_dim.size.split('%', maxsplit=1)
-            block_size = routine.symbol_map[name_parts[0]]
-            if len(name_parts) > 1:
-                block_size = block_size.get_derived_type_member(name_parts[1])
-
+            block_size = resolve_typebound_var(self.block_dim.size, routine.symbol_map)
             stack_alloc = Allocation(variables=(stack_storage.clone(dimensions=(  # pylint: disable=no-member
                 stack_size_var, block_size)),))
             stack_dealloc = Deallocation(variables=(stack_storage.clone(dimensions=None),))  # pylint: disable=no-member

--- a/transformations/transformations/pool_allocator.py
+++ b/transformations/transformations/pool_allocator.py
@@ -23,7 +23,7 @@ from loki import (
     DetachScopesMapper, SymbolAttributes, BasicType, DerivedType,
     is_dimension_constant, recursive_expression_map_update,
     get_pragma_parameters, FindInlineCalls, Interface,
-    dataflow_analysis_attached, resolve_typebound_var
+    dataflow_analysis_attached
 )
 
 __all__ = ['TemporariesPoolAllocatorTransformation']
@@ -435,7 +435,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             )
             variables_append += [stack_storage]
 
-            block_size = resolve_typebound_var(self.block_dim.size, routine.symbol_map)
+            block_size = routine.resolve_typebound_var(self.block_dim.size, routine.symbol_map)
             stack_alloc = Allocation(variables=(stack_storage.clone(dimensions=(  # pylint: disable=no-member
                 stack_size_var, block_size)),))
             stack_dealloc = Deallocation(variables=(stack_storage.clone(dimensions=None),))  # pylint: disable=no-member

--- a/transformations/transformations/single_column_base.py
+++ b/transformations/transformations/single_column_base.py
@@ -11,6 +11,7 @@ from loki import (
     ir, Transformation, FindNodes, Transformer,
     as_tuple, FindExpressions,
     SymbolAttributes, BasicType, SubstituteExpressions,
+    resolve_typebound_var
 )
 
 
@@ -180,9 +181,12 @@ class SCCBaseTransformation(Transformation):
         bounds : tuple of :any:`Scalar`
             Tuple defining the iteration space of the inserted loops.
         """
+
         bounds_str = f'{bounds[0]}:{bounds[1]}'
 
-        bounds_v = (sym.Variable(name=bounds[0]), sym.Variable(name=bounds[1]))
+        variable_map = routine.variable_map
+        bounds_v = (resolve_typebound_var(bounds[0], variable_map),
+                    resolve_typebound_var(bounds[1], variable_map))
 
         mapper = {}
         for stmt in FindNodes(ir.Assignment).visit(routine.body):
@@ -302,7 +306,7 @@ class SCCBaseTransformation(Transformation):
         self.resolve_masked_stmts(routine, loop_variable=v_index)
 
         # Resolve vector notation, eg. VARIABLE(KIDIA:KFDIA)
-        self.resolve_vector_dimension(routine, loop_variable=v_index, bounds=self.horizontal.bounds)
+        self.resolve_vector_dimension(routine, loop_variable=v_index, bounds=bounds)
 
     def process_driver(self, routine):
         """

--- a/transformations/transformations/single_column_base.py
+++ b/transformations/transformations/single_column_base.py
@@ -10,8 +10,7 @@ from loki.transform import resolve_associates
 from loki import (
     ir, Transformation, FindNodes, Transformer,
     as_tuple, FindExpressions,
-    SymbolAttributes, BasicType, SubstituteExpressions,
-    resolve_typebound_var
+    SymbolAttributes, BasicType, SubstituteExpressions
 )
 
 
@@ -178,8 +177,8 @@ class SCCBaseTransformation(Transformation):
         bounds_str = f'{bounds[0]}:{bounds[1]}'
 
         variable_map = routine.variable_map
-        bounds_v = (resolve_typebound_var(bounds[0], variable_map),
-                    resolve_typebound_var(bounds[1], variable_map))
+        bounds_v = (routine.resolve_typebound_var(bounds[0], variable_map),
+                    routine.resolve_typebound_var(bounds[1], variable_map))
 
         mapper = {}
         for stmt in FindNodes(ir.Assignment).visit(routine.body):

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -376,11 +376,13 @@ class SCCDemoteTransformation(Transformation):
 
         if role == 'kernel':
             demote_locals = self.demote_local_arrays
+            preserve_arrays = []
             if item:
                 demote_locals = item.config.get('demote_locals', self.demote_local_arrays)
-            self.process_kernel(routine, demote_locals=demote_locals)
+                preserve_arrays = item.config.get('preserve_arrays', [])
+            self.process_kernel(routine, demote_locals=demote_locals, preserve_arrays=preserve_arrays)
 
-    def process_kernel(self, routine, demote_locals=True):
+    def process_kernel(self, routine, demote_locals=True, preserve_arrays=None):
         """
         Applies the SCCDemote utilities to a "kernel" and demotes all suitable local arrays.
 
@@ -397,6 +399,10 @@ class SCCDemoteTransformation(Transformation):
         # We do this, because need the section blocks to determine which local arrays
         # may carry buffered values between them, so that we may not demote those!
         to_demote = self.kernel_get_locals_to_demote(routine, sections, self.horizontal)
+
+        # Filter out arrays marked explicitly for preservation
+        if preserve_arrays:
+            to_demote = [v for v in to_demote if not v.name in preserve_arrays]
 
         # Demote all private local variables that do not buffer values between sections
         if demote_locals:

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -304,6 +304,11 @@ class SCCDemoteTransformation(Transformation):
     A set of utilities to determine which local arrays can be safely demoted in a
     :any:`Subroutine` as part of a transformation pass.
 
+    Unless the option `demote_local_arrays` is set to `False`, this transformation will demote
+    local arrays that do not buffer values between vector loops. Specific arrays in individual
+    routines can also be marked for preservation by assigning them to the `preserve_arrays` list
+    in the :any:`SchedulerConfig`.
+
     Parameters
     ----------
     horizontal : :any:`Dimension`

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -331,7 +331,8 @@ class SCCDemoteTransformation(Transformation):
             # Only demote local arrays with the horizontal as fast dimension
             arrays = [v for v in arrays if isinstance(v, sym.Array)]
             arrays = [v for v in arrays if v.name not in argument_names]
-            arrays = [v for v in arrays if v.shape and v.shape[0] == horizontal.size]
+            arrays = [v for v in arrays if v.shape and
+                      v.shape[0] in [horizontal.size, *horizontal._aliases]]
 
             # Also demote arrays whose remaning dimensions are known constants
             arrays = [v for v in arrays if all(is_dimension_constant(d) for d in v.shape[1:])]
@@ -401,4 +402,5 @@ class SCCDemoteTransformation(Transformation):
         if demote_locals:
             variables = tuple(v.name for v in to_demote)
             if variables:
-                demote_variables(routine, variable_names=variables, dimensions=self.horizontal.size)
+                demote_variables(routine, variable_names=variables,
+                                 dimensions=[self.horizontal.size, *self.horizontal._aliases])

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -267,7 +267,7 @@ class SCCRevectorTransformation(Transformation):
         """
 
         variable_map = routine.variable_map
-        bounds = SCCBaseTransformation.check_horizontal_var(routine, horizontal)
+        bounds = SCCBaseTransformation.get_horizontal_loop_bounds(routine, horizontal)
 
         v_start = resolve_typebound_var(bounds[0], variable_map)
         v_end = resolve_typebound_var(bounds[1], variable_map)

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -11,8 +11,7 @@ from loki.expression import symbols as sym
 from loki import (
      Transformation, FindNodes, ir, FindScopes, as_tuple, flatten, Transformer,
      NestedTransformer, FindVariables, demote_variables, is_dimension_constant,
-     is_loki_pragma, dataflow_analysis_attached, BasicType, pragmas_attached,
-     resolve_typebound_var
+     is_loki_pragma, dataflow_analysis_attached, BasicType, pragmas_attached
 )
 from transformations.single_column_base import SCCBaseTransformation
 
@@ -269,8 +268,8 @@ class SCCRevectorTransformation(Transformation):
         variable_map = routine.variable_map
         bounds = SCCBaseTransformation.get_horizontal_loop_bounds(routine, horizontal)
 
-        v_start = resolve_typebound_var(bounds[0], variable_map)
-        v_end = resolve_typebound_var(bounds[1], variable_map)
+        v_start = routine.resolve_typebound_var(bounds[0], variable_map)
+        v_end = routine.resolve_typebound_var(bounds[1], variable_map)
 
         # Create a single loop around the horizontal from a given body
         index = SCCBaseTransformation.get_integer_variable(routine, horizontal.index)

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -11,7 +11,8 @@ from loki.expression import symbols as sym
 from loki import (
      Transformation, FindNodes, ir, FindScopes, as_tuple, flatten, Transformer,
      NestedTransformer, FindVariables, demote_variables, is_dimension_constant,
-     is_loki_pragma, dataflow_analysis_attached, BasicType, pragmas_attached
+     is_loki_pragma, dataflow_analysis_attached, BasicType, pragmas_attached,
+     resolve_typebound_var
 )
 from transformations.single_column_base import SCCBaseTransformation
 
@@ -265,9 +266,13 @@ class SCCRevectorTransformation(Transformation):
             The dimension specifying the horizontal vector dimension
         """
 
+        variable_map = routine.variable_map
+        bounds = SCCBaseTransformation.check_horizontal_var(routine, horizontal)
+
+        v_start = resolve_typebound_var(bounds[0], variable_map)
+        v_end = resolve_typebound_var(bounds[1], variable_map)
+
         # Create a single loop around the horizontal from a given body
-        v_start = routine.variable_map[horizontal.bounds[0]]
-        v_end = routine.variable_map[horizontal.bounds[1]]
         index = SCCBaseTransformation.get_integer_variable(routine, horizontal.index)
         bounds = sym.LoopRange((v_start, v_end))
 


### PR DESCRIPTION
This is the final PR needed to transform the SL. It consists of a series of fixes to the SCC transforms, the biggest of which is the ability to use aliased components of a derived-type as the horizontal loop bounds.

NB: this is stacked on top of #249.