### PR TITLE
Allow inlining of Statement Functions

### DIFF
--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -200,7 +200,7 @@ class InlineSubstitutionMapper(LokiIdentityMapper):
             function = expr.routine
             v_result = expr.routine.variable
             # Substitute all arguments through the elemental body
-            arg_map = dict(zip(function.arguments, expr.parameters))
+            arg_map = dict(expr.arg_iter())
             fbody = SubstituteExpressions(arg_map).visit(function.rhs)
             return fbody
 
@@ -208,7 +208,7 @@ class InlineSubstitutionMapper(LokiIdentityMapper):
         v_result = [v for v in function.variables if v == function.name][0]
 
         # Substitute all arguments through the elemental body
-        arg_map = dict(zip(function.arguments, expr.parameters))
+        arg_map = dict(expr.arg_iter())
         fbody = SubstituteExpressions(arg_map).visit(function.body)
 
         # Extract the RHS of the final result variable assignment

--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -60,7 +60,7 @@ class InlineTransformation(Transformation):
     inline_stmt_funcs: bool
         Replaces  :any:`InlineCall` expression to statement functions
         with the corresponding rhs of the statement function if
-        the statement function declaration is available; default: True.
+        the statement function declaration is available; default: False.
     inline_internals : bool
         Inline internal procedure (see :any:`inline_internal_procedures`);
         default: False.
@@ -91,7 +91,7 @@ class InlineTransformation(Transformation):
 
     def __init__(
             self, inline_constants=False, inline_elementals=True,
-            inline_stmt_funcs=True, inline_internals=False,
+            inline_stmt_funcs=False, inline_internals=False,
             inline_marked=True, remove_dead_code=True,
             allowed_aliases=None, adjust_imports=True,
             external_only=True, resolve_sequence_association=False

--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -198,7 +198,6 @@ class InlineSubstitutionMapper(LokiIdentityMapper):
         # if it is an inline call to a Statement Function
         if isinstance(expr.routine, StatementFunction):
             function = expr.routine
-            v_result = expr.routine.variable
             # Substitute all arguments through the elemental body
             arg_map = dict(expr.arg_iter())
             fbody = SubstituteExpressions(arg_map).visit(function.rhs)

--- a/loki/transformations/tests/test_inline.py
+++ b/loki/transformations/tests/test_inline.py
@@ -1144,7 +1144,8 @@ end module inline_declarations
 @pytest.mark.parametrize('frontend', available_frontends(
     (OFP, 'Prefix/elemental support not implemented'))
 )
-def test_inline_transformation(frontend, tmp_path):
+@pytest.mark.parametrize('pass_as_kwarg', (False, True))
+def test_inline_transformation(tmp_path, frontend, pass_as_kwarg):
     """Test combining recursive inlining via :any:`InliningTransformation`."""
 
     fcode_module = """
@@ -1174,7 +1175,7 @@ contains
 end subroutine add_one_and_two
 """
 
-    fcode = """
+    fcode = f"""
 subroutine test_inline_pragma(a, b)
   implicit none
   real(kind=8), intent(inout) :: a(3), b(3)
@@ -1188,15 +1189,15 @@ subroutine test_inline_pragma(a, b)
 
   do i=1, n
     !$loki inline
-    call add_one_and_two(a(i))
+    call add_one_and_two({'a=' if pass_as_kwarg else ''}a(i))
   end do
 
   do i=1, n
     !$loki inline
-    call add_one_and_two(b(i))
+    call add_one_and_two({'a=' if pass_as_kwarg else ''}b(i))
   end do
 
-  a(1) = some_stmt_func(a(2))
+  a(1) = some_stmt_func({'stmt_arg=' if pass_as_kwarg else ''}a(2))
 
 end subroutine test_inline_pragma
 """

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -468,7 +468,7 @@ def replace_selected_kind(routine):
             routine.spec.prepend(imprt)
 
 
-def recursive_expression_map_update(expr_map, max_iterations=10):
+def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=SubstituteExpressionsMapper):
     """
     Utility function to apply a substitution map for expressions to itself
 
@@ -490,6 +490,8 @@ def recursive_expression_map_update(expr_map, max_iterations=10):
     max_iterations : int
         Maximum number of iterations, corresponds to the maximum level of
         nesting that can be replaced.
+    mapper_cls: :any:`SubstituteExpressionsMapper`
+       The underlying mapper to be used (default: :any:`SubstituteExpressionsMapper`).
     """
     def apply_to_init_arg(name, arg, expr, mapper):
         # Helper utility to apply the mapper only to expression arguments and
@@ -504,7 +506,7 @@ def recursive_expression_map_update(expr_map, max_iterations=10):
         # We update the expression map by applying it to the children of each replacement
         # node, thus making sure node replacements are also applied to nested attributes,
         # e.g. call arguments or array subscripts etc.
-        mapper = SubstituteExpressionsMapper(expr_map)
+        mapper = mapper_cls(expr_map)
         prev_map, expr_map = expr_map, {
             expr: type(replacement)(**{
                 name: apply_to_init_arg(name, arg, expr, mapper)


### PR DESCRIPTION
* OFP excluded from test because of some problems with Statement Functions I haven't investigated further yet
* if the order or statement function declaration is "wrong" this won't work as the statement function would be interpreted as array access ... but this is a problem that has nothing to do with the inlining itself

From

```fortran
subroutine stmt_func(arr, ret)
    implicit none
    real, intent(in) :: arr(:)
    real, intent(inout) :: ret(:)
    real :: ret2
    real, parameter :: rtt = 1.0
    real :: PTARE
    real :: FOEDELTA
    FOEDELTA ( PTARE ) = PTARE + 1.0
    real :: FOEEW
    FOEEW ( PTARE ) = PTARE + FOEDELTA(PTARE)

    ret = foeew(arr) 
    ret2 = foedelta(3.0)
end subroutine stmt_func
```

to

```fortran
SUBROUTINE stmt_func (arr, ret)
  IMPLICIT NONE
  REAL, INTENT(IN) :: arr(:)
  REAL, INTENT(INOUT) :: ret(:)
  REAL :: ret2
  REAL, PARAMETER :: rtt = 1.0
  
  ret = arr + arr + 1.0
  ret2 = 3.0 + 1.0
END SUBROUTINE stmt_func
```