### PR TITLE
Fixing nested associate scope-parentage tracking after inlining

### DIFF
--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -339,6 +339,11 @@ class AttachScopes(Visitor):
         # entry in the scope's table
         self._update_symbol_table_with_decls_and_imports(o)
 
+        # Attach parent scope if it is new before passing self down to children
+        parent_scope = kwargs.get('scope', o.parent)
+        if o.parent is not parent_scope and o is not parent_scope:
+            o._reset_parent(parent=parent_scope)
+
         # Then recurse to all children
         kwargs['scope'] = o
         children = tuple(self.visit(i, **kwargs) for i in o.children)

--- a/loki/scope.py
+++ b/loki/scope.py
@@ -297,7 +297,7 @@ class Scope:
         to a scope in the scope hierarchy
         """
         from loki.expression import AttachScopes  # pylint: disable=import-outside-toplevel,cyclic-import
-        AttachScopes().visit(self)
+        AttachScopes().visit(self, scope=self)
 
     def make_complete(self, **frontend_args):
         """

--- a/loki/transform/transform_inline.py
+++ b/loki/transform/transform_inline.py
@@ -498,6 +498,10 @@ def inline_subroutine_calls(routine, calls, callee, allowed_aliases=None):
     # Replace calls to child procedure with the child's body
     routine.body = Transformer(call_map).visit(routine.body)
 
+    # We need this to ensure that symbols, as well as nested scopes
+    # are correctly attached to each other (eg. nested associates).
+    routine.rescope_symbols()
+
 
 def inline_internal_procedures(routine, allowed_aliases=None):
     """


### PR DESCRIPTION
A curious corner case when inlining procedures that would result in nested associates, as the newly created parentage cannot be inferred via the usual pin-hole insertion approach. So, instead we now ensure that we update the parent in `AttachScopes` and call this after the call-inlining is finalised. A test is provided that illustrates the problem.