### PR TITLE
SingleColumn: Demote arrays that are not used at all in the body

### DIFF
--- a/transformations/tests/test_single_column_coalesced.py
+++ b/transformations/tests/test_single_column_coalesced.py
@@ -242,6 +242,7 @@ def test_scc_demote_transformation(frontend, horizontal):
     REAL :: t(nlon,nz)
     REAL :: a(nlon)
     REAL :: b(nlon,psize)
+    REAL :: unused(nlon)
     INTEGER, PARAMETER :: psize = 3
     INTEGER :: jl, jk
     REAL :: c
@@ -280,6 +281,7 @@ def test_scc_demote_transformation(frontend, horizontal):
     assert isinstance(kernel.variable_map['c'], Scalar)
     assert isinstance(kernel.variable_map['t'], Array)
     assert isinstance(kernel.variable_map['q'], Array)
+    assert isinstance(kernel.variable_map['unused'], Scalar)
 
     # Ensure that parameter-sized array b got demoted only
     assert kernel.variable_map['b'].shape == ((3,) if frontend is OMNI else ('psize',))

--- a/transformations/transformations/single_column_coalesced_vector.py
+++ b/transformations/transformations/single_column_coalesced_vector.py
@@ -333,7 +333,7 @@ class SCCDemoteTransformation(Transformation):
             return arrays
 
         # Create a list of all local horizontal temporary arrays
-        candidates = _get_local_arrays(routine.body)
+        candidates = _get_local_arrays(routine.spec)
 
         # Create an index into all variable uses per vector-level section
         vars_per_section = {s: set(v.name.lower() for v in _get_local_arrays(s)) for s in sections}
@@ -343,8 +343,8 @@ class SCCDemoteTransformation(Transformation):
         for arr in candidates:
             counts[arr] = sum(1 if arr.name.lower() in v else 0 for v in vars_per_section.values())
 
-        # Mark temporaries that are only used in one section for demotion
-        to_demote = [k for k, v in counts.items() if v == 1]
+        # Demote temporaries that are only used in one section or not at all
+        to_demote = [k for k, v in counts.items() if v <= 1]
 
         # Filter out variables that we will pass down the call tree
         calls = FindNodes(ir.CallStatement).visit(routine.body)


### PR DESCRIPTION
Pretty much what it says on the tin: somehow we've missed demoting arrays that are unused in the body but are otherwise perfectly fine to demote in the SCC-family demotion step. This PR fixes this.