### PR TITLE
Skip driver routine in `GlobalVariableAnalysis`

### DIFF
--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -421,21 +421,12 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
                 ('rdata(:, :, :)', 'global_var_analysis_data_mod'), ('tt', 'global_var_analysis_data_mod'),
                 ('tt%vals', 'global_var_analysis_data_mod'), (f'iarr({nfld_dim})', 'global_var_analysis_header_mod')
             }
-        },
-        '#driver': {
-            'defines_symbols': {('rdata(:, :, :)', 'global_var_analysis_data_mod')},
-            'uses_symbols': nval_data | nfld_data | {
-                ('rdata(:, :, :)', 'global_var_analysis_data_mod'),
-                ('tt', 'global_var_analysis_data_mod'), ('tt%vals', 'global_var_analysis_data_mod'),
-                (f'iarr({nfld_dim})', 'global_var_analysis_header_mod'),
-                (f'rarr({nval_dim}, {nfld_dim})', 'global_var_analysis_header_mod')
-            }
         }
     }
 
-    assert set(scheduler.items) == set(expected_trafo_data) | {'global_var_analysis_data_mod#some_type'}
+    assert set(scheduler.items) == set(expected_trafo_data) | {'global_var_analysis_data_mod#some_type', '#driver'}
     for item in scheduler.items:
-        if item == 'global_var_analysis_data_mod#some_type':
+        if item == 'global_var_analysis_data_mod#some_type' or item.config['role'] == 'driver':
             continue
         for trafo_data_key, trafo_data_value in item.trafo_data[key].items():
             assert (

--- a/transformations/tests/test_data_offload.py
+++ b/transformations/tests/test_data_offload.py
@@ -421,12 +421,21 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
                 ('rdata(:, :, :)', 'global_var_analysis_data_mod'), ('tt', 'global_var_analysis_data_mod'),
                 ('tt%vals', 'global_var_analysis_data_mod'), (f'iarr({nfld_dim})', 'global_var_analysis_header_mod')
             }
+        },
+        '#driver': {
+            'defines_symbols': {('rdata(:, :, :)', 'global_var_analysis_data_mod')},
+            'uses_symbols': nval_data | nfld_data | {
+                ('rdata(:, :, :)', 'global_var_analysis_data_mod'),
+                ('tt', 'global_var_analysis_data_mod'), ('tt%vals', 'global_var_analysis_data_mod'),
+                (f'iarr({nfld_dim})', 'global_var_analysis_header_mod'),
+                (f'rarr({nval_dim}, {nfld_dim})', 'global_var_analysis_header_mod')
+            }
         }
     }
 
-    assert set(scheduler.items) == set(expected_trafo_data) | {'global_var_analysis_data_mod#some_type', '#driver'}
+    assert set(scheduler.items) == set(expected_trafo_data) | {'global_var_analysis_data_mod#some_type'}
     for item in scheduler.items:
-        if item == 'global_var_analysis_data_mod#some_type' or item.config['role'] == 'driver':
+        if item == 'global_var_analysis_data_mod#some_type':
             continue
         for trafo_data_key, trafo_data_value in item.trafo_data[key].items():
             assert (

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -274,9 +274,6 @@ class GlobalVariableAnalysis(Transformation):
         if 'successors' not in kwargs:
             raise RuntimeError('Cannot apply GlobalVariableAnalysis without successors to store offload analysis data')
 
-        if kwargs['role'] == 'driver':
-            return
-
         item = kwargs['item']
         successors = kwargs['successors']
 

--- a/transformations/transformations/data_offload.py
+++ b/transformations/transformations/data_offload.py
@@ -274,6 +274,9 @@ class GlobalVariableAnalysis(Transformation):
         if 'successors' not in kwargs:
             raise RuntimeError('Cannot apply GlobalVariableAnalysis without successors to store offload analysis data')
 
+        if kwargs['role'] == 'driver':
+            return
+
         item = kwargs['item']
         successors = kwargs['successors']
 


### PR DESCRIPTION
Global variables imported at the driver layer passed down to the compute kernel as a subroutine argument should not be included in the `GlobalVariableAnalysis`. Rather, they should be handled via the `DataOffloadTransformation`.