### PR TITLE
Transformations: Test and fix corner case in get_local_arrays

### DIFF
--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -643,7 +643,7 @@ def get_local_arrays(routine, section, unique=True):
     variables = FindVariables(unique=unique).visit(section)
 
     # Filter all variables by argument name to get local arrays
-    arrays = [v for v in variables if isinstance(v, sym.Array)]
+    arrays = [v for v in variables if isinstance(v, sym.Array) and not v.parent]
     arrays = [v for v in arrays if str(v.name).lower() not in arg_names]
 
     return arrays


### PR DESCRIPTION
_Note: This is a small bug fix to #354 that was overlooked and is currently breaking H24-physics regression._

When running get_local_arrays over the spec of a subroutine we were erroneously picking up component arrays of derived-type arguments that were used for shape definitions. This extends the test for this corner case and fixes it.