### PR TITLE
Pipeline configuration from file

### DIFF
--- a/loki/dimension.py
+++ b/loki/dimension.py
@@ -40,6 +40,14 @@ class Dimension:
         self._size = size
         self._aliases = as_tuple(aliases)
 
+    def __repr__(self):
+        """ Pretty-print dimension details """
+        name = f'<{self.name}>' if self.name else ''
+        index = str(self.index) or ''
+        size = str(self.size) or ''
+        bounds = ','.join(str(b) for b in self.bounds) if self.bounds else ''
+        return f'Dimension{name}[{index},{size},({bounds})]'
+
     @property
     def variables(self):
         return (self.index, self.size) + self.bounds

--- a/loki/transform/pipeline.py
+++ b/loki/transform/pipeline.py
@@ -7,6 +7,8 @@
 
 from inspect import signature, Parameter
 
+from loki.transform.transformation import Transformation
+
 
 class Pipeline:
     """
@@ -54,6 +56,45 @@ class Pipeline:
 
             # Then instantiate with the default *args and the derived **t_kwargs
             self.transformations.append(cls(*args, **t_kwargs))
+
+    def prepend(self, transformation):
+        """
+        Prepend a fully instantiated :any:`Transformation` object to this pipeline.
+
+        Parameters
+        ----------
+        transformation : :any:`Transformation`
+            Transformation object to prepend
+        """
+        assert isinstance(transformation, Transformation)
+
+        self.transformations.insert(0, transformation)
+
+    def append(self, transformation):
+        """
+        Append a fully instantiated :any:`Transformation` object to this pipeline.
+
+        Parameters
+        ----------
+        transformation : :any:`Transformation`
+            Transformation object to append
+        """
+        assert isinstance(transformation, Transformation)
+
+        self.transformations.append(transformation)
+
+    def extend(self, pipeline):
+        """
+        Append all :any`Transformation` objects of a given :any:`Pipeline`
+
+        Parameters
+        ----------
+        pipeline : :any:`Pipeline`
+            Pipeline whose transformations will be appended
+        """
+        assert isinstance(pipeline, Pipeline)
+
+        self.transformations.extend(pipeline.transformations)
 
     def apply(self, source, **kwargs):
         """

--- a/loki/transform/pipeline.py
+++ b/loki/transform/pipeline.py
@@ -7,6 +7,7 @@
 
 from inspect import signature, Parameter
 
+from loki.tools import as_tuple
 from loki.transform.transformation import Transformation
 
 
@@ -37,7 +38,7 @@ class Pipeline:
 
     def __init__(self, *args, classes=None, **kwargs):
         self.transformations = []
-        for cls in classes:
+        for cls in as_tuple(classes):
 
             # Get all relevant constructor parameters from teh MRO,
             # but exclude catch-all keyword args, like ``**kwargs``

--- a/loki/transform/pipeline.py
+++ b/loki/transform/pipeline.py
@@ -71,7 +71,7 @@ class Pipeline:
         if isinstance(other, Pipeline):
             self.extend(other)
             return self
-        raise RuntimeError(f'[Loki::Pipeline] Can not append {other} to pipeline!')
+        raise TypeError(f'[Loki::Pipeline] Can not append {other} to pipeline!')
 
     def __radd__(self, other):
         """ Support native addition via ``+`` operands """
@@ -81,7 +81,7 @@ class Pipeline:
         if isinstance(other, Pipeline):
             other.extend(self)
             return other
-        raise RuntimeError(f'[Loki::Pipeline] Can not append {other} to pipeline!')
+        raise TypeError(f'[Loki::Pipeline] Can not append {other} to pipeline!')
 
     def prepend(self, transformation):
         """

--- a/loki/transform/pipeline.py
+++ b/loki/transform/pipeline.py
@@ -7,7 +7,7 @@
 
 from inspect import signature, Parameter
 
-from loki.tools import as_tuple
+from loki.tools import as_tuple, flatten
 from loki.transform.transformation import Transformation
 
 
@@ -57,6 +57,11 @@ class Pipeline:
 
             # Then instantiate with the default *args and the derived **t_kwargs
             self.transformations.append(cls(*args, **t_kwargs))
+
+    def __str__(self):
+        """ Pretty-print pipeline details """
+        trafo_str = '\n  '.join(flatten(str(t).splitlines() for t in self.transformations))
+        return f'<{self.__class__.__name__}\n  {trafo_str}\n>'
 
     def __add__(self, other):
         """ Support native addition via ``+`` operands """

--- a/loki/transform/pipeline.py
+++ b/loki/transform/pipeline.py
@@ -57,6 +57,26 @@ class Pipeline:
             # Then instantiate with the default *args and the derived **t_kwargs
             self.transformations.append(cls(*args, **t_kwargs))
 
+    def __add__(self, other):
+        """ Support native addition via ``+`` operands """
+        if isinstance(other, Transformation):
+            self.append(other)
+            return self
+        if isinstance(other, Pipeline):
+            self.extend(other)
+            return self
+        raise RuntimeError(f'[Loki::Pipeline] Can not append {other} to pipeline!')
+
+    def __radd__(self, other):
+        """ Support native addition via ``+`` operands """
+        if isinstance(other, Transformation):
+            self.prepend(other)
+            return self
+        if isinstance(other, Pipeline):
+            other.extend(self)
+            return other
+        raise RuntimeError(f'[Loki::Pipeline] Can not append {other} to pipeline!')
+
     def prepend(self, transformation):
         """
         Prepend a fully instantiated :any:`Transformation` object to this pipeline.

--- a/loki/transform/transformation.py
+++ b/loki/transform/transformation.py
@@ -8,6 +8,8 @@
 """
 Base class definition for :ref:`transformations`.
 """
+from pprint import pformat
+
 from loki.module import Module
 from loki.sourcefile import Sourcefile
 from loki.subroutine import Subroutine
@@ -103,6 +105,12 @@ class Transformation:
     # Control Scheduler cache update requirements after applying the transformation
     renames_items = False
     creates_items = False
+
+    def __str__(self):
+        """ Pretty-print transformation details """
+        attrs = '\n    '.join(pformat(self.__dict__).splitlines())
+        header = f'<{self.__class__.__name__}  [{self.__class__.__module__}]'
+        return f'{header}\n    {attrs}>'
 
     def transform_subroutine(self, routine, **kwargs):
         """

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -173,6 +173,21 @@ def convert(
         paths=paths, config=config, frontend=frontend, definitions=definitions, **build_args
     )
 
+    # If requested, apply a custom pipeline from the scheduler config
+    # Note that this new entry point will bypass all other default
+    # behaviour and exit immediately after.
+    if mode in config.pipelines:
+        info(f'[Loki-transform] Applying custom pipeline {mode} from config:')
+        info(str(config.pipelines[mode]))
+
+        scheduler.process( config.pipelines[mode] )
+
+        # Write out all modified source files into the build directory
+        file_write_trafo = FileWriteTransformation(builddir=build, mode=mode)
+        scheduler.process(transformation=file_write_trafo)
+
+        return
+
     # Pull dimension definition from configuration
     horizontal = scheduler.config.dimensions.get('horizontal', None)
     vertical = scheduler.config.dimensions.get('vertical', None)

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -616,6 +616,9 @@ end subroutine test_pipeline_compose
     pipe_b = Pipeline(classes=(MaybeNotTrafo,YesTrafo))
     pipe = YesTrafo() + pipe_a + pipe_b + NoTrafo()
 
+    with pytest.raises(TypeError):
+        pipe += lambda t: t
+
     routine = Subroutine.from_source(fcode)
     pipe.apply(routine)
 
@@ -626,3 +629,10 @@ end subroutine test_pipeline_compose
     assert comments[2].text == '! Maybe not !'
     assert comments[3].text == '! Yes !'
     assert comments[4].text == '! No !'
+
+    # Check that the string representation is sane
+    assert '<YesTrafo  [test_transformation]' in str(pipe)
+    assert '<MaybeTrafo  [test_transformation]' in str(pipe)
+    assert '<MaybeNotTrafo  [test_transformation]' in str(pipe)
+    assert '<YesTrafo  [test_transformation]' in str(pipe)
+    assert '<NoTrafo  [test_transformation]' in str(pipe)

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -610,3 +610,19 @@ end subroutine test_pipeline_compose
     assert comments[1].text == '! Yes !'
     assert comments[2].text == '! No !'
     assert comments[3].text == '! Maybe not !'
+
+    # Now try the same trick, but with the native addition API
+    pipe_a = Pipeline(classes=(MaybeTrafo,))
+    pipe_b = Pipeline(classes=(MaybeNotTrafo,YesTrafo))
+    pipe = YesTrafo() + pipe_a + pipe_b + NoTrafo()
+
+    routine = Subroutine.from_source(fcode)
+    pipe.apply(routine)
+
+    comments = FindNodes(Comment).visit(routine.body)
+    assert len(comments) == 5
+    assert comments[0].text == '! Yes !'
+    assert comments[1].text == '! Maybe !'
+    assert comments[2].text == '! Maybe not !'
+    assert comments[3].text == '! Yes !'
+    assert comments[4].text == '! No !'


### PR DESCRIPTION
_Note this PR is built on top of and depends on #260._

This PR extends the `Pipeline` abstraction to make it composable and allow configuration from via the scheduler config files (in .yml). In particular, it adds `prepend`/`append` methods and support for a native `pipeline += trafo` notation to allow building custom pipelines from instantiated pipelines and transformations. 

It then also adds a new entry to the scheduler config where custom, complex transformation pipelines can be defined that combine internally provided, as well as externally defined transformations to allow full customisation outside of the usual top-level entry points. The use of custom transformation pipelines is then exposed via `loki-transform.py convert`.

This new generic interface for custom pipelines allows us to re-create the thus far internally defined behaviour entirely via config files. For an optional example of how Loki-SCC can be recreated, please see:
https://github.com/ecmwf-ifs/dwarf-p-cloudsc/blob/naml-loki-scc-pipeline-config/src/cloudsc_loki/cloudsc_loki.config#L75

In more detail:
* Add intrinsic `.prepend()` and `.append()` methods to `Pipeline` objects for full instantiated `Transformation` and `Pipeline` objects.
* Add support for native "addition" of transformations and pipelines that behaves as suggested.
* Add pretty-printing that allows a readable representation of complex pipelines under `str(pipeline)`
* Allow instiating `Pipeline` objects in via the `SchedulerConfig` and add entry point to `convert` for these custom pipelines
