### PR TITLE
`DataflowAnalysis` bugfix: preserve body nesting in `visit_MaskedStatement`

### DIFF
--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -189,8 +189,14 @@ class DataflowAnalysisAttacher(Transformer):
     def visit_MaskedStatement(self, o, **kwargs):
         live = kwargs.pop('live_symbols', set())
         conditions = self._symbols_from_expr(o.conditions)
-        body, defines, uses = self._visit_body(o.bodies, live=live, uses=conditions, **kwargs)
-        body = tuple(as_tuple(b,) for b in body)
+
+        body = ()
+        defines = set()
+        uses = set(conditions)
+        for b in o.bodies:
+            _b, defines, uses = self._visit_body(b, live=live, uses=uses, defines=defines, **kwargs)
+            body += (_b,)
+
         default, default_defs, uses = self._visit_body(o.default, live=live, uses=uses, **kwargs)
         o._update(bodies=body, default=default)
         return self.visit_Node(o, live_symbols=live, defines_symbols=defines|default_defs, uses_symbols=uses, **kwargs)

--- a/loki/analyse/tests/test_analyse_dataflow.py
+++ b/loki/analyse/tests/test_analyse_dataflow.py
@@ -497,6 +497,7 @@ subroutine masked_statements(n, mask, vec1, vec2)
 
   where (mask(:) < -5)
     vec1(:) = -5.0
+    vec1(:) = vec1(:) -5.0
   elsewhere (mask(:) > 5)
     vec1(:) =  5.0
   elsewhere
@@ -508,11 +509,14 @@ end subroutine masked_statements
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
     mask = FindNodes(MaskedStatement).visit(routine.body)[0]
+    num_bodies = len(mask.bodies)
     with dataflow_analysis_attached(routine):
         assert len(mask.uses_symbols) == 1
         assert len(mask.defines_symbols) == 1
         assert 'mask' in mask.uses_symbols
         assert 'vec1' in mask.defines_symbols
+
+    assert len(mask.bodies) == num_bodies
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
The `_visit_body` method in the `DataflowAnalysis` flattens the bodies, which can sometimes lead to invalid IR. This PR provides a fix.