### PR TITLE
SCC: Add vectorisation annotations in SCCRevector and translate in SCCAnnotate 

### DIFF
--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -21,7 +21,7 @@ from loki.logging import warning
 from loki.transformations.sanitise import resolve_associates
 from loki.transformations.utilities import (
     recursive_expression_map_update, get_integer_variable,
-    get_loop_bounds, check_routine_pragmas
+    get_loop_bounds, check_routine_sequential
 )
 from loki.transformations.single_column.base import SCCBaseTransformation
 
@@ -246,8 +246,8 @@ class BlockViewToFieldViewTransformation(Transformation):
         v_index = get_integer_variable(routine, name=self.horizontal.index)
         SCCBaseTransformation.resolve_masked_stmts(routine, loop_variable=v_index)
 
-        # Bail if routine is marked as sequential or routine has already been processed
-        if check_routine_pragmas(routine, directive=None):
+        # Bail if routine is marked as sequential
+        if check_routine_sequential(routine):
             return
 
         bounds = get_loop_bounds(routine, self.horizontal)

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -135,9 +135,10 @@ class SCCAnnotateTransformation(Transformation):
         args += [a for a in routine.arguments if isinstance(a.type.dtype, DerivedType)]
         argnames = [str(a.name) for a in args]
 
-        routine.body.prepend(ir.Pragma(keyword='acc', content=f'data present({", ".join(argnames)})'))
-        # Add comment to prevent false-attachment in case it is preceded by an "END DO" statement
-        routine.body.append((ir.Comment(text=''), ir.Pragma(keyword='acc', content='end data')))
+        if argnames:
+            routine.body.prepend(ir.Pragma(keyword='acc', content=f'data present({", ".join(argnames)})'))
+            # Add comment to prevent false-attachment in case it is preceded by an "END DO" statement
+            routine.body.append((ir.Comment(text=''), ir.Pragma(keyword='acc', content='end data')))
 
     def transform_subroutine(self, routine, **kwargs):
         """

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -198,12 +198,6 @@ class SCCAnnotateTransformation(Transformation):
         if self.directive == 'openacc':
             self.insert_annotations(routine, self.horizontal)
 
-        # Remove the vector section wrappers
-        # These have been inserted by SCCDevectorTransformation
-        section_mapper = {s: s.body for s in FindNodes(ir.Section).visit(routine.body) if s.label == 'vector_section'}
-        if section_mapper:
-            routine.body = Transformer(section_mapper).visit(routine.body)
-
     def process_driver(self, routine, targets=None):
         """
         Apply the relevant ``'openacc'`` annotations to the driver loop.
@@ -240,12 +234,6 @@ class SCCAnnotateTransformation(Transformation):
             if self.directive == 'openacc':
                 # Mark all non-parallel loops as `!$acc loop seq`
                 self.kernel_annotate_sequential_loops_openacc(routine)
-
-        # Remove the vector section wrappers
-        # These have been inserted by SCCDevectorTransformation
-        section_mapper = {s: s.body for s in FindNodes(ir.Section).visit(routine.body) if s.label == 'vector_section'}
-        if section_mapper:
-            routine.body = Transformer(section_mapper).visit(routine.body)
 
     @classmethod
     def device_alloc_column_locals(cls, routine, column_locals):

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -14,7 +14,7 @@ from loki.tools import as_tuple
 
 from loki.transformations.sanitise import resolve_associates
 from loki.transformations.utilities import (
-    get_integer_variable, get_loop_bounds, check_routine_pragmas
+    get_integer_variable, get_loop_bounds, check_routine_sequential
 )
 
 
@@ -164,7 +164,7 @@ class SCCBaseTransformation(Transformation):
         """
 
         # Bail if routine is marked as sequential or routine has already been processed
-        if check_routine_pragmas(routine, self.directive):
+        if check_routine_sequential(routine):
             return
 
         # Bail if routine is elemental

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -805,7 +805,7 @@ def test_scc_annotate_empty_data_clause(frontend, horizontal, blocking):
 
        k = n
        do k=1, 3
-          n = k + 1.
+          n = k + 1
        enddo
     end subroutine some_kernel
     """

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -753,9 +753,10 @@ def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_scc_base_routine_seq_pragma(frontend, horizontal):
+def test_scc_annotate_routine_seq_pragma(frontend, horizontal, blocking):
     """
-    Test that `!$loki routine seq` pragmas are replaced correctly by `!$acc routine seq` pragmas.
+    Test that `!$loki routine seq` pragmas are replaced correctly by
+    `!$acc routine seq` pragmas.
     """
 
     fcode = """
@@ -781,14 +782,17 @@ def test_scc_base_routine_seq_pragma(frontend, horizontal):
     assert pragmas[0].keyword == 'loki'
     assert pragmas[0].content == 'routine seq'
 
-    transformation = SCCBaseTransformation(horizontal=horizontal, directive='openacc')
-    transformation.transform_subroutine(routine, role='kernel', targets=['some_kernel',])
+    transformation = SCCAnnotateTransformation(
+        horizontal=horizontal, directive='openacc', block_dim=blocking
+    )
+    transformation.transform_subroutine(
+        routine, role='kernel', targets=['some_kernel',]
+    )
 
     pragmas = FindNodes(Pragma).visit(routine.spec)
     assert len(pragmas) == 1
     assert pragmas[0].keyword == 'acc'
     assert pragmas[0].content == 'routine seq'
-
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -762,8 +762,8 @@ def test_scc_annotate_routine_seq_pragma(frontend, horizontal, blocking):
 
        integer, intent(in) :: nang
        real, dimension(nang), intent(inout) :: work
-!$loki routine seq
        integer :: k
+!$loki routine seq
 
        do k=1,nang
           work(k) = 1.
@@ -774,7 +774,7 @@ def test_scc_annotate_routine_seq_pragma(frontend, horizontal, blocking):
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
-    pragmas = FindNodes(Pragma).visit(routine.spec)
+    pragmas = FindNodes(Pragma).visit(routine.ir)
     assert len(pragmas) == 1
     assert pragmas[0].keyword == 'loki'
     assert pragmas[0].content == 'routine seq'
@@ -782,6 +782,7 @@ def test_scc_annotate_routine_seq_pragma(frontend, horizontal, blocking):
     transformation = SCCAnnotateTransformation(directive='openacc', block_dim=blocking)
     transformation.transform_subroutine(routine, role='kernel', targets=['some_kernel',])
 
+    # Ensure the routine pragma is in the first pragma in the spec
     pragmas = FindNodes(Pragma).visit(routine.spec)
     assert len(pragmas) == 1
     assert pragmas[0].keyword == 'acc'

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -298,8 +298,7 @@ def test_scc_annotate_openacc(frontend, horizontal, blocking):
     scc_transform = (SCCDevectorTransformation(horizontal=horizontal),)
     scc_transform += (SCCDemoteTransformation(horizontal=horizontal),)
     scc_transform += (SCCRevectorTransformation(horizontal=horizontal),)
-    scc_transform += (SCCAnnotateTransformation(horizontal=horizontal,
-                                                directive='openacc', block_dim=blocking),)
+    scc_transform += (SCCAnnotateTransformation(directive='openacc', block_dim=blocking),)
     for transform in scc_transform:
         transform.apply(driver, role='driver', targets=['compute_column'])
         transform.apply(kernel, role='kernel')
@@ -407,9 +406,7 @@ def test_scc_nested(frontend, horizontal, blocking):
     scc_pipeline.apply(inner_kernel, role='kernel')
 
     # Apply annotate twice to test bailing out mechanism
-    scc_annotate = SCCAnnotateTransformation(
-        horizontal=horizontal, directive='openacc', block_dim=blocking
-    )
+    scc_annotate = SCCAnnotateTransformation(directive='openacc', block_dim=blocking)
     scc_annotate.apply(driver, role='driver', targets=['compute_column'])
     scc_annotate.apply(outer_kernel, role='kernel', targets=['compute_q'])
     scc_annotate.apply(inner_kernel, role='kernel')
@@ -782,12 +779,8 @@ def test_scc_annotate_routine_seq_pragma(frontend, horizontal, blocking):
     assert pragmas[0].keyword == 'loki'
     assert pragmas[0].content == 'routine seq'
 
-    transformation = SCCAnnotateTransformation(
-        horizontal=horizontal, directive='openacc', block_dim=blocking
-    )
-    transformation.transform_subroutine(
-        routine, role='kernel', targets=['some_kernel',]
-    )
+    transformation = SCCAnnotateTransformation(directive='openacc', block_dim=blocking)
+    transformation.transform_subroutine(routine, role='kernel', targets=['some_kernel',])
 
     pragmas = FindNodes(Pragma).visit(routine.spec)
     assert len(pragmas) == 1

--- a/loki/transformations/single_column/tests/test_scc_hoist.py
+++ b/loki/transformations/single_column/tests/test_scc_hoist.py
@@ -261,9 +261,7 @@ END MODULE kernel_mod
     transformation += (SCCDevectorTransformation(horizontal=horizontal, trim_vector_sections=trim_vector_sections),)
     transformation += (SCCDemoteTransformation(horizontal=horizontal),)
     transformation += (SCCRevectorTransformation(horizontal=horizontal),)
-    transformation += (SCCAnnotateTransformation(
-        horizontal=horizontal, directive='openacc', block_dim=blocking,
-    ),)
+    transformation += (SCCAnnotateTransformation(directive='openacc', block_dim=blocking),)
     for transform in transformation:
         scheduler.process(transformation=transform)
 

--- a/loki/transformations/single_column/tests/test_scc_vector.py
+++ b/loki/transformations/single_column/tests/test_scc_vector.py
@@ -114,6 +114,8 @@ def test_scc_revector_transformation(frontend, horizontal):
         # Check internal loop pragma annotations
         assert kernel_loops[0].pragma
         assert is_loki_pragma(kernel_loops[0].pragma, starts_with='loop vector')
+        assert kernel_loops[1].pragma
+        assert is_loki_pragma(kernel_loops[1].pragma, starts_with='loop seq')
 
     # Ensure all expressions and array indices are unchanged
     assigns = FindNodes(Assignment).visit(kernel.body)
@@ -221,6 +223,8 @@ END SUBROUTINE compute_column
         # Check internal loop pragma annotations
         assert kernel_loops[0].pragma
         assert is_loki_pragma(kernel_loops[0].pragma, starts_with='loop vector')
+        assert kernel_loops[1].pragma
+        assert is_loki_pragma(kernel_loops[1].pragma, starts_with='loop seq')
 
     # Ensure all expressions and array indices are unchanged
     assigns = FindNodes(Assignment).visit(kernel.body)

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -28,7 +28,7 @@ from loki.transformations.utilities import (
 
 __all__ = [
     'SCCDevectorTransformation', 'SCCRevectorTransformation',
-    'SCCDemoteTransformation'
+    'SCCDemoteTransformation', 'wrap_vector_section'
 ]
 
 
@@ -249,6 +249,33 @@ class SCCDevectorTransformation(Transformation):
         routine.body = Transformer(driver_loop_map).visit(routine.body)
 
 
+def wrap_vector_section(section, routine, horizontal):
+    """
+    Wrap a section of nodes in a vector-level loop across the horizontal.
+
+    Parameters
+    ----------
+    section : tuple of :any:`Node`
+        A section of nodes to be wrapped in a vector-level loop
+    routine : :any:`Subroutine`
+        The subroutine in the vector loops should be removed.
+    horizontal: :any:`Dimension`
+        The dimension specifying the horizontal vector dimension
+    """
+    bounds = get_loop_bounds(routine, dimension=horizontal)
+
+    # Create a single loop around the horizontal from a given body
+    index = get_integer_variable(routine, horizontal.index)
+    bounds = sym.LoopRange(bounds)
+
+    # Ensure we clone all body nodes, to avoid recursion issues
+    vector_loop = ir.Loop(variable=index, bounds=bounds, body=Transformer().visit(section))
+
+    # Add a comment before and after the pragma-annotated loop to ensure
+    # we do not overlap with neighbouring pragmas
+    return (ir.Comment(''), vector_loop, ir.Comment(''))
+
+
 class SCCRevectorTransformation(Transformation):
     """
     A transformation to wrap thread-parallel IR sections within a horizontal loop.
@@ -265,33 +292,6 @@ class SCCRevectorTransformation(Transformation):
         self.horizontal = horizontal
         self.remove_vector_section = remove_vector_section
 
-    @classmethod
-    def wrap_vector_section(cls, section, routine, horizontal):
-        """
-        Wrap a section of nodes in a vector-level loop across the horizontal.
-
-        Parameters
-        ----------
-        section : tuple of :any:`Node`
-            A section of nodes to be wrapped in a vector-level loop
-        routine : :any:`Subroutine`
-            The subroutine in the vector loops should be removed.
-        horizontal: :any:`Dimension`
-            The dimension specifying the horizontal vector dimension
-        """
-        bounds = get_loop_bounds(routine, dimension=horizontal)
-
-        # Create a single loop around the horizontal from a given body
-        index = get_integer_variable(routine, horizontal.index)
-        bounds = sym.LoopRange(bounds)
-
-        # Ensure we clone all body nodes, to avoid recursion issues
-        vector_loop = ir.Loop(variable=index, bounds=bounds, body=Transformer().visit(section))
-
-        # Add a comment before and after the pragma-annotated loop to ensure
-        # we do not overlap with neighbouring pragmas
-        return (ir.Comment(''), vector_loop, ir.Comment(''))
-
     def transform_subroutine(self, routine, **kwargs):
         """
         Apply SCCRevector utilities to a :any:`Subroutine`.
@@ -303,7 +303,7 @@ class SCCRevectorTransformation(Transformation):
         routine : :any:`Subroutine`
             Subroutine to apply this transformation to.
         """
-        mapper = {s.body: self.wrap_vector_section(s.body, routine, self.horizontal)
+        mapper = {s.body: wrap_vector_section(s.body, routine, self.horizontal)
                   for s in FindNodes(ir.Section).visit(routine.body)
                   if s.label == 'vector_section'}
         routine.body = NestedTransformer(mapper).visit(routine.body)

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -24,7 +24,7 @@ from loki.types import BasicType
 from loki.transformations.array_indexing import demote_variables
 from loki.transformations.utilities import (
     get_integer_variable, get_loop_bounds, find_driver_loops,
-    get_local_arrays, check_routine_pragmas
+    get_local_arrays, check_routine_sequential
 )
 
 
@@ -99,7 +99,7 @@ class SCCDevectorTransformation(Transformation):
             # check if calls have been enriched
             if not call.routine is BasicType.DEFERRED:
                 # check if called routine is marked as sequential
-                if check_routine_pragmas(routine=call.routine, directive=None):
+                if check_routine_sequential(routine=call.routine):
                     continue
 
             if call in section:
@@ -415,6 +415,10 @@ class SCCRevectorTransformation(Transformation):
         targets = kwargs.get('targets', ())
 
         if role == 'kernel':
+            # Skip if kernel is marked as `!$loki routine seq`
+            if check_routine_sequential(routine):
+                return
+
             # Revector all marked vector sections within the kernel body
             routine.body = self.revector_section(routine, routine.body)
 
@@ -424,6 +428,9 @@ class SCCRevectorTransformation(Transformation):
 
                 # Mark sequential loops inside vector sections
                 self.mark_seq_loops(routine.body)
+
+            # Mark subroutine as vector parallel for later annotation
+            routine.spec.append(ir.Pragma(keyword='loki', content='routine vector'))
 
         if role == 'driver':
             with pragmas_attached(routine, ir.Loop):

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -314,11 +314,11 @@ class SCCRevectorTransformation(Transformation):
         """
         # Wrap all thread-parallel sections into horizontal thread loops
         mapper = {
-            s.body: wrap_vector_section(s.body, routine, self.horizontal)
+            s: wrap_vector_section(s.body, routine, self.horizontal)
             for s in FindNodes(ir.Section).visit(section)
             if s.label == 'vector_section'
         }
-        return NestedTransformer(mapper).visit(section)
+        return Transformer(mapper).visit(section)
 
     def mark_seq_loops(self, section):
         """

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -5,6 +5,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import re
+
 from more_itertools import split_at
 
 from loki.analyse import dataflow_analysis_attached
@@ -14,7 +16,7 @@ from loki.expression import (
 )
 from loki.ir import (
     nodes as ir, FindNodes, FindScopes, Transformer,
-    NestedTransformer, is_loki_pragma, pragmas_attached
+    NestedTransformer, is_loki_pragma, pragmas_attached, pragma_regions_attached
 )
 from loki.tools import as_tuple, flatten
 from loki.types import BasicType
@@ -320,6 +322,31 @@ class SCCRevectorTransformation(Transformation):
         }
         return Transformer(mapper).visit(section)
 
+    def mark_vector_reductions(self, routine, section):
+        """
+        Mark vector-reduction loops in marked vector-reduction
+        regions.
+
+        If a region explicitly marked with
+        ``!$loki vector-reduction(<reduction clause>)``/
+        ``!$loki end vector-reduction`` is encountered, we replace
+        existing ``!$loki loop vector`` loop pragmas and add the
+        reduction keyword and clause. These will be turned into
+        OpenACC equivalents by :any:`SCCAnnotate`.
+        """
+        with pragma_regions_attached(routine):
+            for region in FindNodes(ir.PragmaRegion).visit(section):
+                if is_loki_pragma(region.pragma, starts_with='vector-reduction'):
+                    if (reduction_clause := re.search(r'reduction\([\w:0-9 \t]+\)', region.pragma.content)):
+
+                        loops = FindNodes(ir.Loop).visit(region)
+                        assert len(loops) == 1
+                        pragma = ir.Pragma(keyword='loki', content=f'loop vector {reduction_clause[0]}')
+                        # Update loop and region in place to remove marker pragmas
+                        loops[0]._update(pragma=(pragma,))
+                        region._update(pragma=None, pragma_post=None)
+
+
     def mark_seq_loops(self, section):
         """
         Mark interior sequential loops in a thread-parallel section
@@ -391,8 +418,11 @@ class SCCRevectorTransformation(Transformation):
             # Revector all marked vector sections within the kernel body
             routine.body = self.revector_section(routine, routine.body)
 
-            # Mark sequential loops inside vector sections
             with pragmas_attached(routine, ir.Loop):
+                # Check for explicitly labelled vector-reduction regions
+                self.mark_vector_reductions(routine, routine.body)
+
+                # Mark sequential loops inside vector sections
                 self.mark_seq_loops(routine.body)
 
         if role == 'driver':
@@ -402,6 +432,9 @@ class SCCRevectorTransformation(Transformation):
                 for loop in driver_loops:
                     # Revector all marked sections within the driver loop body
                     loop._update(body=self.revector_section(routine, loop.body))
+
+                    # Check for explicitly labelled vector-reduction regions
+                    self.mark_vector_reductions(routine, loop.body)
 
                     # Mark sequential loops inside vector sections
                     self.mark_seq_loops(loop.body)

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -298,21 +298,90 @@ class SCCRevectorTransformation(Transformation):
         self.horizontal = horizontal
         self.remove_vector_section = remove_vector_section
 
-    def transform_subroutine(self, routine, **kwargs):
+    def revector_section(self, routine, section):
         """
-        Apply SCCRevector utilities to a :any:`Subroutine`.
-        It wraps all thread-parallel sections within
-        a horizontal loop. The markers placed by :any:`SCCDevectorTransformation` are removed
+        Wrap all thread-parallel :any:`Section` objects within a given
+        code section in a horizontal loop and mark interior loops as
+        ``!$loki loop seq``.
 
         Parameters
         ----------
         routine : :any:`Subroutine`
             Subroutine to apply this transformation to.
+        section : tuple of :any:`Node`
+            Code section in which to replace vector-parallel
+            :any:`Section` objects.
         """
-        mapper = {s.body: wrap_vector_section(s.body, routine, self.horizontal)
-                  for s in FindNodes(ir.Section).visit(routine.body)
-                  if s.label == 'vector_section'}
-        routine.body = NestedTransformer(mapper).visit(routine.body)
+        # Wrap all thread-parallel sections into horizontal thread loops
+        mapper = {
+            s.body: wrap_vector_section(s.body, routine, self.horizontal)
+            for s in FindNodes(ir.Section).visit(section)
+            if s.label == 'vector_section'
+        }
+        return NestedTransformer(mapper).visit(section)
+
+    def mark_seq_loops(self, section):
+        """
+        Mark interior sequential loops in a thread-parallel section
+        with ``!$loki loop seq`` for later annotation.
+
+        This utility requires loop-pragmas to be attached via
+        :any:`pragmas_attached`. It also updates loops in-place.
+
+        Parameters
+        ----------
+        section : tuple of :any:`Node`
+            Code section in which to mark "seq loops".
+        """
+        for loop in FindNodes(ir.Loop).visit(section):
+
+            # Skip loops explicitly marked with `!$loki/claw nodep`
+            if loop.pragma and any('nodep' in p.content.lower() for p in as_tuple(loop.pragma)):
+                continue
+
+            # Mark loop as sequential with `!$loki loop seq`
+            if loop.variable != self.horizontal.index:
+                loop._update(pragma=(ir.Pragma(keyword='loki', content='loop seq'),))
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Wrap vector-parallel sections in vector :any:`Loop` objects.
+
+        This wraps all thread-parallel sections within "kernel"
+        routines or within the parallel loops in "driver" routines.
+
+        The markers placed by :any:`SCCDevectorTransformation` are removed
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            Subroutine to apply this transformation to.
+        role : str
+            Must be either ``"kernel"`` or ``"driver"``
+        targets : tuple or str
+            Tuple of target routine names for determining "driver" loops
+        """
+        role = kwargs['role']
+        targets = kwargs.get('targets', ())
+
+        if role == 'kernel':
+            # Revector all marked vector sections within the kernel body
+            routine.body = self.revector_section(routine, routine.body)
+
+            # Mark sequential loops inside vector sections
+            with pragmas_attached(routine, ir.Loop):
+                self.mark_seq_loops(routine.body)
+
+        if role == 'driver':
+            with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
+                driver_loops = find_driver_loops(routine=routine, targets=targets)
+
+                for loop in driver_loops:
+                    # Revector all marked sections within the driver loop body
+                    loop._update(body=self.revector_section(routine, loop.body))
+
+                    # Mark sequential loops inside vector sections
+                    self.mark_seq_loops(loop.body)
 
         if self.remove_vector_section:
             # Remove the vector section wrappers

--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -19,7 +19,7 @@ from loki.transformations.utilities import (
     single_variable_declaration, recursive_expression_map_update,
     convert_to_lower_case, replace_intrinsics, rename_variables,
     get_integer_variable, get_loop_bounds, is_driver_loop,
-    find_driver_loops, get_local_arrays, check_routine_pragmas
+    find_driver_loops, get_local_arrays, check_routine_sequential
 )
 
 
@@ -520,11 +520,11 @@ end module test_get_local_arrays_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_utilites_check_routine_pragmas(frontend, tmp_path):
-    """ Test :any:`check_routine_pragmas` utility. """
+def test_transform_utilites_check_routine_sequential(frontend, tmp_path):
+    """ Test :any:`check_routine_sequential` utility. """
 
     fcode = """
-module test_check_routine_pragmas_mod
+module test_check_routine_sequential_mod
 implicit none
 contains
 
@@ -546,12 +546,10 @@ contains
     i = i + 1
   end subroutine test_acc_vec
 
-end module test_check_routine_pragmas_mod
+end module test_check_routine_sequential_mod
 """
     module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
 
-    # TODO: This utility needs some serious clean-up, so we're just testing
-    # the bare basics here and promise to do better next time ;)
-    assert check_routine_pragmas(module['test_acc_seq'], directive=None)
-    assert check_routine_pragmas(module['test_loki_seq'], directive=None)
-    assert check_routine_pragmas(module['test_acc_vec'], directive='openacc')
+    assert not check_routine_sequential(module['test_acc_seq'])
+    assert check_routine_sequential(module['test_loki_seq'])
+    assert not check_routine_sequential(module['test_acc_vec'])

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -19,7 +19,7 @@ from loki.expression import (
 )
 from loki.ir import (
     nodes as ir, Import, TypeDef, VariableDeclaration,
-    StatementFunction, Transformer, FindNodes
+    StatementFunction, Transformer, FindNodes, is_loki_pragma
 )
 from loki.module import Module
 from loki.subroutine import Subroutine
@@ -585,7 +585,8 @@ def is_driver_loop(loop, targets):
     """
     if loop.pragma:
         for pragma in loop.pragma:
-            if pragma.keyword.lower() == "loki" and pragma.content.lower() == "driver-loop":
+            if is_loki_pragma(pragma, starts_with='driver-loop') or \
+               is_loki_pragma(pragma, starts_with='loop driver'):
                 return True
     for call in FindNodes(ir.CallStatement).visit(loop.body):
         if call.name in targets:

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -32,7 +32,7 @@ __all__ = [
     'sanitise_imports', 'replace_selected_kind',
     'single_variable_declaration', 'recursive_expression_map_update',
     'get_integer_variable', 'get_loop_bounds', 'find_driver_loops',
-    'get_local_arrays', 'check_routine_pragmas'
+    'get_local_arrays', 'check_routine_sequential'
 ]
 
 
@@ -652,41 +652,17 @@ def get_local_arrays(routine, section, unique=True):
     return arrays
 
 
-def check_routine_pragmas(routine, directive):
+def check_routine_sequential(routine):
     """
-    Check if routine is marked as sequential or has already been processed.
+    Check if routine is marked as "sequential".
 
     Parameters
     ----------
     routine : :any:`Subroutine`
         Subroutine to perform checks on.
-    directive: string or None
-        Directives flavour to use for parallelism annotations; either
-        ``'openacc'`` or ``None``.
     """
-
-    pragmas = FindNodes(ir.Pragma).visit(routine.ir)
-    routine_pragmas = [p for p in pragmas if p.keyword.lower() in ['loki', 'acc']]
-    routine_pragmas = [p for p in routine_pragmas if 'routine' in p.content.lower()]
-
-    seq_pragmas = [r for r in routine_pragmas if 'seq' in r.content.lower()]
-    if seq_pragmas:
-        loki_seq_pragmas = [r for r in routine_pragmas if 'loki' == r.keyword.lower()]
-        if loki_seq_pragmas:
-            if directive == 'openacc':
-                # Mark routine as acc seq
-                mapper = {seq_pragmas[0]: None}
-                routine.spec = Transformer(mapper).visit(routine.spec)
-                routine.body = Transformer(mapper).visit(routine.body)
-
-                # Append the acc pragma to routine.spec, regardless of where the corresponding
-                # loki pragma is found
-                routine.spec.append(ir.Pragma(keyword='acc', content='routine seq'))
-        return True
-
-    vec_pragmas = [r for r in routine_pragmas if 'vector' in r.content.lower()]
-    if vec_pragmas:
-        if directive == 'openacc':
+    for pragma in FindNodes(ir.Pragma).visit(routine.ir):
+        if is_loki_pragma(pragma, starts_with='routine seq'):
             return True
 
     return False


### PR DESCRIPTION
~_Note: Just testing for now..._~

This PR changes the way we add OpenACC annotations in the SCC pipelines and generally refactors `SCCAnnotate` and `SCCRevector`. The key change is that we now insert Loki-specific annotations for vector-loops, driver loops, routine annotations and vector reductions in `SCCRevector` and then let `SCCAnnotate` translate this into OpenACC directives. This is in preparation for the addition of an additional re-vectorisation scheme and the eventual support for OpenMP-offload in the SCC pipelines, as it will allow `SCCAnnotate` to easily switch between directive flavours.

There's also quite a bit of refactoring and clean-up, in particular in the upper control methods of `SCCAnnotate`, as well as the utility method `check_routine_pragmas`. Overall I hope this is now a bit cleaner and better structured for future development.

In more detail:
* `wrap_vector_section` has been made a standalone routine (will be re-used in alternative re-vector scheme).
* `SCCRevector` now annotates vector and sequential loops with respective `!$loki loop` pragmas, as well as marking kernel routines `!%loki routine seq|vector` and adding `!$loki loop vector-reductions` for vector loops in marked vector-reduction regions.
* `SCCRevector` also re-uses some of these utilities when re-vectoring kernel loops; the respective routines have been refactored to work on generic node "sections" (tuple of `Node`).
* `SCCAnnotate` converts `!$loki loop` and `!$loki routine` directives into `!$acc` equivalents and adds `private` clauses to vector loops and `!$acc data present` clauses to kernel routines.
* The `check_routine_pragmas` utility has been renamed `check_routine_sequential` and no longer inserts pragmas at all. It merely checks if a routine has been marked with `!$loki routine seq`. The second use case (check for repeated processing) is now handled explicitly in `SCCAnnotate` when annotating kernel routines (which cannot happen twice!).
* A general tidy-up of `SCCAnnotate` to make utility methods object-bound and re-use common ones in the driver processing code path. We still need the `block_dim`, but the `horizontal` is no longer needed in `SCCAnnotate`.
* `test_scc_vector.py` now also checks for the insertion of certain `!$loki loop` pragmas.