### PR TITLE
ecWAM regression tests: switch to develop-1.3 branch

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           repository: ecmwf-ifs/ecwam
           path: ecwam
-          ref: develop
+          ref: develop-1.3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
Technical development in ecWAM will (at least for the short term) lag one cycle behind the latest scientific version. Therefore it makes more sense to run the loki regression tests on `develop-1.3` which will be the staging branch for further technical developments on top of 49r1 science.