### PR TITLE
Scheduler: Fix handling of external module procedures

### DIFF
--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -1123,11 +1123,12 @@ class ItemFactory:
             return self.item_cache[item_name]
 
         item_conf = config.create_item_config(item_name) if config else None
-        if scope_name not in self.item_cache:
+        scope_item = self.item_cache.get(scope_name)
+        if scope_item is None or isinstance(scope_item, ExternalItem):
             warning(f'Module {scope_name} not found in self.item_cache. Marking {item_name} as an external dependency')
             item = ExternalItem(item_name, source=None, config=item_conf, origin_cls=item_cls)
         else:
-            source = self.item_cache[scope_name].source
+            source = scope_item.source
             item = item_cls(item_name, source=source, config=item_conf)
         self.item_cache[item_name] = item
         return item

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -386,8 +386,8 @@ class ModulePattern(Pattern):
             r'^module[ \t]+(?P<name>\w+)\b.*?$'
             r'(?P<spec>.*?)'
             r'(?P<contains>^contains\n(?:'
-            r'(?:[ \t\w()]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
-            r'(?:[ \t\w()]*?function.*?^end[ \t]*function\b(?:[ \t]\w+)?\n)|'
+            r'(?:[ \t\w()=]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
+            r'(?:[ \t\w()=]*?function.*?^end[ \t]*function\b(?:[ \t]\w+)?\n)|'
             r'(?:^#\w+.*?\n)'
             r')*)?'
             r'^end[ \t]*module\b(?:[ \t](?P=name))?',

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -471,8 +471,9 @@ def test_regex_module_from_source():
     """
     fcode = """
 module some_module
-    implicit none
     use foobar
+    implicit none
+    integer, parameter :: k = selected_int_kind(5)
 contains
     subroutine module_routine
         integer m
@@ -481,9 +482,9 @@ contains
         call routine_b(m, 6)
     end subroutine module_routine
 
-    function module_function(n)
+    integer(kind=k) function module_function(n)
         integer n
-        n = 3
+        module_function = n + 2
     end function module_function
 end module some_module
     """.strip()


### PR DESCRIPTION
Procedures in missing modules (that are recognized as ExternalItem) were not recognized as ExternalItems and instead created as ProcedureItem with missing source. This fixes that erroneous behaviour.