### PR TITLE
ProgramUnit.resolve_typebound_var: raise error if top-level parent is not declared

### DIFF
--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -367,6 +367,8 @@ class TypedSymbol:
         Resolve type-bound variables of arbitrary nested depth.
         """
         name_parts = name_str.split('%', maxsplit=1)
+        if self.type.dtype is not BasicType.DEFERRED and self.type.dtype.typedef is not BasicType.DEFERRED:
+            assert self.type.dtype.typedef.variable_map[name_parts[0]]
         declared_var = Variable(name=f'{self.name}%{name_parts[0]}', scope=self.scope, parent=self)
         if len(name_parts) > 1:
             return declared_var.get_derived_type_member(name_parts[1])  # pylint:disable=no-member

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2120,7 +2120,9 @@ class FParser2IR(GenericVisitor):
             if module_type and module_type.dtype.module != BasicType.DEFERRED:
                 return module_type.dtype.module
 
-        return Module(name=name, parent=kwargs['scope'])
+        module = Module(name=name, parent=kwargs['scope'])
+        self.definitions[name] = module
+        return module
 
     visit_Module_Name = visit_Name
 

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1253,7 +1253,9 @@ class OFP2IR(GenericVisitor):
             if module_type and module_type.dtype.module != BasicType.DEFERRED:
                 return module_type.dtype.module
 
-        return Module(name=name, parent=scope)
+        module = Module(name=name, parent=scope)
+        self.definitions[name] = module
+        return module
 
     def visit_module(self, o, **kwargs):
         # Extract known sections

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -465,8 +465,9 @@ class OMNI2IR(GenericVisitor):
             if module_type and module_type.dtype.module != BasicType.DEFERRED:
                 return module_type.dtype.module
 
-        return Module(name=name, parent=scope)
-
+        module = Module(name=name, parent=scope)
+        self.definitions[name] = module
+        return module
 
     def visit_FmoduleDefinition(self, o, **kwargs):
         # Update the symbol map with local entries

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -822,6 +822,7 @@ class ProgramUnit(Scope):
             _variable_map = self.variable_map
 
         name_parts = name.split('%', maxsplit=1)
-        if (var := _variable_map.get(name_parts[0], None)) and len(name_parts) > 1:
+        var = _variable_map[name_parts[0]]
+        if len(name_parts) > 1:
             var = var.get_derived_type_member(name_parts[1])
         return var

--- a/loki/tests/test_modules.py
+++ b/loki/tests/test_modules.py
@@ -1363,8 +1363,10 @@ end module test
     assert calls[0].function.type.imported
     assert calls[0].function.type.module is source['foo']
     assert calls[0].function.type.dtype.procedure is source['sum']
-    assert calls[0].arguments[0].type.dtype == BasicType.INTEGER
-    assert calls[0].arguments[0].type.imported
-    assert calls[0].arguments[0].type.parameter
-    assert calls[0].arguments[0].type.initial == 16
-    assert calls[0].arguments[0].type.module is source['foo']
+    if frontend != OMNI:
+        # OMNI inlines parameters
+        assert calls[0].arguments[0].type.dtype == BasicType.INTEGER
+        assert calls[0].arguments[0].type.imported
+        assert calls[0].arguments[0].type.parameter
+        assert calls[0].arguments[0].type.initial == 16
+        assert calls[0].arguments[0].type.module is source['foo']

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -2168,6 +2168,7 @@ end subroutine myroutine
     assert len(FindNodes(ir.Assignment).visit(routine.body)) == 3
     assert len(FindNodes(ir.Assignment).visit(new_routine.body)) == 0
 
+
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_call_args_kwargs_conversion(frontend):
 
@@ -2238,3 +2239,75 @@ def test_call_args_kwargs_conversion(frontend):
     for call in FindNodes(ir.CallStatement).visit(driver.body):
         assert tuple(arg.name for arg in call.arguments) == call_args
         assert call.kwarguments == ()
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_typebound_var(frontend, tmp_path):
+    """
+    Test correct behaviour of :any:`Scope.resolve_typebound_var` utility
+    """
+    fcode = """
+module header_mod
+    implicit none
+    type some_type
+        integer :: ival
+    end type some_type
+
+    type other_type
+        type(some_type) :: other
+    end type other_type
+
+    type third_type
+        type(other_type) :: some
+    end type third_type
+end module header_mod
+
+subroutine some_routine
+    use header_mod, only: third_type
+    implicit none
+    type(third_type) :: tt
+end subroutine
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    # routine = Subroutine.from_source(fcode_routine, frontend=frontend, xmods=[tmp_path], definitions=source.definitions) #source['some_routine']
+    routine = source['some_routine']
+
+    tt_some = routine.resolve_typebound_var('tt%some')
+    assert tt_some == 'tt%some'
+    assert tt_some.type.dtype.name == 'other_type'
+    assert tt_some.type.dtype.typedef is source['header_mod']['other_type']
+
+    tt_some_other_ival = routine.resolve_typebound_var('tt%some%other%ival')
+    assert tt_some_other_ival == 'tt%some%other%ival'
+    assert tt_some_other_ival.type.dtype == BasicType.INTEGER
+    assert tt_some_other_ival.parent.type.dtype.name == 'some_type'
+    assert tt_some_other_ival.parent.type.dtype.typedef is source['header_mod']['some_type']
+
+    tt = routine.resolve_typebound_var('tt')
+    assert tt == 'tt'
+    assert tt.type.dtype.name == 'third_type'
+    assert tt.type.dtype.typedef is source['header_mod']['third_type']
+
+    # This does not throw an error as the use-case of incomplete type definitions
+    # may well require working with incomplete type definitions
+    tt_invalid_val = routine.resolve_typebound_var('tt%invalid%val')
+    assert tt_invalid_val == 'tt%invalid%val'
+    assert tt_invalid_val.type.dtype == BasicType.DEFERRED
+    assert tt_invalid_val.parent.type.dtype == BasicType.DEFERRED
+
+    # This throws errors as resolving derived type members for
+    # non-declared derived types should not be possible
+    with pytest.raises(KeyError):
+        routine.resolve_typebound_var('not_tt%invalid')
+
+    with pytest.raises(KeyError):
+        routine.resolve_typebound_var('not_a_var')
+
+    # Instead, we can creatae a deferred type variable in the scope and
+    # resolve members relative to it
+    not_tt = Variable(name='not_tt', scope=routine)
+    assert not_tt.type.dtype == BasicType.DEFERRED
+    not_tt_invalid = not_tt.get_derived_type_member('invalid')
+    assert not_tt_invalid == 'not_tt%invalid'
+    assert not_tt_invalid.type.dtype == BasicType.DEFERRED

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -10,6 +10,7 @@ from loki.expression import (
     symbols as sym, FindExpressions, SubstituteExpressions
 )
 from loki.ir import nodes as ir, FindNodes, Transformer
+from loki.logging import debug
 from loki.tools import as_tuple
 from loki.types import SymbolAttributes, BasicType
 
@@ -180,8 +181,15 @@ class SCCBaseTransformation(Transformation):
         bounds_str = f'{bounds[0]}:{bounds[1]}'
 
         variable_map = routine.variable_map
-        bounds_v = (routine.resolve_typebound_var(bounds[0], variable_map),
-                    routine.resolve_typebound_var(bounds[1], variable_map))
+        try:
+            bounds_v = (routine.resolve_typebound_var(bounds[0], variable_map),
+                        routine.resolve_typebound_var(bounds[1], variable_map))
+        except KeyError:
+            debug(
+                'SCCBaseTransformation.resolve_vector_dimension: '
+                f'Dimension bound {bounds[0]} or {bounds[1]} not found in {routine.name}.'
+            )
+            return
 
         mapper = {}
         for stmt in FindNodes(ir.Assignment).visit(routine.body):

--- a/loki/transformations/tests/test_scc_cuf.py
+++ b/loki/transformations/tests/test_scc_cuf.py
@@ -26,7 +26,7 @@ from loki.transformations.single_column import (
 
 @pytest.fixture(scope='module', name='horizontal')
 def fixture_horizontal():
-    return Dimension(name='horizontal', size='nlon', index='jl', bounds=('start', 'end'))
+    return Dimension(name='horizontal', size='nlon', index='jl', bounds=('start', 'iend'))
 
 
 @pytest.fixture(scope='module', name='vertical')
@@ -176,11 +176,11 @@ def test_scc_cuf_simple(frontend, horizontal, vertical, blocking):
     REAL, INTENT(INOUT)   :: t(nlon,nz,nb)
     REAL, INTENT(INOUT)   :: q(nlon,nz,nb)
     REAL, INTENT(INOUT)   :: z(nlon,nz+1,nb)
-    INTEGER :: b, start, end, ibl, icend
+    INTEGER :: b, start, iend, ibl, icend
 
     start = 1
-    end = tot
-    do b=1,end,nlon
+    iend = tot
+    do b=1,iend,nlon
       ibl = (b-1)/nlon+1
       icend = MIN(nlon,tot-b+1)
       call kernel(start, icend, nlon, nz, q(:,:,b), t(:,:,b), z(:,:,b))
@@ -189,8 +189,8 @@ def test_scc_cuf_simple(frontend, horizontal, vertical, blocking):
 """
 
     fcode_kernel = """
-  SUBROUTINE kernel(start, end, nlon, nz, q, t, z)
-    INTEGER, INTENT(IN) :: start, end  ! Iteration indices
+  SUBROUTINE kernel(start, iend, nlon, nz, q, t, z)
+    INTEGER, INTENT(IN) :: start, iend  ! Iteration indices
     INTEGER, INTENT(IN) :: nlon, nz    ! Size of the horizontal and vertical
     REAL, INTENT(INOUT) :: t(nlon,nz)
     REAL, INTENT(INOUT) :: q(nlon,nz)
@@ -200,19 +200,19 @@ def test_scc_cuf_simple(frontend, horizontal, vertical, blocking):
 
     c = 5.345
     DO jk = 2, nz
-      DO jl = start, end
+      DO jl = start, iend
         t(jl, jk) = c * jk
         q(jl, jk) = q(jl, jk-1) + t(jl, jk) * c
       END DO
     END DO
 
     DO jk = 2, nz
-      DO jl = start, end
+      DO jl = start, iend
         z(jl, jk) = 0.0
       END DO
     END DO
 
-    ! DO JL = START, END
+    ! DO JL = START, IEND
     !   Q(JL, NZ) = Q(JL, NZ) * C
     ! END DO
   END SUBROUTINE kernel


### PR DESCRIPTION
This fixes #307.

Piggy-backed is a small fix with test for missing enrichment between modules within the same source file, reported in #161.