### PR TITLE
Consistent, environment-configurable use of Compiler class in JIT compilation

### DIFF
--- a/loki/build/compiler.py
+++ b/loki/build/compiler.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 
 from loki.logging import info, debug
-from loki.tools import execute, as_tuple, flatten, delete
+from loki.tools import execute, as_tuple, delete
 
 
 __all__ = [
@@ -54,7 +54,7 @@ def compile_and_load(filename, cwd=None, f90wrap_kind_map=None, compiler=None):
     supported via the ``f2py`` and ``f90wrap`` packages.
 
     Parameters
-    -----
+    ----------
     filename : str
         The source file to be compiled.
     cwd : str, optional

--- a/loki/build/jit.py
+++ b/loki/build/jit.py
@@ -54,7 +54,7 @@ def jit_compile(source, filepath=None, objname=None):
             filepath = Path(filepath)
         Sourcefile(filepath).write(source=source)
 
-    pymod = compile_and_load(filepath, cwd=str(filepath.parent), use_f90wrap=True, f90wrap_kind_map=_f90wrap_kind_map)
+    pymod = compile_and_load(filepath, cwd=str(filepath.parent), f90wrap_kind_map=_f90wrap_kind_map)
 
     if objname:
         return getattr(pymod, objname)


### PR DESCRIPTION
JIT compilation was hard coded to `gfortran` and not using the `Compiler` class in the `compile_and_load` method used throughout the test base. This prevented testing with other gfortran versions or different compilers.

The first change in this PR is to make Loki use consistently the `Compiler` class for JIT compilation. This unlocks the use of other compilers when executing tests.

The second change is to inspect the environment for common variables setting the compiler (`CC`, `FC`, `F90`) and choose an appropriate compiler. This consists of two steps:
1. First, we try to identify the compiler "family", for which now "GNU" and "Nvidia" exist (I used the opportuinity to delete the ancient "ESCAPE" compiler definition). This is done by matching the value in the respective env variable against a set of common names, allowing also for absolute/relative paths (e.g. to test user-supplied compilers). A Fortran compiler specification takes precedence over a C-compiler specification in this case.
2. Second, the executable name and compiler flags are overwritten with any values supplied in the environment.

As a side-effect, this enables tests that require compilation also on MacOS. With a user-installed GNU compiler suite (e.g. via homebrew) and setting `CC=gcc-13 FC=gfortran-13`, the tests use now correctly the user-supplied compilers instead of the system-default "gcc-relabeled" clang compiler.