### PR TITLE
Fix: import of private symbols affects the type inference

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -465,6 +465,9 @@ class FParser2IR(GenericVisitor):
             if module is not None:
                 # Import symbol attributes from module, if available
                 for k, v in module.symbol_attrs.items():
+                    # Don't import private module symbols
+                    if v.private == True or (module.default_access_spec == "private" and v.public is None):
+                        continue
                     if k in rename_list:
                         local_name = rename_list[k].name
                         scope.symbol_attrs[local_name] = v.clone(imported=True, module=module, use_name=k)

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -466,7 +466,7 @@ class FParser2IR(GenericVisitor):
                 # Import symbol attributes from module, if available
                 for k, v in module.symbol_attrs.items():
                     # Don't import private module symbols
-                    if v.private == True or (module.default_access_spec == "private" and v.public is None):
+                    if v.private is True or (module.default_access_spec == "private" and v.public is None):
                         continue
                     if k in rename_list:
                         local_name = rename_list[k].name

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -466,7 +466,7 @@ class FParser2IR(GenericVisitor):
                 # Import symbol attributes from module, if available
                 for k, v in module.symbol_attrs.items():
                     # Don't import private module symbols
-                    if v.private is True or (module.default_access_spec == "private" and v.public is None):
+                    if v.private or (module.default_access_spec == "private" and not v.public):
                         continue
                     if k in rename_list:
                         local_name = rename_list[k].name

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1417,7 +1417,7 @@ class OFP2IR(GenericVisitor):
                 # Import symbol attributes from module, if available
                 for k, v in module.symbol_attrs.items():
                     # Don't import private module symbols
-                    if v.private is True or (module.default_access_spec == "private" and v.public is None):
+                    if v.private or (module.default_access_spec == "private" and not v.public):
                         continue
                     if k in rename_list:
                         local_name = rename_list[k].name

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1416,6 +1416,9 @@ class OFP2IR(GenericVisitor):
             if module is not None:
                 # Import symbol attributes from module, if available
                 for k, v in module.symbol_attrs.items():
+                    # Don't import private module symbols
+                    if v.private == True or (module.default_access_spec == "private" and v.public is None):
+                        continue
                     if k in rename_list:
                         local_name = rename_list[k].name
                         scope.symbol_attrs[local_name] = v.clone(

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1417,7 +1417,7 @@ class OFP2IR(GenericVisitor):
                 # Import symbol attributes from module, if available
                 for k, v in module.symbol_attrs.items():
                     # Don't import private module symbols
-                    if v.private == True or (module.default_access_spec == "private" and v.public is None):
+                    if v.private is True or (module.default_access_spec == "private" and v.public is None):
                         continue
                     if k in rename_list:
                         local_name = rename_list[k].name

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -215,6 +215,9 @@ class OMNI2IR(GenericVisitor):
         if module is not None:
             # Import symbol attributes from module, if available
             for k, v in module.symbol_attrs.items():
+                # Don't import private module symbols
+                if v.private == True or (module.default_access_spec == "private" and v.public is None):
+                    continue
                 if k in rename_list:
                     local_name = rename_list[k].name
                     scope.symbol_attrs[local_name] = v.clone(imported=True, module=module, use_name=k)

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -216,7 +216,7 @@ class OMNI2IR(GenericVisitor):
             # Import symbol attributes from module, if available
             for k, v in module.symbol_attrs.items():
                 # Don't import private module symbols
-                if v.private == True or (module.default_access_spec == "private" and v.public is None):
+                if v.private is True or (module.default_access_spec == "private" and v.public is None):
                     continue
                 if k in rename_list:
                     local_name = rename_list[k].name

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -216,7 +216,7 @@ class OMNI2IR(GenericVisitor):
             # Import symbol attributes from module, if available
             for k, v in module.symbol_attrs.items():
                 # Don't import private module symbols
-                if v.private is True or (module.default_access_spec == "private" and v.public is None):
+                if v.private or (module.default_access_spec == "private" and not v.public):
                     continue
                 if k in rename_list:
                     local_name = rename_list[k].name

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -2069,8 +2069,8 @@ end module mod_main
     var = mod_main.subroutines[0].body.body[0].rhs
     # Check if this is really our symbol
     assert var.name == "var"
-    assert var.scope == mod_main
+    assert var.scope is mod_main
     # Check if the symbol is imported
     assert var.type.imported is True
     # Check if the symbol comes from the mod_public module
-    assert var.type.module == mod_public
+    assert var.type.module is mod_public


### PR DESCRIPTION
As described in #309, imports of private symbols destroys the type inference. This pull request propose a simple check of symbols access specificators to filter out the private symbols.

TODO:
- [x] Support for other frontends
- [x] Unit test