### PR TITLE
Avoid variable_map in TypedSymbol.get_derived_type_member and verify type information is derived correctly

### DIFF
--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -364,7 +364,7 @@ class TypedSymbol:
         name_parts = name_str.split('%', maxsplit=1)
         declared_var = Variable(name=f'{self.name}%{name_parts[0]}', scope=self.scope, parent=self)
         if len(name_parts) > 1:
-            return declared_var.get_derived_type_member(name_parts[1])
+            return declared_var.get_derived_type_member(name_parts[1])  # pylint:disable=no-member
         return declared_var
 
 

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -361,14 +361,10 @@ class TypedSymbol:
         """
         Resolve type-bound variables of arbitrary nested depth.
         """
-
         name_parts = name_str.split('%', maxsplit=1)
-        if not (declared_var := self.variable_map.get(name_parts[0], None)):
-            declared_var = Variable(name=name_parts[0], scope=self.scope, parent=self)
-
+        declared_var = Variable(name=f'{self.name}%{name_parts[0]}', scope=self.scope, parent=self)
         if len(name_parts) > 1:
-            declared_var = declared_var.get_derived_type_member(name_parts[1])
-
+            return declared_var.get_derived_type_member(name_parts[1])
         return declared_var
 
 


### PR DESCRIPTION
I played around a little with this because I wanted to see if we can get away without using the symbol's `variable_map`, which can be costly for large and nested derived types. For this, I've also added an additional test that validates that type information is derived correctly.