### PR TITLE
improved `replace_intrinsics` and added `rename_variables`

### DIFF
--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -142,8 +142,12 @@ class ExpressionFinder(Visitor):
         expressions = ()
         for v in o.symbols:
             if v.type.initial is not None:
-                expressions += (self.retrieve(v.type.initial),)
-        return self._return(o, expressions)
+                retrieved = self.retrieve(v.type.initial)
+                if retrieved:
+                    expressions += as_tuple(retrieved)
+        if expressions:
+            return self._return(o, expressions)
+        return super().visit(o.children, **kwargs)
 
 
 class FindExpressions(ExpressionFinder):

--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -138,6 +138,13 @@ class ExpressionFinder(Visitor):
         """
         return self._return(o, ())
 
+    def visit_VariableDeclaration(self, o, **kwargs):
+        expressions = ()
+        for v in o.symbols:
+            if v.type.initial is not None:
+                expressions += (self.retrieve(v.type.initial),)
+        return self._return(o, expressions)
+
 
 class FindExpressions(ExpressionFinder):
     """

--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -139,15 +139,11 @@ class ExpressionFinder(Visitor):
         return self._return(o, ())
 
     def visit_VariableDeclaration(self, o, **kwargs):
-        expressions = ()
+        expressions = as_tuple(super().visit(o.children, **kwargs))
         for v in o.symbols:
             if v.type.initial is not None:
-                retrieved = self.retrieve(v.type.initial)
-                if retrieved:
-                    expressions += as_tuple(retrieved)
-        if expressions:
-            return self._return(o, expressions)
-        return super().visit(o.children, **kwargs)
+                expressions += as_tuple(self.retrieve(v.type.initial))
+        return self._return(o, expressions)
 
 
 class FindExpressions(ExpressionFinder):

--- a/loki/transform/transform_utilities.py
+++ b/loki/transform/transform_utilities.py
@@ -28,7 +28,7 @@ from loki.types import SymbolAttributes, BasicType, DerivedType, ProcedureType
 
 
 __all__ = [
-    'convert_to_lower_case', 'replace_intrinsics', 'sanitise_imports',
+    'convert_to_lower_case', 'replace_intrinsics', 'rename_variables', 'sanitise_imports',
     'replace_selected_kind', 'single_variable_declaration', 'recursive_expression_map_update'
 ]
 
@@ -132,7 +132,17 @@ def replace_intrinsics(routine, function_map=None, symbol_map=None, case_sensiti
     if not case_sensitive:
         symbol_map = CaseInsensitiveDict(symbol_map)
         function_map = CaseInsensitiveDict(function_map)
-
+    # intrinsic symbols
+    var_map = {}
+    for var in FindVariables(unique=False).visit(routine.ir):
+        if var.name in symbol_map:
+            new_var = symbol_map[var.name]
+            if new_var is not None:
+                var_map[var] = var.clone(name=symbol_map[var.name])
+    if var_map:
+        routine.spec = SubstituteExpressions(var_map).visit(routine.spec)
+        routine.body = SubstituteExpressions(var_map).visit(routine.body)
+    # (intrinsic) functions
     callmap = {}
     for call in FindInlineCalls(unique=False).visit(routine.ir):
         if call.name in symbol_map:
@@ -144,6 +154,36 @@ def replace_intrinsics(routine, function_map=None, symbol_map=None, case_sensiti
     routine.spec = SubstituteExpressions(callmap).visit(routine.spec)
     routine.body = SubstituteExpressions(callmap).visit(routine.body)
 
+def rename_variables(routine, symbol_map=None):
+    """
+    Replace symbols/variables including (routine) arguments.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine object in which to replace intrinsic calls
+    symbol_map : dict[str, str]
+        Mapping from symbol/variable names to their replacement
+    """
+    symbol_map = CaseInsensitiveDict(symbol_map) or {}
+    # rename arguments if necessary
+    arguments = ()
+    for arg in routine.arguments:
+        if arg.name in symbol_map:
+            arguments += (arg.clone(name=symbol_map[arg.name]),)
+        else:
+            arguments += (arg,)
+    routine.arguments = arguments
+    # rename variable declarations and usages
+    var_map = {}
+    for var in FindVariables(unique=False).visit(routine.ir):
+        if var.name in symbol_map:
+            new_var = symbol_map[var.name]
+            if new_var is not None:
+                var_map[var] = var.clone(name=symbol_map[var.name])
+    if var_map:
+        routine.spec = SubstituteExpressions(var_map).visit(routine.spec)
+        routine.body = SubstituteExpressions(var_map).visit(routine.body)
 
 def used_names_from_symbol(symbol, modifier=str.lower):
     """

--- a/loki/transform/transform_utilities.py
+++ b/loki/transform/transform_utilities.py
@@ -132,16 +132,6 @@ def replace_intrinsics(routine, function_map=None, symbol_map=None, case_sensiti
     if not case_sensitive:
         symbol_map = CaseInsensitiveDict(symbol_map)
         function_map = CaseInsensitiveDict(function_map)
-    # intrinsic symbols
-    var_map = {}
-    for var in FindVariables(unique=False).visit(routine.ir):
-        if var.name in symbol_map:
-            new_var = symbol_map[var.name]
-            if new_var is not None:
-                var_map[var] = var.clone(name=symbol_map[var.name])
-    if var_map:
-        routine.spec = SubstituteExpressions(var_map).visit(routine.spec)
-        routine.body = SubstituteExpressions(var_map).visit(routine.body)
     # (intrinsic) functions
     callmap = {}
     for call in FindInlineCalls(unique=False).visit(routine.ir):

--- a/tests/test_subroutine.py
+++ b/tests/test_subroutine.py
@@ -525,7 +525,7 @@ end subroutine routine_dim_shapes
                       ['(v1,)', '(1:v1, 1:v2)', '(1:v1, 1:v2 - 1)'])
 
     # Ensure that all spec variables (including dimension symbols) are scoped correctly
-    spec_vars = FindVariables(unique=False).visit(routine.spec)
+    spec_vars = [v for v in FindVariables(unique=False).visit(routine.spec) if v.name.lower() != 'selected_real_kind']
     assert all(v.scope == routine for v in spec_vars)
     assert all(isinstance(v, (Scalar, Array)) for v in spec_vars)
 
@@ -1343,6 +1343,8 @@ end subroutine test_subroutine_rescope
         if var.name == 'ext1':
             assert var.scope is routine
         else:
+            if var.name.lower() == 'selected_int_kind':
+                continue
             assert var.scope is nested_routine
 
     # Make sure the KIND parameter symbol in the variable's type is also correctly rescoped

--- a/tests/test_transform_utilities.py
+++ b/tests/test_transform_utilities.py
@@ -201,7 +201,7 @@ def test_tranform_utilites_replace_intrinsics(frontend):
 subroutine replace_intrinsics()
     implicit none
     real :: a, b, eps
-    real, parameter :: param = min(0.1, epsilon*1000.)
+    real, parameter :: param = min(0.1, epsilon(param)*1000.)
 
     eps = param * 10.
     eps = 0.1


### PR DESCRIPTION
`replace_intrinsics()` wasn't working properly, especially for used symbols/functions within the `routine.spec` e.g., for initialising parameters ...

`rename_variables()` as additional utility to rename variables/arguments e.g. `const` within ecwam ...