### PR TITLE
RemoveCodeTransformation: make call_names and intrinsic_names configurable

### DIFF
--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -207,7 +207,8 @@ def convert(
     if not remove_code_trafo:
         remove_code_trafo = RemoveCodeTransformation(
             remove_marked_regions=True, remove_dead_code=False,
-            call_names=('ABOR1', 'DR_HOOK'), intrinsic_names=('WRITE(NULOUT',)
+            call_names=scheduler.config.default.get('call_names', None) or ('ABOR1', 'DR_HOOK'),
+            intrinsic_names=scheduler.config.default.get('intrinsic_names', None) or ('WRITE(NULOUT',)
         )
     scheduler.process(transformation=remove_code_trafo)
 
@@ -225,7 +226,7 @@ def convert(
         inline_trafo = InlineTransformation(
             inline_internals=inline_members, inline_marked=inline_marked,
             remove_dead_code=eliminate_dead_code, allowed_aliases=horizontal.index,
-            resolve_sequence_association=resolve_sequence_association_inlined_calls 
+            resolve_sequence_association=resolve_sequence_association_inlined_calls
         )
     scheduler.process(transformation=inline_trafo)
 

--- a/tests/test_transform_remove_code.py
+++ b/tests/test_transform_remove_code.py
@@ -401,7 +401,9 @@ def test_remove_code_transformation(frontend, source, include_intrinsics, kernel
     config = {
         'default': {
             'role': 'kernel', 'expand': True, 'strict': False,
-            'disable': ['dr_hook', 'abor1']
+            'disable': ['dr_hook', 'abor1'],
+            'call_names': ['dr_hook', 'abor1'],
+            'intrinsic_names': ['write(nulout']
         },
         'routines': {
             'rick_astley': {'role': 'driver'},
@@ -412,8 +414,8 @@ def test_remove_code_transformation(frontend, source, include_intrinsics, kernel
 
     # Apply the transformation to the call tree
     transformation = RemoveCodeTransformation(
-        call_names=('ABOR1', 'DR_HOOK'),
-        intrinsic_names=('WRITE(NULOUT',) if include_intrinsics else (),
+        call_names=scheduler.config.default['call_names'],
+        intrinsic_names=scheduler.config.default['intrinsic_names'] if include_intrinsics else (),
         kernel_only=kernel_only
     )
     scheduler.process(transformation=transformation)


### PR DESCRIPTION
This PR makes the `call_names` and `intrinsic_names` constructor args in the `RemoveCodeTransformation` configurable.