### PR TITLE
SCCHoist: hoist inline call temporaries and don't hoist statically declared arrays

### DIFF
--- a/loki/transform/transform_hoist_variables.py
+++ b/loki/transform/transform_hoist_variables.py
@@ -364,9 +364,9 @@ class HoistVariablesTransformation(Transformation):
         """
 
         if self.as_kwarguments:
-            new_args = dict((a.name, v.clone(dimensions=None)) for (a, v) in variables)
-            _call_clone = call.clone(kwparameters=call.kw_parameters)
-            _call_clone.kw_parameters.update(new_args)
+            kw_params = call.kw_parameters
+            kw_params.update(dict((a.name, v.clone(dimensions=None)) for (a, v) in variables))
+            _call_clone = call.clone(kw_parameters=kw_params)
             vmap = {call: _call_clone}
         else:
             new_args = tuple(v.clone(dimensions=None) for v in variables)

--- a/loki/transform/transform_hoist_variables.py
+++ b/loki/transform/transform_hoist_variables.py
@@ -87,6 +87,7 @@ from loki.tools.util import is_iterable, as_tuple, CaseInsensitiveDict
 from loki.transform.transformation import Transformation
 from loki.transform.transform_utilities import single_variable_declaration
 from loki.batch.item import ProcedureItem
+from loki.expression.expr_visitors import FindInlineCalls
 import loki.expression.symbols as sym
 
 
@@ -141,6 +142,7 @@ class HoistVariablesAnalysis(Transformation):
             item.trafo_data[self._key]["hoist_variables"] = []
 
         calls = FindNodes(CallStatement).visit(routine.body)
+        calls += FindInlineCalls().visit(routine.body)
         call_map = CaseInsensitiveDict((str(call.name), call) for call in calls)
 
         for child in successors:
@@ -240,7 +242,7 @@ class HoistVariablesTransformation(Transformation):
             routine.arguments += hoisted_temporaries
 
         call_map = {}
-        for call in FindNodes(CallStatement).visit(routine.body):
+        for call in FindNodes(CallStatement).visit(routine.body) + list(FindInlineCalls().visit(routine.body)):
             # Only process calls in this call tree
             if str(call.name) not in successor_map:
                 continue
@@ -257,9 +259,14 @@ class HoistVariablesTransformation(Transformation):
                     routine=routine, call=call, variables=hoisted_variables
                 )
             elif role == "kernel":
-                call_map[call] = self.kernel_call_argument_remapping(
-                    routine=routine, call=call, variables=hoisted_variables
-                )
+                if isinstance(call, CallStatement):
+                    call_map[call] = self.kernel_call_argument_remapping(
+                        routine=routine, call=call, variables=hoisted_variables
+                    )
+                else:
+                    self.kernel_inline_call_argument_remapping(
+                        routine=routine, call=call, variables=hoisted_variables
+                    )
 
         routine.body = Transformer(call_map).visit(routine.body)
 
@@ -341,6 +348,30 @@ class HoistVariablesTransformation(Transformation):
         new_args = tuple(v.clone(dimensions=None) for v in variables)
         return call.clone(arguments=call.arguments + new_args)
 
+    def kernel_inline_call_argument_remapping(self, routine, call, variables):
+        """
+        Append hoisted temporaries to inline function call arguments.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The subroutine to add the variable declaration to.
+        call : :any:`InlineCall`
+            ProcedureSymbol to which hoisted variables will be added.
+        variables : tuple of :any:`Variable`
+            The tuple of variables to be declared.
+        """
+
+        if self.as_kwarguments:
+            new_args = dict((a.name, v.clone(dimensions=None)) for (a, v) in variables)
+            _call_clone = call.clone(kwparameters=call.kw_parameters)
+            _call_clone.kw_parameters.update(new_args)
+            vmap = {call: _call_clone}
+            routine.body = SubstituteExpressions(vmap).visit(routine.body)
+        else:
+            new_args = tuple(v.clone(dimensions=None) for v in variables)
+            vmap = {call: call.clone(parameters=call.parameters + new_args)}
+            routine.body = SubstituteExpressions(vmap).visit(routine.body)
 
 class HoistTemporaryArraysAnalysis(HoistVariablesAnalysis):
     """
@@ -382,10 +413,16 @@ class HoistTemporaryArraysAnalysis(HoistVariablesAnalysis):
         routine : :any:`Subroutine`
             The subroutine find the variables.
         """
+
+        # Determine function result variable name
+        if not (result_name := routine.result_name):
+            result_name = routine.name
+
         return [var for var in routine.variables
                 if var not in routine.arguments    # local variable
                 and not var.type.parameter         # not a parameter
                 and isinstance(var, sym.Array)     # is an array
+                and not var.name.lower() == result_name.lower()
                 and (self.dim_vars is None         # if dim_vars not empty check if at least one dim is within dim_vars
                      or any(dim_var in self.dim_vars for dim_var in FindVariables().visit(var.dimensions)))]
 

--- a/loki/transform/transform_hoist_variables.py
+++ b/loki/transform/transform_hoist_variables.py
@@ -368,11 +368,11 @@ class HoistVariablesTransformation(Transformation):
             _call_clone = call.clone(kwparameters=call.kw_parameters)
             _call_clone.kw_parameters.update(new_args)
             vmap = {call: _call_clone}
-            routine.body = SubstituteExpressions(vmap).visit(routine.body)
         else:
             new_args = tuple(v.clone(dimensions=None) for v in variables)
             vmap = {call: call.clone(parameters=call.parameters + new_args)}
-            routine.body = SubstituteExpressions(vmap).visit(routine.body)
+
+        routine.body = SubstituteExpressions(vmap).visit(routine.body)
 
 class HoistTemporaryArraysAnalysis(HoistVariablesAnalysis):
     """

--- a/tests/sources/projHoist/module/driver_inline_mod.f90
+++ b/tests/sources/projHoist/module/driver_inline_mod.f90
@@ -1,0 +1,18 @@
+module transformation_module_hoist_inline
+    USE subroutines_inline_mod, only: kernel1, kernel2
+    implicit none
+    integer, parameter :: len = 3
+contains
+
+    subroutine inline_driver(a, b, c)
+        integer, intent(in) :: a
+        integer, intent(inout) :: b(a)
+        integer, intent(inout) :: c(a, len)
+        real :: x, y
+        call kernel1(a, b, c)
+        call kernel2(a, b)
+        call kernel1(a, b, c)
+    end subroutine inline_driver
+
+end module transformation_module_hoist_inline
+

--- a/tests/sources/projHoist/module/subroutines_inline_mod.f90
+++ b/tests/sources/projHoist/module/subroutines_inline_mod.f90
@@ -57,7 +57,7 @@ contains
         integer, intent(inout) :: b(a2)
         real, intent(inout) :: x(a2)
         integer z(a2)
-        integer :: d2_tmp(len)
+        integer :: d2_tmp(len,len)
         z = init_int(a2)
         b = z
     end subroutine device2

--- a/tests/sources/projHoist/module/subroutines_inline_mod.f90
+++ b/tests/sources/projHoist/module/subroutines_inline_mod.f90
@@ -1,0 +1,66 @@
+module subroutines_inline_mod
+    implicit none
+    integer, parameter :: len = 3
+contains
+
+    function func1(a)
+        integer, intent(in) :: a
+        integer :: func1(a)
+
+        func1 = 1
+    end function func1
+
+    subroutine kernel1(a, b, c)
+        integer, intent(in) :: a
+        integer, intent(inout) :: b(a)
+        integer, intent(inout) :: c(a, len)
+        real :: x(a)
+        integer :: y(a, len)
+        real :: k1_tmp(a, len)
+        y = 11
+        c = y
+        x = func1(a)
+    end subroutine kernel1
+
+    subroutine kernel2(a1, b)
+        integer, intent(in) :: a1
+        integer, intent(inout) :: b(a1)
+        real :: x(a1)
+        real :: y, z
+        real :: k2_tmp(a1, a1)
+        call device1(a1, b, x, k2_tmp)
+        call device2(a1, b, x)
+    end subroutine kernel2
+
+    subroutine device1(a1, b, x, y)
+        integer, intent(in) :: a1
+        integer, intent(inout) :: b(a1)
+        real, intent(inout) :: x(a1)
+        real, intent(inout) :: y(a1, a1)
+        real :: z
+        integer :: d1_tmp
+        call device2(a1, b, x)
+        call device2(a1, b, x)
+    end subroutine device1
+
+    function init_int(a2) result(TMP)
+        integer, intent(in) :: a2
+        integer :: tmp(a2)
+        integer :: tmp0(a2)
+
+        tmp0 = 42
+        tmp = tmp0
+    end function init_int
+
+    subroutine device2(a2, b, x)
+        integer, intent(in) :: a2
+        integer, intent(inout) :: b(a2)
+        real, intent(inout) :: x(a2)
+        integer z(a2)
+        integer :: d2_tmp(len)
+        z = init_int(a2)
+        b = z
+    end subroutine device2
+
+end module subroutines_inline_mod
+

--- a/tests/test_transform_hoist_variables.py
+++ b/tests/test_transform_hoist_variables.py
@@ -283,9 +283,9 @@ def test_hoist_arrays_inline(here, frontend, config, as_kwarguments):
     subroutine_arguments = {
         "inline_driver": ['a', 'b', 'c'],
         "kernel1": ['a', 'b', 'c', 'x', 'y', 'k1_tmp'],
-        "kernel2": ['a1', 'b', 'x', 'k2_tmp', 'device2_z', 'device2_d2_tmp', 'init_int_tmp0'],
-        "device1": ['a1', 'b', 'x', 'y', 'device2_z', 'device2_d2_tmp', 'init_int_tmp0'],
-        "device2": ['a2', 'b', 'x', 'z', 'd2_tmp', 'init_int_tmp0'],
+        "kernel2": ['a1', 'b', 'x', 'k2_tmp', 'device2_z', 'init_int_tmp0'],
+        "device1": ['a1', 'b', 'x', 'y', 'device2_z', 'init_int_tmp0'],
+        "device2": ['a2', 'b', 'x', 'z', 'init_int_tmp0'],
         "init_int": ['a2', 'tmp0'],
         "func1": ['a']
     }
@@ -300,20 +300,17 @@ def test_hoist_arrays_inline(here, frontend, config, as_kwarguments):
     }
     if not as_kwarguments:
         call_arguments["kernel1"] += ('kernel1_x', 'kernel1_y', 'kernel1_k1_tmp')
-        call_arguments["kernel2"] += ('kernel2_x', 'kernel2_k2_tmp', 'device2_z', 'device2_d2_tmp', 'init_int_tmp0')
-        call_arguments["device1"] += ('device2_z', 'device2_d2_tmp', 'init_int_tmp0')
-        call_arguments["device2"] += ('device2_z', 'device2_d2_tmp', 'init_int_tmp0')
+        call_arguments["kernel2"] += ('kernel2_x', 'kernel2_k2_tmp', 'device2_z', 'init_int_tmp0')
+        call_arguments["device1"] += ('device2_z', 'init_int_tmp0')
+        call_arguments["device2"] += ('device2_z', 'init_int_tmp0')
         call_arguments["init_int"] += ('tmp0',)
 
     call_kwarguments = {
         "kernel1": (('x', 'kernel1_x'), ('y', 'kernel1_y'), ('k1_tmp', 'kernel1_k1_tmp')) if as_kwarguments else (),
         "kernel2": (('x', 'kernel2_x'), ('k2_tmp', 'kernel2_k2_tmp'),
-            ('device2_z', 'device2_z'), ('device2_d2_tmp', 'device2_d2_tmp'), ('init_int_tmp0', 'init_int_tmp0'))
-            if as_kwarguments else (),
-        "device1": (('device2_z', 'device2_z'), ('device2_d2_tmp', 'device2_d2_tmp'),
-                    ('init_int_tmp0', 'init_int_tmp0')) if as_kwarguments else (),
-        "device2": (('z', 'device2_z'), ('d2_tmp', 'device2_d2_tmp'), ('init_int_tmp0', 'init_int_tmp0'))
-                   if as_kwarguments else (),
+            ('device2_z', 'device2_z'), ('init_int_tmp0', 'init_int_tmp0')) if as_kwarguments else (),
+        "device1": (('device2_z', 'device2_z'), ('init_int_tmp0', 'init_int_tmp0')) if as_kwarguments else (),
+        "device2": (('z', 'device2_z'), ('init_int_tmp0', 'init_int_tmp0')) if as_kwarguments else (),
         "init_int": (('init_int_tmp0', 'init_int_tmp0'),) if as_kwarguments else ()
     }
 
@@ -346,9 +343,9 @@ def test_hoist_arrays(here, frontend, config, as_kwarguments):
         "driver": ['a', 'b', 'c'],
         "another_driver": ['a', 'b', 'c'],
         "kernel1": ['a', 'b', 'c', 'x', 'y', 'k1_tmp'],
-        "kernel2": ['a1', 'b', 'x', 'k2_tmp', 'device2_z', 'device2_d2_tmp'],
-        "device1": ['a1', 'b', 'x', 'y', 'device2_z', 'device2_d2_tmp'],
-        "device2": ['a2', 'b', 'x', 'z', 'd2_tmp'],
+        "kernel2": ['a1', 'b', 'x', 'k2_tmp', 'device2_z'],
+        "device1": ['a1', 'b', 'x', 'y', 'device2_z'],
+        "device2": ['a2', 'b', 'x', 'z'],
     }
 
     call_arguments = {
@@ -359,16 +356,16 @@ def test_hoist_arrays(here, frontend, config, as_kwarguments):
     }
     if not as_kwarguments:
         call_arguments["kernel1"] += ('kernel1_x', 'kernel1_y', 'kernel1_k1_tmp')
-        call_arguments["kernel2"] += ('kernel2_x', 'kernel2_k2_tmp', 'device2_z', 'device2_d2_tmp')
-        call_arguments["device1"] += ('device2_z', 'device2_d2_tmp')
-        call_arguments["device2"] += ('device2_z', 'device2_d2_tmp')
+        call_arguments["kernel2"] += ('kernel2_x', 'kernel2_k2_tmp', 'device2_z')
+        call_arguments["device1"] += ('device2_z',)
+        call_arguments["device2"] += ('device2_z',)
 
     call_kwarguments = {
         "kernel1": (('x', 'kernel1_x'), ('y', 'kernel1_y'), ('k1_tmp', 'kernel1_k1_tmp')) if as_kwarguments else (),
         "kernel2": (('x', 'kernel2_x'), ('k2_tmp', 'kernel2_k2_tmp'),
-            ('device2_z', 'device2_z'), ('device2_d2_tmp', 'device2_d2_tmp')) if as_kwarguments else (),
-        "device1": (('device2_z', 'device2_z'), ('device2_d2_tmp', 'device2_d2_tmp')) if as_kwarguments else (),
-        "device2": (('z', 'device2_z'), ('d2_tmp', 'device2_d2_tmp')) if as_kwarguments else ()
+            ('device2_z', 'device2_z')) if as_kwarguments else (),
+        "device1": (('device2_z', 'device2_z'), ) if as_kwarguments else (),
+        "device2": (('z', 'device2_z'), ) if as_kwarguments else ()
     }
 
     check_arguments(scheduler=scheduler, subroutine_arguments=subroutine_arguments, call_arguments=call_arguments,

--- a/tests/test_transform_hoist_variables.py
+++ b/tests/test_transform_hoist_variables.py
@@ -47,28 +47,36 @@ def fixture_config():
                 'role': 'driver',
                 'expand': True,
             },
+            'inline_driver': {
+                'role': 'driver',
+                'expand': True,
+            },
         }
     }
 
 
-def compile_and_test(scheduler, here, a=(5,), frontend="",  test_name=""):
+def compile_and_test(scheduler, here, a=(5,), frontend="",  test_name="", items=None, inline=False):
     """
     Compile the source code and call the driver function in order to test the results for correctness.
     """
     assert is_iterable(a) and all(isinstance(_a, int) for _a in a)
-    items = [scheduler["transformation_module_hoist#driver"], scheduler["subroutines_mod#kernel1"]]
+    if not items:
+        items = [scheduler["transformation_module_hoist#driver"], scheduler["subroutines_mod#kernel1"]]
     for item in items:
         suffix = '.F90'
         item.source.path = here / 'build' / Path(f"{item.source.path.stem}").with_suffix(suffix=suffix)
     libname = f'lib_{test_name}_{frontend}'
     builder = Builder(source_dirs=here/'build', build_dir=here/'build')
     lib = jit_compile_lib([item.source for item in items], path=here/'build', name=libname, builder=builder)
-    item = scheduler["transformation_module_hoist#driver"]
+    item = items[0]
     for _a in a:
         parameter_length = 3
         b = np.zeros((_a,), dtype=np.int32, order='F')
         c = np.zeros((_a, parameter_length), dtype=np.int32, order='F')
-        lib.Transformation_Module_Hoist.driver(_a, b, c)
+        if inline:
+            lib.Transformation_Module_Hoist_Inline.inline_driver(_a, b, c)
+        else:
+            lib.Transformation_Module_Hoist.driver(_a, b, c)
         assert (b == 42).all()
         assert (c == 11).all()
     builder.clean()
@@ -77,14 +85,20 @@ def compile_and_test(scheduler, here, a=(5,), frontend="",  test_name=""):
     clean_test(filepath=here.parent / item.source.path.with_suffix(suffix).name)
 
 
-def check_arguments(scheduler, subroutine_arguments, call_arguments, call_kwarguments, include_device_functions=False):
+def check_arguments(scheduler, subroutine_arguments, call_arguments, call_kwarguments, driver_item=None,
+                    driver_name=None, include_device_functions=False, include_another_driver=True,
+                    subroutine_mod=None):
     """
     Check the subroutine and call arguments of each subroutine.
     """
     # driver
-    item = scheduler['transformation_module_hoist#driver']
-    assert [arg.name for arg in item.ir.arguments] == subroutine_arguments["driver"]
-    for call in FindNodes(ir.CallStatement).visit(item.ir.body):
+    if not driver_item:
+        driver_item = scheduler['transformation_module_hoist#driver']
+    if not driver_name:
+        driver_name = "driver"
+
+    assert [arg.name for arg in driver_item.ir.arguments] == subroutine_arguments[driver_name]
+    for call in FindNodes(ir.CallStatement).visit(driver_item.ir.body):
         if "kernel1" in call.name:
             assert call.arguments == call_arguments["kernel1"]
             assert call.kwarguments == call_kwarguments["kernel1"]
@@ -92,17 +106,21 @@ def check_arguments(scheduler, subroutine_arguments, call_arguments, call_kwargu
             assert call.arguments == call_arguments["kernel2"]
             assert call.kwarguments == call_kwarguments["kernel2"]
     # another driver
-    item = scheduler['transformation_module_hoist#another_driver']
-    assert [arg.name for arg in item.ir.arguments] == subroutine_arguments["another_driver"]
-    for call in FindNodes(ir.CallStatement).visit(item.ir.body):
-        if "kernel1" in call.name:
-            assert call.arguments == call_arguments["kernel1"]
-            assert call.kwarguments == call_kwarguments["kernel1"]
+    if include_another_driver:
+        item = scheduler['transformation_module_hoist#another_driver']
+        assert [arg.name for arg in item.ir.arguments] == subroutine_arguments["another_driver"]
+        for call in FindNodes(ir.CallStatement).visit(item.ir.body):
+            if "kernel1" in call.name:
+                assert call.arguments == call_arguments["kernel1"]
+                assert call.kwarguments == call_kwarguments["kernel1"]
     # kernel 1
-    item = scheduler['subroutines_mod#kernel1']
+    if not subroutine_mod:
+        subroutine_mod = 'subroutines_mod'
+
+    item = scheduler[subroutine_mod + '#kernel1']
     assert [arg.name for arg in item.ir.arguments] == subroutine_arguments["kernel1"]
     # kernel 2
-    item = scheduler['subroutines_mod#kernel2']
+    item = scheduler[subroutine_mod + '#kernel2']
     assert [arg.name for arg in item.ir.arguments] == subroutine_arguments["kernel2"]
     for call in FindNodes(ir.CallStatement).visit(item.ir.body):
         if "device1" in call.name:
@@ -113,14 +131,14 @@ def check_arguments(scheduler, subroutine_arguments, call_arguments, call_kwargu
             assert call.kwarguments == call_kwarguments["device2"]
     if include_device_functions:
         # device 1
-        item = scheduler['subroutines_mod#device1']
+        item = scheduler[subroutine_mod + '#device1']
         assert [arg.name for arg in item.ir.arguments] == subroutine_arguments["device1"]
         for call in FindNodes(ir.CallStatement).visit(item.ir.body):
             if "device2" in call.name:
                 assert call.arguments == call_arguments["device2"]
                 assert call.kwarguments == call_kwarguments["device2"]
         # device 2
-        item = scheduler['subroutines_mod#device2']
+        item = scheduler[subroutine_mod + '#device2']
         assert [arg.name for arg in item.ir.arguments] == subroutine_arguments["device2"]
 
 
@@ -219,7 +237,7 @@ def test_hoist_disable(here, frontend, config, as_kwarguments):
 
     call_arguments = {
         "kernel1": ('a', 'b', 'c'),
-        "kernel2": ('a', 'b'), 
+        "kernel2": ('a', 'b'),
         "device1": ('a1', 'b', 'x', 'k2_tmp'),
         "device2": ('a1', 'b', 'x')
     }
@@ -245,6 +263,67 @@ def test_hoist_disable(here, frontend, config, as_kwarguments):
         frontend=frontend, test_name="all_hoisted_disable"
     )
 
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('as_kwarguments', [False, True])
+def test_hoist_arrays_inline(here, frontend, config, as_kwarguments):
+    """
+    Testing hoist functionality for local arrays using the :class:`HoistTemporaryArraysAnalysis` for the *Analysis*
+    part. The hoisted kernel contains inline function calls.
+    """
+
+    proj = here/'sources/projHoist'
+    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['inline_driver',], frontend=frontend)
+
+    # Transformation: Analysis
+    scheduler.process(transformation=HoistTemporaryArraysAnalysis())
+    # Transformation: Synthesis
+    scheduler.process(transformation=HoistVariablesTransformation(as_kwarguments=as_kwarguments))
+
+    # check generated source code
+    subroutine_arguments = {
+        "inline_driver": ['a', 'b', 'c'],
+        "kernel1": ['a', 'b', 'c', 'x', 'y', 'k1_tmp'],
+        "kernel2": ['a1', 'b', 'x', 'k2_tmp', 'device2_z', 'device2_d2_tmp', 'init_int_tmp0'],
+        "device1": ['a1', 'b', 'x', 'y', 'device2_z', 'device2_d2_tmp', 'init_int_tmp0'],
+        "device2": ['a2', 'b', 'x', 'z', 'd2_tmp', 'init_int_tmp0'],
+        "init_int": ['a2', 'tmp0'],
+        "func1": ['a']
+    }
+
+    call_arguments = {
+        "kernel1": ('a', 'b', 'c'),
+        "kernel2": ('a', 'b'),
+        "device1": ('a1', 'b', 'x', 'k2_tmp'),
+        "device2": ('a1', 'b', 'x'),
+        "init_int": ('a2',),
+        "func1": ('a',)
+    }
+    if not as_kwarguments:
+        call_arguments["kernel1"] += ('kernel1_x', 'kernel1_y', 'kernel1_k1_tmp')
+        call_arguments["kernel2"] += ('kernel2_x', 'kernel2_k2_tmp', 'device2_z', 'device2_d2_tmp', 'init_int_tmp0')
+        call_arguments["device1"] += ('device2_z', 'device2_d2_tmp', 'init_int_tmp0')
+        call_arguments["device2"] += ('device2_z', 'device2_d2_tmp', 'init_int_tmp0')
+        call_arguments["init_int"] += ('tmp0',)
+
+    call_kwarguments = {
+        "kernel1": (('x', 'kernel1_x'), ('y', 'kernel1_y'), ('k1_tmp', 'kernel1_k1_tmp')) if as_kwarguments else (),
+        "kernel2": (('x', 'kernel2_x'), ('k2_tmp', 'kernel2_k2_tmp'),
+            ('device2_z', 'device2_z'), ('device2_d2_tmp', 'device2_d2_tmp'), ('init_int_tmp0', 'init_int_tmp0'))
+            if as_kwarguments else (),
+        "device1": (('device2_z', 'device2_z'), ('device2_d2_tmp', 'device2_d2_tmp'),
+                    ('init_int_tmp0', 'init_int_tmp0')) if as_kwarguments else (),
+        "device2": (('z', 'device2_z'), ('d2_tmp', 'device2_d2_tmp'), ('init_int_tmp0', 'init_int_tmp0'))
+                   if as_kwarguments else (),
+        "init_int": (('init_int_tmp0', 'init_int_tmp0'),) if as_kwarguments else ()
+    }
+
+    check_arguments(scheduler=scheduler, subroutine_arguments=subroutine_arguments, call_arguments=call_arguments,
+           call_kwarguments=call_kwarguments, driver_item=scheduler['transformation_module_hoist_inline#inline_driver'],
+           driver_name='inline_driver', include_another_driver=False, subroutine_mod='subroutines_inline_mod')
+    compile_and_test(scheduler=scheduler, here=here, a=(5, 10, 100), frontend=frontend,
+                     test_name="hoisted_arrays_inline",
+                     items=[scheduler["transformation_module_hoist_inline#inline_driver"],
+                            scheduler["subroutines_inline_mod#kernel1"]], inline=True)
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('as_kwarguments', [False, True])
@@ -274,7 +353,7 @@ def test_hoist_arrays(here, frontend, config, as_kwarguments):
 
     call_arguments = {
         "kernel1": ('a', 'b', 'c'),
-        "kernel2": ('a', 'b'), 
+        "kernel2": ('a', 'b'),
         "device1": ('a1', 'b', 'x', 'k2_tmp'),
         "device2": ('a1', 'b', 'x')
     }


### PR DESCRIPTION
This PR adds the capability to hoist temporaries declared in inline function calls. It also changes the default behaviour so that statically declared arrays are no longer hoisted.