### PR TITLE
MaskedTransformer: Fix in-place rebuilding of scoped nodes

### DIFF
--- a/loki/ir/transformer.py
+++ b/loki/ir/transformer.py
@@ -485,7 +485,7 @@ class MaskedTransformer(Transformer):
 
         # Update rebuilt node
         if kwargs['parent_active']:
-            o._update(rebuilt)
+            o._update(*rebuilt)
             return o
         return tuple(i for i in rebuilt if i is not None) or None
 

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -979,6 +979,14 @@ end subroutine masked_transformer
     assert len(FindNodes(Assignment).visit(body)) == 3
     assert not FindNodes(Associate).visit(body)
 
+    # Retains all nodes but the last, but check with ``inplace=True``
+    body = MaskedTransformer(start=None, stop=assignments[-1], active=True, inplace=True).visit(routine.body)
+    assert len(FindNodes(Assignment).visit(body)) == len(assignments) - 1
+    assocs = FindNodes(Associate).visit(body)
+    assert len(assocs) == 1
+    assert len(assocs[0].body) == len(assignments) - 1
+    assert all(isinstance(n, Assignment) for n in assocs[0].body)
+
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_nested_masked_transformer(frontend):


### PR DESCRIPTION
The offending line was accidentally packing the `associations` tuple and `body` tuple of `Associate` object together on rebuild, which inserted rogue symbols into the body of the associate when it is rebuilt in-place. This happens, for example, during pragma-region attachment. 