### PR TITLE
Transformations: Internalise `IdemTransformation`

### DIFF
--- a/loki/batch/configure.py
+++ b/loki/batch/configure.py
@@ -275,7 +275,7 @@ class TransformationConfig:
         self.module = module
         self.classname = classname or self.name
         self.path = path
-        self.options = dict(options)
+        self.options = dict(options) if options else {}
 
     def resolve_dimensions(self, dimensions):
         """

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -2378,6 +2378,10 @@ def test_transformation_config(config):
                 'module_suffix': '_roll',
                 'replace_ignore_items': False,
             }
+        },
+        # Instantiate IdemTransformation entry without options
+        'IdemTransformation': {
+            'module': 'loki.transformations',
         }
     }
     cfg = SchedulerConfig.from_dict(my_config)

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -14,6 +14,7 @@ language features.
 
 # pylint: disable=too-many-lines
 
+import platform
 from pathlib import Path
 from time import perf_counter
 import numpy as np
@@ -946,6 +947,9 @@ END SUBROUTINE SOME_ROUTINE
     assert directives[1].text == '#endif'
 
 
+@pytest.mark.skipif(platform.system() == 'Darwin',
+    reason='Timeout utility test sporadically fails on MacOS CI runners.'
+)
 @pytest.mark.usefixtures('reset_regex_frontend_timeout')
 def test_regex_timeout():
     """

--- a/loki/transformations/__init__.py
+++ b/loki/transformations/__init__.py
@@ -19,6 +19,7 @@ from loki.transformations.data_offload import * # noqa
 from loki.transformations.drhook import * # noqa
 from loki.transformations.extract import * # noqa
 from loki.transformations.hoist_variables import * # noqa
+from loki.transformations.idempotence import * # noqa
 from loki.transformations.inline import * # noqa
 from loki.transformations.parametrise import * # noqa
 from loki.transformations.raw_stack_allocator import * # noqa

--- a/loki/transformations/idempotence.py
+++ b/loki/transformations/idempotence.py
@@ -10,8 +10,9 @@ from loki.batch import Transformation
 
 class IdemTransformation(Transformation):
     """
-    A custom transformation pipeline that primarily does nothing,
-    allowing us to test simple parse-unparse cycles.
+    A custom transformation that does absolutely nothing!
+
+    This can be used to test simple parse-unparse cycles.
     """
 
     def transform_subroutine(self, routine, **kwargs):

--- a/loki/transformations/idempotence.py
+++ b/loki/transformations/idempotence.py
@@ -1,0 +1,18 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki.batch import Transformation
+
+
+class IdemTransformation(Transformation):
+    """
+    A custom transformation pipeline that primarily does nothing,
+    allowing us to test simple parse-unparse cycles.
+    """
+
+    def transform_subroutine(self, routine, **kwargs):
+        pass

--- a/loki/transformations/tests/test_idempotence.py
+++ b/loki/transformations/tests/test_idempotence.py
@@ -1,0 +1,69 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import copy
+import pytest
+
+from loki import Subroutine, fgen
+from loki.frontend import available_frontends
+
+from loki.transformations import IdemTransformation
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_idempotence(frontend, tmp_path):
+    """ Test the do-nothing equivalence of :any:`IdemTransformations` """
+
+    fcode_driver = """
+  SUBROUTINE column_driver(nlon, nproma, nlev, nz, q, nb)
+    INTEGER, INTENT(IN)   :: nlon, nz, nb  ! Size of the horizontal and vertical
+    INTEGER, INTENT(IN)   :: nproma, nlev  ! Aliases of horizontal and vertical sizes
+    REAL, INTENT(INOUT)   :: q(nlon,nz,nb)
+    INTEGER :: b, start, end
+
+    start = 1
+    end = nlon
+    do b=1, nb
+      call compute_column(start, end, nlon, nproma, nz, q(:,:,b))
+    end do
+  END SUBROUTINE column_driver
+"""
+
+    fcode_kernel = """
+  SUBROUTINE compute_column(start, end, nlon, nproma, nlev, nz, q)
+    INTEGER, INTENT(IN) :: start, end   ! Iteration indices
+    INTEGER, INTENT(IN) :: nlon, nz     ! Size of the horizontal and vertical
+    INTEGER, INTENT(IN) :: nproma, nlev ! Aliases of horizontal and vertical sizes
+    REAL, INTENT(INOUT) :: q(nlon,nz)
+    REAL :: t(nlon,nz)
+    REAL :: c
+
+    c = 5.345
+    DO jk = 2, nz
+      DO jl = start, end
+        t(jl, jk) = c * jk
+        q(jl, jk) = q(jl, jk-1) + t(jl, jk) * c
+      END DO
+    END DO
+  END SUBROUTINE compute_column
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
+
+    driver_before = copy.deepcopy(driver)
+    kernel_before = copy.deepcopy(kernel)
+
+    idempotence = IdemTransformation()
+    idempotence.apply(driver, role='driver')
+    idempotence.apply(kernel, role='kernel')
+
+    assert not id(driver_before.ir) == id(driver.ir)
+    assert not id(kernel_before.ir) == id(kernel.ir)
+    assert driver_before.ir == driver.ir
+    assert kernel_before.ir == kernel.ir
+    assert fgen(driver_before) == fgen(driver)
+    assert fgen(kernel_before) == fgen(kernel)

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -35,6 +35,7 @@ from loki.transformations.data_offload import (
 from loki.transformations.transform_derived_types import DerivedTypeArgumentsTransformation
 from loki.transformations.drhook import DrHookTransformation
 from loki.transformations.hoist_variables import HoistTemporaryArraysAnalysis
+from loki.transformations.idempotence import IdemTransformation
 from loki.transformations.inline import InlineTransformation
 from loki.transformations.pool_allocator import TemporariesPoolAllocatorTransformation
 from loki.transformations.remove_code import RemoveCodeTransformation
@@ -45,16 +46,6 @@ from loki.transformations.single_column import (
     HoistTemporaryArraysDeviceAllocatableTransformation,
 )
 from loki.transformations.transpile import FortranCTransformation
-
-
-class IdemTransformation(Transformation):
-    """
-    A custom transformation pipeline that primarily does nothing,
-    allowing us to test simple parse-unparse cycles.
-    """
-
-    def transform_subroutine(self, routine, **kwargs):
-        pass
 
 
 @click.group()

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -58,11 +58,7 @@ def cli(debug):
 
 
 @cli.command()
-@click.option('--mode', '-m', default='idem',
-              type=click.Choice(
-                  ['idem', "c", 'idem-stack', 'sca', 'claw', 'scc', 'scc-hoist', 'scc-stack',
-                   'cuf-parametrise', 'cuf-hoist', 'cuf-dynamic', 'scc-raw-stack']
-              ),
+@click.option('--mode', '-m', default='idem', type=click.STRING,
               help='Transformation mode, selecting which code transformations to apply.')
 @click.option('--config', default=None, type=click.Path(),
               help='Path to custom scheduler configuration file')
@@ -183,6 +179,12 @@ def convert(
         scheduler.process(transformation=file_write_trafo)
 
         return
+
+    # If we do not use a custom pipeline, it should be one of the internally supported ones
+    assert mode in [
+        'idem', 'c', 'idem-stack', 'sca', 'claw', 'scc', 'scc-hoist', 'scc-stack',
+        'cuf-parametrise', 'cuf-hoist', 'cuf-dynamic', 'scc-raw-stack'
+    ]
 
     # Pull dimension definition from configuration
     horizontal = scheduler.config.dimensions.get('horizontal', None)


### PR DESCRIPTION
This change move the `IdemTransformation` that we often use for testing to the `loki.transformations` sub-package and fixes a configure bug when omitting the `options` entry in TOML(!)-based configuration entries. This is in preparation for the full move to config-file transformation configuration in CLOUDSC. 