### PR TITLE
IR: Fix `get_pragma_params` for multiline pragmas

### DIFF
--- a/loki/ir/pragma_utils.py
+++ b/loki/ir/pragma_utils.py
@@ -149,6 +149,8 @@ def get_pragma_parameters(pragma, starts_with=None, only_loki_pragmas=True):
         if only_loki_pragmas and p.keyword.lower() != 'loki':
             continue
         content = p.content or ''
+        # Remove any line-continuation markers
+        content = content.replace('&', '')
         if starts_with is not None:
             if not content.lower().startswith(starts_with.lower()):
                 continue

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -207,7 +207,7 @@ def convert(
     remove_code_trafo = scheduler.config.transformations.get('RemoveCodeTransformation', None)
     if not remove_code_trafo:
         remove_code_trafo = RemoveCodeTransformation(
-            remove_marked_regions=True, remove_dead_code=False,
+            remove_marked_regions=True, remove_dead_code=False, kernel_only=True,
             call_names=('ABOR1', 'DR_HOOK'), intrinsic_names=('WRITE(NULOUT',)
         )
     scheduler.process(transformation=remove_code_trafo)


### PR DESCRIPTION
The recent addition of `parse_expr` for reading pragma parameters does not account for multi-line pragmas with `&` linebreaks. This PR fixes this and adds a small test for this.

I've also piggy-backed a small fix to loki-transform.py, where the recent introduction of `RemoveCodeTransformation` was not told to keep `DR_HOOK` calls in the drivers via the `kernel_only` option. With these two changes, EC-physics regression should be fine again.  