### PR TITLE
`HoistVariablesAnalysis`: remove unused explicit interfaces after inlining

### DIFF
--- a/loki/transformations/hoist_variables.py
+++ b/loki/transformations/hoist_variables.py
@@ -153,10 +153,6 @@ class HoistVariablesAnalysis(Transformation):
             if not isinstance(child, ProcedureItem):
                 continue
 
-            # skip successors that might have been inlined
-            if not call_map.get(child.local_name, None):
-                continue
-
             arg_map = dict(call_map[child.local_name].arg_iter())
             hoist_variables = []
             for var in child.trafo_data[self._key]["hoist_variables"]:

--- a/loki/transformations/hoist_variables.py
+++ b/loki/transformations/hoist_variables.py
@@ -152,6 +152,11 @@ class HoistVariablesAnalysis(Transformation):
         for child in successors:
             if not isinstance(child, ProcedureItem):
                 continue
+
+            # skip successors that might have been inlined
+            if not call_map.get(child.local_name, None):
+                continue
+
             arg_map = dict(call_map[child.local_name].arg_iter())
             hoist_variables = []
             for var in child.trafo_data[self._key]["hoist_variables"]:

--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -15,7 +15,7 @@ from collections import defaultdict, ChainMap
 from loki.batch import Transformation
 from loki.ir import (
     Import, Comment, Assignment, VariableDeclaration, CallStatement,
-    Transformer, FindNodes, pragmas_attached, is_loki_pragma, Interface
+    Transformer, FindNodes, pragmas_attached, is_loki_pragma
 )
 from loki.expression import (
     symbols as sym, FindVariables, FindInlineCalls, FindLiterals,
@@ -607,14 +607,14 @@ def inline_marked_subroutines(routine, allowed_aliases=None, adjust_imports=True
                 import_map[impt] = impt.clone(symbols=new_symbols) if new_symbols else None
 
         # Remove explicit interfaces of inlined routines
-        for intf in FindNodes(Interface).visit(routine.ir):
+        for intf in routine.interfaces:
             if not intf.spec:
-                _body = []
-                for s in intf.symbols:
-                    if s.name not in callees or s.name in not_inlined:
-                        _body += [s.type.dtype.procedure,]
+                _body = tuple(
+	                    s.type.dtype.procedure for s in intf.symbols
+	                    if s.name not in callees or s.name in not_inlined
+                )
                 if _body:
-                    import_map[intf] = intf.clone(body=as_tuple(_body))
+                    import_map[intf] = intf.clone(body=_body)
                 else:
                     import_map[intf] = None
 

--- a/loki/transformations/single_column/hoist.py
+++ b/loki/transformations/single_column/hoist.py
@@ -65,12 +65,13 @@ class SCCHoistTemporaryArraysTransformation(HoistVariablesTransformation):
 
         # Add explicit device-side allocations/deallocations for hoisted temporaries
         vnames = ', '.join(v.name for v in variables)
-        pragma = ir.Pragma(keyword='acc', content=f'enter data create({vnames})')
-        pragma_post = ir.Pragma(keyword='acc', content=f'exit data delete({vnames})')
+        if vnames:
+            pragma = ir.Pragma(keyword='acc', content=f'enter data create({vnames})')
+            pragma_post = ir.Pragma(keyword='acc', content=f'exit data delete({vnames})')
 
-        # Add comments around standalone pragmas to avoid false attachment
-        routine.body.prepend((ir.Comment(''), pragma, ir.Comment('')))
-        routine.body.append((ir.Comment(''), pragma_post, ir.Comment('')))
+            # Add comments around standalone pragmas to avoid false attachment
+            routine.body.prepend((ir.Comment(''), pragma, ir.Comment('')))
+            routine.body.append((ir.Comment(''), pragma_post, ir.Comment('')))
 
     def driver_call_argument_remapping(self, routine, call, variables):
         """

--- a/loki/transformations/single_column/tests/test_single_column_coalesced.py
+++ b/loki/transformations/single_column/tests/test_single_column_coalesced.py
@@ -1127,6 +1127,147 @@ def test_single_column_coalesced_hoist_nested_openacc(frontend, horizontal, vert
         assert outer_kernel_pragmas[2].keyword == 'acc'
         assert outer_kernel_pragmas[2].content == 'end data'
 
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_single_column_coalesced_hoist_nested_inline_openacc(frontend, horizontal, vertical, blocking):
+    """
+    Test the correct addition of OpenACC pragmas to SCC format code
+    when hoisting array temporaries to driver.
+    """
+
+    fcode_driver = """
+  SUBROUTINE column_driver(nlon, nz, q, nb)
+    INTEGER, INTENT(IN)   :: nlon, nz, nb  ! Size of the horizontal and vertical
+    REAL, INTENT(INOUT)   :: q(nlon,nz,nb)
+    INTEGER :: b, start, end
+
+    start = 1
+    end = nlon
+    do b=1, nb
+      call compute_column(start, end, nlon, nz, q(:,:,b))
+    end do
+  END SUBROUTINE column_driver
+"""
+
+    fcode_outer_kernel = """
+  SUBROUTINE compute_column(start, end, nlon, nz, q)
+    INTEGER, INTENT(IN) :: start, end  ! Iteration indices
+    INTEGER, INTENT(IN) :: nlon, nz    ! Size of the horizontal and vertical
+    REAL, INTENT(INOUT) :: q(nlon,nz)
+    INTEGER :: jl, jk
+    REAL :: c
+
+    c = 5.345
+    DO JL = START, END
+      Q(JL, NZ) = Q(JL, NZ) + 1.0
+    END DO
+
+    !$loki inline
+    call update_q(start, end, nlon, nz, q, c)
+
+    DO JL = START, END
+      Q(JL, NZ) = Q(JL, NZ) * C
+    END DO
+  END SUBROUTINE compute_column
+"""
+
+    fcode_inner_kernel = """
+  SUBROUTINE update_q(start, end, nlon, nz, q, c)
+    INTEGER, INTENT(IN) :: start, end  ! Iteration indices
+    INTEGER, INTENT(IN) :: nlon, nz    ! Size of the horizontal and vertical
+    REAL, INTENT(INOUT) :: q(nlon,nz)
+    REAL, INTENT(IN)    :: c
+    REAL :: t(nlon,nz)
+    INTEGER :: jl, jk
+
+    DO jk = 2, nz
+      DO jl = start, end
+        t(jl, jk) = c * jk
+        q(jl, jk) = q(jl, jk-1) + t(jl, jk) * c
+      END DO
+    END DO
+  END SUBROUTINE update_q
+"""
+
+    # Mimic the scheduler internal mechanis to apply the transformation cascade
+    outer_kernel_source = Sourcefile.from_source(fcode_outer_kernel, frontend=frontend)
+    inner_kernel_source = Sourcefile.from_source(fcode_inner_kernel, frontend=frontend)
+    driver_source = Sourcefile.from_source(fcode_driver, frontend=frontend)
+    driver = driver_source['column_driver']
+    outer_kernel = outer_kernel_source['compute_column']
+    inner_kernel = inner_kernel_source['update_q']
+    outer_kernel.enrich(inner_kernel)  # Attach kernel source to driver call
+    driver.enrich(outer_kernel)  # Attach kernel source to driver call
+
+    driver_item = ProcedureItem(name='#column_driver', source=driver)
+    outer_kernel_item = ProcedureItem(name='#compute_column', source=outer_kernel)
+    inner_kernel_item = ProcedureItem(name='#update_q', source=inner_kernel)
+
+    scc_hoist = SCCHoistPipeline(
+        horizontal=horizontal, block_dim=blocking,
+        dim_vars=(vertical.size,), directive='openacc'
+    )
+
+    InlineTransformation(allowed_aliases=horizontal.index).apply(outer_kernel)
+
+    # Apply in reverse order to ensure hoisting analysis gets run on kernel first
+    scc_hoist.apply(inner_kernel, role='kernel', item=inner_kernel_item)
+    scc_hoist.apply(
+        outer_kernel, role='kernel', item=outer_kernel_item,
+        targets=['compute_q'], successors=(inner_kernel_item,)
+    )
+    scc_hoist.apply(
+        driver, role='driver', item=driver_item,
+        targets=['compute_column'], successors=(outer_kernel_item,)
+    )
+
+    # Ensure calls have correct arguments
+    # driver
+    calls = FindNodes(CallStatement).visit(driver.body)
+    assert len(calls) == 1
+    assert calls[0].arguments == ('start', 'end', 'nlon', 'nz', 'q(:, :, b)',
+            'compute_column_t(:, :, b)')
+
+    # Ensure a single outer parallel loop in driver
+    with pragmas_attached(driver, Loop):
+        driver_loops = FindNodes(Loop).visit(driver.body)
+        assert len(driver_loops) == 1
+        assert driver_loops[0].variable == 'b'
+        assert driver_loops[0].bounds == '1:nb'
+        assert driver_loops[0].pragma[0].keyword == 'acc'
+        assert driver_loops[0].pragma[0].content == 'parallel loop gang vector_length(nlon)'
+
+        # Ensure we have a kernel call in the driver loop
+        kernel_calls = FindNodes(CallStatement).visit(driver_loops[0])
+        assert len(kernel_calls) == 1
+        assert kernel_calls[0].name == 'compute_column'
+
+    # Ensure that the intermediate kernel contains two wrapped loops and an unwrapped call statement
+    with pragmas_attached(outer_kernel, Loop):
+        outer_kernel_loops = FindNodes(Loop).visit(outer_kernel.body)
+        assert len(outer_kernel_loops) == 2
+        assert outer_kernel_loops[0].variable == 'jl'
+        assert outer_kernel_loops[0].bounds == 'start:end'
+        assert outer_kernel_loops[0].pragma[0].keyword == 'acc'
+        assert outer_kernel_loops[0].pragma[0].content == 'loop vector'
+
+        # check correctly nested vertical loop from inlined routine
+        assert outer_kernel_loops[1] in FindNodes(Loop).visit(outer_kernel_loops[0].body)
+
+        # Ensure the call was inlined
+        assert not FindNodes(CallStatement).visit(outer_kernel.body)
+
+        # Ensure the routine has been marked properly
+        outer_kernel_pragmas = FindNodes(Pragma).visit(outer_kernel.ir)
+        assert len(outer_kernel_pragmas) == 3
+        assert outer_kernel_pragmas[0].keyword == 'acc'
+        assert outer_kernel_pragmas[0].content == 'routine vector'
+        assert outer_kernel_pragmas[1].keyword == 'acc'
+        assert outer_kernel_pragmas[1].content == 'data present(q, t)'
+        assert outer_kernel_pragmas[2].keyword == 'acc'
+        assert outer_kernel_pragmas[2].content == 'end data'
+
+
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_single_column_coalesced_nested(frontend, horizontal, blocking):
     """

--- a/loki/transformations/single_column/tests/test_single_column_coalesced.py
+++ b/loki/transformations/single_column/tests/test_single_column_coalesced.py
@@ -1214,7 +1214,7 @@ def test_single_column_coalesced_hoist_nested_inline_openacc(frontend, horizonta
     scc_hoist.apply(inner_kernel, role='kernel', item=inner_kernel_item)
     scc_hoist.apply(
         outer_kernel, role='kernel', item=outer_kernel_item,
-        targets=['compute_q'], successors=(inner_kernel_item,)
+        targets=['compute_q'], successors=()
     )
     scc_hoist.apply(
         driver, role='driver', item=driver_item,


### PR DESCRIPTION
This small PR implements two bug fixes:
- `HoistVariablesAnalysis` now skips successors that might no longer be present (e.g. they were inlined)
- Unused explicit interfaces of inlined subroutines are now removed