### PR TITLE
Docs: Update to links from static doc pages

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -19,8 +19,8 @@ representation to a string representation in the syntax of the target language.
 
 .. autosummary::
 
-   loki.visitors.pprint.Stringifier
-   loki.visitors.pprint.pprint
+   loki.ir.pprint.Stringifier
+   loki.ir.pprint.pprint
 
 Typically, this includes also a custom mapper for expression trees as a
 subclass of :any:`LokiStringifyMapper`. For convenience, each of these
@@ -50,5 +50,5 @@ Currently, Loki has backends to generate Fortran, C, Python, and Maxeler MaxJ
    compatible with the target language. Adapting the IR to the desired output
    format needs to be done before calling the relevant code generation routine.
    For language transpilation (e.g., Fortran to C), corresponding
-   :doc:`transformations <transformations>` must be applied
+   :doc:`transformations <transform>` must be applied
    (e.g., :any:`FortranCTransformation`).

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -53,11 +53,12 @@ provided for this are:
 Example transformations and current features
 ============================================
 
-Loki is primarily an API and toolbox, requiring developers to create their
-own head scripts to create and invoke source-to-source translation toolchains.
-A small set of transformations considered generic enough are provided by the
-package itself in :mod:`loki.transform`. The majority of more complex transformations
-are collected in a separate Python package that lives under ``transformations``.
+Loki is primarily an API and toolbox, allowing developers to create their
+own head scripts and to create and invoke source-to-source translation toolchains.
+In addition, a set of supported transformations is provided by the
+package itself in :mod:`loki.transformations`. These range from utilities
+that can be used with generic Fortran codes to highly bespoke transformations
+for generating GPU code based on highly model-specific assumptions.
 
 The ``loki_transform.py`` script is provided by the Loki install. The primary
 transformation passes provided by these example transformations are:

--- a/docs/source/internal_representation.rst
+++ b/docs/source/internal_representation.rst
@@ -259,7 +259,6 @@ Mix-ins
 
 .. autosummary::
 
-   loki.expression.symbols.ExprMetadataMixin
    loki.expression.symbols.StrCompareMixin
 
 Expression modules

--- a/docs/source/loki_api.rst
+++ b/docs/source/loki_api.rst
@@ -8,5 +8,4 @@ API reference
 
    loki
    scripts
-   transformations
    lint_rules

--- a/docs/source/transform.rst
+++ b/docs/source/transform.rst
@@ -105,11 +105,11 @@ side-effects.
 Typically, transformations should be implemented by users to encode the
 transformation pipeline for their individual use-case. However, Loki comes
 with a growing number of built-in transformations that are implemented in
-the :mod:`loki.transform` namespace:
+the :mod:`loki.transformations` namespace:
 
 .. autosummary::
 
-   loki.transform
+   loki.transformations
 
 This includes also a number of tools for common transformation tasks that
 are provided as functions that can be readily used when implementing new
@@ -281,17 +281,17 @@ Other traversal modes may be added in the future.
 
 .. autosummary::
 
-   loki.bulk.scheduler.Scheduler
-   loki.bulk.scheduler.SGraph
-   loki.bulk.scheduler.SFilter
-   loki.bulk.configure.SchedulerConfig
-   loki.bulk.configure.TransformationConfig
-   loki.bulk.configure.ItemConfig
-   loki.bulk.item.Item
-   loki.bulk.item.FileItem
-   loki.bulk.item.ModuleItem
-   loki.bulk.item.ProcedureItem
-   loki.bulk.item.TypeDefItem
-   loki.bulk.item.ProcedureBindingItem
-   loki.bulk.item.InterfaceItem
-   loki.bulk.item.ItemFactory
+   loki.batch.scheduler.Scheduler
+   loki.batch.scheduler.SGraph
+   loki.batch.scheduler.SFilter
+   loki.batch.configure.SchedulerConfig
+   loki.batch.configure.TransformationConfig
+   loki.batch.configure.ItemConfig
+   loki.batch.item.Item
+   loki.batch.item.FileItem
+   loki.batch.item.ModuleItem
+   loki.batch.item.ProcedureItem
+   loki.batch.item.TypeDefItem
+   loki.batch.item.ProcedureBindingItem
+   loki.batch.item.InterfaceItem
+   loki.batch.item.ItemFactory

--- a/docs/source/visitors.rst
+++ b/docs/source/visitors.rst
@@ -46,10 +46,10 @@ for that job with some bespoke variants for specific use cases.
 
 .. autosummary::
 
-   loki.visitors.FindNodes
-   loki.visitors.FindScopes
-   loki.visitors.SequenceFinder
-   loki.visitors.PatternFinder
+   loki.ir.find.FindNodes
+   loki.ir.find.FindScopes
+   loki.ir.find.SequenceFinder
+   loki.ir.find.PatternFinder
 
 A common pattern for using :any:`FindNodes` is the following:
 
@@ -71,10 +71,10 @@ nodes according to a mapper.
 
 .. autosummary::
 
-   loki.visitors.Transformer
-   loki.visitors.NestedTransformer
-   loki.visitors.MaskedTransformer
-   loki.visitors.NestedMaskedTransformer
+   loki.ir.transformer.Transformer
+   loki.ir.transformer.NestedTransformer
+   loki.ir.transformer.MaskedTransformer
+   loki.ir.transformer.NestedMaskedTransformer
 
 :any:`Transformer` is commonly used in conjunction with :any:`FindNodes`, with
 the latter being used to build the mapper for the first. The following example
@@ -107,8 +107,8 @@ pretty-printer for the IR that is useful for debugging.
 
 .. autosummary::
 
-   loki.visitors.pprint.Stringifier
-   loki.visitors.pprint
+   loki.ir.pprint.Stringifier
+   loki.ir.pprint
 
 Implementing new visitors
 -------------------------

--- a/loki/__init__.py
+++ b/loki/__init__.py
@@ -5,6 +5,10 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+"""
+The Loki source-to-source translation package for Fortran codes.
+"""
+
 from importlib.metadata import version, PackageNotFoundError
 
 # Import the global configuration map

--- a/loki/analyse/__init__.py
+++ b/loki/analyse/__init__.py
@@ -4,5 +4,8 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Advanced analysis utilities, such as dataflow analysis functionalities.
+"""
 
 from loki.analyse.analyse_dataflow import *  # noqa

--- a/loki/analyse/util_linear_algebra.py
+++ b/loki/analyse/util_linear_algebra.py
@@ -72,11 +72,12 @@ def yield_one_d_systems(matrix, right_hand_side):
 
     Example
     -------
-    ```python
-    for A, b in yield_one_d_systems(matrix, right_hand_side):
-        # Solve the one-dimensional problem A * x = b
-        solution = solve_one_d_system(A, b)
-    ```
+
+    .. code-block:: python
+
+        for A, b in yield_one_d_systems(matrix, right_hand_side):
+            # Solve the one-dimensional problem A * x = b
+            solution = solve_one_d_system(A, b)
     """
     # yield systems with empty left hand side (A) and non empty right hand side
     mask = np.all(matrix == 0, axis=1)

--- a/loki/analyse/util_polyhedron.py
+++ b/loki/analyse/util_polyhedron.py
@@ -142,9 +142,11 @@ class Polyhedron:
         Return all lower bounds imposed on a variable.
 
         The lower bounds for the variable `j` are given by the index set:
-        ```
+
+        ``
         L = {i | A_ij < 0, i in {0, ..., d-1}}
-        ```
+        ``
+
         Parameters
         ----------
         index_or_variable : int or str or sym.Array or sym.Scalar
@@ -204,9 +206,10 @@ class Polyhedron:
         Return all upper bounds imposed on a variable.
 
         The upper bounds for the variable `j` are given by the index set:
-        ```
+        ``
         U = {i | A_ij > 0, i in {0, ..., d-1}}
-        ```
+        ``
+
         Parameters
         ----------
         index_or_variable : int or str or sym.Array or sym.Scalar

--- a/loki/backend/__init__.py
+++ b/loki/backend/__init__.py
@@ -4,6 +4,9 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Backend classes that convert Loki IR into output code in various languages.
+"""
 
 from loki.backend.fgen import * # noqa
 from loki.backend.cgen import * # noqa

--- a/loki/batch/__init__.py
+++ b/loki/batch/__init__.py
@@ -9,7 +9,7 @@ Batch processing abstraction for processing large source trees with Loki.
 
 This sub-package provides the :any:`Scheduler` class that allows Loki
 transformations to be applied over large source trees. For this it
-provides the basic :any:`Transformation` and :and:`Pipeline` classes
+provides the basic :any:`Transformation` and :any:`Pipeline` classes
 that provide the core interfaces for batch processing, as well as the
 configuration utilities for large call tree traversals.
 """

--- a/loki/batch/__init__.py
+++ b/loki/batch/__init__.py
@@ -4,6 +4,15 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Batch processing abstraction for processing large source trees with Loki.
+
+This sub-package provides the :any:`Scheduler` class that allows Loki
+transformations to be applied over large source trees. For this it
+provides the basic :any:`Transformation` and :and:`Pipeline` classes
+that provide the core interfaces for batch processing, as well as the
+configuration utilities for large call tree traversals.
+"""
 
 from loki.batch.configure import * # noqa
 from loki.batch.item import * # noqa

--- a/loki/batch/configure.py
+++ b/loki/batch/configure.py
@@ -38,7 +38,7 @@ class SchedulerConfig:
     routines : dict of dicts or list of dicts
         Dicts with routine-specific options.
     dimensions : dict of dicts or list of dicts
-        Dicts with options to define :any`Dimension` objects.
+        Dicts with options to define :any:`Dimension` objects.
     disable : list of str
         Subroutine names that are entirely disabled and will not be
         added to either the callgraph that we traverse, nor the
@@ -46,7 +46,7 @@ class SchedulerConfig:
         pop up in many routines but can be ignored in terms of program
         control flow, like ``flush`` or ``abort``.
     enable_imports : bool
-￼        Disable the inclusion of module imports as scheduler dependencies.
+￼       Disable the inclusion of module imports as scheduler dependencies.
     transformation_configs : dict
         Dicts with transformation-specific options
     frontend_args : dict

--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -72,7 +72,7 @@ class Item(ItemConfig):
     * :any:`InterfaceItem`: corresponding to :any:`Interface`
     * :any:`TypeDefItem`: corresponding to :any:`TypeDef`
     * :any:`ProcedureBindingItem`: corresponding to the :any:`ProcedureSymbol`
-      that is declared in a :any:`Declaration` in a derived type.
+      that is declared in a :any:`ProcedureDeclaration` in a derived type.
 
     The IR node corresponding to an item can be obtain via the :attr:`ir` property.
 
@@ -1397,7 +1397,7 @@ class ItemFactory:
             The config object from which the item configuration will be derived
         module_names : list of str, optional
             List of module candidates in which to create the definition items. If not provided,
-            all :any:`ModuleItems` in the cache will be considered.
+            all :any:`ModuleItem` in the cache will be considered.
         only : list of :any:`Item` classes, optional
             Filter the generated items to include only those of the type provided in the list
 

--- a/loki/batch/sfilter.py
+++ b/loki/batch/sfilter.py
@@ -36,7 +36,7 @@ class SFilter:
     reverse : bool, optional
         Iterate over the dependency graph in reverse direction
     exclude_ignored : bool, optional
-        Exclude :any:`Item`s that have the ``is_ignored`` property
+        Exclude :any:`Item` objects that have the ``is_ignored`` property
     include_external : bool, optional
         Do not skip :any:`ExternalItem` in the iterator
     """

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -60,7 +60,7 @@ class SGraph:
 
     def as_filegraph(self, item_factory, config=None, item_filter=None, exclude_ignored=False):
         """
-        Convert the :any:`Sgraph` to a dependency graph that only contains
+        Convert the :any:`SGraph` to a dependency graph that only contains
         :any:`FileItem` nodes.
 
         Parameters

--- a/loki/build/__init__.py
+++ b/loki/build/__init__.py
@@ -8,7 +8,7 @@
 Just-in-Time compilation utilities used in the Loki test base.
 
 These allow compilation and wrapping of generated Fortran source code
-using `f90wrap <https://github.com/jameskermode/f90wrap>` for
+using `f90wrap <https://github.com/jameskermode/f90wrap>`_ for
 execution from Python tests.
 """
 

--- a/loki/build/__init__.py
+++ b/loki/build/__init__.py
@@ -4,6 +4,13 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Just-in-Time compilation utilities used in the Loki test base.
+
+These allow compilation and wrapping of generated Fortran source code
+using `f90wrap <https://github.com/jameskermode/f90wrap>` for
+execution from Python tests.
+"""
 
 from loki.logging import * # noqa
 

--- a/loki/expression/__init__.py
+++ b/loki/expression/__init__.py
@@ -6,7 +6,7 @@
 # nor does it submit to any jurisdiction.
 """
 Expression layer of the two-level Loki IR based on `Pymbolic
-<https://github.com/inducer/pymbolic`_.
+<https://github.com/inducer/pymbolic>`_.
 """
 
 from loki.expression.expr_visitors import *  # noqa

--- a/loki/expression/__init__.py
+++ b/loki/expression/__init__.py
@@ -4,6 +4,10 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Expression layer of the two-level Loki IR based on `Pymbolic
+<https://github.com/inducer/pymbolic`.
+"""
 
 from loki.expression.expr_visitors import *  # noqa
 from loki.expression.symbols import *  # noqa

--- a/loki/expression/__init__.py
+++ b/loki/expression/__init__.py
@@ -6,7 +6,7 @@
 # nor does it submit to any jurisdiction.
 """
 Expression layer of the two-level Loki IR based on `Pymbolic
-<https://github.com/inducer/pymbolic`.
+<https://github.com/inducer/pymbolic`_.
 """
 
 from loki.expression.expr_visitors import *  # noqa

--- a/loki/frontend/__init__.py
+++ b/loki/frontend/__init__.py
@@ -8,8 +8,8 @@
 Frontend parsers that create Loki IR from input Fortran code.
 
 This includes code sanitisation utilities and several frontend parser
-interfaces, including the REGEX-frontend that used for fast source
-code exploration in large call trees.
+interfaces, including the REGEX-frontend that is used for fast source
+code exploration in large call and dependency trees.
 """
 
 from loki.frontend.preprocessing import *  # noqa

--- a/loki/frontend/__init__.py
+++ b/loki/frontend/__init__.py
@@ -4,6 +4,13 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Frontend parsers that create Loki IR from input Fortran code.
+
+This includes code sanitisation utilities and several frontend parser
+interfaces, including the REGEX-frontend that used for fast source
+code exploration in large call trees.
+"""
 
 from loki.frontend.preprocessing import *  # noqa
 from loki.frontend.source import *  # noqa

--- a/loki/ir/__init__.py
+++ b/loki/ir/__init__.py
@@ -5,6 +5,10 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+"""
+The Loki internal representation (IR) and associated APIs for tree traversal.
+"""
+
 from loki.ir.find import *  # noqa
 from loki.ir.ir_graph import *  # noqa
 from loki.ir.nodes import *  # noqa

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -63,14 +63,14 @@ class Node:
     metadata.
 
     Attributes
-    -----------
+    ----------
     traversable : list of str
         The traversable fields of the Node; that is, fields walked over by
         a :any:`Visitor`. All arguments in :py:meth:`__init__` whose
         name appear in this list are treated as traversable fields.
 
     Parameters
-    -----------
+    ----------
     source : :any:`Source`, optional
         the information about the original source for the Node.
     label : str, optional

--- a/loki/ir/pragma_utils.py
+++ b/loki/ir/pragma_utils.py
@@ -33,7 +33,7 @@ def is_loki_pragma(pragma, starts_with=None):
 
     Parameters
     ----------
-    pragma : :any:`Pragma` or `list`/`tuple` of `ir.Pragma` or `None`
+    pragma : :any:`Pragma` or `list`/`tuple` of :any:`Pragma` or `None`
         the pragma or list of pragmas to check.
     starts_with : str, optional
         the keyword the pragma content must start with.
@@ -349,7 +349,7 @@ def attach_pragmas(ir, node_type, attach_pragma_post=True):
         the root of (a section of the) intermediate representation in which
         pragmas are to be attached.
     node_type : list
-        the (list of) :any:`ir.Node` types pragmas should be attached to.
+        the (list of) :any:`Node` types pragmas should be attached to.
     attach_pragma_post : bool, optional
         process ``pragma_post`` attachments.
     """
@@ -377,7 +377,7 @@ def detach_pragmas(ir, node_type, detach_pragma_post=True):
         the root node of the (section of the) intermediate representation
         in which pragmas are to be detached.
     node_type :
-        the (list of) :any:`ir.Node` types that pragmas should be detached from.
+        the (list of) :any:`Node` types that pragmas should be detached from.
     detach_pragma_post: bool, optional
         process ``pragma_post`` attachments.
     """
@@ -435,7 +435,7 @@ def pragmas_attached(module_or_routine, node_type, attach_pragma_post=True):
     module_or_routine : :any:`Module` or :any:`Subroutine`
         the program unit in which pragmas are to be inlined.
     node_type :
-        the (list of) :any:`ir.Node` types, that pragmas should be
+        the (list of) :any:`Node` types, that pragmas should be
         attached to.
     attach_pragma_post : bool, optional
         process ``pragma_post`` attachments.

--- a/loki/lint/__init__.py
+++ b/loki/lint/__init__.py
@@ -4,6 +4,9 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Code linting infrastructure to allow coding standard checks using Loki.
+"""
 
 from loki.lint.utils import * # noqa
 from loki.lint.rules import * # noqa

--- a/loki/logging.py
+++ b/loki/logging.py
@@ -4,6 +4,9 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Loki's logger classes and logging utilities.
+"""
 
 import logging
 import sys

--- a/loki/tools/__init__.py
+++ b/loki/tools/__init__.py
@@ -4,6 +4,9 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Collection of tools and utility methods used throughout Loki.
+"""
 
 from loki.tools.util import *  # noqa
 from loki.tools.files import *  # noqa

--- a/loki/tools/files.py
+++ b/loki/tools/files.py
@@ -254,6 +254,7 @@ def write_env_launch_script(here, binary, args):
     This writes a simple script of the form
 
     .. code-block::
+
        source env.sh
        bin/<binary> <args>
        exit $?

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -706,11 +706,11 @@ def stdchannel_redirected(stdchannel, dest_filename):
 
     e.g.:
 
-    ```
-    with stdchannel_redirected(sys.stderr, os.devnull):
-        if compiler.has_function('clock_gettime', libraries=['rt']):
-            libraries.append('rt')
-    ```
+    .. code-block:: python
+
+        with stdchannel_redirected(sys.stderr, os.devnull):
+            if compiler.has_function('clock_gettime', libraries=['rt']):
+                libraries.append('rt')
 
     Source: https://stackoverflow.com/a/17753573
 
@@ -719,11 +719,11 @@ def stdchannel_redirected(stdchannel, dest_filename):
     Additionally, capturing of sys.stdout/sys.stderr needs to be disabled explicitly,
     i.e., use the fixture `capsys` and wrap the above:
 
-    ```
-    with capsys.disabled():
-        with stdchannel_redirected(sys.stdout, 'stdout.log'):
-            function()
-    ```
+    .. code-block:: python
+
+        with capsys.disabled():
+            with stdchannel_redirected(sys.stdout, 'stdout.log'):
+                function()
     """
 
     def try_dup(fd):

--- a/loki/transformations/__init__.py
+++ b/loki/transformations/__init__.py
@@ -4,6 +4,13 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+"""
+Sub-package with supported source code transformation passes.
+
+This sub-package includes general source code trnasformations and
+bespoke :any:`Transformation` and :any:`Pipeline` classes for
+IFS-specific source-to-source recipes that target GPUs.
+"""
 
 from loki.transformations.array_indexing import * # noqa
 from loki.transformations.build_system import * # noqa

--- a/loki/transformations/__init__.py
+++ b/loki/transformations/__init__.py
@@ -7,7 +7,7 @@
 """
 Sub-package with supported source code transformation passes.
 
-This sub-package includes general source code trnasformations and
+This sub-package includes general source code transformations and
 bespoke :any:`Transformation` and :any:`Pipeline` classes for
 IFS-specific source-to-source recipes that target GPUs.
 """

--- a/loki/transformations/extract.py
+++ b/loki/transformations/extract.py
@@ -32,7 +32,9 @@ def extract_contained_procedures(procedure):
     3. All procedures are removed from the CONTAINS block of ``procedure``.
 
     As a basic example of this transformation, the Fortran subroutine:
+
     .. code-block::
+
         subroutine outer()
             integer :: y
             integer :: o
@@ -47,8 +49,11 @@ def extract_contained_procedures(procedure):
                o = x + y ! Note, 'y' is "global" here!
             end subroutine inner
         end subroutine outer
+
     is modified to:
+
     .. code-block::
+
         subroutine outer()
             integer :: y
             integer :: o
@@ -57,8 +62,11 @@ def extract_contained_procedures(procedure):
             call inner(o, y) ! 'y' now passed as argument.
             contains
         end subroutine outer
+
     and the (modified) child:
+
     .. code-block::
+
         subroutine inner(o, y)
                integer, intent(inout) :: o
                integer, intent(inout) :: y
@@ -66,6 +74,7 @@ def extract_contained_procedures(procedure):
                x = 4
                o = x + y ! Note, 'y' is no longer "global"
         end subroutine inner
+
     is returned.
     """
     new_procedures = []

--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -230,7 +230,8 @@ def inline_constant_parameters(routine, external_only=True):
     The ``.type.initial`` property is used to derive the replacement
     value,a which means for symbols imported from external modules,
     the parent :any:`Module` needs to be supplied in the
-    ``definitions`` to the constructor when creating :param:`routine`.
+    ``definitions`` to the constructor when creating the
+    :any:`Subroutine`.
 
     Variables that are replaced are also removed from their
     corresponding import statements, with empty import statements

--- a/loki/transformations/sanitise.py
+++ b/loki/transformations/sanitise.py
@@ -138,24 +138,31 @@ def transform_sequence_association(routine):
     Housekeeping routine to replace scalar syntax when passing arrays as arguments
     For example, a call like
 
-    real :: a(m,n)
+    .. code-block::
 
-    call myroutine(a(i,j))
+        real :: a(m,n)
+
+        call myroutine(a(i,j))
 
     where myroutine looks like
 
-    subroutine myroutine(a)
-        real :: a(5)
-    end subroutine myroutine
+    .. code-block::
+
+        subroutine myroutine(a)
+            real :: a(5)
+        end subroutine myroutine
 
     should be changed to
 
-    call myroutine(a(i:m,j)
+    .. code-block::
+
+        call myroutine(a(i:m,j)
 
     Parameters
     ----------
     routine : :any:`Subroutine`
         The subroutine where calls will be changed
+
     """
 
     #List calls in routine, but make sure we have the called routine definition

--- a/loki/transformations/transform_derived_types.py
+++ b/loki/transformations/transform_derived_types.py
@@ -41,6 +41,7 @@ class DerivedTypeArgumentsTransformation(Transformation):
     (relevant) derived type arguments by its member variables
 
     .. note::
+
        This transformation requires a Scheduler traversal that
        processes callees before callers.
 
@@ -377,6 +378,7 @@ class DerivedTypeArgumentsTransformation(Transformation):
         of this routine on the right:
 
         .. code-block::
+
             var name            | return value (parent_name, expansion, new use)   | remarks
            ---------------------+--------------------------------------------------+------------------------------------
             SOME_VAR            | ('some_var', None, None)                         | No expansion

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,10 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Standalone scripts that provide the top-level entry-point to the Loki API.
+"""


### PR DESCRIPTION
_~Filing early to get the resulting change and errors logs. Please ignore for now...~_

General documentation update following the move of sub-packages. This primarily does three things:
1. Update static links in the documentation pages to sub-packages that have moved
2. General update of docstrings that trigger silent errors or warnings in the docs build
3. Addition of sub-package docstrings to give a brief overview of the respective sub-packages (the auto-generated API list looked empty to me).

Unfortunately, I didn't get everything in the docstring clean-up commit, and there are still a few warnings I do not understand. The overall impact should be net-positive though. 