### PR TITLE
Transformation to hoist temporaries in kernel language transpilation

### DIFF
--- a/transformations/transformations/scc_cuf.py
+++ b/transformations/transformations/scc_cuf.py
@@ -78,8 +78,7 @@ class HoistTemporaryArraysPragmaOffloadTransformation(HoistVariablesTransformati
         var: :any:`Variable`
             The variable to be declared
         """
-        for var in variables:
-            routine.variables += tuple([var.clone(scope=routine)])
+        routine.variables += tuple(var.clone(scope=routine) for var in variables)
 
         vnames = ', '.join(v.name for v in variables)
         pragma = ir.Pragma(keyword='acc', content=f'enter data create({vnames})')


### PR DESCRIPTION
hoisting arrays via pragma offload for low-level GPU implementations (no block index, which makes it different to `SCCHoistTemporaryArraysTransformation`)