### PR TITLE
DrHookTransformation: Add explicit label renaming

### DIFF
--- a/loki/transformations/drhook.py
+++ b/loki/transformations/drhook.py
@@ -58,25 +58,28 @@ class DrHookTransformation(Transformation):
         Dict with explicit label rename mappings
     remove : bool
         Flag to explicitly remove calls to ``DR_HOOK``
+    kernel_only : boolean
+        Only apply to subroutines marked as "kernel"; default: ``False``
     """
 
     recurse_to_internal_procedures = True
 
-    def __init__(self, suffix=None, rename=None, remove=False, **kwargs):
+    def __init__(
+            self, suffix=None, rename=None, remove=False, kernel_only=True
+    ):
         self.suffix = suffix
         self.rename = rename
         self.remove = remove
-
-        super().__init__(**kwargs)
+        self.kernel_only = kernel_only
 
     def transform_subroutine(self, routine, **kwargs):
         """
         Apply transformation to subroutine object
         """
-        role = kwargs['item'].role
+        role = kwargs.get('role')
 
         # Leave DR_HOOK annotations in driver routine
-        if role == 'driver':
+        if self.kernel_only and role == 'driver':
             return
 
         mapper = {}

--- a/loki/transformations/drhook.py
+++ b/loki/transformations/drhook.py
@@ -55,6 +55,8 @@ class DrHookTransformation(Transformation):
         Remove calls to ``DR_HOOK``
     """
 
+    recurse_to_internal_procedures = True
+
     def __init__(self, suffix=None, remove=False, **kwargs):
         self.remove = remove
         self.suffix = suffix
@@ -69,9 +71,6 @@ class DrHookTransformation(Transformation):
         # Leave DR_HOOK annotations in driver routine
         if role == 'driver':
             return
-
-        for r in routine.members:
-            self.transform_subroutine(r, **kwargs)
 
         mapper = {}
         for call in FindNodes(CallStatement).visit(routine.body):

--- a/loki/transformations/drhook.py
+++ b/loki/transformations/drhook.py
@@ -49,14 +49,15 @@ class DrHookTransformation(Transformation):
 
     Parameters
     ----------
+    suffix : str
+        String suffix to append to DrHook labels
     remove : bool
         Remove calls to ``DR_HOOK``
-    mode : str
-        Transformation mode to insert into DrHook labels
     """
-    def __init__(self, remove=False, mode=None, **kwargs):
+
+    def __init__(self, suffix=None, remove=False, **kwargs):
         self.remove = remove
-        self.mode = mode
+        self.suffix = suffix
         super().__init__(**kwargs)
 
     def transform_subroutine(self, routine, **kwargs):
@@ -79,7 +80,7 @@ class DrHookTransformation(Transformation):
                 if self.remove:
                     mapper[call] = None
                 else:
-                    new_label = f'{call.arguments[0].value.upper()}_{str(self.mode).upper()}'
+                    new_label = f'{call.arguments[0].value.upper()}_{str(self.suffix).upper()}'
                     new_args = (Literal(value=new_label),) + call.arguments[1:]
                     mapper[call] = call.clone(arguments=new_args)
 
@@ -90,6 +91,6 @@ class DrHookTransformation(Transformation):
 
         routine.body = Transformer(mapper).visit(routine.body)
 
-        #Get rid of unused import and variable
+        # Get rid of unused import and variable
         if self.remove:
             remove_unused_drhook_import(routine)

--- a/loki/transformations/tests/test_drhook.py
+++ b/loki/transformations/tests/test_drhook.py
@@ -132,7 +132,7 @@ def test_dr_hook_transformation(frontend, config, source, tmp_path):
     """Test DrHook transformation for a renamed Subroutine"""
     scheduler_config = SchedulerConfig.from_dict(config)
     scheduler = Scheduler(paths=source, config=scheduler_config, frontend=frontend, xmods=[tmp_path])
-    scheduler.process(transformation=DrHookTransformation(mode='you_up'))
+    scheduler.process(transformation=DrHookTransformation(suffix='you_up'))
 
     for item in SFilter(scheduler.sgraph, item_filter=ProcedureItem):
         drhook_calls = [
@@ -165,7 +165,7 @@ def test_dr_hook_transformation_remove(frontend, config, source, tmp_path):
     """Test DrHook transformation in remove mode"""
     scheduler_config = SchedulerConfig.from_dict(config)
     scheduler = Scheduler(paths=source, config=scheduler_config, frontend=frontend, xmods=[tmp_path])
-    scheduler.process(transformation=DrHookTransformation(mode='you_up', remove=True))
+    scheduler.process(transformation=DrHookTransformation(suffix='you_up', remove=True))
 
     for item in SFilter(scheduler.sgraph, item_filter=ProcedureItem):
         drhook_calls = [

--- a/loki/transformations/tests/test_drhook.py
+++ b/loki/transformations/tests/test_drhook.py
@@ -210,7 +210,7 @@ def test_dr_hook_transformation_rename(frontend, config, source):
         transformation=DrHookTransformation(rename={
             'rick_astley': 'my_man_dave',
             'never_gonna_run_around': 'see_ya_later',
-        })
+        }, kernel_only=False)
     )
 
     for item in SFilter(scheduler.sgraph, item_filter=ProcedureItem):

--- a/loki/transformations/tests/test_drhook.py
+++ b/loki/transformations/tests/test_drhook.py
@@ -197,3 +197,40 @@ def test_dr_hook_transformation_remove(frontend, config, source, tmp_path):
             assert not drhook_calls
             assert not drhook_imports
             assert 'zhook_handle' not in item.ir.variables
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'Incomplete source tree impossible with OMNI')]
+))
+def test_dr_hook_transformation_rename(frontend, config, source):
+    """Test DrHook transformation in remove mode"""
+    scheduler_config = SchedulerConfig.from_dict(config)
+    scheduler = Scheduler(paths=source, config=scheduler_config, frontend=frontend)
+    scheduler.process(
+        transformation=DrHookTransformation(rename={
+            'rick_astley': 'my_man_dave',
+            'never_gonna_run_around': 'see_ya_later',
+        })
+    )
+
+    for item in SFilter(scheduler.sgraph, item_filter=ProcedureItem):
+        drhook_calls = [
+            call for call in FindNodes(CallStatement).visit(item.ir.ir)
+            if call.name == 'dr_hook'
+        ]
+        if item.local_name == 'rick_astley':
+            assert drhook_calls[0].arguments[0] == 'my_man_dave'
+            assert drhook_calls[1].arguments[0] == 'my_man_dave'
+
+        if item.local_name == 'never_gonna_give':
+            assert drhook_calls[0].arguments[0] == 'never_gonna_give'
+            assert drhook_calls[1].arguments[0] == 'never_gonna_give'
+
+            assert len(item.ir.members) == 1
+            inner = item.ir.members[0]
+            inner_calls = [
+                call for call in FindNodes(CallStatement).visit(inner.ir)
+                if call.name == 'dr_hook'
+            ]
+            assert inner_calls[0].arguments[0] == 'see_ya_later'
+            assert inner_calls[1].arguments[0] == 'see_ya_later'

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -202,7 +202,7 @@ def convert(
 
     # Re-write DR_HOOK labels for non-GPU paths
     if 'scc' not in mode:
-        scheduler.process( DrHookTransformation(mode=mode, remove=False) )
+        scheduler.process( DrHookTransformation(suffix=mode, remove=False) )
 
     # Perform general source removal of unwanted calls or code regions
     # (do not perfrom Dead Code Elimination yet, inlining will do this.)


### PR DESCRIPTION
This PR adds an renaming option to the `DrHookTransformation` that allows and explicit renaming via a string-to-string dict in addition to the current append-suffix mode. This allows a broader use for this housekeeping transformation, eg. when generating control-flow subroutines.

With this, I've also added a few minor clean-ups and fixes, as detailed below:
* Rename the argument `mode` to `suffix`, as it's a suffix we add to the DR_HOOK labels
* Use the `Transformation.recurse_to_internal_procedures` class property instead of explicit recursion calls
* Add a `kernel_only` argument (`True` by default), with which we can force it to apply to "driver" routines as well
* Add `rename` argument (dict) that gets used when/if a label is matched for explicit label renaming.