### PR TITLE
Fix DEV_ALLOC_SIZE for ecwam regression and add SCC-HOIST variant

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Install ECWAM dependencies
         run: |
           sudo apt-get -o Acquire::Retries=3 install -y libopenmpi-dev
-          source loki-activate
-          pip install fypp
+          pip install pyyaml fypp
 
       - name: Run CLOUDSC and ECWAM regression tests
         env:

--- a/loki/transformations/tests/test_ecwam.py
+++ b/loki/transformations/tests/test_ecwam.py
@@ -47,7 +47,7 @@ def fixture_bundle_create(here, local_loki_bundle):
 
 @pytest.mark.usefixtures('bundle_create')
 @pytest.mark.skipif(not HAVE_FP, reason="FP needed for ECWAM parsing")
-@pytest.mark.parametrize('mode', ['idem', 'idem-stack', 'scc', 'scc-stack'])
+@pytest.mark.parametrize('mode', ['idem', 'idem-stack', 'scc', 'scc-stack', 'scc-hoist'])
 def test_ecwam(here, mode, tmp_path):
     build_dir = tmp_path/'build'
     build_cmd = [
@@ -68,7 +68,7 @@ def test_ecwam(here, mode, tmp_path):
     # Raise stack limit
     resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
     env = os.environ.copy()
-    env.update({'OMP_STACKSIZE': '2G', 'NVCOMPILER_ACC_CUDA_HEAPSIZE': '2G'})
+    env.update({'OMP_STACKSIZE': '2G', 'NVCOMPILER_ACC_CUDA_HEAPSIZE': '2G', 'DEV_ALLOC_SIZE': '2147483648'})
 
     # create rundir
     rundir = build_dir/'wamrun_48'


### PR DESCRIPTION
A few small changes to fix the ecwam regression tests. What was causing the runtime failures was the default `DEV_ALLOC_SIZE` in the FIELD_API buddy allocator. The change to the fypp+pyyaml installation is for a future ecwam update which relies on (in the absence of fckit) the system python installation having fypp+pyyaml.