### PR TITLE
InlineTransformation: Update Scheduler SGraph if marked_inline is activated

### DIFF
--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -503,8 +503,10 @@ class Scheduler:
 
         if transformation.creates_items:
             self._discover()
-
             self._parse_items()
+
+        if transformation.creates_edges:
+            self._discover()
 
     def callgraph(self, path, with_file_graph=False, with_legend=False):
         """

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -505,9 +505,6 @@ class Scheduler:
             self._discover()
             self._parse_items()
 
-        if transformation.creates_edges:
-            self._discover()
-
     def callgraph(self, path, with_file_graph=False, with_legend=False):
         """
         Generate a callgraph visualization and dump to file.

--- a/loki/batch/transformation.py
+++ b/loki/batch/transformation.py
@@ -105,7 +105,6 @@ class Transformation:
     # Control Scheduler cache update requirements after applying the transformation
     renames_items = False
     creates_items = False
-    creates_edges = False
 
     def __str__(self):
         """ Pretty-print transformation details """

--- a/loki/batch/transformation.py
+++ b/loki/batch/transformation.py
@@ -105,6 +105,7 @@ class Transformation:
     # Control Scheduler cache update requirements after applying the transformation
     renames_items = False
     creates_items = False
+    creates_edges = False
 
     def __str__(self):
         """ Pretty-print transformation details """

--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -74,20 +74,20 @@ class InlineTransformation(Transformation):
         inlining constants (default: True)
     resolve_sequence_association: bool
         Resolve sequence association for routines that contain calls to inline (default: False)
-    creates_edges: bool
-        Run the scheduler discovery mechanism to re-compute the callgraph edges (default: False)
     """
 
     # Ensure correct recursive inlining by traversing from the leaves
     reverse_traversal = True
+
+    # This transformation will potentially change the edges in the callgraph
+    creates_items = False
 
     def __init__(
             self, inline_constants=False, inline_elementals=True,
             inline_internals=False, inline_marked=True,
             remove_dead_code=True, allowed_aliases=None,
             adjust_imports=True, external_only=True,
-            resolve_sequence_association=False,
-            creates_edges=False
+            resolve_sequence_association=False
     ):
         self.inline_constants = inline_constants
         self.inline_elementals = inline_elementals
@@ -98,7 +98,8 @@ class InlineTransformation(Transformation):
         self.adjust_imports = adjust_imports
         self.external_only = external_only
         self.resolve_sequence_association = resolve_sequence_association
-        self.creates_edges = creates_edges
+        if self.inline_marked:
+            self.creates_items = True
 
     def transform_subroutine(self, routine, **kwargs):
 
@@ -198,8 +199,8 @@ class InlineSubstitutionMapper(LokiIdentityMapper):
 
 def resolve_sequence_association_for_inlined_calls(routine, inline_internals, inline_marked):
     """
-    Resolve sequence association in calls to all member procedures (if `inline_internals = True`) 
-    or in calls to procedures that have been marked with an inline pragma (if `inline_marked = True`). 
+    Resolve sequence association in calls to all member procedures (if `inline_internals = True`)
+    or in calls to procedures that have been marked with an inline pragma (if `inline_marked = True`).
     If both `inline_internals` and `inline_marked` are `False`, no processing is done.
     """
     call_map = {}
@@ -215,9 +216,9 @@ def resolve_sequence_association_for_inlined_calls(routine, inline_internals, in
                     # asked sequence assoc to happen with inlining, so source for routine should be
                     # found in calls to be inlined.
                     raise ValueError(
-                        f"Cannot resolve sequence association for call to `{call.name}` " + 
-                        f"to be inlined in routine `{routine.name}`, because " + 
-                        f"the `CallStatement` referring to `{call.name}` does not contain " + 
+                        f"Cannot resolve sequence association for call to ``{call.name}`` " +
+                        f"to be inlined in routine ``{routine.name}``, because " +
+                        f"the ``CallStatement`` referring to ``{call.name}`` does not contain " +
                         "the source code of the procedure. " +
                         "If running in batch processing mode, please recheck Scheduler configuration."
                     )

--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -74,6 +74,8 @@ class InlineTransformation(Transformation):
         inlining constants (default: True)
     resolve_sequence_association: bool
         Resolve sequence association for routines that contain calls to inline (default: False)
+    creates_edges: bool
+        Run the scheduler discovery mechanism to re-compute the callgraph edges (default: False)
     """
 
     # Ensure correct recursive inlining by traversing from the leaves
@@ -84,7 +86,8 @@ class InlineTransformation(Transformation):
             inline_internals=False, inline_marked=True,
             remove_dead_code=True, allowed_aliases=None,
             adjust_imports=True, external_only=True,
-            resolve_sequence_association=False
+            resolve_sequence_association=False,
+            creates_edges=False
     ):
         self.inline_constants = inline_constants
         self.inline_elementals = inline_elementals
@@ -95,6 +98,7 @@ class InlineTransformation(Transformation):
         self.adjust_imports = adjust_imports
         self.external_only = external_only
         self.resolve_sequence_association = resolve_sequence_association
+        self.creates_edges = creates_edges
 
     def transform_subroutine(self, routine, **kwargs):
 

--- a/loki/transformations/tests/test_inline.py
+++ b/loki/transformations/tests/test_inline.py
@@ -17,6 +17,7 @@ from loki.build import jit_compile, jit_compile_lib, Builder, Obj
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI, OFP
 from loki.ir import nodes as ir, FindNodes
+from loki.batch import Scheduler, SchedulerConfig
 
 from loki.transformations.inline import (
     inline_elemental_functions, inline_constant_parameters,
@@ -963,7 +964,6 @@ end module inline_declarations
 """
     module = Module.from_source(fcode, frontend=frontend)
     outer = module['outer']
-    inner = module['inner']
 
     inline_marked_subroutines(routine=outer, adjust_imports=True)
 
@@ -1328,3 +1328,78 @@ end module test_inline_mod
     assert imports[0].symbols == ('x',)
     assert imports[1].module == 'bnds_module'
     assert 'm' in imports[1].symbols and 'n' in imports[1].symbols
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_inline_transformation_intermediate(tmp_path, frontend):
+    fcode_outermost = """
+module outermost_mod
+implicit none
+contains
+subroutine outermost()
+use intermediate_mod, only: intermediate
+
+!$loki inline
+call intermediate()
+
+end subroutine outermost
+end module outermost_mod
+"""
+
+    fcode_intermediate = """
+module intermediate_mod
+implicit none
+contains
+subroutine intermediate()
+use innermost_mod, only: innermost
+
+call innermost()
+
+end subroutine intermediate
+end module intermediate_mod
+"""
+
+    fcode_innermost = """
+module innermost_mod
+implicit none
+contains
+subroutine innermost()
+
+end subroutine innermost
+end module innermost_mod
+"""
+
+    (tmp_path/'outermost_mod.F90').write_text(fcode_outermost)
+    (tmp_path/'intermediate_mod.F90').write_text(fcode_intermediate)
+    (tmp_path/'innermost_mod.F90').write_text(fcode_innermost)
+
+    config = {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True
+        },
+        'routines': {
+            'outermost': {'role': 'kernel'}
+        }
+    }
+
+    scheduler = Scheduler(paths=[tmp_path], config=SchedulerConfig.from_dict(config), frontend=frontend)
+
+    def _get_successors(item):
+        return scheduler.sgraph.successors(scheduler[item])
+
+    # check graph edges before transformation
+    assert len(scheduler.items) == 3
+    assert len(_get_successors('outermost_mod#outermost')) == 1
+    assert scheduler['intermediate_mod#intermediate'] in _get_successors('outermost_mod#outermost')
+    assert len(_get_successors('intermediate_mod#intermediate')) == 1
+    assert scheduler['innermost_mod#innermost'] in _get_successors('intermediate_mod#intermediate')
+
+    scheduler.process( transformation=InlineTransformation(creates_edges=True) )
+
+    # check graph edges were updated correctly
+    assert len(scheduler.items) == 2
+    assert len(_get_successors('outermost_mod#outermost')) == 1
+    assert scheduler['innermost_mod#innermost'] in _get_successors('outermost_mod#outermost')

--- a/loki/transformations/tests/test_inline.py
+++ b/loki/transformations/tests/test_inline.py
@@ -1397,7 +1397,7 @@ end module innermost_mod
     assert len(_get_successors('intermediate_mod#intermediate')) == 1
     assert scheduler['innermost_mod#innermost'] in _get_successors('intermediate_mod#intermediate')
 
-    scheduler.process( transformation=InlineTransformation(creates_edges=True) )
+    scheduler.process( transformation=InlineTransformation() )
 
     # check graph edges were updated correctly
     assert len(scheduler.items) == 2


### PR DESCRIPTION
Certain transformations (e.g. `InlineTransformation`) might create or delete callgraph edges without renaming or creating new items. Updating the `sgraph` in such cases requires only `scheduler._discover` to be triggered. This PR adds such an option to the `Transformation` class.