### PR TITLE
Improve `parse_expr` and use in `process_dimension_pragmas`

### DIFF
--- a/loki/expression/expr_visitors.py
+++ b/loki/expression/expr_visitors.py
@@ -11,7 +11,9 @@ Visitor classes for traversing and transforming all expression trees in
 """
 from pymbolic.primitives import Expression
 
-from loki.ir import Node, Visitor, Transformer
+from loki.ir.nodes import Node
+from loki.ir.visitor import Visitor
+from loki.ir.transformer import Transformer
 from loki.tools import flatten, as_tuple
 from loki.expression.mappers import (
     SubstituteExpressionsMapper, ExpressionRetriever, AttachScopesMapper

--- a/loki/expression/parser.py
+++ b/loki/expression/parser.py
@@ -109,7 +109,11 @@ class PymbolicMapper(Mapper):
     map_array = map_meta_symbol
 
     def map_slice(self, expr, *args, **kwargs):
-        return sym.RangeIndex(tuple(self.rec(child, *args, **kwargs) for child in expr.children))
+        children = tuple(self.rec(child, *args, **kwargs) if child is not None else child for child in expr.children)
+        if len(children) == 1 and children[0] is None:
+            # this corresponds to ':' (sym.RangeIndex((None, None)))
+            children = (None, None)
+        return sym.RangeIndex(children)
 
     map_range = map_slice
     map_range_index = map_slice

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -1009,18 +1009,18 @@ def test_string_compare():
     ('ansatz(a + 1)', 'a', True),
     ('ansatz(b + 1)', 'a', False),  # Ensure no false positives
 ])
-@pytest.mark.parametrize('parse', (parse_expr, parse_fparser_expression))
+@pytest.mark.parametrize('parse', (
+    parse_expr,
+    pytest.param(parse_fparser_expression,
+        marks=pytest.mark.skipif(not HAVE_FP, reason='parse_fparser_expression not available!'))
+))
 def test_subexpression_match(parse, expr, string, ref):
     """
     Test that we can identify individual symbols or sub-expressions in
     expressions via canonical string matching.
     """
     scope = Scope()
-    if parse is parse_fparser_expression and not HAVE_FP:
-        with pytest.raises(RuntimeError):
-            expr = parse(expr, scope)
-    else:
-        expr = parse(expr, scope)
+    expr = parse(expr, scope)
     assert (string in expr) == ref
 
 
@@ -1033,17 +1033,17 @@ def test_subexpression_match(parse, expr, string, ref):
     ('5 + (4 + 3) - (2*1)', '5 + (4 + 3) - (2*1)'),
     ('a*(b*(c+(d+e)))', 'a*(b*(c + (d + e)))'),
 ])
-@pytest.mark.parametrize('parse', (parse_expr, parse_fparser_expression))
+@pytest.mark.parametrize('parse', (
+    parse_expr,
+    pytest.param(parse_fparser_expression,
+        marks=pytest.mark.skipif(not HAVE_FP, reason='parse_fparser_expression not available!'))
+))
 def test_parse_expression(parse, source, ref):
     """
     Test the utility function that parses simple expressions.
     """
     scope = Scope()
-    if parse is parse_fparser_expression and not HAVE_FP:
-        with pytest.raises(RuntimeError):
-            ir = parse(source, scope)
-    else:
-        ir = parse(source, scope)
+    ir = parse(source, scope)  # pylint: disable=redefined-outer-name
     assert isinstance(ir, pmbl.Expression)
     assert str(ir) == ref
 

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -1747,6 +1747,10 @@ end module external_mod
     assert all(_parsed.scope == routine for _parsed in [parsed.base, parsed.exponent])
     assert to_str(parsed) == 'a**b'
 
+    parsed = parse_expr(convert_to_case(':', mode=case))
+    assert isinstance(parsed, sym.RangeIndex)
+    assert to_str(parsed) == ':'
+
     parsed = parse_expr(convert_to_case('a:b', mode=case), scope=routine)
     assert isinstance(parsed, sym.RangeIndex)
     assert all(isinstance(_parsed,  sym.Scalar) for _parsed in [parsed.lower, parsed.upper])

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1864,7 +1864,7 @@ class FParser2IR(GenericVisitor):
 
         # Update array shapes with Loki dimension pragmas
         with pragmas_attached(routine, ir.VariableDeclaration):
-            routine.spec = process_dimension_pragmas(routine.spec)
+            routine.spec = process_dimension_pragmas(routine.spec, scope=routine)
 
         if isinstance(o, Fortran2003.Subroutine_Body):
             # Return the subroutine object along with any clutter before it for interface declarations

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1230,7 +1230,7 @@ class OFP2IR(GenericVisitor):
 
         # Update array shapes with Loki dimension pragmas
         with pragmas_attached(routine, ir.VariableDeclaration):
-            routine.spec = process_dimension_pragmas(routine.spec)
+            routine.spec = process_dimension_pragmas(routine.spec, scope=routine)
 
         return routine
 

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -433,7 +433,7 @@ class OMNI2IR(GenericVisitor):
 
         # Update array shapes with Loki dimension pragmas
         with pragmas_attached(routine, ir.VariableDeclaration):
-            routine.spec = process_dimension_pragmas(routine.spec)
+            routine.spec = process_dimension_pragmas(routine.spec, scope=routine)
 
         return routine
 

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -1970,3 +1970,64 @@ end module some_mod
 
 
 # TODO: Add tests for source sanitizer with other frontends
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI does not like Loki pragmas, yet!')]))
+def test_frontend_routine_variables_dimension_pragmas(frontend):
+    """
+    Test that `!$loki dimension` pragmas can be used to verride the
+    conceptual `.shape` of local and argument variables.
+    """
+    fcode = """
+subroutine routine_variables_dimensions(x, y, v0, v1, v2, v3, v4)
+  integer, parameter :: jprb = selected_real_kind(13,300)
+  integer, intent(in) :: x, y
+
+  !$loki dimension(10)
+  real(kind=jprb), intent(inout) :: v0(:)
+  !$loki dimension(x)
+  real(kind=jprb), intent(inout) :: v1(:)
+  !$loki dimension(x,y,:)
+  real(kind=jprb), dimension(:,:,:), intent(inout) :: v2, v3
+  !$loki dimension(x,y)
+  real(kind=jprb), pointer, intent(inout) :: v4(:,:)
+  !$loki dimension(x+y,2*x)
+  real(kind=jprb), allocatable :: v5(:,:)
+  !$loki dimension(x/2, x**2, (x+y)/x)
+  real(kind=jprb), dimension(:, :, :), pointer :: v6
+
+end subroutine routine_variables_dimensions
+"""
+    def to_str(expr):
+        return str(expr).lower().replace(' ', '')
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert routine.variable_map['v0'].shape[0] == 10
+    assert isinstance(routine.variable_map['v0'].shape[0], sym.IntLiteral)
+    assert isinstance(routine.variable_map['v1'].shape[0], sym.Scalar)
+    assert routine.variable_map['v2'].shape[0] == 'x'
+    assert routine.variable_map['v2'].shape[1] == 'y'
+    assert routine.variable_map['v2'].shape[2] == ':'
+    assert isinstance(routine.variable_map['v2'].shape[0], sym.Scalar)
+    assert isinstance(routine.variable_map['v2'].shape[1], sym.Scalar)
+    assert isinstance(routine.variable_map['v2'].shape[2], sym.RangeIndex)
+    assert routine.variable_map['v3'].shape[0] == 'x'
+    assert routine.variable_map['v3'].shape[1] == 'y'
+    assert routine.variable_map['v3'].shape[2] == ':'
+    assert isinstance(routine.variable_map['v3'].shape[0], sym.Scalar)
+    assert isinstance(routine.variable_map['v3'].shape[1], sym.Scalar)
+    assert isinstance(routine.variable_map['v3'].shape[2], sym.RangeIndex)
+    assert routine.variable_map['v4'].shape[0] == 'x'
+    assert routine.variable_map['v4'].shape[1] == 'y'
+    assert isinstance(routine.variable_map['v4'].shape[0], sym.Scalar)
+    assert isinstance(routine.variable_map['v4'].shape[1], sym.Scalar)
+    assert to_str(routine.variable_map['v5'].shape[0]) == 'x+y'
+    assert to_str(routine.variable_map['v5'].shape[1]) == '2*x'
+    assert isinstance(routine.variable_map['v5'].shape[0], sym.Sum)
+    assert isinstance(routine.variable_map['v5'].shape[1], sym.Product)
+    assert to_str(routine.variable_map['v6'].shape[0]) == 'x/2'
+    assert to_str(routine.variable_map['v6'].shape[1]) == 'x**2'
+    assert to_str(routine.variable_map['v6'].shape[2]) == '(x+y)/x'
+    assert isinstance(routine.variable_map['v6'].shape[0], sym.Quotient)
+    assert isinstance(routine.variable_map['v6'].shape[1], sym.Power)
+    assert isinstance(routine.variable_map['v6'].shape[2], sym.Quotient)

--- a/loki/ir/tests/test_pragma_utils.py
+++ b/loki/ir/tests/test_pragma_utils.py
@@ -50,7 +50,9 @@ def test_is_loki_pragma(keyword, content, starts_with, ref):
     ('dataflow group(1) group(2)', 'dataflow', {'group': ['1', '2']}),
     ('foo bar(^£!$%*[]:@+-_=~#/?.,<>;) baz foobar(abc_123")', 'foo',
      {'bar':'^£!$%*[]:@+-_=~#/?.,<>;', 'baz': None, 'foobar': 'abc_123"'}),
-    ('target map(a) map(to: b) map(from: c)', None, {'target': None, 'map': ['a', 'to: b', 'from: c']})
+    ('target map(a) map(to: b) map(from: c)', None, {'target': None, 'map': ['a', 'to: b', 'from: c']}),
+    ('arg1(val1) arg2(val2/val3) arg3((val1 + val2)/(val3))', None, {'arg1': 'val1',
+        'arg2': 'val2/val3', 'arg3': '(val1 + val2)/(val3)'})
 ])
 def test_get_pragma_parameters(content, starts_with, ref):
     """

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -644,7 +644,7 @@ end subroutine routine_variables_dimensions
     assert fexprgen(routine.variable_map['v3'].shape) == '(x, y, :)'
     assert fexprgen(routine.variable_map['v4'].shape) == '(x, y)'
     assert fexprgen(routine.variable_map['v5'].shape) == '(y, :)'
-    assert fexprgen(routine.variable_map['v6'].shape) == '(x+y,)'
+    assert fexprgen(routine.variable_map['v6'].shape) == '(x + y,)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
Improve `parse_expr` and use in `process_dimension_pragmas`.

* add correct parsing of `:` to `RangeIndex((None, None))`
* support `DerivedType` s