### PR TITLE
REGEX frontend: white space and nesting bugfix

### DIFF
--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -389,7 +389,7 @@ class ModulePattern(Pattern):
             r'(?:[ \t\w()=]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]*\w+)?\n)|'
             r'(?:[ \t\w()=]*?function.*?^end[ \t]*function\b(?:[ \t]*\w+)?\n)|'
             r'(?:^#\w+.*?\n)'
-            r')*)?'
+            r')*?)?'
             r'^end[ \t]*module\b(?:[ \t](?P=name))?',
             re.IGNORECASE | re.DOTALL | re.MULTILINE
         )
@@ -473,7 +473,7 @@ class SubroutineFunctionPattern(Pattern):
             r'(?:[ \t\w()=]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
             r'(?:[ \t\w()=]*?function.*?^end[ \t]*function\b(?:[ \t]\w+)?\n)|'
             r'(?:^#\w+.*?\n)'
-            r')*)?'
+            r')*?)?'
             r'^end[ \t]*(?P=keyword)\b(?:[ \t](?P=name))?',
             re.IGNORECASE | re.DOTALL | re.MULTILINE
         )

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -386,8 +386,8 @@ class ModulePattern(Pattern):
             r'^module[ \t]+(?P<name>\w+)\b.*?$'
             r'(?P<spec>.*?)'
             r'(?P<contains>^contains\n(?:'
-            r'(?:[ \t\w()=]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]\w+)?\n)|'
-            r'(?:[ \t\w()=]*?function.*?^end[ \t]*function\b(?:[ \t]\w+)?\n)|'
+            r'(?:[ \t\w()=]*?subroutine.*?^end[ \t]*subroutine\b(?:[ \t]*\w+)?\n)|'
+            r'(?:[ \t\w()=]*?function.*?^end[ \t]*function\b(?:[ \t]*\w+)?\n)|'
             r'(?:^#\w+.*?\n)'
             r')*)?'
             r'^end[ \t]*module\b(?:[ \t](?P=name))?',

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -521,12 +521,13 @@ contains
         m = 2
 
         call routine_b(m, 6)
-    end subroutine module_routine
+    end subroutine   module_routine
 
     function module_function(n)
         integer n
-        n = 3
-    end function module_function
+        integer module_function
+        module_function = n + 3
+    end function   module_function
 end module some_module
 
 module other_module
@@ -565,7 +566,7 @@ contains
         integer c
         c = 8
     end subroutine !add"£^£$
-end subroutine routine_b
+endsubroutine  routine_b
 
 function function_d(d)
     integer d

--- a/tests/test_frontends.py
+++ b/tests/test_frontends.py
@@ -572,22 +572,47 @@ function function_d(d)
     integer d
     d = 6
 end function function_d
+
+module last_module
+    implicit none
+contains
+    subroutine last_routine1
+        call contained()
+        contains
+        subroutine contained
+        integer n
+        n = 1
+        end subroutine contained
+    end subroutine last_routine1
+    subroutine last_routine2
+        call contained2()
+        contains
+        subroutine contained2
+        integer m
+        m = 1
+        end subroutine contained2
+    end subroutine last_routine2
+end module last_module
     """.strip()
 
     sourcefile = Sourcefile.from_source(fcode, frontend=REGEX)
-    assert [m.name for m in sourcefile.modules] == ['some_module', 'other_module']
+    assert [m.name for m in sourcefile.modules] == ['some_module', 'other_module', 'last_module']
     assert [r.name for r in sourcefile.routines] == [
         'routine_a', 'routine_b', 'function_d'
     ]
     assert [r.name for r in sourcefile.all_subroutines] == [
-        'routine_a', 'routine_b', 'function_d', 'module_routine', 'module_function'
+        'routine_a', 'routine_b', 'function_d', 'module_routine', 'module_function',
+        'last_routine1', 'last_routine2'
     ]
 
+    assert len(r := sourcefile['last_module']['last_routine1'].routines) == 1 and r[0].name == 'contained'
+    assert len(r := sourcefile['last_module']['last_routine2'].routines) == 1 and r[0].name == 'contained2'
+
     code = sourcefile.to_fortran()
-    assert code.count('SUBROUTINE') == 10
+    assert code.count('SUBROUTINE') == 18
     assert code.count('FUNCTION') == 6
-    assert code.count('CONTAINS') == 2
-    assert code.count('MODULE') == 4
+    assert code.count('CONTAINS') == 5
+    assert code.count('MODULE') == 6
 
 
 def test_regex_sourcefile_from_file(here):


### PR DESCRIPTION
Discovered with IFS source files.

Two small fixes for the REGEX frontend patterns, with tests that triggered before the corresponding changes:
- Multiple or no white space around the `end` statement for procedures
- Matching of module procedures is now lazy to match internal subprograms in module procedures