### PR TITLE
fix for 'resolve_vector_notation' utility

### DIFF
--- a/loki/transformations/array_indexing.py
+++ b/loki/transformations/array_indexing.py
@@ -119,15 +119,15 @@ def resolve_vector_notation(routine):
                     # Create new index variable
                     vtype = SymbolAttributes(BasicType.INTEGER)
                     ivar = sym.Variable(name=f'{ivar_basename}_{i}', type=vtype, scope=routine)
-                    shape_index_map[s] = ivar
+                    shape_index_map[(i, s)] = ivar
                     index_range_map[ivar] = s
 
                     if ivar not in vdims:
                         vdims.append(ivar)
 
             # Add index variable to range replacement
-            new_dims = as_tuple(shape_index_map.get(s, d)
-                                for d, s in zip(v.dimensions, as_tuple(v.shape)))
+            new_dims = as_tuple(shape_index_map.get((i, s), d)
+                                for i, d, s in zip(count(), v.dimensions, as_tuple(v.shape)))
             vmap[v] = v.clone(dimensions=new_dims)
 
         index_vars.update(list(vdims))


### PR DESCRIPTION
problem occurred whenever two dimensions had the same size

e.g.,

```fortran
integer :: ret1(param1, param1)
...
ret1(:, :) = 0
```

resulted in:

```fortran
  DO i_ret1_1=1,param1
    DO i_ret1_0=1,param1
      ret1(i_ret1_1, i_ret1_1) = 0
    END DO
  END DO
```

instead of the correct result:

```fortran
  DO i_ret1_1=1,param1
    DO i_ret1_0=1,param1
      ret1(i_ret1_0, i_ret1_1) = 0
    END DO
  END DO
```

