### PR TITLE
Revert "DEPENDENCY TRAFO: statement functions included via c-style imports preserved" (#251)

### DIFF
--- a/loki/transform/dependency_transform.py
+++ b/loki/transform/dependency_transform.py
@@ -320,7 +320,7 @@ class DependencyTransformation(Transformation):
         for im in imports:
             if im.c_import:
                 target_symbol = im.module.split('.')[0].lower()
-                if targets and target_symbol.lower() in targets and 'intfb' in im.module.lower():
+                if targets and target_symbol.lower() in targets:
                     # Modify the the basename of the C-style header import
                     s = '.'.join(im.module.split('.')[1:])
                     im._update(module=f'{target_symbol}{self.suffix}.{s}')
@@ -490,7 +490,7 @@ class ModuleWrapTransformation(Transformation):
         for im in imports:
             if im.c_import:
                 target_symbol = im.module.split('.')[0].lower()
-                if targets and target_symbol.lower() in targets and 'intfb' in im.module.lower():
+                if targets and target_symbol.lower() in targets:
                     # Create a new module import with explicitly qualified symbol
                     modname = f'{target_symbol}{self.module_suffix}'
                     _update_item(target_symbol.lower(), modname)

--- a/tests/test_transform_dependency.py
+++ b/tests/test_transform_dependency.py
@@ -205,7 +205,6 @@ SUBROUTINE driver(a, b, c)
   INTEGER, INTENT(INOUT) :: a, b, c
 
 #include "kernel.intfb.h"
-#include "kernel.func.h"
 
   CALL kernel(a, b ,c)
 END SUBROUTINE driver
@@ -246,9 +245,6 @@ END SUBROUTINE kernel
     assert '#include "kernel.intfb.h"' not in driver.to_fortran()
     assert '#include "kernel_test.intfb.h"' in driver.to_fortran()
 
-    # Check that imported function was not modified
-    assert '#include "kernel.func.h"' in driver.to_fortran()
-
     # Check that header file was generated and clean up
     assert header_file.exists()
     header_file.unlink()
@@ -266,7 +262,6 @@ def test_dependency_transformation_module_wrap(frontend, use_scheduler, tempdir,
 SUBROUTINE driver(a, b, c)
   INTEGER, INTENT(INOUT) :: a, b, c
 
-#include "kernel.func.h"
 #include "kernel.intfb.h"
 
   CALL kernel(a, b ,c)
@@ -325,11 +320,10 @@ END SUBROUTINE kernel
     calls = FindNodes(CallStatement).visit(driver['driver'].body)
     assert len(calls) == 1
     assert calls[0].name == 'kernel_test'
-    imports = FindNodes(Import).visit(driver['driver'].ir)
-    assert len(imports) == 2
+    imports = FindNodes(Import).visit(driver['driver'].spec)
+    assert len(imports) == 1
     assert imports[0].module == 'kernel_test_mod'
     assert 'kernel_test' in [str(s) for s in imports[0].symbols]
-    assert imports[1].module == 'kernel.func.h'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
This reverts commit 86c2f97fa7bd39b833f69a9b535fcda2b314b494 as it was found to break ec-phys regression due to the intfb assumption.

We will need to find a different solution to resolve this naming clash.