### PR TITLE
`SCCBaseTransformation.get_integer_variable` now also checks module imports

### DIFF
--- a/transformations/transformations/single_column_base.py
+++ b/transformations/transformations/single_column_base.py
@@ -110,9 +110,7 @@ class SCCBaseTransformation(Transformation):
         name : string
             Name of the variable to find the in the routine.
         """
-        if name in routine.variable_map:
-            v_index = routine.variable_map[name]
-        else:
+        if not (v_index := routine.symbol_map.get(name, None)):
             dtype = SymbolAttributes(BasicType.INTEGER)
             v_index = sym.Variable(name=name, type=dtype, scope=routine)
         return v_index


### PR DESCRIPTION
The `get_integer_variable` utility in `SCCBaseTransformation` now also checks if the integer has been imported via a module.