### PR TITLE
Transformations: Move common SCC utility routines to `utilities`

### DIFF
--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -12,7 +12,9 @@ from loki.tools import as_tuple
 from loki.types import SymbolAttributes, BasicType
 from loki.expression import Variable, Array, RangeIndex, FindVariables, SubstituteExpressions
 from loki.transformations.sanitise import resolve_associates
-from loki.transformations.utilities import recursive_expression_map_update
+from loki.transformations.utilities import (
+    recursive_expression_map_update, get_integer_variable
+)
 from loki.transformations.single_column.base import SCCBaseTransformation
 
 __all__ = ['BlockViewToFieldViewTransformation', 'InjectBlockIndexTransformation']
@@ -232,7 +234,7 @@ class BlockViewToFieldViewTransformation(Transformation):
 
         # Sanitize the subroutine
         resolve_associates(routine)
-        v_index = SCCBaseTransformation.get_integer_variable(routine, name=self.horizontal.index)
+        v_index = get_integer_variable(routine, name=self.horizontal.index)
         SCCBaseTransformation.resolve_masked_stmts(routine, loop_variable=v_index)
 
         # Bail if routine is marked as sequential or routine has already been processed

--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -13,7 +13,7 @@ from loki.types import SymbolAttributes, BasicType
 from loki.expression import Variable, Array, RangeIndex, FindVariables, SubstituteExpressions
 from loki.transformations.sanitise import resolve_associates
 from loki.transformations.utilities import (
-    recursive_expression_map_update, get_integer_variable
+    recursive_expression_map_update, get_integer_variable, get_loop_bounds
 )
 from loki.transformations.single_column.base import SCCBaseTransformation
 
@@ -241,7 +241,7 @@ class BlockViewToFieldViewTransformation(Transformation):
         if SCCBaseTransformation.check_routine_pragmas(routine, directive=None):
             return
 
-        bounds = SCCBaseTransformation.get_horizontal_loop_bounds(routine, self.horizontal)
+        bounds = get_loop_bounds(routine, self.horizontal)
         SCCBaseTransformation.resolve_vector_dimension(routine, loop_variable=v_index, bounds=bounds)
 
         # for kernels we process the entire body

--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -13,7 +13,8 @@ from loki.types import SymbolAttributes, BasicType
 from loki.expression import Variable, Array, RangeIndex, FindVariables, SubstituteExpressions
 from loki.transformations.sanitise import resolve_associates
 from loki.transformations.utilities import (
-    recursive_expression_map_update, get_integer_variable, get_loop_bounds
+    recursive_expression_map_update, get_integer_variable,
+    get_loop_bounds, check_routine_pragmas
 )
 from loki.transformations.single_column.base import SCCBaseTransformation
 
@@ -238,7 +239,7 @@ class BlockViewToFieldViewTransformation(Transformation):
         SCCBaseTransformation.resolve_masked_stmts(routine, loop_variable=v_index)
 
         # Bail if routine is marked as sequential or routine has already been processed
-        if SCCBaseTransformation.check_routine_pragmas(routine, directive=None):
+        if check_routine_pragmas(routine, directive=None):
             return
 
         bounds = get_loop_bounds(routine, self.horizontal)

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -19,9 +19,8 @@ from loki.logging import info
 from loki.tools import as_tuple, flatten
 from loki.types import DerivedType
 
-from loki.transformations.single_column.base import SCCBaseTransformation
 from loki.transformations.utilities import (
-    find_driver_loops, get_local_arrays
+    find_driver_loops, get_local_arrays, check_routine_pragmas
 )
 
 
@@ -207,7 +206,7 @@ class SCCAnnotateTransformation(Transformation):
         """
 
         # Bail if routine is marked as sequential
-        if SCCBaseTransformation.check_routine_pragmas(routine, self.directive):
+        if check_routine_pragmas(routine, self.directive):
             return
 
         if self.directive == 'openacc':

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -20,6 +20,7 @@ from loki.tools import as_tuple, flatten, CaseInsensitiveDict
 from loki.types import DerivedType
 
 from loki.transformations.single_column.base import SCCBaseTransformation
+from loki.transformations.utilities import find_driver_loops
 
 
 __all__ = ['SCCAnnotateTransformation']
@@ -239,7 +240,7 @@ class SCCAnnotateTransformation(Transformation):
                 break
 
         with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
-            driver_loops = SCCBaseTransformation.find_driver_loops(routine=routine, targets=targets)
+            driver_loops = find_driver_loops(routine=routine, targets=targets)
             for loop in driver_loops:
                 loops = FindNodes(ir.Loop).visit(loop.body)
                 kernel_loops = [l for l in loops if l.variable == self.horizontal.index]

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -12,10 +12,9 @@ from loki.expression import (
 from loki.ir import nodes as ir, FindNodes, Transformer
 from loki.logging import debug
 from loki.tools import as_tuple
-from loki.types import SymbolAttributes, BasicType
-
 
 from loki.transformations.sanitise import resolve_associates
+from loki.transformations.utilities import get_integer_variable
 
 
 __all__ = ['SCCBaseTransformation']
@@ -108,23 +107,6 @@ class SCCBaseTransformation(Transformation):
                 raise RuntimeError(f'No horizontol {name} variable matching {_bounds[0]} found in {routine.name}')
 
         return bounds
-
-    @classmethod
-    def get_integer_variable(cls, routine, name):
-        """
-        Find a local variable in the routine, or create an integer-typed one.
-
-        Parameters
-        ----------
-        routine : :any:`Subroutine`
-            The subroutine in which to find the variable
-        name : string
-            Name of the variable to find the in the routine.
-        """
-        if not (v_index := routine.symbol_map.get(name, None)):
-            dtype = SymbolAttributes(BasicType.INTEGER)
-            v_index = sym.Variable(name=name, type=dtype, scope=routine)
-        return v_index
 
     @classmethod
     def resolve_masked_stmts(cls, routine, loop_variable):
@@ -299,7 +281,7 @@ class SCCBaseTransformation(Transformation):
         bounds = self.get_horizontal_loop_bounds(routine, self.horizontal)
 
         # Find the iteration index variable for the specified horizontal
-        v_index = self.get_integer_variable(routine, name=self.horizontal.index)
+        v_index = get_integer_variable(routine, name=self.horizontal.index)
 
         # Associates at the highest level, so they don't interfere
         # with the sections we need to do for detecting subroutine calls

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -10,7 +10,6 @@ from loki.expression import (
     symbols as sym, FindExpressions, SubstituteExpressions
 )
 from loki.ir import nodes as ir, FindNodes, Transformer
-from loki.logging import debug
 from loki.tools import as_tuple
 
 from loki.transformations.sanitise import resolve_associates
@@ -97,8 +96,6 @@ class SCCBaseTransformation(Transformation):
         """
 
         bounds_str = f'{bounds[0]}:{bounds[1]}'
-
-        variable_map = routine.variable_map
 
         mapper = {}
         for stmt in FindNodes(ir.Assignment).visit(routine.body):

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -167,58 +167,6 @@ class SCCBaseTransformation(Transformation):
         if mapper and loop_variable not in routine.variables:
             routine.variables += as_tuple(loop_variable)
 
-    @staticmethod
-    def is_driver_loop(loop, targets):
-        """
-        Test/check whether a given loop is a *driver loop*.
-
-        Parameters
-        ----------
-        loop : :any: `Loop`
-            The loop to test if it is a *driver loop*.
-        targets : list or string
-            List of subroutines that are to be considered as part of
-            the transformation call tree.
-        """
-        if loop.pragma:
-            for pragma in loop.pragma:
-                if pragma.keyword.lower() == "loki" and pragma.content.lower() == "driver-loop":
-                    return True
-        for call in FindNodes(ir.CallStatement).visit(loop.body):
-            if call.name in targets:
-                return True
-        return False
-
-    @classmethod
-    def find_driver_loops(cls, routine, targets):
-        """
-        Find and return all driver loops of a given `routine`.
-
-        A *driver loop* is specified either by a call to a routine within
-        `targets` or by the pragma `!$loki driver-loop`.
-
-        Parameters
-        ----------
-        routine : :any:`Subroutine`
-            The subroutine in which to find the driver loops.
-        targets : list or string
-            List of subroutines that are to be considered as part of
-            the transformation call tree.
-        """
-
-        driver_loops = []
-        nested_driver_loops = []
-        for loop in FindNodes(ir.Loop).visit(routine.body):
-            if loop in nested_driver_loops:
-                continue
-
-            if not cls.is_driver_loop(loop, targets):
-                continue
-
-            driver_loops.append(loop)
-            loops = FindNodes(ir.Loop).visit(loop.body)
-            nested_driver_loops.extend(loops)
-        return driver_loops
 
     def transform_subroutine(self, routine, **kwargs):
         """

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -99,15 +99,6 @@ class SCCBaseTransformation(Transformation):
         bounds_str = f'{bounds[0]}:{bounds[1]}'
 
         variable_map = routine.variable_map
-        try:
-            bounds_v = (routine.resolve_typebound_var(bounds[0], variable_map),
-                        routine.resolve_typebound_var(bounds[1], variable_map))
-        except KeyError:
-            debug(
-                'SCCBaseTransformation.resolve_vector_dimension: '
-                f'Dimension bound {bounds[0]} or {bounds[1]} not found in {routine.name}.'
-            )
-            return
 
         mapper = {}
         for stmt in FindNodes(ir.Assignment).visit(routine.body):
@@ -116,7 +107,7 @@ class SCCBaseTransformation(Transformation):
             if ranges:
                 exprmap = {r: loop_variable for r in ranges}
                 loop = ir.Loop(
-                    variable=loop_variable, bounds=sym.LoopRange(bounds_v),
+                    variable=loop_variable, bounds=sym.LoopRange(bounds),
                     body=as_tuple(SubstituteExpressions(exprmap).visit(stmt))
                 )
                 mapper[stmt] = loop

--- a/loki/transformations/single_column/hoist.py
+++ b/loki/transformations/single_column/hoist.py
@@ -9,7 +9,7 @@ from loki.expression import symbols as sym
 from loki.ir import nodes as ir
 
 from loki.transformations.hoist_variables import HoistVariablesTransformation
-from loki.transformations.single_column.base import SCCBaseTransformation
+from loki.transformations.utilities import get_integer_variable
 
 
 __all__ = ['SCCHoistTemporaryArraysTransformation']
@@ -55,7 +55,7 @@ class SCCHoistTemporaryArraysTransformation(HoistVariablesTransformation):
                 'for array argument hoisting.'
             )
 
-        block_var = SCCBaseTransformation.get_integer_variable(routine, self.block_dim.size)
+        block_var = get_integer_variable(routine, self.block_dim.size)
         routine.variables += tuple(
             v.clone(
                 dimensions=v.dimensions + (block_var,),
@@ -95,7 +95,7 @@ class SCCHoistTemporaryArraysTransformation(HoistVariablesTransformation):
                 '[Loki] SingleColumnCoalescedTransform: No blocking dimension found '
                 'for array argument hoisting.'
             )
-        idx_var = SCCBaseTransformation.get_integer_variable(routine, self.block_dim.index)
+        idx_var = get_integer_variable(routine, self.block_dim.index)
         if self.as_kwarguments:
             new_kwargs = tuple(
                 (a.name, v.clone(dimensions=tuple(sym.RangeIndex((None, None))

--- a/loki/transformations/single_column/scc_cuf.py
+++ b/loki/transformations/single_column/scc_cuf.py
@@ -22,7 +22,9 @@ from loki.transformations.hoist_variables import HoistVariablesTransformation
 from loki.transformations.sanitise import resolve_associates
 from loki.transformations.single_column.base import SCCBaseTransformation
 from loki.transformations.single_column.vector import SCCDevectorTransformation
-from loki.transformations.utilities import single_variable_declaration
+from loki.transformations.utilities import (
+    single_variable_declaration, get_integer_variable
+)
 
 
 __all__ = [
@@ -745,7 +747,7 @@ class SccCufTransformation(Transformation):
             The subroutines depth
         """
 
-        v_index = SCCBaseTransformation.get_integer_variable(routine, name=self.horizontal.index)
+        v_index = get_integer_variable(routine, name=self.horizontal.index)
         resolve_associates(routine)
         SCCBaseTransformation.resolve_masked_stmts(routine, loop_variable=v_index)
         SCCBaseTransformation.resolve_vector_dimension(routine, loop_variable=v_index, bounds=self.horizontal.bounds)

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -18,7 +18,8 @@ from loki.ir import (
 )
 
 from loki.transformations import (
-    DataOffloadTransformation, SanitiseTransformation, InlineTransformation
+    DataOffloadTransformation, SanitiseTransformation,
+    InlineTransformation, get_loop_bounds
 )
 from loki.transformations.single_column import (
     SCCBaseTransformation, SCCDevectorTransformation,
@@ -948,11 +949,11 @@ end subroutine kernel
     transform = SCCBaseTransformation(horizontal=horizontal_bounds_aliases)
     transform.apply(alias, role='kernel')
 
-    bounds = SCCBaseTransformation.get_horizontal_loop_bounds(routine, horizontal_bounds_aliases)
+    bounds = get_loop_bounds(routine, dimension=horizontal_bounds_aliases)
     assert bounds[0] == 'start'
     assert bounds[1] == 'end'
 
-    bounds = SCCBaseTransformation.get_horizontal_loop_bounds(alias, horizontal_bounds_aliases)
+    bounds = get_loop_bounds(alias, dimension=horizontal_bounds_aliases)
     assert bounds[0] == 'bnds%start'
     assert bounds[1] == 'bnds%end'
 

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -22,7 +22,8 @@ from loki.types import BasicType
 from loki.transformations.array_indexing import demote_variables
 from loki.transformations.single_column.base import SCCBaseTransformation
 from loki.transformations.utilities import (
-    get_integer_variable, get_loop_bounds, find_driver_loops
+    get_integer_variable, get_loop_bounds, find_driver_loops,
+    get_local_arrays
 )
 
 
@@ -336,36 +337,49 @@ class SCCDemoteTransformation(Transformation):
         self.demote_local_arrays = demote_local_arrays
 
     @classmethod
-    def kernel_get_locals_to_demote(cls, routine, sections, horizontal):
+    def get_locals_to_demote(cls, routine, sections, horizontal):
+        """
+        Create a list of local temporary arrays after checking that
+        demotion is safe.
 
-        argument_names = [v.name for v in routine.arguments]
+        Demotion is considered safe if the temporary is only used
+        within one coherent vector-section (see
+        :any:`extract_vector_sections`).
 
-        def _get_local_arrays(section):
-            """
-            Filters out local argument arrays that solely buffer the
-            horizontal vector dimension
-            """
-            arrays = FindVariables(unique=False).visit(section)
-            # Only demote local arrays with the horizontal as fast dimension
-            arrays = [v for v in arrays if isinstance(v, sym.Array)]
-            arrays = [v for v in arrays if v.name not in argument_names]
-            arrays = [v for v in arrays if v.shape and
-                      v.shape[0] in [horizontal.size, *horizontal._aliases]]
+        Local temporaries get demoted if they have:
+        * Only one dimension, which is the ``horizontal``
+        * Have the ``horizontal`` as the innermost dimension, with all
+          other dimensions being declared constant parameters.
 
-            # Also demote arrays whose remaning dimensions are known constants
-            arrays = [v for v in arrays if all(is_dimension_constant(d) for d in v.shape[1:])]
-            return arrays
+        """
+        # Create a list of local temporary arrays to filter down
+        candidates = get_local_arrays(routine, routine.spec)
 
-        # Create a list of all local horizontal temporary arrays
-        candidates = _get_local_arrays(routine.spec)
+        # Only demote local arrays with the horizontal as fast dimension
+        candidates = [
+            v for v in candidates if v.shape and
+            v.shape[0] in [horizontal.size, *horizontal._aliases]
+        ]
+        # Also demote arrays whose remaning dimensions are known constants
+        candidates = [
+            v for v in candidates
+            if all(is_dimension_constant(d) for d in v.shape[1:])
+        ]
 
         # Create an index into all variable uses per vector-level section
-        vars_per_section = {s: set(v.name.lower() for v in _get_local_arrays(s)) for s in sections}
+        vars_per_section = {
+            s: set(
+                v.name.lower() for v in get_local_arrays(routine, s, unique=False)
+            ) for s in sections
+        }
 
         # Count in how many sections each temporary is used
         counts = {}
         for arr in candidates:
-            counts[arr] = sum(1 if arr.name.lower() in v else 0 for v in vars_per_section.values())
+            counts[arr] = sum(
+                1 if arr.name.lower() in v else 0
+                for v in vars_per_section.values()
+            )
 
         # Demote temporaries that are only used in one section or not at all
         to_demote = [k for k, v in counts.items() if v <= 1]
@@ -411,12 +425,15 @@ class SCCDemoteTransformation(Transformation):
         """
 
         # Find vector sections marked in the SCCDevectorTransformation
-        sections = [s for s in FindNodes(ir.Section).visit(routine.body) if s.label == 'vector_section']
+        sections = [
+            s for s in FindNodes(ir.Section).visit(routine.body)
+            if s.label == 'vector_section'
+        ]
 
         # Extract the local variables to demote after we wrap the sections in vector loops.
         # We do this, because need the section blocks to determine which local arrays
         # may carry buffered values between them, so that we may not demote those!
-        to_demote = self.kernel_get_locals_to_demote(routine, sections, self.horizontal)
+        to_demote = self.get_locals_to_demote(routine, sections, self.horizontal)
 
         # Filter out arrays marked explicitly for preservation
         if preserve_arrays:
@@ -426,5 +443,7 @@ class SCCDemoteTransformation(Transformation):
         if demote_locals:
             variables = tuple(v.name for v in to_demote)
             if variables:
-                demote_variables(routine, variable_names=variables,
-                                 dimensions=[self.horizontal.size, *self.horizontal._aliases])
+                demote_variables(
+                    routine, variable_names=variables,
+                    dimensions=[self.horizontal.size, *self.horizontal._aliases]
+                )

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -20,10 +20,9 @@ from loki.tools import as_tuple, flatten
 from loki.types import BasicType
 
 from loki.transformations.array_indexing import demote_variables
-from loki.transformations.single_column.base import SCCBaseTransformation
 from loki.transformations.utilities import (
     get_integer_variable, get_loop_bounds, find_driver_loops,
-    get_local_arrays
+    get_local_arrays, check_routine_pragmas
 )
 
 
@@ -98,7 +97,7 @@ class SCCDevectorTransformation(Transformation):
             # check if calls have been enriched
             if not call.routine is BasicType.DEFERRED:
                 # check if called routine is marked as sequential
-                if SCCBaseTransformation.check_routine_pragmas(routine=call.routine, directive=None):
+                if check_routine_pragmas(routine=call.routine, directive=None):
                     continue
 
             if call in section:

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -278,8 +278,6 @@ class SCCRevectorTransformation(Transformation):
         horizontal: :any:`Dimension`
             The dimension specifying the horizontal vector dimension
         """
-
-        variable_map = routine.variable_map
         bounds = get_loop_bounds(routine, dimension=horizontal)
 
         # Create a single loop around the horizontal from a given body

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -22,7 +22,7 @@ from loki.types import BasicType
 from loki.transformations.array_indexing import demote_variables
 from loki.transformations.single_column.base import SCCBaseTransformation
 from loki.transformations.utilities import (
-    get_integer_variable, get_loop_bounds
+    get_integer_variable, get_loop_bounds, find_driver_loops
 )
 
 
@@ -229,7 +229,7 @@ class SCCDevectorTransformation(Transformation):
         """
 
         with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
-            driver_loops = SCCBaseTransformation.find_driver_loops(routine=routine, targets=targets)
+            driver_loops = find_driver_loops(routine=routine, targets=targets)
 
         # remove vector loops
         driver_loop_map = {}

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -21,6 +21,7 @@ from loki.types import BasicType
 
 from loki.transformations.array_indexing import demote_variables
 from loki.transformations.single_column.base import SCCBaseTransformation
+from loki.transformations.utilities import get_integer_variable
 
 
 __all__ = [
@@ -283,7 +284,7 @@ class SCCRevectorTransformation(Transformation):
         v_end = routine.resolve_typebound_var(bounds[1], variable_map)
 
         # Create a single loop around the horizontal from a given body
-        index = SCCBaseTransformation.get_integer_variable(routine, horizontal.index)
+        index = get_integer_variable(routine, horizontal.index)
         bounds = sym.LoopRange((v_start, v_end))
 
         # Ensure we clone all body nodes, to avoid recursion issues

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -21,7 +21,9 @@ from loki.types import BasicType
 
 from loki.transformations.array_indexing import demote_variables
 from loki.transformations.single_column.base import SCCBaseTransformation
-from loki.transformations.utilities import get_integer_variable
+from loki.transformations.utilities import (
+    get_integer_variable, get_loop_bounds
+)
 
 
 __all__ = [
@@ -278,7 +280,7 @@ class SCCRevectorTransformation(Transformation):
         """
 
         variable_map = routine.variable_map
-        bounds = SCCBaseTransformation.get_horizontal_loop_bounds(routine, horizontal)
+        bounds = get_loop_bounds(routine, dimension=horizontal)
 
         v_start = routine.resolve_typebound_var(bounds[0], variable_map)
         v_end = routine.resolve_typebound_var(bounds[1], variable_map)

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -282,12 +282,9 @@ class SCCRevectorTransformation(Transformation):
         variable_map = routine.variable_map
         bounds = get_loop_bounds(routine, dimension=horizontal)
 
-        v_start = routine.resolve_typebound_var(bounds[0], variable_map)
-        v_end = routine.resolve_typebound_var(bounds[1], variable_map)
-
         # Create a single loop around the horizontal from a given body
         index = get_integer_variable(routine, horizontal.index)
-        bounds = sym.LoopRange((v_start, v_end))
+        bounds = sym.LoopRange(bounds)
 
         # Ensure we clone all body nodes, to avoid recursion issues
         vector_loop = ir.Loop(variable=index, bounds=bounds, body=Transformer().visit(section))

--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -471,11 +471,11 @@ subroutine test_get_local_arrays(n, start, end, arr)
   tmp = 2.0
 
   do i=start, end
-    local(i) = tmp * arr(i)
+    local(i) = tmp * ARR(i)
   end do
 
   do i=start, end
-    arr(ji) = tmp * local(i)
+    ARR(ji) = tmp * local(i)
   end do
 end subroutine test_get_local_arrays
 """

--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -359,7 +359,7 @@ end subroutine test_get_integer_variable
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_utilites_get_loop_bounds(frontend):
+def test_transform_utilites_get_loop_bounds(frontend, tmp_path):
     """ Test :any:`get_loop_bounds` utility. """
 
     fcode = """
@@ -386,7 +386,8 @@ subroutine test_get_loop_bounds(dim, n, start, end, arr)
 end subroutine test_get_loop_bounds
 end module test_get_loop_bounds_mod
 """
-    routine = Module.from_source(fcode, frontend=frontend)['test_get_loop_bounds']
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['test_get_loop_bounds']
 
     x = Dimension(name='x', size='n', index='i', bounds=('start', 'end'))
     y = Dimension(name='y', size='n', index='i', bounds=('a', 'b'))
@@ -495,7 +496,7 @@ end subroutine test_get_local_arrays
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_utilites_check_routine_pragmas(frontend):
+def test_transform_utilites_check_routine_pragmas(frontend, tmp_path):
     """ Test :any:`check_routine_pragmas` utility. """
 
     fcode = """
@@ -523,7 +524,7 @@ contains
 
 end module test_check_routine_pragmas_mod
 """
-    module = Module.from_source(fcode, frontend=frontend)
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
 
     # TODO: This utility needs some serious clean-up, so we're just testing
     # the bare basics here and promise to do better next time ;)

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -557,11 +557,11 @@ def get_loop_bounds(routine, dimension):
     """
 
     bounds = ()
-    variables = routine.variables
+    variable_map = routine.variable_map
     for name, _bounds in zip(['start', 'end'], dimension.bounds_expressions):
         for bound in _bounds:
-            if bound.split('%', maxsplit=1)[0] in variables:
-                bounds += (bound,)
+            if bound.split('%', maxsplit=1)[0] in variable_map:
+                bounds += (routine.resolve_typebound_var(bound, variable_map),)
                 break
         else:
             raise RuntimeError(

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -28,9 +28,10 @@ from loki.types import SymbolAttributes, BasicType, DerivedType, ProcedureType
 
 
 __all__ = [
-    'convert_to_lower_case', 'replace_intrinsics', 'rename_variables', 'sanitise_imports',
-    'replace_selected_kind', 'single_variable_declaration', 'recursive_expression_map_update',
-    'get_integer_variable'
+    'convert_to_lower_case', 'replace_intrinsics', 'rename_variables',
+    'sanitise_imports', 'replace_selected_kind',
+    'single_variable_declaration', 'recursive_expression_map_update',
+    'get_integer_variable', 'get_loop_bounds'
 ]
 
 
@@ -538,3 +539,32 @@ def get_integer_variable(routine, name):
         dtype = SymbolAttributes(BasicType.INTEGER)
         v_index = sym.Variable(name=name, type=dtype, scope=routine)
     return v_index
+
+
+def get_loop_bounds(routine, dimension):
+    """
+    Check loop bounds for a particular :any:`Dimension` in a
+    :any:`Subroutine`.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        Subroutine to perform checks on.
+    dimension : :any:`Dimension`
+        :any:`Dimension` object describing the variable conventions
+        used to define the data dimension and iteration space.
+    """
+
+    bounds = ()
+    variables = routine.variables
+    for name, _bounds in zip(['start', 'end'], dimension.bounds_expressions):
+        for bound in _bounds:
+            if bound.split('%', maxsplit=1)[0] in variables:
+                bounds += (bound,)
+                break
+        else:
+            raise RuntimeError(
+                f'No {name} variable matching {_bounds[0]} found in {routine.name}'
+            )
+
+    return bounds

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -31,7 +31,8 @@ __all__ = [
     'convert_to_lower_case', 'replace_intrinsics', 'rename_variables',
     'sanitise_imports', 'replace_selected_kind',
     'single_variable_declaration', 'recursive_expression_map_update',
-    'get_integer_variable', 'get_loop_bounds', 'find_driver_loops'
+    'get_integer_variable', 'get_loop_bounds', 'find_driver_loops',
+    'get_local_arrays'
 ]
 
 
@@ -621,3 +622,28 @@ def find_driver_loops(routine, targets):
         loops = FindNodes(ir.Loop).visit(loop.body)
         nested_driver_loops.extend(loops)
     return driver_loops
+
+
+def get_local_arrays(routine, section, unique=True):
+    """
+    Collect all local temporary array symbols in a given section.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine in which to find local arrays.
+    section : :any:`Section` or tuple of :any:`Node`
+        The section or list of nodes to scan for local temporary
+        symbols.
+    unique : bool, optional
+        Flag whether to return unique instances of each symbol;
+        default: ``False``
+    """
+    arg_names = tuple(a.name for a in routine.arguments)
+    variables = FindVariables(unique=unique).visit(section)
+
+    # Filter all variables by argument name to get local arrays
+    arrays = [v for v in variables if isinstance(v, sym.Array)]
+    arrays = [v for v in arrays if v.name not in arg_names]
+
+    return arrays

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -639,12 +639,12 @@ def get_local_arrays(routine, section, unique=True):
         Flag whether to return unique instances of each symbol;
         default: ``False``
     """
-    arg_names = tuple(a.name for a in routine.arguments)
+    arg_names = tuple(a.lower() for a in routine._dummies)
     variables = FindVariables(unique=unique).visit(section)
 
     # Filter all variables by argument name to get local arrays
     arrays = [v for v in variables if isinstance(v, sym.Array)]
-    arrays = [v for v in arrays if v.name not in arg_names]
+    arrays = [v for v in arrays if str(v.name).lower() not in arg_names]
 
     return arrays
 

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -29,7 +29,8 @@ from loki.types import SymbolAttributes, BasicType, DerivedType, ProcedureType
 
 __all__ = [
     'convert_to_lower_case', 'replace_intrinsics', 'rename_variables', 'sanitise_imports',
-    'replace_selected_kind', 'single_variable_declaration', 'recursive_expression_map_update'
+    'replace_selected_kind', 'single_variable_declaration', 'recursive_expression_map_update',
+    'get_integer_variable'
 ]
 
 
@@ -520,3 +521,20 @@ def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=Subs
             break
 
     return expr_map
+
+
+def get_integer_variable(routine, name):
+    """
+    Find a local variable in the routine, or create an integer-typed one.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine in which to find the variable
+    name : string
+        Name of the variable to find the in the routine.
+    """
+    if not (v_index := routine.symbol_map.get(name, None)):
+        dtype = SymbolAttributes(BasicType.INTEGER)
+        v_index = sym.Variable(name=name, type=dtype, scope=routine)
+    return v_index


### PR DESCRIPTION
~Another small housekeeping change. This one adds a new sub-package `transformations.single_column.util` sub-package for common utilities that may be used across the several SCC sub-stages.~

A small housekeeping change that moves utility methods from `SCCBaseTransformation` to the the common `transformations.utilities` subpackage. This primarily removes the awkward dependency on the `SCCBaseTransformation` class in other SCC sub-components, which provided this previously. 

This change is largely cosmetic (simply copying methods over), except for the `get_local_arrays` utility, which is now used by the demotion and the annotations sub-component. This is in preparation for a more complex refactoring of the annotation sub-component to support multiple vectorisation and annotation schemes in a future PR. 