### PR TITLE
Fixed logical evaluation of PRESENT intrinsics on Array variables

### DIFF
--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -415,7 +415,7 @@ def map_call_to_procedure_body(call, caller):
         check for check in FindInlineCalls().visit(callee.body) if check.function == 'PRESENT'
     )
     present_map = {
-        check: sym.Literal('.true.') if check.arguments[0] in call.arg_map else sym.Literal('.false.')
+        check: sym.Literal('.true.') if check.arguments[0] in [arg.name for arg in call.arg_map] else sym.Literal('.false.')
         for check in present_checks
     }
     argmap.update(present_map)


### PR DESCRIPTION
During inlining_member_procedures, PRESENT intrinsics are evaluated according the the actual presence of the concerned variables in the caller arguments.

However, this evaluation always returns false when evaluating Array variables.

This is due to the fact that we compare the array in the PRESENT call which has only the array's name, with the array declaration (from call.arg_map) which includes the dimensions.

I propose to correct that checking the existence of the variable in the list of variables names from call.arg_map, instead of checking directly in the variables from call.arg_map.



