### PR TITLE
POC - linter: missing kind specifier for real literals and possible fix via git patch

### DIFF
--- a/lint_rules/lint_rules/ifs_arpege_coding_standards.py
+++ b/lint_rules/lint_rules/ifs_arpege_coding_standards.py
@@ -72,14 +72,161 @@ class MissingKindSpecifierRealLiterals(GenericRule):
                     rule_report.add(f'Real/Float literal without kind specifier "{literal}"', node)
 
     @classmethod
+    def fix_subroutinei_test_2(cls, subroutine, rule_report, config, sourcefile=None):
+        """
+        ...
+        """
+        for node, literals in literal_nodes:
+            literal_map = {}
+            for literal in literals:
+                if literal.kind is None and 'e' not in literal.value.lower() and 'd' not in literal.value.lower():
+                    literal_map[literal] = FloatLiteral(value=literal.value, kind='JPRB')
+            if literal_map:
+                # fixed_node = SubstituteExpressions(literal_map).visit(node)
+                # for key in literal_map:
+                #     fixed_node = re.sub(rf'{re.escape()}',
+                #             , content, flags = re.S)
+                indent = int((len(node.source.string) - len(node.source.string.lstrip(' ')))/2)
+                fixed_node_str = fgen(fixed_node, depth=indent)
+                with open (f'loki_lint_{subroutine.name}_new_file_fixed_node_str.F90', 'w') as f:
+                    f.write(fixed_node_str)
+                content_new = re.sub(rf'{re.escape(node.source.string)}',
+                        fixed_node_str, content, flags = re.S)
+                content = content_new
+        with open (f'loki_lint_{subroutine.name}_new_file.F90', 'w') as f:
+            f.write(content_new)
+        diff = difflib.unified_diff(original_content.splitlines(), content_new.splitlines(),
+                f'a/{sourcefile.path}', f'b/{sourcefile.path}', lineterm='')
+        diff_str = '\n'.join(list(diff))
+        # print(f"---{sourcefile.path}------")
+        # print(diff_str)
+        # print(f"--------------------------")
+        with open (f'loki_lint_{subroutine.name}.approach_2.patch', 'w') as f:
+            f.write(diff_str)
+            f.write('\n')
+
+    @classmethod
+    def fix_subroutine_test(cls, subroutine, rule_report, config, sourcefile=None):
+        """
+        ...
+        """
+        # sourcefile = subroutine.source.file
+        print(f"fix_subroutine: subroutine: {subroutine} | subroutine.source: {subroutine.source} | subroutine.source.file: {subroutine.source.file}")
+        original_content = read_file(str(sourcefile.path))
+        content = original_content
+        literals = FindFloatLiterals(with_ir_node=False).visit(subroutine.body)
+        literal_map = {}
+        for literal in literals:
+            if literal.kind is None:
+                literal_map[literal] = FloatLiteral(value=literal.value, kind='JPRB')
+        # content_new = content
+        if literal_map:
+            for key in literal_map:
+                # print(f"replace ")
+                # content_new = re.sub(rf'{re.escape(str(key))}', rf'{re.escape(str(literal_map[key]))}', content, flags = re.S)
+                content_new = re.sub(rf'{re.escape(str(key))}', str(literal_map[key]), content, flags = re.S)
+                content = content_new
+        diff = difflib.unified_diff(original_content.splitlines(), content_new.splitlines(),
+                f'a/{sourcefile.path}', f'b/{sourcefile.path}', lineterm='')
+        diff_str = '\n'.join(list(diff))
+        # print(f"---{sourcefile.path}------")
+        # print(diff_str)
+        # print(f"--------------------------")
+        with open (f'loki_lint_{subroutine.name}.approach_2.patch', 'w') as f:
+            f.write(diff_str)
+            f.write('\n')
+        
+        """
+        for node, literals in literal_nodes:
+            literal_map = {}
+            for literal in literals:
+                if literal.kind is None:
+                    literal_map[literal] = FloatLiteral(value=literal.value, kind='JPRB')
+            if literal_map:
+                # fixed_node = SubstituteExpressions(literal_map).visit(node)
+                # indent = int((len(node.source.string) - len(node.source.string.lstrip(' ')))/2)
+                # fixed_node_str = fgen(fixed_node, depth=indent)
+                # with open (f'loki_lint_{subroutine.name}_new_file_fixed_node_str.F90', 'w') as f:
+                #     f.write(fixed_node_str)
+                # content_new = re.sub(rf'{re.escape(node.source.string)}',
+                #         fixed_node_str, content, flags = re.S)
+                # content = content_new
+        with open (f'loki_lint_{subroutine.name}_new_file.F90', 'w') as f:
+            f.write(content_new)
+        diff = difflib.unified_diff(original_content.splitlines(), content_new.splitlines(),
+                f'a/{sourcefile.path}', f'b/{sourcefile.path}', lineterm='')
+        diff_str = '\n'.join(list(diff))
+        # print(f"---{sourcefile.path}------")
+        # print(diff_str)
+        # print(f"--------------------------")
+        with open (f'loki_lint_{subroutine.name}.approach_2.patch', 'w') as f:
+            f.write(diff_str)
+            f.write('\n')
+        """
+
+    @classmethod
     def fix_subroutine(cls, subroutine, rule_report, config, sourcefile=None):
         """
         ...
         """
+        # sourcefile = subroutine.source.file
+        print(f"fix_subroutine: subroutine: {subroutine} | subroutine.source: {subroutine.source} | subroutine.source.file: {subroutine.source.file}")
+        original_content = read_file(str(sourcefile.path))
+        content = original_content
+        literal_nodes = FindFloatLiterals(with_ir_node=True).visit(subroutine.body)
+        content_new = None
+        for node, literals in literal_nodes:
+            # print(f"node.source: {node.source.string} | {type(node.source.string)}")
+            literal_map = {}
+            for literal in literals:
+                if literal.kind is None and 'e' not in str(literal.value).lower() and 'd' not in str(literal.value).lower():
+                    literal_map[literal] = FloatLiteral(value=literal.value, kind='JPRB')
+            if literal_map:
+                # fixed_node = SubstituteExpressions(literal_map).visit(node)
+                fixed_node = node.source.string
+                # if hasattr(node, 'comment') and node.comment is not None:
+                #     comment = node.comment
+                #     fixed_node._update(comment=None)
+                # else:
+                #     comment = None 
+                for key in literal_map:
+                    fixed_node = re.sub(rf'{re.escape(str(key))}',
+                        str(literal_map[key]), fixed_node, flags = re.S)
+                # indent = int((len(node.source.string) - len(node.source.string.lstrip(' ')))/2)
+                # fixed_node_str = fgen(fixed_node, depth=indent)
+                # if comment is not None:
+                #     fixed_node._update(comment=comment)
+                fixed_node_str = str(fixed_node)
+                # with open (f'loki_lint_{subroutine.name}_new_file_fixed_node_str.F90', 'w') as f:
+                #     f.write(fixed_node_str)
+                content_new = re.sub(rf'{re.escape(node.source.string)}',
+                        fixed_node_str, content, flags = re.S)
+                content = content_new
+        # with open (f'loki_lint_{subroutine.name}_new_file.F90', 'w') as f:
+        #     f.write(content_new)
+        if content_new is not None:
+            diff = difflib.unified_diff(original_content.splitlines(), content_new.splitlines(),
+                    f'a/{sourcefile.path}', f'b/{sourcefile.path}', lineterm='')
+            diff_str = '\n'.join(list(diff))
+            # print(f"---{sourcefile.path}------")
+            # print(diff_str)
+            # print(f"--------------------------")
+            with open (f'loki_lint_{subroutine.name}.patch', 'w') as f:
+                f.write(diff_str)
+                f.write('\n')
+
+    @classmethod
+    def fix_subroutine_working(cls, subroutine, rule_report, config, sourcefile=None):
+        """
+        ...
+        """
+        # sourcefile = subroutine.source.file
+        print(f"fix_subroutine: subroutine: {subroutine} | subroutine.source: {subroutine.source} | subroutine.source.file: {subroutine.source.file}")
         original_content = read_file(str(sourcefile.path))
         content = original_content
         literal_nodes = FindFloatLiterals(with_ir_node=True).visit(subroutine.body)
         for node, literals in literal_nodes:
+            # print(f"node.source: {node.source.string} | {type(node.source.string)}")
             literal_map = {}
             for literal in literals:
                 if literal.kind is None:
@@ -88,9 +235,13 @@ class MissingKindSpecifierRealLiterals(GenericRule):
                 fixed_node = SubstituteExpressions(literal_map).visit(node)
                 indent = int((len(node.source.string) - len(node.source.string.lstrip(' ')))/2)
                 fixed_node_str = fgen(fixed_node, depth=indent)
+                with open (f'loki_lint_{subroutine.name}_new_file_fixed_node_str.F90', 'w') as f:
+                    f.write(fixed_node_str)
                 content_new = re.sub(rf'{re.escape(node.source.string)}',
                         fixed_node_str, content, flags = re.S)
                 content = content_new
+        with open (f'loki_lint_{subroutine.name}_new_file.F90', 'w') as f:
+            f.write(content_new)
         diff = difflib.unified_diff(original_content.splitlines(), content_new.splitlines(),
                 f'a/{sourcefile.path}', f'b/{sourcefile.path}', lineterm='')
         diff_str = '\n'.join(list(diff))
@@ -100,7 +251,6 @@ class MissingKindSpecifierRealLiterals(GenericRule):
         with open (f'loki_lint_{subroutine.name}.patch', 'w') as f:
             f.write(diff_str)
             f.write('\n')
-
 
 class MissingImplicitNoneRule(GenericRule):
     """

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -173,7 +173,7 @@ class LokiStringifyMapper(StringifyMapper):
         numerator = self.rec_with_force_parens_around(expr.numerator, PREC_PRODUCT, *args, **kwargs)
         kwargs['force_parens_around'] = self.multiplicative_primitives
         denominator = self.rec_with_force_parens_around(expr.denominator, PREC_PRODUCT, *args, **kwargs)
-        return self.parenthesize_if_needed(self.format('%s / %s', numerator, denominator),
+        return self.parenthesize_if_needed(self.format('%s/%s', numerator, denominator),
                                            enclosing_prec, PREC_PRODUCT)
 
     def map_parenthesised_add(self, expr, enclosing_prec, *args, **kwargs):
@@ -206,7 +206,7 @@ class LokiStringifyMapper(StringifyMapper):
 
     def map_array_subscript(self, expr, enclosing_prec, *args, **kwargs):
         name_str = self.rec(expr.aggregate, PREC_NONE, *args, **kwargs)
-        index_str = self.join_rec(', ', expr.index_tuple, PREC_NONE, *args, **kwargs)
+        index_str = self.join_rec(',', expr.index_tuple, PREC_NONE, *args, **kwargs)
         return f'{name_str}({index_str})'
 
     map_string_subscript = map_array_subscript

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -22,7 +22,7 @@ import pytest
 from loki import (
     Module, Subroutine, FindVariables, BasicType, config, Sourcefile,
     RawSource, RegexParserClass, ProcedureType, DerivedType,
-    PreprocessorDirective, config_override
+    PreprocessorDirective, config_override, FindLiterals
 )
 from loki.build import jit_compile, clean_test
 from loki.expression import symbols as sym
@@ -53,7 +53,23 @@ def fixture_reset_regex_frontend_timeout():
     yield
     config['regex-frontend-timeout'] = original_timeout
 
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_literals_kind(frontend):
+    """
+    """
 
+    fcode = """
+SUBROUTINE SOME_SUBROUTINE()
+REAL :: A
+A = 0.d0
+END SUBROUTINE
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    literals = FindLiterals().visit(routine.body)
+    # print(f"literals: {literals}")
+    for literal in literals:
+        print(f"literal: '{literal}' | {literal.kind}")
+    
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_check_alloc_opts(here, frontend):
     """

--- a/loki/ir/pprint.py
+++ b/loki/ir/pprint.py
@@ -150,7 +150,8 @@ class Stringifier(Visitor):
                  required to observe the line width limit.
         :rtype: str
         """
-        if not no_indent:
+        # print(f"items: {items}")
+        if not no_indent and items != ('',):
             items = [self.indent, *items]
         if no_wrap:
             # Simply concatenate items and append the comment

--- a/loki/lint/linter.py
+++ b/loki/lint/linter.py
@@ -226,7 +226,7 @@ class Linter:
         sourcefile = Fixer.fix(sourcefile, file_report.fixable_reports, config)
 
         # Create the the source string for the output
-        sourcefile.write(conservative=True)
+        # sourcefile.write(conservative=True)
 
 
 class LinterTransformation(Transformation):
@@ -291,7 +291,15 @@ def check_and_fix_file(path, linter, fix=False, backup_suffix=None):
         if fix:
             linter.fix(source, report, backup_suffix=backup_suffix)
     except Exception as exc:  # pylint: disable=broad-except
-        linter.reporter.add_file_error(path, type(exc), str(exc))
+        print(f"exc: {exc}")
+        orig_file = str(path).replace('source/ifs-source/', '')
+        subdir = orig_file.split('/')[0]
+        with open(f"files_exception_{subdir}.txt", "a") as myfile:
+            myfile.write(f"{orig_file}: {exc}\n")
+        try:
+            linter.reporter.add_file_error(path, type(exc), str(exc))
+        except Exception as e:
+            print(f" ... e: {e}")
         if loki_config['debug']:
             raise exc
         return False

--- a/loki/lint/rules.py
+++ b/loki/lint/rules.py
@@ -175,7 +175,7 @@ class GenericRule:
                     cls.check(member, rule_report, config, **kwargs)
 
     @classmethod
-    def fix_module(cls, module, rule_report, config):
+    def fix_module(cls, module, rule_report, config, sourcefile=None):
         """
         Fix rule violations on module level
 
@@ -183,7 +183,7 @@ class GenericRule:
         """
 
     @classmethod
-    def fix_subroutine(cls, subroutine, rule_report, config):
+    def fix_subroutine(cls, subroutine, rule_report, config, sourcefile=None):
         """
         Fix rule violations on subroutine level
 

--- a/loki/lint/utils.py
+++ b/loki/lint/utils.py
@@ -23,7 +23,7 @@ class Fixer:
     """
 
     @classmethod
-    def fix_module(cls, module, reports, config):  # pylint: disable=unused-argument
+    def fix_module(cls, module, reports, config, sourcefile):  # pylint: disable=unused-argument
         """
         Call `fix_module` for all rules and apply the transformations.
         """
@@ -33,14 +33,14 @@ class Fixer:
         return module
 
     @classmethod
-    def fix_subroutine(cls, subroutine, reports, config):
+    def fix_subroutine(cls, subroutine, reports, config, sourcefile):
         """
         Call `fix_subroutine` for all rules and apply the transformations.
         """
         mapper = {}
         for report in reports:
             rule_config = config[report.rule.__name__]
-            mapper.update(report.rule.fix_subroutine(subroutine, report, rule_config) or {})
+            mapper.update(report.rule.fix_subroutine(subroutine, report, rule_config, sourcefile) or {})
 
         if mapper:
             # Apply the changes and invalidate source objects
@@ -87,10 +87,10 @@ class Fixer:
             # Depth-first traversal
             if hasattr(ast, 'subroutines') and ast.subroutines is not None:
                 for routine in ast.subroutines:
-                    cls.fix_subroutine(routine, reports, config)
+                    cls.fix_subroutine(routine, reports, config, ast)
             if hasattr(ast, 'modules') and ast.modules is not None:
                 for module in ast.modules:
-                    cls.fix_module(module, reports, config)
+                    cls.fix_module(module, reports, config, ast)
 
             cls.fix_sourcefile(ast, reports, config)
 
@@ -99,18 +99,18 @@ class Fixer:
             # Depth-first traversal
             if hasattr(ast, 'subroutines') and ast.subroutines is not None:
                 for routine in ast.subroutines:
-                    cls.fix_subroutine(routine, reports, config)
+                    cls.fix_subroutine(routine, reports, config, ast)
 
-            cls.fix_module(ast, reports, config)
+            cls.fix_module(ast, reports, config, ast)
 
         # Fix on subroutine level
         elif isinstance(ast, Subroutine):
             # Depth-first traversal
             if hasattr(ast, 'members') and ast.members is not None:
                 for routine in ast.members:
-                    cls.fix_subroutine(routine, reports, config)
+                    cls.fix_subroutine(routine, reports, config, ast)
 
-            cls.fix_subroutine(ast, reports, config)
+            cls.fix_subroutine(ast, reports, config, ast)
 
         return ast
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = {text = "Apache-2.0"}
 dynamic = ["version", "readme"]
 dependencies = [
   "numpy<1.24",  # essential for tests, loop transformations and other dependencies
-  "pymbolic>=2022.1",  # essential for expression tree
+  "pymbolic==2022.2",  # essential for expression tree
   "PyYAML",  # essential for loki-lint
   "pcpp",  # essential for preprocessing
   "more-itertools",  # essential for SCC transformation


### PR DESCRIPTION
What it does/How it works:

* read the original Fortran file
* find all real literals (including its nodes `with_ir_node=True`)
* if `literal.kind is None`: fix kind and save in dict
* apply dict via `SubstituteExpressions` to the relevant node (only!)
* substitute in the Fortran file representation/string the newly generated node with the old node (using `node.source.string`) 
* generate diff/patch using `difflib` and write to file
* (git apply this file/patch)

__________

Demonstration with CLOUDSC:

With this config file 

```
basedir: .
include:
  - src/cloudsc_fortran/*.F90

rules:
  - MissingKindSpecifierRealLiterals

junitxml_file: linter.xml
violations_file: test_new_violations.yml

max_workers: 4
```

applied to the CLOUDSC dwarf via e.g., `loki-lint.py check -c lint_config.yml --fix --worker 4` 
generates a file "loki_lint_CLOUDSC.patch" which looks like

```
--- a/src/cloudsc_fortran/cloudsc.F90
+++ b/src/cloudsc_fortran/cloudsc.F90
@@ -2048,11 +2048,11 @@
         ! otherwise faster to freeze (snow or ice pellets)
         ZQPRETOT(JL) = MAX(ZQX(JL,JK,NCLDQS)+ZQX(JL,JK,NCLDQR),ZEPSEC)
         PRAINFRAC_TOPRFZ(JL) = ZQX(JL,JK,NCLDQR)/ZQPRETOT(JL)
-        IF (PRAINFRAC_TOPRFZ(JL) > 0.8) THEN 
-          LLRAINLIQ(JL) = .True.
+        IF (PRAINFRAC_TOPRFZ(JL) > 0.8_JPRB) THEN
+          LLRAINLIQ(JL) = .true.
         ELSE
-          LLRAINLIQ(JL) = .False.
-        ENDIF
+          LLRAINLIQ(JL) = .false.
+        END IF
       ENDIF

       ! If temperature less than zero
@@ -2382,15 +2382,15 @@

       ZAPLUSB   = RCL_APB1*ZVPICE-RCL_APB2*ZVPICE*ZTP1(JL,JK)+ &
      &             PAP(JL,JK)*RCL_APB3*ZTP1(JL,JK)**3
-      ZCORRFAC  = (1.0/ZRHO(JL))**0.5
-      ZCORRFAC2 = ((ZTP1(JL,JK)/273.0)**1.5)*(393.0/(ZTP1(JL,JK)+120.0))
+      ZCORRFAC = (1.0_JPRB / ZRHO(JL))**0.5_JPRB
+      ZCORRFAC2 = ((ZTP1(JL, JK) / 273.0_JPRB)**1.5_JPRB)*(393.0_JPRB / (ZTP1(JL, JK) + 120.0_JPRB))

       ZPR02 = ZRHO(JL)*ZPRECLR*RCL_CONST1S/(ZTCG*ZFACX1S)

       ZTERM1 = (ZQSICE(JL,JK)-ZQE)*ZTP1(JL,JK)**2*ZVPICE*ZCORRFAC2*ZTCG* &
      &          RCL_CONST2S*ZFACX1S/(ZRHO(JL)*ZAPLUSB*ZQSICE(JL,JK))
-      ZTERM2 = 0.65*RCL_CONST6S*ZPR02**RCL_CONST4S+RCL_CONST3S*ZCORRFAC**0.5 &
-     &          *ZRHO(JL)**0.5*ZPR02**RCL_CONST5S/ZCORRFAC2**0.5
+      ZTERM2 = 0.65_JPRB*RCL_CONST6S*ZPR02**RCL_CONST4S + RCL_CONST3S*ZCORRFAC**0.5_JPRB*ZRHO(JL)**0.5_JPRB*ZPR02**RCL_CONST5S /  &
+      & ZCORRFAC2**0.5_JPRB

       ZDPEVAP = MAX(ZCOVPCLR(JL)*ZTERM1*ZTERM2*PTSPHY,0.0_JPRB)

```

and can be applied via `git apply --whitespace=fix loki_lint_*.patch`

resulting in `git diff`

```
diff --git a/src/cloudsc_fortran/cloudsc.F90 b/src/cloudsc_fortran/cloudsc.F90
index 17f7144..035bf07 100644
--- a/src/cloudsc_fortran/cloudsc.F90
+++ b/src/cloudsc_fortran/cloudsc.F90
@@ -2048,11 +2048,11 @@ DO JK=NCLDTOP,KLEV
         ! otherwise faster to freeze (snow or ice pellets)
         ZQPRETOT(JL) = MAX(ZQX(JL,JK,NCLDQS)+ZQX(JL,JK,NCLDQR),ZEPSEC)
         PRAINFRAC_TOPRFZ(JL) = ZQX(JL,JK,NCLDQR)/ZQPRETOT(JL)
-        IF (PRAINFRAC_TOPRFZ(JL) > 0.8) THEN 
-          LLRAINLIQ(JL) = .True.
+        IF (PRAINFRAC_TOPRFZ(JL) > 0.8_JPRB) THEN
+          LLRAINLIQ(JL) = .true.
         ELSE
-          LLRAINLIQ(JL) = .False.
-        ENDIF
+          LLRAINLIQ(JL) = .false.
+        END IF
       ENDIF
     
       ! If temperature less than zero
@@ -2382,15 +2382,15 @@ ENDIF ! on IEVAPRAIN
 
       ZAPLUSB   = RCL_APB1*ZVPICE-RCL_APB2*ZVPICE*ZTP1(JL,JK)+ &
      &             PAP(JL,JK)*RCL_APB3*ZTP1(JL,JK)**3
-      ZCORRFAC  = (1.0/ZRHO(JL))**0.5
-      ZCORRFAC2 = ((ZTP1(JL,JK)/273.0)**1.5)*(393.0/(ZTP1(JL,JK)+120.0))
+      ZCORRFAC = (1.0_JPRB / ZRHO(JL))**0.5_JPRB
+      ZCORRFAC2 = ((ZTP1(JL, JK) / 273.0_JPRB)**1.5_JPRB)*(393.0_JPRB / (ZTP1(JL, JK) + 120.0_JPRB))
 
       ZPR02 = ZRHO(JL)*ZPRECLR*RCL_CONST1S/(ZTCG*ZFACX1S)
 
       ZTERM1 = (ZQSICE(JL,JK)-ZQE)*ZTP1(JL,JK)**2*ZVPICE*ZCORRFAC2*ZTCG* &
      &          RCL_CONST2S*ZFACX1S/(ZRHO(JL)*ZAPLUSB*ZQSICE(JL,JK))
-      ZTERM2 = 0.65*RCL_CONST6S*ZPR02**RCL_CONST4S+RCL_CONST3S*ZCORRFAC**0.5 &
-     &          *ZRHO(JL)**0.5*ZPR02**RCL_CONST5S/ZCORRFAC2**0.5
+      ZTERM2 = 0.65_JPRB*RCL_CONST6S*ZPR02**RCL_CONST4S + RCL_CONST3S*ZCORRFAC**0.5_JPRB*ZRHO(JL)**0.5_JPRB*ZPR02**RCL_CONST5S /  &
+      & ZCORRFAC2**0.5_JPRB
 
       ZDPEVAP = MAX(ZCOVPCLR(JL)*ZTERM1*ZTERM2*PTSPHY,0.0_JPRB)
  
```

________

Also tested for "ifs-source" with "include: arpifs/phys_ec/**/*.F90".

**Some notes:**

* we could also directly substitute within the Fortran file and don't use the git patch approach
* just a POC to show how we could fix things and minimise the diff (as we don't use fgen() for all of the Fortran file/subroutine)
    *  diff is still relatively large for the transformed/fixed nodes (white space, indentation, new lines, ...)

**Current limitations:**

* problematic for multiple Rules/Fixes that apply to the same node (not tested but this won't work)
    * we would need to have a common dict/map per node for all the rules before applying `SubstituteExpressions`

