### PR TITLE
Fix derived type inheritance when parent type is not available (#330)

### DIFF
--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -1535,8 +1535,8 @@ class TypeDef(ScopedNode, InternalNode, _TypeDefBase):
             return None
         if not self.parent:
             return BasicType.DEFERRED
-        parent_type = self.parent.symbol_attrs[self.extends]
-        if not isinstance(parent_type.dtype, DerivedType):
+        parent_type = self.parent.symbol_attrs.lookup(self.extends)
+        if not (parent_type and isinstance(parent_type.dtype, DerivedType)):
             return BasicType.DEFERRED
         return parent_type.dtype.typedef
 

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -1535,7 +1535,10 @@ class TypeDef(ScopedNode, InternalNode, _TypeDefBase):
             return None
         if not self.parent:
             return BasicType.DEFERRED
-        return self.parent.symbol_attrs[self.extends].dtype.typedef
+        parent_type = self.parent.symbol_attrs[self.extends]
+        if not isinstance(parent_type.dtype, DerivedType):
+            return BasicType.DEFERRED
+        return parent_type.dtype.typedef
 
     @property
     def declarations(self):

--- a/loki/tests/test_derived_types.py
+++ b/loki/tests/test_derived_types.py
@@ -1523,7 +1523,8 @@ end module some_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_derived_type_inheritance_missing_parent(frontend, tmp_path):
+@pytest.mark.parametrize('qualified_import', (True, False))
+def test_derived_type_inheritance_missing_parent(frontend, qualified_import, tmp_path):
     fcode_parent = """
 module parent_mod
     implicit none
@@ -1533,9 +1534,9 @@ module parent_mod
 end module parent_mod
     """.strip()
 
-    fcode_derived = """
+    fcode_derived = f"""
 module derived_mod
-    use parent_mod, only: parent_type
+    use parent_mod{", only: parent_type" if qualified_import else ""}
     implicit none
     type, public, extends(parent_type) :: derived_type
         integer :: val2


### PR DESCRIPTION
This assumed parent definition was always available in the symbol table, which it isn't if the parent is defined in a different module and no enrichment has been applied.