### PR TITLE
Tools: Disable timeout utility test on MacOS due to sporadic failures

### DIFF
--- a/loki/tools/tests/test_tools.py
+++ b/loki/tools/tests/test_tools.py
@@ -9,6 +9,7 @@
 Unit tests for utility functions and classes in loki.tools.
 """
 
+import platform
 import sys
 import operator as op
 from contextlib import contextmanager
@@ -310,6 +311,9 @@ def test_execute(here, capsys):
     execute(cmd)
 
 
+@pytest.mark.skipif(platform.system() == 'Darwin',
+    reason='Timeout utility test sporadically fails on MacOS CI runners.'
+)
 def test_timeout():
     # Should not trigger:
     start = perf_counter()


### PR DESCRIPTION
We suspect the failures to be due to load on CI runners, so disabling this test for now.