### PR TITLE
JIT compilation updates and compatibility with f90wrap v0.2.14

### DIFF
--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -2035,7 +2035,6 @@ end subroutine caller
             successors = kwargs.get('successors')
             assert set(successors) == set(self.expected_successors[item.name])
 
-    tmp_path = tmp_path/'test_scheduler_successors'
     (tmp_path/'some_mod.F90').write_text(fcode_mod)
     (tmp_path/'caller.F90').write_text(fcode)
 
@@ -2564,7 +2563,7 @@ end subroutine test_scheduler_filter_program_units_file_graph_driver
     (None, ['SOME_DEFINITION'], True, [], {}),
     # Global preprocessing with local definition for one file, re-adding a dependency on 3
     (
-        {'test_scheduler_frontend_args/file3_4.F90': {'defines': ['SOME_DEFINITION','LOCAL_DEFINITION']}},
+        {'file3_4.F90': {'defines': ['SOME_DEFINITION','LOCAL_DEFINITION']}},
         ['SOME_DEFINITION'],
         True,
         [],
@@ -2575,7 +2574,7 @@ end subroutine test_scheduler_filter_program_units_file_graph_driver
     ),
     # Global preprocessing with preprocessing switched off for 2
     (
-        {'test_scheduler_frontend_args/file2.F90': {'preprocess': False}},
+        {'file2.F90': {'preprocess': False}},
         ['SOME_DEFINITION'],
         True,
         ['#test_scheduler_frontend_args2'],
@@ -2586,7 +2585,7 @@ end subroutine test_scheduler_filter_program_units_file_graph_driver
     ),
     # No preprocessing except for 2
     (
-        {'test_scheduler_frontend_args/file2.F90': {'preprocess': True, 'defines': ['SOME_DEFINITION']}},
+        {'file2.F90': {'preprocess': True, 'defines': ['SOME_DEFINITION']}},
         None,
         False,
         ['#test_scheduler_frontend_args1', '#test_scheduler_frontend_args4'],

--- a/loki/batch/tests/test_transformation.py
+++ b/loki/batch/tests/test_transformation.py
@@ -370,7 +370,7 @@ def test_transformation_post_apply_module(here, frontend, post_apply_rescope_sym
             assert module.variable_map['j'].scope is tmp_scope
 
     fcode = """
-module transformation_module_post_apply
+module module_post_apply
   integer :: i = 0
 contains
   subroutine test_post_apply(ret)
@@ -378,7 +378,7 @@ contains
     i = i + 1
     ret = i
   end subroutine test_post_apply
-end module transformation_module_post_apply
+end module module_post_apply
     """.strip()
 
     module = Module.from_source(fcode, frontend=frontend)

--- a/loki/build/obj.py
+++ b/loki/build/obj.py
@@ -5,17 +5,9 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import re
+from functools import cached_property
 from pathlib import Path
-
-try:
-    from functools import cached_property
-except ImportError:
-    try:
-        from cached_property import cached_property
-    except ImportError:
-        def cached_property(func):
-            return func
+import re
 
 from loki.logging import debug
 from loki.tools import execute, as_tuple, flatten, cached_func
@@ -59,6 +51,11 @@ class Obj:
         return obj
 
     __xnew_cached_ = staticmethod(cached_func(__new_stage2_))
+
+    @classmethod
+    def clear_cache(cls):
+        debug('Clearing Obj cache')
+        cls._Obj__xnew_cached_.cache_clear()
 
     def __init__(self, name=None, source_path=None):  # pylint: disable=unused-argument
         self.path = None  # The eventual .o path

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -30,7 +30,7 @@ from loki.frontend import (
 )
 from loki.ir import nodes as ir, FindNodes
 from loki.tools import (
-    gettempdir, filehash, stdchannel_redirected, stdchannel_is_captured
+    filehash, stdchannel_redirected, stdchannel_is_captured
 )
 
 # pylint: disable=too-many-lines
@@ -489,7 +489,7 @@ end subroutine index_ranges
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_strings(here, frontend, capsys):
+def test_strings(tmp_path, frontend, capsys):
     """
     Test recognition of literal strings.
     """
@@ -504,16 +504,14 @@ subroutine strings()
   print *, "42!"
 end subroutine strings
 """
-    filepath = here/(f'expression_strings_{frontend}.f90')
+    filepath = tmp_path/(f'expression_strings_{frontend}.f90')
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
     function = jit_compile(routine, filepath=filepath, objname='strings')
-    output_file = gettempdir()/filehash(str(filepath), prefix='', suffix='.log')
+    output_file = tmp_path/filehash(str(filepath), prefix='', suffix='.log')
     with capsys.disabled():
         with stdchannel_redirected(sys.stdout, output_file):
             function()
-
-    clean_test(filepath)
 
     with open(output_file, 'r') as f:
         output_str = f.read()

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -15,7 +15,6 @@ language features.
 # pylint: disable=too-many-lines
 
 from pathlib import Path
-from shutil import rmtree
 from time import perf_counter
 import numpy as np
 import pytest
@@ -23,7 +22,7 @@ import pytest
 from loki import (
     Module, Subroutine, FindVariables, BasicType, config, Sourcefile,
     RawSource, RegexParserClass, ProcedureType, DerivedType,
-    PreprocessorDirective, config_override, gettempdir
+    PreprocessorDirective, config_override
 )
 from loki.build import jit_compile, clean_test
 from loki.expression import symbols as sym
@@ -1852,7 +1851,7 @@ end subroutine test_inline_comments
 
 @pytest.mark.parametrize('from_file', (True, False))
 @pytest.mark.parametrize('preprocess', (True, False))
-def test_source_sanitize_fp_source(from_file, preprocess):
+def test_source_sanitize_fp_source(tmp_path, from_file, preprocess):
     """
     Test that source sanitizing works as expected and postprocessing
     rules are correctly applied
@@ -1871,11 +1870,7 @@ end subroutine some_routine
 """.strip()
 
     if from_file:
-        workdir = gettempdir()/'test_source_sanitize_fp_source'
-        if workdir.exists():
-            rmtree(workdir)
-        workdir.mkdir()
-        filepath = workdir/'some_routine.F90'
+        filepath = tmp_path/'some_routine.F90'
         filepath.write_text(fcode)
         obj = Sourcefile.from_file(filepath, frontend=FP, preprocess=preprocess, defines=('MY_VAR=5',))
     else:
@@ -1891,9 +1886,6 @@ end subroutine some_routine
         assert '"we print CPP value ", MY_VAR' in obj.to_fortran()
 
     assert 'newunit=fu' in obj.to_fortran()
-
-    if from_file:
-        rmtree(workdir)
 
 
 @pytest.mark.parametrize('preprocess', (True, False))

--- a/loki/lint/tests/test_reporter.py
+++ b/loki/lint/tests/test_reporter.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     HAVE_YAML = False
 
+from loki.ir import Intrinsic
 from loki.lint.linter import lint_files
 from loki.lint.reporter import (
     ProblemReport, RuleReport, FileReport,

--- a/loki/lint/tests/test_reporter.py
+++ b/loki/lint/tests/test_reporter.py
@@ -16,7 +16,6 @@ try:
 except ImportError:
     HAVE_YAML = False
 
-from loki import Intrinsic, gettempdir
 from loki.lint.linter import lint_files
 from loki.lint.reporter import (
     ProblemReport, RuleReport, FileReport,
@@ -123,10 +122,9 @@ def test_violation_file_handler(dummy_file, dummy_file_report):
     assert 'GenericRule' in file_report['rules']
 
 
-def test_lazy_textfile():
+def test_lazy_textfile(tmp_path):
     # Choose the output file and make sure it doesn't exist
-    filename = gettempdir()/'lazytextfile.log'
-    filename.unlink(missing_ok=True)
+    filename = tmp_path/'lazytextfile.log'
 
     # Instantiating the object should _not_ create the file
     f = LazyTextfile(filename)
@@ -145,12 +143,10 @@ def test_lazy_textfile():
     del f
     assert filename.read_text() == 's0me TEXT AAAAND other Th1ngs!!!'
 
-    filename.unlink(missing_ok=True)
-
 
 @pytest.mark.parametrize('max_workers', [None, 1])
 @pytest.mark.parametrize('fail_on,failures', [(None,0), ('kernel',4)])
-def test_linter_junitxml(testdir, max_workers, fail_on, failures):
+def test_linter_junitxml(tmp_path, testdir, max_workers, fail_on, failures):
     class RandomFailingRule(GenericRule):
         type = RuleType.WARN
         docs = {'title': 'A dummy rule for the sake of testing the Linter'}
@@ -162,8 +158,7 @@ def test_linter_junitxml(testdir, max_workers, fail_on, failures):
                 rule_report.add(cls.__name__, subroutine)
 
     basedir = testdir/'sources'
-    junitxml_file = gettempdir()/'linter_junitxml_outputfile.xml'
-    junitxml_file.unlink(missing_ok=True)
+    junitxml_file = tmp_path/'linter_junitxml_outputfile.xml'
     config = {
         'basedir': str(basedir),
         'include': ['projA/**/*.f90', 'projA/**/*.F90'],
@@ -182,14 +177,12 @@ def test_linter_junitxml(testdir, max_workers, fail_on, failures):
     assert xml.attrib['tests'] == '15'
     assert xml.attrib['failures'] == str(failures)
 
-    junitxml_file.unlink(missing_ok=True)
-
 
 @pytest.mark.skipif(not HAVE_YAML, reason='Pyyaml not installed')
 @pytest.mark.parametrize('max_workers', [None, 1])
 @pytest.mark.parametrize('fail_on,failures', [(None,0), ('kernel',4)])
 @pytest.mark.parametrize('use_line_hashes', [None, False, True])
-def test_linter_violation_file(testdir, rules, max_workers, fail_on, failures, use_line_hashes):
+def test_linter_violation_file(tmp_path, testdir, rules, max_workers, fail_on, failures, use_line_hashes):
     class RandomFailingRule(GenericRule):
         type = RuleType.WARN
         docs = {'title': 'A dummy rule for the sake of testing the Linter'}
@@ -201,8 +194,7 @@ def test_linter_violation_file(testdir, rules, max_workers, fail_on, failures, u
                 rule_report.add(cls.__name__, subroutine)
 
     basedir = testdir/'sources'
-    violations_file = gettempdir()/'linter_violations_file.yml'
-    violations_file.unlink(missing_ok=True)
+    violations_file = tmp_path/'linter_violations_file.yml'
     config = {
         'basedir': str(basedir),
         'include': ['projA/**/*.f90', 'projA/**/*.F90'],
@@ -244,5 +236,3 @@ def test_linter_violation_file(testdir, rules, max_workers, fail_on, failures, u
     checked = lint_files([RandomFailingRule, rules.DummyRule], config)
     assert checked == 15
     assert yaml.safe_load(violations_file.read_text()) is None
-
-    violations_file.unlink(missing_ok=True)

--- a/loki/tests/sources/sourcefile_cpp_stmt_func.F90
+++ b/loki/tests/sources/sourcefile_cpp_stmt_func.F90
@@ -1,4 +1,4 @@
-module sourcefile_cpp_stmt_func_mod
+module cpp_stmt_func_mod
 
     IMPLICIT NONE
 
@@ -8,15 +8,15 @@ module sourcefile_cpp_stmt_func_mod
 
 contains
 
-subroutine sourcefile_cpp_stmt_func(KIDIA, KFDIA, KLON, KLEV, ZFOEEW)
+subroutine cpp_stmt_func(KIDIA, KFDIA, KLON, KLEV, ZFOEEW)
     INTEGER(KIND=JPIM),INTENT(IN)    :: KLON, KLEV
-    INTEGER(KIND=JPIM),INTENT(IN)    :: KIDIA 
-    INTEGER(KIND=JPIM),INTENT(IN)    :: KFDIA 
+    INTEGER(KIND=JPIM),INTENT(IN)    :: KIDIA
+    INTEGER(KIND=JPIM),INTENT(IN)    :: KFDIA
     REAL(KIND=JPRB)   ,INTENT(OUT)   :: ZFOEEW(KLON,KLEV)
 
     INTEGER(KIND=JPIM) :: JK, JL
 
-    REAL(KIND=JPRB) :: ZTP1(KLON,KLEV)   
+    REAL(KIND=JPRB) :: ZTP1(KLON,KLEV)
     REAL(KIND=JPRB) :: PAP(KLON,KLEV)
     REAL(KIND=JPRB) :: ZALFA
 
@@ -45,6 +45,6 @@ subroutine sourcefile_cpp_stmt_func(KIDIA, KFDIA, KLON, KLEV, ZFOEEW)
                 &  (1.0_JPRB-ZALFA)*FOEEICE(ZTP1(JL,JK)))/PAP(JL,JK),0.5_JPRB)
         END DO
     END DO
-end subroutine sourcefile_cpp_stmt_func
+end subroutine cpp_stmt_func
 
-end module sourcefile_cpp_stmt_func_mod
+end module cpp_stmt_func_mod

--- a/loki/tests/test_derived_types.py
+++ b/loki/tests/test_derived_types.py
@@ -21,7 +21,7 @@ from loki import (
     StringSubscript, Conditional, CallStatement, ProcedureSymbol,
     FindVariables
 )
-from loki.build import jit_compile, jit_compile_lib, clean_test
+from loki.build import jit_compile, jit_compile_lib, clean_test, Obj
 from loki.frontend import available_frontends, OMNI, OFP
 
 
@@ -32,7 +32,8 @@ def fixture_here():
 
 @pytest.fixture(scope='module', name='builder')
 def fixture_builder(here):
-    return Builder(source_dirs=here, build_dir=here/'build')
+    yield Builder(source_dirs=here, build_dir=here/'build')
+    Obj.clear_cache()
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/tests/test_sourcefile.py
+++ b/loki/tests/test_sourcefile.py
@@ -203,12 +203,12 @@ def test_sourcefile_cpp_stmt_func(here, frontend):
     filepath = sourcepath/'sourcefile_cpp_stmt_func.F90'
 
     source = Sourcefile.from_file(filepath, includes=sourcepath, preprocess=True, frontend=frontend)
-    module = source['sourcefile_cpp_stmt_func_mod']
+    module = source['cpp_stmt_func_mod']
     module.name += f'_{frontend!s}'
 
     # OMNI inlines statement functions, so we can't check the representation
     if frontend != OMNI:
-        routine = source['sourcefile_cpp_stmt_func']
+        routine = source['cpp_stmt_func']
         stmt_func_decls = FindNodes(StatementFunction).visit(routine.spec)
         assert len(stmt_func_decls) == 4
 
@@ -227,7 +227,7 @@ def test_sourcefile_cpp_stmt_func(here, frontend):
     klon, klev = 10, 5
     kidia, kfdia = 1, klon
     zfoeew = np.zeros((klon, klev), order='F')
-    mod.sourcefile_cpp_stmt_func(kidia, kfdia, klon, klev, zfoeew)
+    mod.cpp_stmt_func(kidia, kfdia, klon, klev, zfoeew)
     assert (zfoeew == 0.25).all()
 
     clean_test(filepath)

--- a/loki/transformations/tests/test_array_indexing.py
+++ b/loki/transformations/tests/test_array_indexing.py
@@ -10,7 +10,7 @@ import pytest
 import numpy as np
 
 from loki import Module, Subroutine, fgen
-from loki.build import jit_compile, jit_compile_lib, clean_test, Builder
+from loki.build import jit_compile, jit_compile_lib, clean_test, Builder, Obj
 from loki.expression import symbols as sym, FindVariables
 from loki.frontend import available_frontends
 from loki.ir import FindNodes, CallStatement
@@ -30,7 +30,8 @@ def fixture_here():
 
 @pytest.fixture(scope='function', name='builder')
 def fixture_builder(tmp_path):
-    return Builder(source_dirs=tmp_path, build_dir=tmp_path)
+    yield Builder(source_dirs=tmp_path, build_dir=tmp_path)
+    Obj.clear_cache()
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/tests/test_array_indexing.py
+++ b/loki/transformations/tests/test_array_indexing.py
@@ -344,18 +344,18 @@ end subroutine transform_demote_dimension_arguments
 @pytest.mark.parametrize('start_index', (0, 1, 5))
 def test_transform_normalize_array_shape_and_access(here, frontend, start_index):
     """
-    Test normalization of array shape and access, thus changing arrays with start 
+    Test normalization of array shape and access, thus changing arrays with start
     index different than "1" to have start index "1".
 
-    E.g., ``x1(5:len)`` -> ```x1(1:len-4)`` 
+    E.g., ``x1(5:len)`` -> ```x1(1:len-4)``
     """
     fcode = f"""
-    module transform_normalize_array_shape_and_access_mod
+    module norm_arr_shape_access_mod
     implicit none
-    
+
     contains
 
-    subroutine transform_normalize_array_shape_and_access(x1, x2, x3, x4, assumed_x1, l1, l2, l3, l4)
+    subroutine norm_arr_shape_access(x1, x2, x3, x4, assumed_x1, l1, l2, l3, l4)
         ! use nested_routine_mod, only : nested_routine
         implicit none
         integer :: i1, i2, i3, i4, c1, c2, c3, c4
@@ -394,7 +394,7 @@ def test_transform_normalize_array_shape_and_access(here, frontend, start_index)
             end do
             c1 = c1 + 1
         end do
-    end subroutine transform_normalize_array_shape_and_access
+    end subroutine norm_arr_shape_access
 
     subroutine nested_routine(nested_x1, l1, c1)
         implicit none
@@ -406,7 +406,7 @@ def test_transform_normalize_array_shape_and_access(here, frontend, start_index)
         end do
     end subroutine nested_routine
 
-    end module transform_normalize_array_shape_and_access_mod
+    end module norm_arr_shape_access_mod
     """
 
     def init_arguments(l1, l2, l3, l4):
@@ -429,10 +429,10 @@ def test_transform_normalize_array_shape_and_access(here, frontend, start_index)
     module = Module.from_source(fcode, frontend=frontend)
     for routine in module.routines:
         normalize_range_indexing(routine) # Fix OMNI nonsense
-    filepath = here/(f'transform_normalize_array_shape_and_access_{frontend}.f90')
+    filepath = here/(f'norm_arr_shape_access_{frontend}.f90')
     # compile and test "original" module/function
-    mod = jit_compile(module, filepath=filepath, objname='transform_normalize_array_shape_and_access_mod')
-    function = getattr(mod, 'transform_normalize_array_shape_and_access')
+    mod = jit_compile(module, filepath=filepath, objname='norm_arr_shape_access_mod')
+    function = getattr(mod, 'norm_arr_shape_access')
     orig_x1, orig_x2, orig_x3, orig_x4, orig_assumed_x1 = init_arguments(l1, l2, l3, l4)
     function(orig_x1, orig_x2, orig_x3, orig_x4, orig_assumed_x1, l1, l2, l3, l4)
     clean_test(filepath)
@@ -441,14 +441,14 @@ def test_transform_normalize_array_shape_and_access(here, frontend, start_index)
     for routine in module.routines:
         normalize_array_shape_and_access(routine)
 
-    filepath = here/(f'transform_normalize_array_shape_and_access_normalized_{frontend}.f90')
+    filepath = here/(f'norm_arr_shape_access_normalized_{frontend}.f90')
     # compile and test "normalized" module/function
-    mod = jit_compile(module, filepath=filepath, objname='transform_normalize_array_shape_and_access_mod')
-    function = getattr(mod, 'transform_normalize_array_shape_and_access')
+    mod = jit_compile(module, filepath=filepath, objname='norm_arr_shape_access_mod')
+    function = getattr(mod, 'norm_arr_shape_access')
     x1, x2, x3, x4, assumed_x1 = init_arguments(l1, l2, l3, l4)
     function(x1, x2, x3, x4, assumed_x1, l1, l2, l3, l4)
     clean_test(filepath)
-    # validate the routine "transform_normalize_array_shape_and_access"
+    # validate the routine "norm_arr_shape_access"
     validate_routine(module.subroutines[0])
     # validate the nested routine to see whether the assumed size array got correctly handled
     assert module.subroutines[1].variable_map['nested_x1'] == 'nested_x1(:)'
@@ -470,7 +470,7 @@ def test_transform_flatten_arrays(here, frontend, builder, start_index):
     index arithmetic.
     """
     fcode = f"""
-    subroutine transform_flatten_arrays(x1, x2, x3, x4, l1, l2, l3, l4)
+    subroutine transf_flatten_arr(x1, x2, x3, x4, l1, l2, l3, l4)
         implicit none
         integer :: i1, i2, i3, i4, c1, c2, c3, c4
         integer, intent(in) :: l1, l2, l3, l4
@@ -503,7 +503,7 @@ def test_transform_flatten_arrays(here, frontend, builder, start_index):
             c1 = c1 + 1
         end do
 
-    end subroutine transform_flatten_arrays
+    end subroutine transf_flatten_arr
     """
     def init_arguments(l1, l2, l3, l4, flattened=False):
         x1 = np.zeros(shape=(l1,), order='F', dtype=np.int32)
@@ -573,7 +573,7 @@ def test_transform_flatten_arrays(here, frontend, builder, start_index):
     f2c.apply(source=f2c_routine, path=here)
     libname = f'fc_{f2c_routine.name}_{start_index}_{frontend}'
     c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_function = c_kernel.transform_flatten_arrays_fc_mod.transform_flatten_arrays_fc
+    fc_function = c_kernel.transf_flatten_arr_fc_mod.transf_flatten_arr_fc
     f2c_x1, f2c_x2, f2c_x3, f2c_x4 = init_arguments(l1, l2, l3, l4, flattened=True)
     fc_function(f2c_x1, f2c_x2, f2c_x3, f2c_x4, l1, l2, l3, l4)
     validate_routine(c_routine)
@@ -593,8 +593,8 @@ def test_transform_flatten_arrays(here, frontend, builder, start_index):
 @pytest.mark.parametrize('ignore', ((), ('i2',), ('i4', 'i1')))
 def test_shift_to_zero_indexing(frontend, ignore):
     """
-    Test shifting array dimensions to zero (or rather shift dimension `dim` 
-    to `dim - 1`). This does not produce valid Fortran, but is part of the 
+    Test shifting array dimensions to zero (or rather shift dimension `dim`
+    to `dim - 1`). This does not produce valid Fortran, but is part of the
     F2C transpilation logic.
     """
     fcode = """

--- a/loki/transformations/tests/test_data_offload.py
+++ b/loki/transformations/tests/test_data_offload.py
@@ -6,11 +6,10 @@
 # nor does it submit to any jurisdiction.
 
 from pathlib import Path
-from shutil import rmtree
 import pytest
 
 from loki import (
-    Sourcefile, gettempdir, Scheduler,  FindInlineCalls
+    Sourcefile, Scheduler,  FindInlineCalls
 )
 from loki.frontend import available_frontends, OMNI
 from loki.ir import (
@@ -245,7 +244,7 @@ def test_data_offload_region_multiple(frontend):
 
 
 @pytest.fixture(name='global_variable_analysis_code')
-def fixture_global_variable_analysis_code():
+def fixture_global_variable_analysis_code(tmp_path):
     fcode = {
         #------------------------------
         'global_var_analysis_header_mod': (
@@ -355,16 +354,9 @@ end subroutine driver
         ).strip()
     }
 
-    workdir = gettempdir()/'test_global_variable_analysis'
-    if workdir.exists():
-        rmtree(workdir)
-    workdir.mkdir()
     for name, code in fcode.items():
-        (workdir/f'{name}.F90').write_text(code)
-
-    yield workdir
-
-    rmtree(workdir)
+        (tmp_path/f'{name}.F90').write_text(code)
+    return tmp_path
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/tests/test_hoist_variables.py
+++ b/loki/transformations/tests/test_hoist_variables.py
@@ -13,7 +13,7 @@ import pytest
 import numpy as np
 
 from loki import (
-    Scheduler, SchedulerConfig, is_iterable, gettempdir,
+    Scheduler, SchedulerConfig, is_iterable,
     normalize_range_indexing, FindInlineCalls
 )
 from loki.build import jit_compile_lib, clean_test, Builder
@@ -534,7 +534,7 @@ def test_hoist_allocatable(here, testdir, frontend, config, as_kwarguments):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_hoist_mixed_variable_declarations(frontend, config):
+def test_hoist_mixed_variable_declarations(tmp_path, frontend, config):
 
     fcode_driver = """
 subroutine driver(NLON, NZ, NB, FIELD1, FIELD2)
@@ -586,10 +586,8 @@ contains
 end module kernel_mod
     """.strip()
 
-    basedir = gettempdir()/'test_hoist_mixed_variable_declarations'
-    basedir.mkdir(exist_ok=True)
-    (basedir/'driver.F90').write_text(fcode_driver)
-    (basedir/'kernel_mod.F90').write_text(fcode_kernel)
+    (tmp_path/'driver.F90').write_text(fcode_driver)
+    (tmp_path/'kernel_mod.F90').write_text(fcode_kernel)
 
     config = {
         'default': {
@@ -603,7 +601,7 @@ end module kernel_mod
         }
     }
 
-    scheduler = Scheduler(paths=[basedir], config=SchedulerConfig.from_dict(config), frontend=frontend)
+    scheduler = Scheduler(paths=[tmp_path], config=SchedulerConfig.from_dict(config), frontend=frontend)
 
     if frontend == OMNI:
         for item in scheduler.items:

--- a/loki/transformations/tests/test_inline.py
+++ b/loki/transformations/tests/test_inline.py
@@ -117,20 +117,20 @@ end module parameters_mod
 """
 
     fcode = """
-module transform_inline_constant_parameters_mod
+module transf_inline_const_param_mod
   ! TODO: use parameters_mod, only: b
   implicit none
   integer, parameter :: c = 1+1
 contains
-  subroutine transform_inline_constant_parameters(v1, v2, v3)
+  subroutine transf_inline_const_param(v1, v2, v3)
     use parameters_mod, only: a, b
     integer, intent(in) :: v1
     integer, intent(out) :: v2, v3
 
     v2 = v1 + b - a
     v3 = c
-  end subroutine transform_inline_constant_parameters
-end module transform_inline_constant_parameters_mod
+  end subroutine transf_inline_const_param
+end module transf_inline_const_param_mod
 """
     # Generate reference code, compile run and verify
     param_module = Module.from_source(fcode_module, frontend=frontend)
@@ -138,7 +138,7 @@ end module transform_inline_constant_parameters_mod
     refname = f'ref_{module.name}_{ frontend}'
     reference = jit_compile_lib([module, param_module], path=here, name=refname, builder=builder)
 
-    v2, v3 = reference.transform_inline_constant_parameters_mod.transform_inline_constant_parameters(10)
+    v2, v3 = reference.transf_inline_const_param_mod.transf_inline_const_param(10)
     assert v2 == 8
     assert v3 == 2
     (here/f'{module.name}.f90').unlink()
@@ -146,16 +146,16 @@ end module transform_inline_constant_parameters_mod
 
     # Now transform with supplied elementals but without module
     module = Module.from_source(fcode, definitions=param_module, frontend=frontend)
-    assert len(FindNodes(ir.Import).visit(module['transform_inline_constant_parameters'].spec)) == 1
+    assert len(FindNodes(ir.Import).visit(module['transf_inline_const_param'].spec)) == 1
     for routine in module.subroutines:
         inline_constant_parameters(routine, external_only=True)
-    assert not FindNodes(ir.Import).visit(module['transform_inline_constant_parameters'].spec)
+    assert not FindNodes(ir.Import).visit(module['transf_inline_const_param'].spec)
 
     # Hack: rename module to use a different filename in the build
     module.name = f'{module.name}_'
     obj = jit_compile_lib([module], path=here, name=f'{module.name}_{frontend}', builder=builder)
 
-    v2, v3 = obj.transform_inline_constant_parameters_mod_.transform_inline_constant_parameters(10)
+    v2, v3 = obj.transf_inline_const_param_mod_.transf_inline_const_param(10)
     assert v2 == 8
     assert v3 == 2
 
@@ -175,16 +175,16 @@ end module kind_parameters_mod
 """
 
     fcode = """
-module transform_inline_constant_parameters_kind_mod
+module transf_inl_const_param_kind_mod
   implicit none
 contains
-  subroutine transform_inline_constant_parameters_kind(v1)
+  subroutine transf_inl_const_param_kind(v1)
     use kind_parameters_mod, only: jprb
     real(kind=jprb), intent(out) :: v1
 
     v1 = real(2, kind=jprb) + 3.
-  end subroutine transform_inline_constant_parameters_kind
-end module transform_inline_constant_parameters_kind_mod
+  end subroutine transf_inl_const_param_kind
+end module transf_inl_const_param_kind_mod
 """
     # Generate reference code, compile run and verify
     param_module = Module.from_source(fcode_module, frontend=frontend)
@@ -192,23 +192,23 @@ end module transform_inline_constant_parameters_kind_mod
     refname = f'ref_{module.name}_{frontend}'
     reference = jit_compile_lib([module, param_module], path=here, name=refname, builder=builder)
 
-    v1 = reference.transform_inline_constant_parameters_kind_mod.transform_inline_constant_parameters_kind()
+    v1 = reference.transf_inl_const_param_kind_mod.transf_inl_const_param_kind()
     assert v1 == 5.
     (here/f'{module.name}.f90').unlink()
     (here/f'{param_module.name}.f90').unlink()
 
     # Now transform with supplied elementals but without module
     module = Module.from_source(fcode, definitions=param_module, frontend=frontend)
-    assert len(FindNodes(ir.Import).visit(module['transform_inline_constant_parameters_kind'].spec)) == 1
+    assert len(FindNodes(ir.Import).visit(module['transf_inl_const_param_kind'].spec)) == 1
     for routine in module.subroutines:
         inline_constant_parameters(routine, external_only=True)
-    assert not FindNodes(ir.Import).visit(module['transform_inline_constant_parameters_kind'].spec)
+    assert not FindNodes(ir.Import).visit(module['transf_inl_const_param_kind'].spec)
 
     # Hack: rename module to use a different filename in the build
     module.name = f'{module.name}_'
     obj = jit_compile_lib([module], path=here, name=f'{module.name}_{frontend}', builder=builder)
 
-    v1 = obj.transform_inline_constant_parameters_kind_mod_.transform_inline_constant_parameters_kind()
+    v1 = obj.transf_inl_const_param_kind_mod_.transf_inl_const_param_kind()
     assert v1 == 5.
 
     (here/f'{module.name}.f90').unlink()
@@ -227,17 +227,17 @@ end module replace_kind_parameters_mod
 """
 
     fcode = """
-module transform_inline_constant_parameters_replace_kind_mod
+module transf_inl_const_param_repl_kind_mod
   implicit none
 contains
-  subroutine transform_inline_constant_parameters_replace_kind(v1)
+  subroutine transf_inl_const_param_repl_kind(v1)
     use replace_kind_parameters_mod, only: jprb
     real(kind=jprb), intent(out) :: v1
     real(kind=jprb) :: a = 3._JPRB
 
     v1 = 1._jprb + real(2, kind=jprb) + a
-  end subroutine transform_inline_constant_parameters_replace_kind
-end module transform_inline_constant_parameters_replace_kind_mod
+  end subroutine transf_inl_const_param_repl_kind
+end module transf_inl_const_param_repl_kind_mod
 """
     # Generate reference code, compile run and verify
     param_module = Module.from_source(fcode_module, frontend=frontend)

--- a/loki/transformations/tests/test_inline.py
+++ b/loki/transformations/tests/test_inline.py
@@ -13,7 +13,7 @@ from loki import (
     Module, Subroutine, FindVariables, BasicType, DerivedType,
     FindInlineCalls
 )
-from loki.build import jit_compile, jit_compile_lib, Builder
+from loki.build import jit_compile, jit_compile_lib, Builder, Obj
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI, OFP
 from loki.ir import nodes as ir, FindNodes
@@ -34,7 +34,8 @@ def fixture_here():
 
 @pytest.fixture(scope='module', name='builder')
 def fixture_builder(here):
-    return Builder(source_dirs=here, build_dir=here/'build')
+    yield Builder(source_dirs=here, build_dir=here/'build')
+    Obj.clear_cache()
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/tests/test_inline.py
+++ b/loki/transformations/tests/test_inline.py
@@ -117,20 +117,20 @@ end module parameters_mod
 """
 
     fcode = """
-module transf_inline_const_param_mod
+module inline_const_param_mod
   ! TODO: use parameters_mod, only: b
   implicit none
   integer, parameter :: c = 1+1
 contains
-  subroutine transf_inline_const_param(v1, v2, v3)
+  subroutine inline_const_param(v1, v2, v3)
     use parameters_mod, only: a, b
     integer, intent(in) :: v1
     integer, intent(out) :: v2, v3
 
     v2 = v1 + b - a
     v3 = c
-  end subroutine transf_inline_const_param
-end module transf_inline_const_param_mod
+  end subroutine inline_const_param
+end module inline_const_param_mod
 """
     # Generate reference code, compile run and verify
     param_module = Module.from_source(fcode_module, frontend=frontend)
@@ -138,7 +138,7 @@ end module transf_inline_const_param_mod
     refname = f'ref_{module.name}_{ frontend}'
     reference = jit_compile_lib([module, param_module], path=here, name=refname, builder=builder)
 
-    v2, v3 = reference.transf_inline_const_param_mod.transf_inline_const_param(10)
+    v2, v3 = reference.inline_const_param_mod.inline_const_param(10)
     assert v2 == 8
     assert v3 == 2
     (here/f'{module.name}.f90').unlink()
@@ -146,16 +146,16 @@ end module transf_inline_const_param_mod
 
     # Now transform with supplied elementals but without module
     module = Module.from_source(fcode, definitions=param_module, frontend=frontend)
-    assert len(FindNodes(ir.Import).visit(module['transf_inline_const_param'].spec)) == 1
+    assert len(FindNodes(ir.Import).visit(module['inline_const_param'].spec)) == 1
     for routine in module.subroutines:
         inline_constant_parameters(routine, external_only=True)
-    assert not FindNodes(ir.Import).visit(module['transf_inline_const_param'].spec)
+    assert not FindNodes(ir.Import).visit(module['inline_const_param'].spec)
 
     # Hack: rename module to use a different filename in the build
     module.name = f'{module.name}_'
     obj = jit_compile_lib([module], path=here, name=f'{module.name}_{frontend}', builder=builder)
 
-    v2, v3 = obj.transf_inline_const_param_mod_.transf_inline_const_param(10)
+    v2, v3 = obj.inline_const_param_mod_.inline_const_param(10)
     assert v2 == 8
     assert v3 == 2
 
@@ -175,16 +175,16 @@ end module kind_parameters_mod
 """
 
     fcode = """
-module transf_inl_const_param_kind_mod
+module inline_const_param_kind_mod
   implicit none
 contains
-  subroutine transf_inl_const_param_kind(v1)
+  subroutine inline_const_param_kind(v1)
     use kind_parameters_mod, only: jprb
     real(kind=jprb), intent(out) :: v1
 
     v1 = real(2, kind=jprb) + 3.
-  end subroutine transf_inl_const_param_kind
-end module transf_inl_const_param_kind_mod
+  end subroutine inline_const_param_kind
+end module inline_const_param_kind_mod
 """
     # Generate reference code, compile run and verify
     param_module = Module.from_source(fcode_module, frontend=frontend)
@@ -192,23 +192,23 @@ end module transf_inl_const_param_kind_mod
     refname = f'ref_{module.name}_{frontend}'
     reference = jit_compile_lib([module, param_module], path=here, name=refname, builder=builder)
 
-    v1 = reference.transf_inl_const_param_kind_mod.transf_inl_const_param_kind()
+    v1 = reference.inline_const_param_kind_mod.inline_const_param_kind()
     assert v1 == 5.
     (here/f'{module.name}.f90').unlink()
     (here/f'{param_module.name}.f90').unlink()
 
     # Now transform with supplied elementals but without module
     module = Module.from_source(fcode, definitions=param_module, frontend=frontend)
-    assert len(FindNodes(ir.Import).visit(module['transf_inl_const_param_kind'].spec)) == 1
+    assert len(FindNodes(ir.Import).visit(module['inline_const_param_kind'].spec)) == 1
     for routine in module.subroutines:
         inline_constant_parameters(routine, external_only=True)
-    assert not FindNodes(ir.Import).visit(module['transf_inl_const_param_kind'].spec)
+    assert not FindNodes(ir.Import).visit(module['inline_const_param_kind'].spec)
 
     # Hack: rename module to use a different filename in the build
     module.name = f'{module.name}_'
     obj = jit_compile_lib([module], path=here, name=f'{module.name}_{frontend}', builder=builder)
 
-    v1 = obj.transf_inl_const_param_kind_mod_.transf_inl_const_param_kind()
+    v1 = obj.inline_const_param_kind_mod_.inline_const_param_kind()
     assert v1 == 5.
 
     (here/f'{module.name}.f90').unlink()
@@ -227,17 +227,17 @@ end module replace_kind_parameters_mod
 """
 
     fcode = """
-module transf_inl_const_param_repl_kind_mod
+module inline_param_repl_kind_mod
   implicit none
 contains
-  subroutine transf_inl_const_param_repl_kind(v1)
+  subroutine inline_param_repl_kind(v1)
     use replace_kind_parameters_mod, only: jprb
     real(kind=jprb), intent(out) :: v1
     real(kind=jprb) :: a = 3._JPRB
 
     v1 = 1._jprb + real(2, kind=jprb) + a
-  end subroutine transf_inl_const_param_repl_kind
-end module transf_inl_const_param_repl_kind_mod
+  end subroutine inline_param_repl_kind
+end module inline_param_repl_kind_mod
 """
     # Generate reference code, compile run and verify
     param_module = Module.from_source(fcode_module, frontend=frontend)

--- a/loki/transformations/tests/test_transform_region.py
+++ b/loki/transformations/tests/test_transform_region.py
@@ -372,7 +372,7 @@ def test_transform_region_to_call(here, frontend):
     A very simple region-to-call test case
     """
     fcode = """
-subroutine transform_region_to_call(a, b, c)
+subroutine reg_to_call(a, b, c)
   integer, intent(out) :: a, b, c
 
   a = 5
@@ -383,7 +383,7 @@ subroutine transform_region_to_call(a, b, c)
 !$loki end region-to-call
 
   c = a + b
-end subroutine transform_region_to_call
+end subroutine reg_to_call
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = here/(f'{routine.name}_{frontend}.f90')
@@ -424,7 +424,7 @@ def test_transform_region_to_call_multiple(here, frontend):
     Test hoisting with multiple groups and multiple regions per group
     """
     fcode = """
-subroutine transform_region_to_call_multiple(a, b, c)
+subroutine reg_to_call_mult(a, b, c)
   integer, intent(out) :: a, b, c
 
   a = 1
@@ -442,7 +442,7 @@ subroutine transform_region_to_call_multiple(a, b, c)
 !$loki region-to-call in(a,b) out(c)
   c = a + b
 !$loki end region-to-call
-end subroutine transform_region_to_call_multiple
+end subroutine reg_to_call_mult
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = here/(f'{routine.name}_{frontend}.f90')
@@ -486,7 +486,7 @@ def test_transform_region_to_call_arguments(here, frontend):
     and automatic derivation of arguments
     """
     fcode = """
-subroutine transform_region_to_call_arguments(a, b, c)
+subroutine reg_to_call_args(a, b, c)
   integer, intent(out) :: a, b, c
 
   a = 1
@@ -505,7 +505,7 @@ subroutine transform_region_to_call_arguments(a, b, c)
 !$loki region-to-call name(func_c) inout(b)
   c = a + b
 !$loki end region-to-call
-end subroutine transform_region_to_call_arguments
+end subroutine reg_to_call_args
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = here/(f'{routine.name}_{frontend}.f90')
@@ -559,7 +559,7 @@ def test_transform_region_to_call_arrays(here, frontend):
     Test hoisting with array variables
     """
     fcode = """
-subroutine transform_region_to_call_arrays(a, b, n)
+subroutine reg_to_call_arrays(a, b, n)
   integer, intent(out) :: a(n), b(n)
   integer, intent(in) :: n
   integer :: j
@@ -582,7 +582,7 @@ subroutine transform_region_to_call_arrays(a, b, n)
   end do
   b(n) = 1
 !$loki end region-to-call
-end subroutine transform_region_to_call_arrays
+end subroutine reg_to_call_arrays
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     normalize_range_indexing(routine)
@@ -646,10 +646,10 @@ end module region_to_call_mod
     """.strip()
 
     fcode = """
-module transform_region_to_call_imports_mod
+module region_to_call_imports_mod
   implicit none
 contains
-  subroutine transform_region_to_call_imports(a, b)
+  subroutine region_to_call_imports(a, b)
     use region_to_call_mod, only: param, arr1, arr2
     integer, intent(out) :: a(10), b(10)
     integer :: j
@@ -673,8 +673,8 @@ contains
       b(j) = arr2(j) - a(j)
     end do
 !$loki end region-to-call
-  end subroutine transform_region_to_call_imports
-end module transform_region_to_call_imports_mod
+  end subroutine region_to_call_imports
+end module region_to_call_imports_mod
 """
     ext_module = Module.from_source(fcode_module, frontend=frontend)
     module = Module.from_source(fcode, frontend=frontend, definitions=ext_module)

--- a/loki/transformations/tests/test_transform_region.py
+++ b/loki/transformations/tests/test_transform_region.py
@@ -13,7 +13,7 @@ from loki import (
     Module, Subroutine, Section, as_tuple, FindNodes, Loop,
     Assignment, CallStatement, Intrinsic
 )
-from loki.build import jit_compile, jit_compile_lib, Builder
+from loki.build import jit_compile, jit_compile_lib, Builder, Obj
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends
 
@@ -25,7 +25,8 @@ from loki.transformations.transform_region import (
 
 @pytest.fixture(scope='function', name='builder')
 def fixture_builder(tmp_path):
-    return Builder(source_dirs=tmp_path, build_dir=tmp_path/'build')
+    yield Builder(source_dirs=tmp_path, build_dir=tmp_path/'build')
+    Obj.clear_cache()
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/transpile/tests/test_maxeler/test_maxeler.py
+++ b/loki/transformations/transpile/tests/test_maxeler/test_maxeler.py
@@ -101,7 +101,8 @@ def fixture_here():
 @pytest.fixture(scope='module', name='builder')
 def fixture_builder(here):
     include_dirs = get_max_includes() if is_maxeler_available() else []
-    return Builder(source_dirs=here, include_dirs=include_dirs, build_dir=here/'build')
+    yield Builder(source_dirs=here, include_dirs=include_dirs, build_dir=here/'build')
+    Obj.clear_cache()
 
 
 def max_transpile(routine, path, builder, frontend, objects=None, wrap=None):

--- a/loki/transformations/transpile/tests/test_sdfg.py
+++ b/loki/transformations/transpile/tests/test_sdfg.py
@@ -5,15 +5,17 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import itertools
 import importlib
+import itertools
+from shutil import rmtree
 from pathlib import Path
 import numpy as np
 import pytest
 
 from loki import Subroutine
-from loki.build import jit_compile, clean_test
+from loki.build import jit_compile
 from loki.frontend import available_frontends
+from loki.tools import gettempdir
 
 from loki.transformations.transpile import FortranPythonTransformation
 
@@ -30,9 +32,14 @@ pytestmark = [
     )
 ]
 
-@pytest.fixture(scope='module', name='here')
-def fixture_here():
-    return Path(__file__).parent
+
+@pytest.fixture(scope='function', name='tempdir')
+def fixture_tempdir(request):
+    basedir = gettempdir()/request.function.__name__
+    basedir.mkdir(exist_ok=True)
+    yield basedir
+    if basedir.exists():
+        rmtree(basedir)
 
 
 def load_module(path):
@@ -47,9 +54,9 @@ def load_module(path):
         return importlib.import_module(path.stem)
 
 
-def create_sdfg(routine, here):
+def create_sdfg(routine, tempdir):
     trafo = FortranPythonTransformation(with_dace=True, suffix='_py')
-    routine.apply(trafo, path=here)
+    routine.apply(trafo, path=tempdir)
 
     mod = load_module(trafo.py_path)
     function = getattr(mod, routine.name)
@@ -57,7 +64,7 @@ def create_sdfg(routine, here):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_sdfg_routine_copy(here, frontend):
+def test_sdfg_routine_copy(tempdir, frontend):
 
     fcode = """
 subroutine routine_copy(n, x, y)
@@ -77,7 +84,7 @@ end subroutine routine_copy
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
     # Test the reference solution
-    filepath = here/(f'routine_copy_{frontend}.f90')
+    filepath = tempdir/(f'routine_copy_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='routine_copy')
 
     n = 64
@@ -89,7 +96,7 @@ end subroutine routine_copy
     assert all(x_ref == y)
 
     # Create and compile the SDFG
-    sdfg = create_sdfg(routine, here)
+    sdfg = create_sdfg(routine, tempdir)
     assert sdfg.validate() is None
 
     csdfg = sdfg.compile()
@@ -100,14 +107,11 @@ end subroutine routine_copy
     csdfg(n=np.int32(n), x=x, y=y)
     assert all(x_ref == y)
 
-    clean_test(filepath)
-    (here / (routine.name + '.py')).unlink()
-
 
 @pytest.mark.xfail(reason='Scalar inout arguments do not work in dace')
 @pytest.mark.filterwarnings('ignore:The value of the smallest subnormal.*class \'numpy.float64\':UserWarning')
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_sdfg_routine_axpy_scalar(here, frontend):
+def test_sdfg_routine_axpy_scalar(tempdir, frontend):
 
     fcode = """
 subroutine routine_axpy_scalar(a, x, y)
@@ -124,7 +128,7 @@ end subroutine routine_axpy_scalar
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
     # Test the reference solution
-    filepath = here/(f'sdfg_routine_axpy_scalar_{frontend}.f90')
+    filepath = tempdir/(f'sdfg_routine_axpy_scalar_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='routine_axpy_scalar')
 
     a = np.float64(23)
@@ -135,7 +139,7 @@ end subroutine routine_axpy_scalar
     assert x_out == a * x + y
 
     # Create and compile the SDFG
-    sdfg = create_sdfg(routine, here)
+    sdfg = create_sdfg(routine, tempdir)
     assert sdfg.validate() is None
 
     csdfg = sdfg.compile()
@@ -146,12 +150,9 @@ end subroutine routine_axpy_scalar
     csdfg(a=a, x=x_out, y=y)
     assert x_out == a * x + y
 
-    clean_test(filepath)
-    (here / (routine.name + '.py')).unlink()
-
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_sdfg_routine_copy_stream(here, frontend):
+def test_sdfg_routine_copy_stream(tempdir, frontend):
 
     fcode = """
 subroutine routine_copy_stream(length, alpha, vector_in, vector_out)
@@ -172,7 +173,7 @@ end subroutine routine_copy_stream
     # TODO: make alpha a true scalar, which doesn't seem to work with SDFG at the moment???
 
     # Test the reference solution
-    filepath = here/(f'sdfg_routine_copy_stream_{frontend}.f90')
+    filepath = tempdir/(f'sdfg_routine_copy_stream_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='routine_copy_stream')
 
     length = 32
@@ -183,7 +184,7 @@ end subroutine routine_copy_stream
     assert np.all(vector_out == np.array(range(length)) + alpha)
 
     # Create and compile the SDFG
-    sdfg = create_sdfg(routine, here)
+    sdfg = create_sdfg(routine, tempdir)
     assert sdfg.validate() is None
 
     csdfg = sdfg.compile()
@@ -195,12 +196,9 @@ end subroutine routine_copy_stream
     csdfg(length=length, alpha=alpha, vector_in=vec_in, vector_out=vec_out)
     assert np.all(vec_out == np.array(range(length)) + alpha)
 
-    clean_test(filepath)
-    (here / (routine.name + '.py')).unlink()
-
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_sdfg_routine_fixed_loop(here, frontend):
+def test_sdfg_routine_fixed_loop(tempdir, frontend):
 
     fcode = """
 subroutine routine_fixed_loop(scalar, vector, vector_out, tensor, tensor_out)
@@ -224,7 +222,7 @@ subroutine routine_fixed_loop(scalar, vector, vector_out, tensor, tensor_out)
 end subroutine routine_fixed_loop
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/(f'sdfg_routine_fixed_loop_{frontend}.f90')
+    filepath = tempdir/(f'sdfg_routine_fixed_loop_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='routine_fixed_loop')
 
     # Test the reference solution
@@ -240,7 +238,7 @@ end subroutine routine_fixed_loop
     assert np.all(tensor_out == ref_tensor)
 
     # Create and compile the SDFG
-    sdfg = create_sdfg(routine, here)
+    sdfg = create_sdfg(routine, tempdir)
     assert sdfg.validate() is None
 
     csdfg = sdfg.compile()
@@ -257,15 +255,12 @@ end subroutine routine_fixed_loop
     assert np.all(vector == ref_vector)
     assert np.all(tensor_out == ref_tensor)
 
-    clean_test(filepath)
-    (here / (routine.name + '.py')).unlink()
-
 
 @pytest.mark.skip(reason=('This translates successfully but the generated OpenMP code does not '
                           'honour the loop-carried dependency, thus creating data races for more '
                           'than 1 thread.'))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_sdfg_routine_loop_carried_dependency(here, frontend):
+def test_sdfg_routine_loop_carried_dependency(tempdir, frontend):
 
     fcode = """
 subroutine routine_loop_carried_dependency(vector)
@@ -281,7 +276,7 @@ subroutine routine_loop_carried_dependency(vector)
 end subroutine routine_loop_carried_dependency
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/(f'sdfg_routine_loop_carried_dependency_{frontend}.f90')
+    filepath = tempdir/(f'sdfg_routine_loop_carried_dependency_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='routine_loop_carried_dependency')
 
     # Test the reference solution
@@ -292,7 +287,7 @@ end subroutine routine_loop_carried_dependency
     assert np.all(vector == ref_vector)
 
     # Create and compile the SDFG
-    sdfg = create_sdfg(routine, here)
+    sdfg = create_sdfg(routine, tempdir)
     assert sdfg.validate() is None
 
     csdfg = sdfg.compile()
@@ -305,16 +300,13 @@ end subroutine routine_loop_carried_dependency
     csdfg(vector=vector)
     assert np.all(vector == ref_vector)
 
-    clean_test(filepath)
-    (here / (routine.name + '.py')).unlink()
-
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_sdfg_routine_moving_average(here, frontend):
+def test_sdfg_routine_moving_average(tempdir, frontend):
     # TODO: This needs more work to properly handle boundary values.
     # In the current form, these values seem to be handled in a way
     # that causes race conditions. Either this is a DaCe bug or we are
-    # using DaCe wrong here.
+    # using DaCe wrong tempdir.
 
     fcode = """
 subroutine routine_moving_average(length, data_in, data_out)
@@ -354,7 +346,7 @@ subroutine routine_moving_average(length, data_in, data_out)
 end subroutine routine_moving_average
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/(f'sdfg_routine_moving_average_{frontend}.f90')
+    filepath = tempdir/(f'sdfg_routine_moving_average_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='routine_moving_average')
 
     # Create random input data
@@ -373,7 +365,7 @@ end subroutine routine_moving_average
     assert np.all(data_out[1:-1] == expected[1:-1])
 
     # Create and compile the SDFG
-    sdfg = create_sdfg(routine, here)
+    sdfg = create_sdfg(routine, tempdir)
     assert sdfg.validate() is None
 
     csdfg = sdfg.compile()
@@ -383,6 +375,3 @@ end subroutine routine_moving_average
     data_out = np.zeros(shape=(n,), order='F')
     csdfg(length=n, data_in=data_in, data_out=data_out)
     assert np.all(data_out[1:-1] == expected[1:-1])
-
-    clean_test(filepath)
-    (here / (routine.name + '.py')).unlink()

--- a/loki/transformations/transpile/tests/test_transpile.py
+++ b/loki/transformations/transpile/tests/test_transpile.py
@@ -10,7 +10,7 @@ import pytest
 import numpy as np
 
 from loki import Subroutine, Module, cgen
-from loki.build import jit_compile, jit_compile_lib, clean_test, Builder
+from loki.build import jit_compile, jit_compile_lib, clean_test, Builder, Obj
 import loki.expression.symbols as sym
 from loki.frontend import available_frontends, OFP
 import loki.ir as ir
@@ -21,7 +21,8 @@ from loki.transformations.transpile import FortranCTransformation
 
 @pytest.fixture(scope='function', name='builder')
 def fixture_builder(tmp_path):
-    return Builder(source_dirs=tmp_path, build_dir=tmp_path)
+    yield Builder(source_dirs=tmp_path, build_dir=tmp_path)
+    Obj.clear_cache()
 
 
 @pytest.mark.parametrize('case_sensitive', (False, True))

--- a/loki/transformations/transpile/tests/test_transpile.py
+++ b/loki/transformations/transpile/tests/test_transpile.py
@@ -5,7 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from pathlib import Path
+from shutil import rmtree
 import pytest
 import numpy as np
 
@@ -14,24 +14,29 @@ from loki.build import jit_compile, jit_compile_lib, clean_test, Builder
 import loki.expression.symbols as sym
 from loki.frontend import available_frontends, OFP
 import loki.ir as ir
+from loki.tools import gettempdir
 
 from loki.transformations.array_indexing import normalize_range_indexing
 from loki.transformations.transpile import FortranCTransformation
 
 
-@pytest.fixture(scope='module', name='here')
-def fixture_here():
-    return Path(__file__).parent
+@pytest.fixture(scope='function', name='tempdir')
+def fixture_tempdir(request):
+    basedir = gettempdir()/request.function.__name__
+    basedir.mkdir(exist_ok=True)
+    yield basedir
+    if basedir.exists():
+        rmtree(basedir)
 
 
-@pytest.fixture(scope='module', name='builder')
-def fixture_builder(here):
-    return Builder(source_dirs=here, build_dir=here/'build')
+@pytest.fixture(scope='function', name='builder')
+def fixture_builder(tempdir):
+    return Builder(source_dirs=tempdir, build_dir=tempdir)
 
 
 @pytest.mark.parametrize('case_sensitive', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_case_sensitivity(here, frontend, case_sensitive):
+def test_transpile_case_sensitivity(tempdir, frontend, case_sensitive):
     """
     A simple test for testing lowering the case and case-sensitivity
     for specific symbols.
@@ -62,25 +67,23 @@ end subroutine transpile_case_sensitivity
     routine.body = (routine.body, assignment, call, inline_call_assignment)
 
     f2c = FortranCTransformation()
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     ccode = f2c.c_path.read_text().replace(' ', '').replace('\n', ' ').replace('\r', '').replace('\t', '')
     assert convert_case('transpile_case_sensitivity_c(inta,intsOmE_vAr,intoTher_VaR)', case_sensitive) in ccode
     assert convert_case('a=threadIdx%x;', case_sensitive) in ccode
     assert convert_case('somE_cALl(a);', case_sensitive) in ccode
     assert convert_case('a=somE_InlINeCaLl(1);', case_sensitive) in ccode
 
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_simple_loops(here, builder, frontend, use_c_ptr):
+def test_transpile_simple_loops(tempdir, builder, frontend, use_c_ptr):
     """
     A simple test routine to test C transpilation of loops
     """
 
     fcode = """
-subroutine transpile_simple_loops(n, m, scalar, vector, tensor)
+subroutine simple_loops(n, m, scalar, vector, tensor)
   use iso_fortran_env, only: real64
   implicit none
   integer, intent(in) :: n, m
@@ -99,14 +102,14 @@ subroutine transpile_simple_loops(n, m, scalar, vector, tensor)
         tensor(i, j) = 10.* j + i
      end do
   end do
-end subroutine transpile_simple_loops
+end subroutine simple_loops
 """
 
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     normalize_range_indexing(routine) # Fix OMNI nonsense
-    filepath = here/(f'transpile_simple_loops{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transpile_simple_loops')
+    filepath = tempdir/(f'simple_loops{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname='simple_loops')
 
     n, m = 3, 4
     scalar = 2.0
@@ -121,10 +124,10 @@ end subroutine transpile_simple_loops
 
     # Generate and test the transpiled C kernel
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_function = c_kernel.transpile_simple_loops_fc_mod.transpile_simple_loops_fc
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
+    fc_function = c_kernel.simple_loops_fc_mod.simple_loops_fc
 
     # check the generated F2C wrapper
     with open(f2c.wrapperpath, 'r') as f2c_f:
@@ -151,15 +154,10 @@ end subroutine transpile_simple_loops
                              [12., 22., 32., 42.],
                              [13., 23., 33., 43.]])
 
-    builder.clean()
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_arguments(here, builder, frontend, use_c_ptr):
+def test_transpile_arguments(tempdir, builder, frontend, use_c_ptr):
     """
     A test the correct exchange of arguments with varying intents
     """
@@ -209,7 +207,7 @@ end subroutine transpile_arguments
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     normalize_range_indexing(routine) # Fix OMNI nonsense
-    filepath = here/(f'transpile_arguments{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
+    filepath = tempdir/(f'transpile_arguments{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='transpile_arguments')
     a, b, c = function(n, array, array_io, a_io, b_io, c_io)
 
@@ -220,9 +218,9 @@ end subroutine transpile_arguments
 
     # Generate and test the transpiled C kernel
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
     fc_function = c_kernel.transpile_arguments_fc_mod.transpile_arguments_fc
 
     # check the generated F2C wrapper
@@ -251,15 +249,10 @@ end subroutine transpile_arguments
     assert a_io[0] == 3. and np.isclose(b_io[0], 5.2) and np.isclose(c_io[0], 7.1)
     assert a == 8 and np.isclose(b, 3.2) and np.isclose(c, 4.1)
 
-    builder.clean()
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_derived_type(here, builder, frontend, use_c_ptr):
+def test_transpile_derived_type(tempdir, builder, frontend, use_c_ptr):
     """
     Tests handling and type-conversion of various argument types
     """
@@ -278,7 +271,7 @@ end module transpile_type_mod
 """
 
     fcode_routine = """
-subroutine transpile_derived_type(a_struct)
+subroutine transp_der_type(a_struct)
   use transpile_type_mod, only: my_struct
   implicit none
   type(my_struct), intent(inout) :: a_struct
@@ -286,65 +279,58 @@ subroutine transpile_derived_type(a_struct)
   a_struct%a = a_struct%a + 4
   a_struct%b = a_struct%b + 5.
   a_struct%c = a_struct%c + 6.
-end subroutine transpile_derived_type
+end subroutine transp_der_type
 """
     builder.clean()
 
     module = Module.from_source(fcode_type, frontend=frontend)
     routine = Subroutine.from_source(fcode_routine, definitions=module, frontend=frontend)
     refname = f'ref_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    reference = jit_compile_lib([module, routine], path=here, name=refname, builder=builder)
+    reference = jit_compile_lib([module, routine], path=tempdir, name=refname, builder=builder)
 
     # Test the reference solution
     a_struct = reference.transpile_type_mod.my_struct()
     a_struct.a = 4
     a_struct.b = 5.
     a_struct.c = 6.
-    reference.transpile_derived_type(a_struct)
+    reference.transp_der_type(a_struct)
     assert a_struct.a == 8
     assert a_struct.b == 10.
     assert a_struct.c == 12.
 
     # Translate the header module to expose parameters
     mod2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    mod2c.apply(source=module, path=here, role='header')
+    mod2c.apply(source=module, path=tempdir, role='header')
 
     # Create transformation object and apply
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here, role='kernel')
+    f2c.apply(source=routine, path=tempdir, role='kernel')
 
     # Build and wrap the cross-compiled library
     sources = [module, f2c.wrapperpath, f2c.c_path]
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib(sources=sources, path=here, name=libname, builder=builder)
+    c_kernel = jit_compile_lib(sources=sources, path=tempdir, name=libname, builder=builder)
 
     a_struct = c_kernel.transpile_type_mod.my_struct()
     a_struct.a = 4
     a_struct.b = 5.
     a_struct.c = 6.
-    function = c_kernel.transpile_derived_type_fc_mod.transpile_derived_type_fc
+    function = c_kernel.transp_der_type_fc_mod.transp_der_type_fc
     function(a_struct)
     assert a_struct.a == 8
     assert a_struct.b == 10.
     assert a_struct.c == 12.
 
-    builder.clean()
-    mod2c.wrapperpath.unlink()
-    mod2c.c_path.unlink()
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-    (here/f'{module.name}.f90').unlink()
-
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_associates(here, builder, frontend, use_c_ptr):
+def test_transpile_associates(tempdir, builder, frontend, use_c_ptr):
     """
     Tests C-transpilation of associate statements
     """
 
     fcode_type = """
-module transpile_type_mod
+module assoc_type_mod
   use iso_fortran_env, only: real32, real64
   implicit none
 
@@ -353,12 +339,12 @@ module transpile_type_mod
      real(kind=real32) :: b
      real(kind=real64) :: c
   end type my_struct
-end module transpile_type_mod
+end module assoc_type_mod
 """
 
     fcode_routine = """
-subroutine transpile_associates(a_struct)
-  use transpile_type_mod, only: my_struct
+subroutine transp_assoc(a_struct)
+  use assoc_type_mod, only: my_struct
   implicit none
   type(my_struct), intent(inout) :: a_struct
 
@@ -368,54 +354,46 @@ subroutine transpile_associates(a_struct)
   a_struct_b = a_struct%b + 5.
   a_struct_c = a_struct_a + a_struct%b + a_struct_c
   end associate
-end subroutine transpile_associates
+end subroutine transp_assoc
 """
-    builder.clean()
 
     module = Module.from_source(fcode_type, frontend=frontend)
     routine = Subroutine.from_source(fcode_routine, definitions=module, frontend=frontend)
     refname = f'ref_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    reference = jit_compile_lib([module, routine], path=here, name=refname, builder=builder)
+    reference = jit_compile_lib([module, routine], path=tempdir, name=refname, builder=builder)
 
     # Test the reference solution
-    a_struct = reference.transpile_type_mod.my_struct()
+    a_struct = reference.assoc_type_mod.my_struct()
     a_struct.a = 4
     a_struct.b = 5.
     a_struct.c = 6.
-    reference.transpile_associates(a_struct)
+    reference.transp_assoc(a_struct)
     assert a_struct.a == 8
     assert a_struct.b == 10.
     assert a_struct.c == 24.
 
     # Translate the header module to expose parameters
     mod2c = FortranCTransformation()
-    mod2c.apply(source=module, path=here, role='header')
+    mod2c.apply(source=module, path=tempdir, role='header')
 
     # Create transformation object and apply
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here, role='kernel')
+    f2c.apply(source=routine, path=tempdir, role='kernel')
 
     # Build and wrap the cross-compiled library
     sources = [module, f2c.wrapperpath, f2c.c_path]
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib(sources=sources, path=here, name=libname, builder=builder)
+    c_kernel = jit_compile_lib(sources=sources, path=tempdir, name=libname, builder=builder)
 
-    a_struct = c_kernel.transpile_type_mod.my_struct()
+    a_struct = c_kernel.assoc_type_mod.my_struct()
     a_struct.a = 4
     a_struct.b = 5.
     a_struct.c = 6.
-    function = c_kernel.transpile_associates_fc_mod.transpile_associates_fc
+    function = c_kernel.transp_assoc_fc_mod.transp_assoc_fc
     function(a_struct)
     assert a_struct.a == 8
     assert a_struct.b == 10.
     assert a_struct.c == 24.
-
-    builder.clean()
-    mod2c.wrapperpath.unlink()
-    mod2c.c_path.unlink()
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-    (here/f'{module.name}.f90').unlink()
 
 
 @pytest.mark.skip(reason='More thought needed on how to test structs-of-arrays')
@@ -448,15 +426,16 @@ def test_transpile_derived_type_array():
 ! end subroutine transpile_derived_type_array
     """
 
+
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_module_variables(here, builder, frontend, use_c_ptr):
+def test_transpile_module_variables(tempdir, builder, frontend, use_c_ptr):
     """
     Tests the use of imported module variables (via getter routines in C)
     """
 
     fcode_type = """
-module transpile_type_mod
+module mod_var_type_mod
   use iso_fortran_env, only: real32, real64
   implicit none
 
@@ -465,13 +444,13 @@ module transpile_type_mod
   integer :: PARAM1
   real(kind=real32) :: param2
   real(kind=real64) :: param3
-end module transpile_type_mod
+end module mod_var_type_mod
 """
 
     fcode_routine = """
-subroutine transpile_module_variables(a, b, c)
+subroutine transp_mod_var(a, b, c)
   use iso_fortran_env, only: real32, real64
-  use transpile_type_mod, only: PARAM1, param2, param3
+  use mod_var_type_mod, only: PARAM1, param2, param3
 
   integer, intent(out) :: a
   real(kind=real32), intent(out) :: b
@@ -480,57 +459,50 @@ subroutine transpile_module_variables(a, b, c)
   a = 1 + PARAM1  ! Ensure downcasing is done right
   b = 1. + param2
   c = 1. + param3
-end subroutine transpile_module_variables
+end subroutine transp_mod_var
 """
 
     module = Module.from_source(fcode_type, frontend=frontend)
     routine = Subroutine.from_source(fcode_routine, definitions=module, frontend=frontend)
     refname = f'ref_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    reference = jit_compile_lib([module, routine], path=here, name=refname, builder=builder)
+    reference = jit_compile_lib([module, routine], path=tempdir, name=refname, builder=builder)
 
-    reference.transpile_type_mod.param1 = 2
-    reference.transpile_type_mod.param2 = 4.
-    reference.transpile_type_mod.param3 = 3.
-    a, b, c = reference.transpile_module_variables()
+    reference.mod_var_type_mod.param1 = 2
+    reference.mod_var_type_mod.param2 = 4.
+    reference.mod_var_type_mod.param3 = 3.
+    a, b, c = reference.transp_mod_var()
     assert a == 3 and b == 5. and c == 4.
 
     # Translate the header module to expose parameters
     mod2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    mod2c.apply(source=module, path=here, role='header')
+    mod2c.apply(source=module, path=tempdir, role='header')
 
     # Create transformation object and apply
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here, role='kernel')
+    f2c.apply(source=routine, path=tempdir, role='kernel')
 
     # Build and wrap the cross-compiled library
     sources = [module, mod2c.wrapperpath, f2c.wrapperpath, f2c.c_path]
-    wrap = [here/'transpile_type_mod.f90', f2c.wrapperpath.name]
+    wrap = [tempdir/'mod_var_type_mod.f90', f2c.wrapperpath.name]
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib(sources=sources, wrap=wrap, path=here, name=libname, builder=builder)
+    c_kernel = jit_compile_lib(sources=sources, wrap=wrap, path=tempdir, name=libname, builder=builder)
 
-    c_kernel.transpile_type_mod.param1 = 2
-    c_kernel.transpile_type_mod.param2 = 4.
-    c_kernel.transpile_type_mod.param3 = 3.
-    a, b, c = c_kernel.transpile_module_variables_fc_mod.transpile_module_variables_fc()
+    c_kernel.mod_var_type_mod.param1 = 2
+    c_kernel.mod_var_type_mod.param2 = 4.
+    c_kernel.mod_var_type_mod.param3 = 3.
+    a, b, c = c_kernel.transp_mod_var_fc_mod.transp_mod_var_fc()
     assert a == 3 and b == 5. and c == 4.
-
-    builder.clean()
-    mod2c.wrapperpath.unlink()
-    mod2c.c_path.unlink()
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-    (here/f'{module.name}.f90').unlink()
 
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_vectorization(here, builder, frontend, use_c_ptr):
+def test_transpile_vectorization(tempdir, builder, frontend, use_c_ptr):
     """
     Tests vector-notation conversion and local multi-dimensional arrays.
     """
 
     fcode = """
-subroutine transpile_vectorization(n, m, scalar, v1, v2)
+subroutine transp_vect(n, m, scalar, v1, v2)
   use iso_fortran_env, only: real64
   implicit none
   integer, intent(in) :: n, m
@@ -545,13 +517,13 @@ subroutine transpile_vectorization(n, m, scalar, v1, v2)
   matrix(:, :) = scalar + 2.
   v2(:) = matrix(:, 2)
   v2(1) = 1.
-end subroutine transpile_vectorization
+end subroutine transp_vect
 """
 
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/(f'transpile_vectorization{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transpile_vectorization')
+    filepath = tempdir/(f'transp_vect{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname='transp_vect')
 
     n, m = 3, 4
     scalar = 2.0
@@ -564,10 +536,10 @@ end subroutine transpile_vectorization
 
     # Generate and test the transpiled C kernel
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_function = c_kernel.transpile_vectorization_fc_mod.transpile_vectorization_fc
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
+    fc_function = c_kernel.transp_vect_fc_mod.transp_vect_fc
 
     # Test the trnapiled C kernel
     n, m = 3, 4
@@ -579,15 +551,10 @@ end subroutine transpile_vectorization
     assert np.all(v1 == 3.)
     assert v2[0] == 1. and np.all(v2[1:] == 4.)
 
-    builder.clean()
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_intrinsics(here, builder, frontend, use_c_ptr):
+def test_transpile_intrinsics(tempdir, builder, frontend, use_c_ptr):
     """
     A simple test routine to test supported intrinsic functions
     """
@@ -609,7 +576,7 @@ end subroutine transpile_intrinsics
 
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/(f'transpile_intrinsics{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
+    filepath = tempdir/(f'transpile_intrinsics{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='transpile_intrinsics')
 
     # Test the reference solution
@@ -620,30 +587,25 @@ end subroutine transpile_intrinsics
 
     # Generate and test the transpiled C kernel
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
     fc_function = c_kernel.transpile_intrinsics_fc_mod.transpile_intrinsics_fc
 
     vmin, vmax, vabs, vmin_nested, vmax_nested = fc_function(v1, v2, v3, v4)
     assert vmin == 2. and vmax == 4. and vabs == 2.
     assert vmin_nested == 1. and vmax_nested == 5.
 
-    builder.clean()
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_loop_indices(here, builder, frontend, use_c_ptr):
+def test_transpile_loop_indices(tempdir, builder, frontend, use_c_ptr):
     """
     Test to ensure loop indexing translates correctly
     """
 
     fcode = """
-subroutine transpile_loop_indices(n, idx, mask1, mask2, mask3)
+subroutine transp_loop_ind(n, idx, mask1, mask2, mask3)
   ! Test to ensure loop indexing translates correctly
   use iso_fortran_env, only: real64
   integer, intent(in) :: n, idx
@@ -664,13 +626,13 @@ subroutine transpile_loop_indices(n, idx, mask1, mask2, mask3)
      mask2(i) = i
   end do
   mask3(n) = 3.0
-end subroutine transpile_loop_indices
+end subroutine transp_loop_ind
 """
 
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/(f'transpile_loop_indices{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transpile_loop_indices')
+    filepath = tempdir/(f'transp_loop_ind{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname='transp_loop_ind')
 
     # Test the reference solution
     n = 6
@@ -689,10 +651,10 @@ end subroutine transpile_loop_indices
 
     # Generate and test the transpiled C kernel
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_function = c_kernel.transpile_loop_indices_fc_mod.transpile_loop_indices_fc
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
+    fc_function = c_kernel.transp_loop_ind_fc_mod.transp_loop_ind_fc
 
     mask1 = np.zeros(shape=(n,), order='F', dtype=np.int32)
     mask2 = np.zeros(shape=(n,), order='F', dtype=np.int32)
@@ -705,21 +667,16 @@ end subroutine transpile_loop_indices
     assert np.all(mask3[:-1] == 0.)
     assert mask3[-1] == 3.
 
-    builder.clean()
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_logical_statements(here, builder, frontend, use_c_ptr):
+def test_transpile_logical_statements(tempdir, builder, frontend, use_c_ptr):
     """
     A simple test routine to test logical statements
     """
 
     fcode = """
-subroutine transpile_logical_statements(v1, v2, v_xor, v_xnor, v_nand, v_neqv, v_val)
+subroutine logical_stmts(v1, v2, v_xor, v_xnor, v_nand, v_neqv, v_val)
   logical, intent(in) :: v1, v2
   logical, intent(out) :: v_xor, v_nand, v_xnor, v_neqv, v_val(2)
 
@@ -730,13 +687,13 @@ subroutine transpile_logical_statements(v1, v2, v_xor, v_xnor, v_nand, v_neqv, v
   v_val(1) = .true.
   v_val(2) = .false.
 
-end subroutine transpile_logical_statements
+end subroutine logical_stmts
 """
 
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/(f'transpile_logical_statements{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transpile_logical_statements')
+    filepath = tempdir/(f'logical_stmts{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname='logical_stmts')
 
     # Test the reference solution
     for v1 in range(2):
@@ -751,10 +708,10 @@ end subroutine transpile_logical_statements
 
     # Generate and test the transpiled C kernel
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_function = c_kernel.transpile_logical_statements_fc_mod.transpile_logical_statements_fc
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
+    fc_function = c_kernel.logical_stmts_fc_mod.logical_stmts_fc
 
     for v1 in range(2):
         for v2 in range(2):
@@ -766,20 +723,15 @@ end subroutine transpile_logical_statements
             assert v_neqv == ((not (v1 and v2)) and (v1 or v2))
             assert v_val[0] and not v_val[1]
 
-    builder.clean()
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_multibody_conditionals(here, builder, frontend, use_c_ptr):
+def test_transpile_multibody_conditionals(tempdir, builder, frontend, use_c_ptr):
     """
     Test correct transformation of multi-body conditionals.
     """
     fcode = """
-subroutine transpile_multibody_conditionals(in1, out1, out2)
+subroutine multibody_cond(in1, out1, out2)
   integer, intent(in) :: in1
   integer, intent(out) :: out1, out2
 
@@ -799,12 +751,12 @@ subroutine transpile_multibody_conditionals(in1, out1, out2)
   else
     out2 = in1
   end if
-end subroutine transpile_multibody_conditionals
+end subroutine multibody_cond
 """
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/(f'transpile_multibody_conditionals{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transpile_multibody_conditionals')
+    filepath = tempdir/(f'multibody_cond{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname='multibody_cond')
 
     out1, out2 = function(5)
     assert out1 == 1 and out2 == 4
@@ -822,10 +774,10 @@ end subroutine transpile_multibody_conditionals
 
     # Generate and test the transpiled C kernel
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_function = c_kernel.transpile_multibody_conditionals_fc_mod.transpile_multibody_conditionals_fc
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
+    fc_function = c_kernel.multibody_cond_fc_mod.multibody_cond_fc
 
     out1, out2 = fc_function(5)
     assert out1 == 1 and out2 == 4
@@ -838,16 +790,13 @@ end subroutine transpile_multibody_conditionals
 
     out1, out2 = fc_function(10)
     assert out1 == 5 and out2 == 5
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
 
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends(
     skip=[(OFP, 'Prefix/elemental support not implemented')]
 ))
-def test_transpile_inline_elemental_functions(here, builder, frontend, use_c_ptr):
+def test_transpile_inline_elemental_functions(tempdir, builder, frontend, use_c_ptr):
     """
     Test correct inlining of elemental functions in C transpilation.
     """
@@ -867,7 +816,7 @@ end module multiply_mod_c
 """
 
     fcode = """
-subroutine transpile_inline_elemental_functions(v1, v2, v3)
+subroutine inline_elemental(v1, v2, v3)
   use iso_fortran_env, only: real64
   use multiply_mod_c, only: multiply
   real(kind=real64), intent(in) :: v1
@@ -875,44 +824,40 @@ subroutine transpile_inline_elemental_functions(v1, v2, v3)
 
   v2 = multiply(v1, 6._real64)
   v3 = 600. + multiply(6._real64, 11._real64)
-end subroutine transpile_inline_elemental_functions
+end subroutine inline_elemental
 """
     # Generate reference code, compile run and verify
     module = Module.from_source(fcode_module, frontend=frontend)
     routine = Subroutine.from_source(fcode, frontend=frontend)
     refname = f'ref_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    reference = jit_compile_lib([module, routine], path=here, name=refname, builder=builder)
+    reference = jit_compile_lib([module, routine], path=tempdir, name=refname, builder=builder)
 
-    v2, v3 = reference.transpile_inline_elemental_functions(11.)
+    v2, v3 = reference.inline_elemental(11.)
     assert v2 == 66.
     assert v3 == 666.
 
-    (here/f'{module.name}.f90').unlink()
-    (here/f'{routine.name}.f90').unlink()
+    (tempdir/f'{module.name}.f90').unlink()
+    (tempdir/f'{routine.name}.f90').unlink()
 
     # Now transpile with supplied elementals but without module
     routine = Subroutine.from_source(fcode, definitions=module, frontend=frontend)
 
     f2c = FortranCTransformation(inline_elementals=True, use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_mod = c_kernel.transpile_inline_elemental_functions_fc_mod
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
+    fc_mod = c_kernel.inline_elemental_fc_mod
 
-    v2, v3 = fc_mod.transpile_inline_elemental_functions_fc(11.)
+    v2, v3 = fc_mod.inline_elemental_fc(11.)
     assert v2 == 66.
     assert v3 == 666.
-
-    builder.clean()
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
 
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends(
     skip=[(OFP, 'Prefix/elemental support not implemented')]
 ))
-def test_transpile_inline_elementals_recursive(here, builder, frontend, use_c_ptr):
+def test_transpile_inline_elementals_recursive(tempdir, builder, frontend, use_c_ptr):
     """
     Test correct inlining of nested elemental functions.
     """
@@ -946,7 +891,7 @@ end module multiply_plus_one_mod
 """
 
     fcode = """
-subroutine transpile_inline_elementals_recursive(v1, v2, v3)
+subroutine inline_elementals_rec(v1, v2, v3)
   use iso_fortran_env, only: real64
   use multiply_plus_one_mod, only: multiply_plus_one
   real(kind=real64), intent(in) :: v1
@@ -954,42 +899,38 @@ subroutine transpile_inline_elementals_recursive(v1, v2, v3)
 
   v2 = multiply_plus_one(v1, 6._real64)
   v3 = 600. + multiply_plus_one(5._real64, 11._real64)
-end subroutine transpile_inline_elementals_recursive
+end subroutine inline_elementals_rec
 """
     # Generate reference code, compile run and verify
     module = Module.from_source(fcode_module, frontend=frontend)
     routine = Subroutine.from_source(fcode, frontend=frontend)
     refname = f'ref_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    reference = jit_compile_lib([module, routine], path=here, name=refname, builder=builder)
+    reference = jit_compile_lib([module, routine], path=tempdir, name=refname, builder=builder)
 
-    v2, v3 = reference.transpile_inline_elementals_recursive(10.)
+    v2, v3 = reference.inline_elementals_rec(10.)
     assert v2 == 66.
     assert v3 == 666.
 
-    (here/f'{module.name}.f90').unlink()
-    (here/f'{routine.name}.f90').unlink()
+    (tempdir/f'{module.name}.f90').unlink()
+    (tempdir/f'{routine.name}.f90').unlink()
 
     # Now transpile with supplied elementals but without module
     routine = Subroutine.from_source(fcode, definitions=module, frontend=frontend)
 
     f2c = FortranCTransformation(inline_elementals=True, use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_mod = c_kernel.transpile_inline_elementals_recursive_fc_mod
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
+    fc_mod = c_kernel.inline_elementals_rec_fc_mod
 
-    v2, v3 = fc_mod.transpile_inline_elementals_recursive_fc(10.)
+    v2, v3 = fc_mod.inline_elementals_rec_fc(10.)
     assert v2 == 66.
     assert v3 == 666.
-
-    builder.clean()
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
 
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_expressions(here, builder, frontend, use_c_ptr):
+def test_transpile_expressions(tempdir, builder, frontend, use_c_ptr):
     """
     A simple test to verify expression parenthesis and resolution
     of minus sign
@@ -1014,7 +955,7 @@ end subroutine transpile_expressions
 
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/f'{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend!s}.f90'
+    filepath = tempdir/f'{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend!s}.f90'
     function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     n = 10
@@ -1026,9 +967,9 @@ end subroutine transpile_expressions
 
     # Generate and test the transpiled C kernel
     f2c = FortranCTransformation(use_c_ptr=use_c_ptr)
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
     libname = f'fc_{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
     fc_function = c_kernel.transpile_expressions_fc_mod.transpile_expressions_fc
 
     # Make sure minus signs are represented correctly in the C code
@@ -1045,15 +986,10 @@ end subroutine transpile_expressions
 
     assert np.all(vector == [i * scalar for i in range(1, n+1)])
 
-    builder.clean()
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_call(here, frontend, use_c_ptr):
+def test_transpile_call(tempdir, frontend, use_c_ptr):
     fcode_module = """
 module transpile_call_kernel_mod
   implicit none
@@ -1082,15 +1018,12 @@ subroutine transpile_call_driver(a)
     call transpile_call_kernel(a, b, arr2(1, 1), arr1, len)
 end subroutine transpile_call_driver
 """
-    unlink_paths = []
     module = Module.from_source(fcode_module, frontend=frontend)
     routine = Subroutine.from_source(fcode, frontend=frontend, definitions=module)
-    f2c = FortranCTransformation(use_c_ptr=use_c_ptr, path=here)
-    f2c.apply(source=module.subroutine_map['transpile_call_kernel'], path=here, role='kernel')
-    unlink_paths.extend([f2c.wrapperpath, f2c.c_path])
+    f2c = FortranCTransformation(use_c_ptr=use_c_ptr, path=tempdir)
+    f2c.apply(source=module.subroutine_map['transpile_call_kernel'], path=tempdir, role='kernel')
     ccode_kernel = f2c.c_path.read_text().replace(' ', '').replace('\n', '')
-    f2c.apply(source=routine, path=here, role='kernel')
-    unlink_paths.extend([f2c.wrapperpath, f2c.c_path])
+    f2c.apply(source=routine, path=tempdir, role='kernel')
     ccode_driver = f2c.c_path.read_text().replace(' ', '').replace('\n', '')
 
     assert "int*a,intb,int*c" in ccode_kernel
@@ -1100,13 +1033,10 @@ end subroutine transpile_call_driver
     # check for applied Reference
     assert "transpile_call_kernel((&a),b,(&arr2[" in ccode_driver
 
-    for path in unlink_paths:
-        path.unlink()
-
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('f_type', ['integer', 'real'])
-def test_transpile_inline_functions(here, frontend, f_type):
+def test_transpile_inline_functions(tempdir, frontend, f_type):
     """
     Test correct transpilation of functions in C transpilation.
     """
@@ -1122,7 +1052,7 @@ end function add
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
     f2c = FortranCTransformation()
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
 
     f_type_map = {'integer': 'int', 'real': 'double'}
     c_routine = cgen(routine)
@@ -1132,7 +1062,7 @@ end function add
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('f_type', ['integer', 'real'])
-def test_transpile_inline_functions_return(here, frontend, f_type):
+def test_transpile_inline_functions_return(tempdir, frontend, f_type):
     """
     Test correct transpilation of functions in C transpilation.
     """
@@ -1148,7 +1078,7 @@ end function add
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
     f2c = FortranCTransformation()
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
 
     f_type_map = {'integer': 'int', 'real': 'double'}
     c_routine = cgen(routine)
@@ -1157,13 +1087,13 @@ end function add
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_multiconditional(here, builder, frontend):
+def test_transpile_multiconditional(tempdir, builder, frontend):
     """
     A simple test to verify multiconditionals/select case statements.
     """
 
     fcode = """
-subroutine transpile_multi_conditional(in, out)
+subroutine multi_cond(in, out)
   implicit none
   integer, intent(in) :: in
   integer, intent(inout) :: out
@@ -1177,7 +1107,7 @@ subroutine transpile_multi_conditional(in, out)
         out = 100
   end select
 
-end subroutine transpile_multi_conditional
+end subroutine multi_cond
 """.strip()
 
     # for testing purposes
@@ -1188,7 +1118,7 @@ end subroutine transpile_multi_conditional
 
     # compile original Fortran version
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/f'{routine.name}_{frontend!s}.f90'
+    filepath = tempdir/f'{routine.name}_{frontend!s}.f90'
     function = jit_compile(routine, filepath=filepath, objname=routine.name)
     # test Fortran version
     for i, val in enumerate(test_vals):
@@ -1198,30 +1128,24 @@ end subroutine transpile_multi_conditional
 
     # apply F2C trafo
     f2c = FortranCTransformation()
-    f2c.apply(source=routine, path=here)
+    f2c.apply(source=routine, path=tempdir)
 
     # check whether 'switch' statement is within C code
     assert 'switch' in cgen(routine)
 
     # compile C version
     libname = f'fc_{routine.name}_{frontend}'
-    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=here, name=libname, builder=builder)
-    fc_function = c_kernel.transpile_multi_conditional_fc_mod.transpile_multi_conditional_fc
+    c_kernel = jit_compile_lib([f2c.wrapperpath, f2c.c_path], path=tempdir, name=libname, builder=builder)
+    fc_function = c_kernel.multi_cond_fc_mod.multi_cond_fc
     # test C version
     for i, val in enumerate(test_vals):
         in_var = val
         fc_function(in_var, out_var)
         assert out_var == expected_results[i]
 
-    # cleanup ...
-    builder.clean()
-    clean_test(filepath)
-    f2c.wrapperpath.unlink()
-    f2c.c_path.unlink()
-
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transpile_multiconditional_range(here, frontend):
+def test_transpile_multiconditional_range(tempdir, frontend):
     """
     A simple test to verify multiconditionals/select case statements.
     """
@@ -1250,7 +1174,7 @@ end subroutine transpile_multi_conditional_range
 
     # compile original Fortran version
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = here/f'{routine.name}_{frontend!s}.f90'
+    filepath = tempdir/f'{routine.name}_{frontend!s}.f90'
     function = jit_compile(routine, filepath=filepath, objname=routine.name)
     # test Fortran version
     for i, val in enumerate(test_vals):
@@ -1265,4 +1189,4 @@ end subroutine transpile_multi_conditional_range
     #  'NotImplementedError' is raised
     f2c = FortranCTransformation()
     with pytest.raises(NotImplementedError):
-        f2c.apply(source=routine, path=here)
+        f2c.apply(source=routine, path=tempdir)


### PR DESCRIPTION
The latest release of f90wrap includes module names in the name of generated interface routines (introduced in https://github.com/jameskermode/f90wrap/pull/215). This lets them grow quickly beyond the Fortran length limit of 63 characters for names, and gfortran (not even 13.2) does not allow to lift that limitation.

Therefore, I have shorted the module and routine names in the test base where the character limit was exceeded.
In the process, I also introduced the use of `tempdir` fixtures more widely to ensure clean-up of test files is handled gracefully and the littering of the source directory is reduced.