### PR TITLE
Updates for EC-physics regression

### DIFF
--- a/loki/bulk/configure.py
+++ b/loki/bulk/configure.py
@@ -42,6 +42,8 @@ class SchedulerConfig:
         visualisation. These are intended for utility routines that
         pop up in many routines but can be ignored in terms of program
         control flow, like ``flush`` or ``abort``.
+    enable_imports : bool
+￼        Disable the inclusion of module imports as scheduler dependencies.
     transformation_configs : dict
         Dicts with transformation-specific options
     frontend_args : dict
@@ -50,11 +52,12 @@ class SchedulerConfig:
 
     def __init__(
             self, default, routines, disable=None, dimensions=None,
-            transformation_configs=None, frontend_args=None
+            transformation_configs=None, enable_imports=False, frontend_args=None
     ):
         self.default = default
         self.disable = as_tuple(disable)
         self.dimensions = dimensions
+        self.enable_imports = enable_imports
 
         self.routines = CaseInsensitiveDict(routines)
         self.transformation_configs = transformation_configs
@@ -74,8 +77,7 @@ class SchedulerConfig:
         default = config.get('default', {})
         routines = config.get('routines', [])
         disable = default.get('disable', None)
-        if 'imports' in default:
-            warning('The enable_imports option in the scheduler config is deprecated. Imports are always enabled.')
+        enable_imports = default.get('enable_imports', False)
 
         # Add any dimension definitions contained in the config dict
         dimensions = config.get('dimensions', {})
@@ -91,7 +93,8 @@ class SchedulerConfig:
 
         return cls(
             default=default, routines=routines, disable=disable, dimensions=dimensions,
-            transformation_configs=transformation_configs, frontend_args=frontend_args
+            transformation_configs=transformation_configs, frontend_args=frontend_args,
+            enable_imports=enable_imports
         )
 
     @classmethod

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -748,7 +748,8 @@ class SGraph:
         if new_items:
             self.add_nodes(new_items)
 
-        self.add_edges((item, item_) for item_ in dependencies)
+        # Careful not to include cycles (from recursive TypeDefs)
+        self.add_edges((item, item_) for item_ in dependencies if not item == item_)
         return new_items
 
     def _populate(self, seed, item_factory, config):

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -576,7 +576,8 @@ class Scheduler:
         sources_to_remove = []
         sources_to_transform = []
 
-        for item in self.items:
+        # Filter the SGraph to get a pure call-tree
+        for item in SFilter(self.sgraph, item_filter=ProcedureItem):
             if item.is_ignored:
                 continue
 

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -618,7 +618,6 @@ class Scheduler:
                     sources_to_append += [newsource]
                     sources_to_remove += [sourcepath]
 
-        info(f'[Loki] CMakePlanner writing plan: {filepath}')
         with Path(filepath).open('w') as f:
             s_transform = '\n'.join(f'    {s}' for s in sources_to_transform)
             f.write(f'set( LOKI_SOURCES_TO_TRANSFORM \n{s_transform}\n   )\n')

--- a/loki/bulk/scheduler.py
+++ b/loki/bulk/scheduler.py
@@ -250,7 +250,10 @@ class Scheduler:
         :any:`SGraph`
             A dependency graph containing only :any:`FileItem` nodes
         """
-        return self.sgraph.as_filegraph(self.item_factory, self.config)
+        item_filter = None if self.config.enable_imports else ProcedureItem
+        return self.sgraph.as_filegraph(
+            self.item_factory, self.config, item_filter=item_filter
+        )
 
     def __getitem__(self, name):
         """
@@ -273,7 +276,7 @@ class Scheduler:
         # Force the parsing of the routines
         default_frontend_args = self.build_args.copy()
         default_frontend_args['definitions'] = as_tuple(default_frontend_args['definitions']) + self.definitions
-        for item in SFilter(self.sgraph.as_filegraph(self.item_factory, self.config), reverse=True):
+        for item in SFilter(self.file_graph, reverse=True):
             frontend_args = self.config.create_frontend_args(item.name, default_frontend_args)
             item.source.make_complete(**frontend_args)
 
@@ -588,7 +591,8 @@ class Scheduler:
         sources_to_transform = []
 
         # Filter the SGraph to get a pure call-tree
-        for item in SFilter(self.sgraph, item_filter=ProcedureItem):
+        item_filter = None if self.config.enable_imports else ProcedureItem
+        for item in SFilter(self.sgraph, item_filter=item_filter):
             if item.is_ignored:
                 continue
 

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -287,7 +287,7 @@ class ProgramUnit(Scope):
         xmods = frontend_args.get('xmods')
         parser_classes = frontend_args.get('parser_classes', RegexParserClass.AllClasses)
         if frontend == Frontend.REGEX and self._parser_classes:
-            if self._parser_classes & parser_classes:
+            if self._parser_classes == parser_classes:
                 return
             parser_classes = parser_classes | self._parser_classes
 

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -287,7 +287,7 @@ class ProgramUnit(Scope):
         xmods = frontend_args.get('xmods')
         parser_classes = frontend_args.get('parser_classes', RegexParserClass.AllClasses)
         if frontend == Frontend.REGEX and self._parser_classes:
-            if self._parser_classes == parser_classes:
+            if self._parser_classes & parser_classes:
                 return
             parser_classes = parser_classes | self._parser_classes
 

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -22,7 +22,7 @@ from loki.frontend import (
 
 )
 from loki.ir import Section, RawSource, Comment, PreprocessorDirective
-from loki.logging import info, perf
+from loki.logging import info, debug, perf
 from loki.module import Module
 from loki.program_unit import ProgramUnit
 from loki.subroutine import Subroutine
@@ -362,11 +362,12 @@ class Sourcefile:
         if not self._incomplete:
             return
 
+        frontend = frontend_args.pop('frontend', FP)
+
         log = f'[Loki::Sourcefile] Finished constructing from {self.path}' + ' in {:.2f}s'
-        with Timer(logger=info, text=log):
+        with Timer(logger=debug if frontend == REGEX else info, text=log):
 
             # Sanitize frontend_args
-            frontend = frontend_args.pop('frontend', FP)
             if isinstance(frontend, str):
                 frontend = Frontend[frontend.upper()]
             if frontend == REGEX:

--- a/tests/test_cmake.py
+++ b/tests/test_cmake.py
@@ -63,7 +63,7 @@ def fixture_config(here):
     the file path
     """
     default_config = {
-        'default': {'role': 'kernel', 'expand': True, 'strict': True},
+        'default': {'role': 'kernel', 'expand': True, 'strict': True, 'enable_imports': True},
         'routines': {
             'driverB': {'role': 'driver'},
         }

--- a/tests/test_lint/test_linter.py
+++ b/tests/test_lint/test_linter.py
@@ -478,7 +478,8 @@ def test_linter_lint_files_scheduler(here, rules, routines, files):
                 'role': 'kernel',
                 'expand': True,
                 'strict': False,
-                'block': ['compute_l2']
+                'block': ['compute_l2'],
+                'enable_imports': True,
             },
             'routines': routines
         }

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -86,7 +86,8 @@ def fixture_config():
             'role': 'kernel',
             'expand': True,
             'strict': True,
-            'disable': ['abort']
+            'disable': ['abort'],
+            'enable_imports': True,
         },
         'routines': {}
     }
@@ -995,7 +996,9 @@ def test_scheduler_dependencies_ignore(here, preprocess, frontend):
     projB = here/'sources/projB'
 
     configA = SchedulerConfig.from_dict({
-        'default': {'role': 'kernel', 'expand': True, 'strict': True},
+        'default': {
+            'role': 'kernel', 'expand': True, 'strict': True, 'enable_imports': True
+        },
         'routines': {
             'driverB': {'role': 'driver'},
             'kernelB': {'ignore': ['ext_driver']},
@@ -1003,7 +1006,9 @@ def test_scheduler_dependencies_ignore(here, preprocess, frontend):
     })
 
     configB = SchedulerConfig.from_dict({
-        'default': {'role': 'kernel', 'expand': True, 'strict': True},
+        'default': {
+            'role': 'kernel', 'expand': True, 'strict': True, 'enable_imports': True
+        },
         'routines': {
             'ext_driver': {'role': 'kernel'}
         }
@@ -1387,7 +1392,7 @@ def test_scheduler_typebound(here, config, frontend, proj_typebound_dependencies
 
     scheduler = Scheduler(
         paths=proj, seed_routines=['driver'], config=config,
-        full_parse=False, frontend=frontend
+        full_parse=False, frontend=frontend,
     )
 
     assert set(scheduler.items) == set(proj_typebound_dependencies)

--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -37,6 +37,7 @@ def fixture_config():
             'role': 'kernel',
             'expand': True,
             'strict': True,
+            'enable_imports': True,
         },
     }
 

--- a/transformations/tests/test_pool_allocator.py
+++ b/transformations/tests/test_pool_allocator.py
@@ -173,6 +173,7 @@ end module kernel_mod
             'role': 'kernel',
             'expand': True,
             'strict': True,
+            'enable_imports': True,
         },
         'routines': {
             'driver': {'role': 'driver'}
@@ -505,7 +506,8 @@ end module kernel_mod
             'mode': 'idem',
             'role': 'kernel',
             'expand': True,
-            'strict': True
+            'strict': True,
+            'enable_imports': True,
         },
         'routines': {
             'driver': {'role': 'driver'}
@@ -789,7 +791,8 @@ end module kernel_mod
             'mode': 'idem',
             'role': 'kernel',
             'expand': True,
-            'strict': True
+            'strict': True,
+            'enable_imports': True,
         },
         'routines': {
             'driver': {'role': 'driver', 'real_kind': 'jwrb'}
@@ -1020,7 +1023,8 @@ def test_pool_allocator_more_call_checks(frontend, block_dim, caplog):
             'mode': 'idem',
             'role': 'kernel',
             'expand': True,
-            'strict': True
+            'strict': True,
+            'enable_imports': True,
         },
         'routines': {
             'kernel': {}
@@ -1151,7 +1155,8 @@ end module kernel_mod
             'role': 'kernel',
             'expand': True,
             'strict': True,
-            'disable': ['parkind1']
+            'disable': ['parkind1'],
+            'enable_imports': True,
         },
         'routines': {
             'driver': {'role': 'driver'}

--- a/transformations/tests/test_transform_derived_types.py
+++ b/transformations/tests/test_transform_derived_types.py
@@ -33,6 +33,7 @@ def fixture_config():
             'role': 'kernel',
             'expand': True,
             'strict': True,
+            'enable_imports': True,
         },
         'routines': {
             'driver': {


### PR DESCRIPTION
This PR brings in a set of small changes (mostly discussed offline) that aligns the new scheduler with prior behaviour and thus gets EC-physics to pass again (in a reasonable amount of time). The main updates are concerned with the CMake-planning stage, where we need to re-introduce the `enable_imports` option and honour it for default parse traversals, as well as the disabling of the SGraph caching (which otherwise makes things prohibitively slow).

In some more detail:
* Reduce the logging of `make_complete` to only trigger on non-REGEX frontends
* Avoid self-reference cycles when building the SGraph (no longer needed after `ExternalItem` addition, but thought I'd keep it anyways)
* (Temporarily) stop caching the SGraph, and instead re-build it after each use of discovery and item-parsing. Note that this is meant as temporary until we can improve the re-build speed of large graphs via caching.
* Bugfix: Fix the bailout mechanism for parser_classes in `make_complete` with REGEX frontend (as suggested by @reuterbal )
* Re-introduce the `enable_imports` options for the `Scheduler`, which allows us to prune the search tree for EC-physics significantly