### PR TITLE
F2C: optional case-sensitivity for variables/symbols

### DIFF
--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -172,7 +172,7 @@ class CCodegen(Stringifier):
                 aptr += ['*']
             else:
                 aptr += ['']
-        arguments = [f'{self.visit(a.type, **kwargs)} {p}{a.name.lower()}'
+        arguments = [f'{self.visit(a.type, **kwargs)} {p}{a.name}'
                      for a, p in zip(o.arguments, aptr)]
 
         # check whether to return something and define function return type accordingly

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -128,6 +128,7 @@ class TypedSymbol:
         self.name = kwargs['name']
         self.parent = kwargs.pop('parent', None)
         self.scope = kwargs.pop('scope', None)
+        self.case_sensitive = kwargs.pop('case_sensitive', False)
 
         # Use provided type or try to determine from scope
         self._type = None
@@ -339,6 +340,8 @@ class TypedSymbol:
                 kwargs['type'] = self.type
         if 'parent' not in kwargs and self.parent:
             kwargs['parent'] = self.parent
+        if 'case_sensitive' not in kwargs and self.case_sensitive:
+            kwargs['case_sensitive'] = self.case_sensitive
 
         return Variable(**kwargs)
 
@@ -502,6 +505,7 @@ class MetaSymbol(StrCompareMixin, pmbl.AlgebraicLeaf):
     """
 
     def __init__(self, symbol, *args, **kwargs):
+        self.case_sensitive = kwargs.pop('case_sensitive', False)
         super().__init__(*args, **kwargs)
         self._symbol = symbol
 
@@ -666,8 +670,9 @@ class Scalar(MetaSymbol):  # pylint: disable=too-many-ancestors
     def __init__(self, name, scope=None, type=None, **kwargs):
         # Stop complaints about `type` in this function
         # pylint: disable=redefined-builtin
-        symbol = VariableSymbol(name=name, scope=scope, type=type, **kwargs)
-        super().__init__(symbol=symbol)
+        case_sensitive = kwargs.pop('case_sensitive', False)
+        symbol = VariableSymbol(name=name, scope=scope, type=type, case_sensitive=case_sensitive, **kwargs)
+        super().__init__(symbol=symbol, case_sensitive=case_sensitive)
 
     mapper_method = intern('map_scalar')
 

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -116,6 +116,8 @@ class TypedSymbol:
         The type of that symbol. Defaults to :any:`BasicType.DEFERRED`.
     parent : :any:`Scalar` or :any:`Array`, optional
         The derived type variable this variable belongs to.
+    case_sensitive : bool, optional
+        Mark the name of this symbol as case-sensitive (default: `False`)
     *args : optional
         Any other positional arguments for other parent classes
     **kwargs : optional
@@ -128,7 +130,7 @@ class TypedSymbol:
         self.name = kwargs['name']
         self.parent = kwargs.pop('parent', None)
         self.scope = kwargs.pop('scope', None)
-        self.case_sensitive = kwargs.pop('case_sensitive', False)
+        self.case_sensitive = kwargs.pop('case_sensitive', config['case-sensitive'])
 
         # Use provided type or try to determine from scope
         self._type = None
@@ -505,7 +507,6 @@ class MetaSymbol(StrCompareMixin, pmbl.AlgebraicLeaf):
     """
 
     def __init__(self, symbol, *args, **kwargs):
-        self.case_sensitive = kwargs.pop('case_sensitive', False)
         super().__init__(*args, **kwargs)
         self._symbol = symbol
 
@@ -643,6 +644,13 @@ class MetaSymbol(StrCompareMixin, pmbl.AlgebraicLeaf):
         """
         return self.symbol.rescope(scope)
 
+    @property
+    def case_sensitive(self):
+        """
+        Property to indicate that the name of this symbol is case-sensitive.
+        """
+        return self.symbol.case_sensitive
+
     def get_derived_type_member(self, name_str):
         """
         Resolve type-bound variables of arbitrary nested depth.
@@ -670,9 +678,8 @@ class Scalar(MetaSymbol):  # pylint: disable=too-many-ancestors
     def __init__(self, name, scope=None, type=None, **kwargs):
         # Stop complaints about `type` in this function
         # pylint: disable=redefined-builtin
-        case_sensitive = kwargs.pop('case_sensitive', False)
-        symbol = VariableSymbol(name=name, scope=scope, type=type, case_sensitive=case_sensitive, **kwargs)
-        super().__init__(symbol=symbol, case_sensitive=case_sensitive)
+        symbol = VariableSymbol(name=name, scope=scope, type=type, **kwargs)
+        super().__init__(symbol=symbol)
 
     mapper_method = intern('map_scalar')
 
@@ -703,7 +710,6 @@ class Array(MetaSymbol):
     def __init__(self, name, scope=None, type=None, dimensions=None, **kwargs):
         # Stop complaints about `type` in this function
         # pylint: disable=redefined-builtin
-
         symbol = VariableSymbol(name=name, scope=scope, type=type, **kwargs)
         if dimensions:
             symbol = ArraySubscript(symbol, dimensions)

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -122,7 +122,7 @@ class TypedSymbol:
         Any other keyword arguments for other parent classes
     """
 
-    init_arg_names = ('name', 'scope', 'parent', 'type', )
+    init_arg_names = ('name', 'scope', 'parent', 'type', 'case_sensitive', )
 
     def __init__(self, *args, **kwargs):
         self.name = kwargs['name']
@@ -155,7 +155,7 @@ class TypedSymbol:
         symbol objects. We do not recurse here, since we own the
         "name" attribute, which pymbolic will otherwise replicate.
         """
-        return (self.name, None, self._parent, self._type, )
+        return (self.name, None, self._parent, self._type, self.case_sensitive, )
 
     @property
     def scope(self):

--- a/loki/transform/fortran_c_transform.py
+++ b/loki/transform/fortran_c_transform.py
@@ -23,6 +23,7 @@ from loki.transform.transform_inline import (
 )
 from loki.sourcefile import Sourcefile
 from loki.backend import cgen, fgen
+from loki.logging import debug
 from loki.ir import (
     Section, Import, Intrinsic, Interface, CallStatement, VariableDeclaration,
     TypeDef, Assignment, Transformer, FindNodes
@@ -75,6 +76,9 @@ class DeReferenceTrafo(Transformer):
 
     def visit_CallStatement(self, o, **kwargs):
         new_args = ()
+        if o.routine is BasicType.DEFERRED:
+            debug(f'DeReferenceTrafo: Skipping call to {o.name!s} due to missing procedure enrichment')
+            return o
         call_arg_map = dict((v,k) for k,v in o.arg_map.items())
         for arg in o.arguments:
             if not self.is_dereference(arg) and (isinstance(call_arg_map[arg], Array)\

--- a/loki/transform/transform_utilities.py
+++ b/loki/transform/transform_utilities.py
@@ -89,7 +89,8 @@ def convert_to_lower_case(routine):
     variables = FindVariables(unique=False).visit(routine.ir)
     vmap = {
         v: v.clone(name=v.name.lower()) for v in variables
-        if isinstance(v, (sym.Scalar, sym.Array, sym.DeferredTypeSymbol)) and not v.name.islower()
+        if isinstance(v, (sym.Scalar, sym.Array, sym.DeferredTypeSymbol)) and not v.name.islower()\
+                and not v.case_sensitive
     }
 
     # Capture nesting by applying map to itself before applying to the routine
@@ -100,7 +101,7 @@ def convert_to_lower_case(routine):
     # Downcase inline calls to, but only after the above has been propagated,
     # so that we  capture the updates from the variable update in the arguments
     mapper = {
-        c: c.clone(function=c.function.clone(name=c.name.lower()))
+        c: c.clone(function=c.function.clone(name=c.name.lower() if not c.function.case_sensitive else c.name))
         for c in FindInlineCalls().visit(routine.ir) if not c.name.islower()
     }
     mapper.update(


### PR DESCRIPTION
`convert_to_lower_case()` if not variable/symbol `.case_sensitive=True`

Imported for things like: 

```c
... = threadIdx.x
cudaMalloc(...)
```