### PR TITLE
Support for representing cray pointers using OFP or FP (fixes #338)

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -210,14 +210,17 @@ def rget_child(node, node_type):
     Searches for the last, immediate child of the supplied node that is of
     the specified type.
 
-    :param node: the node whose children will be searched.
-    :type node: :py:class:`fparser.two.utils.Base`
-    :param node_type: the class(es) of child node to search for.
-    :type node_type: type or tuple of type
+    Parameters
+    ----------
+    node : :any:`fparser.two.utils.Base`
+        the node whose children will be searched
+    node_type : class name or tuple of class names
+        the class(es) of child node to search for.
 
-    :returns: the last child node of type node_type that is encountered or None.
-    :rtype: py:class:`fparser.two.utils.Base`
-
+    Returns
+    -------
+    :any:`fparser.two.utils.Base`
+        the last child node of type node_type that is encountered or ``None``.
     """
     for child in reversed(node.children):
         if isinstance(child, node_type):
@@ -227,7 +230,7 @@ def rget_child(node, node_type):
 
 def extract_fparser_source(node, raw_source):
     """
-    Extract the :any:`Source` object for any py:class:`fparser.two.utils.BlockBase`
+    Extract the :any:`Source` object for any :any:`fparser.two.utils.BlockBase`
     from the raw source string.
     """
     assert isinstance(node, BlockBase)
@@ -3211,6 +3214,7 @@ class FParser2IR(GenericVisitor):
     visit_Backspace_Stmt = visit_Intrinsic_Stmt
     visit_Rewind_Stmt = visit_Intrinsic_Stmt
     visit_Entry_Stmt = visit_Intrinsic_Stmt
+    visit_Cray_Pointer_Stmt = visit_Intrinsic_Stmt
 
     def visit_Cpp_If_Stmt(self, o, **kwargs):
         return ir.PreprocessorDirective(text=o.tostr(), source=kwargs.get('source'))

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -778,6 +778,8 @@ class OFP2IR(GenericVisitor):
                 return self.visit(o.find('module-nature'), **kwargs)
             if o.find('enum-def-stmt') is not None:
                 return self.create_enum(o, **kwargs)
+            if o.find('cray-pointer-stmt') is not None:
+                return ir.Intrinsic(text=source.string.strip(), label=label, source=source)
             raise ValueError('Unsupported declaration')
         if o.attrib['type'] in ('implicit', 'intrinsic', 'parameter'):
             return ir.Intrinsic(text=source.string.strip(), label=label, source=source)


### PR DESCRIPTION
The Cray pointer statement is understood by OFP and FParser but was not handled when translating the parse tree to Loki's IR. This adds functionality to represent these as `Intrinsic` nodes in the IR.