### PR TITLE
OMNI: Fix dimension range-indexing in frontend

### DIFF
--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -473,11 +473,11 @@ end subroutine index_ranges
     # OMNI will insert implicit lower=1 into shape declarations,
     # we simply have to live with it... :(
     assert str(vmap['v4']) == 'v4(dim)' or str(vmap['v4']) == 'v4(1:dim)'
-    assert str(vmap['v5']) == 'v5(1:dim)'
+    assert str(vmap['v5']) == 'v5(1:dim)' or str(vmap['v5']) == 'v5(dim)'
 
     vmap_body = {v.name: v for v in FindVariables().visit(routine.body)}
     assert str(vmap_body['v1']) == 'v1(::2)'
-    assert str(vmap_body['v2']) == 'v2(1:dim)'
+    assert str(vmap_body['v2']) == 'v2(dim)' or str(vmap_body['v2']) == 'v2(1:dim)'
     assert str(vmap_body['v3']) == 'v3(0:4:2)'
     assert str(vmap_body['v5']) == 'v5(:)'
 
@@ -1853,13 +1853,8 @@ end module external_mod
     assert isinstance(parsed, sym.Array)
     assert all(isinstance(_parsed,  sym.Scalar) for _parsed in parsed.dimensions)
     assert all(_parsed.scope == routine for _parsed in parsed.dimensions)
-    if frontend == OMNI:
-        assert all(isinstance(_parsed,  sym.RangeIndex) for _parsed in parsed.shape)
-        assert all(isinstance(_parsed.upper,  sym.Scalar) for _parsed in parsed.shape)
-        assert all(_parsed.upper.scope == routine for _parsed in parsed.shape)
-    else:
-        assert all(isinstance(_parsed,  sym.Scalar) for _parsed in parsed.shape)
-        assert all(_parsed.scope == routine for _parsed in parsed.shape)
+    assert all(isinstance(_parsed,  sym.Scalar) for _parsed in parsed.shape)
+    assert all(_parsed.scope == routine for _parsed in parsed.shape)
     assert to_str(parsed) == 'arr(i1,i2,i3)'
 
     parsed = parse_expr(convert_to_case('my_func(i1)', mode=case), scope=routine)

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -212,12 +212,9 @@ end module
     module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     routine = module['associates']
     variables = FindVariables().visit(routine.body)
-    if frontend == OMNI:
-        assert all(v.shape == ('1:3',)
-                   for v in variables if v.name in ['vector', 'vector2'])
-    else:
-        assert all(v.shape == ('3',)
-                   for v in variables if v.name in ['vector', 'vector2'])
+    assert all(
+        v.shape == ('3',) for v in variables if v.name in ['vector', 'vector2']
+    )
 
     for assoc in FindNodes(ir.Associate).visit(routine.body):
         for var in FindVariables().visit(assoc.body):

--- a/loki/frontend/tests/test_omni.py
+++ b/loki/frontend/tests/test_omni.py
@@ -40,13 +40,13 @@ end module omni_derived_type_mod
 
     assert len(module.typedefs) == 3
     explicit_symbols = FindVariables(unique=False).visit(module['explicit'].body)
-    assert explicit_symbols == ('scalar', 'vector(1:3)', 'matrix(1:3, 1:3)')
+    assert explicit_symbols == ('scalar', 'vector(3)', 'matrix(3, 3)')
 
     deferred_symbols = FindVariables(unique=False).visit(module['deferred'].body)
     assert deferred_symbols == ('scalar', 'vector(:)', 'matrix(:, :)')
 
     ranged_symbols = FindVariables(unique=False).visit(module['ranged'].body)
-    assert ranged_symbols == ('scalar', 'vector(1:3)', 'matrix(0:3, 0:3)')
+    assert ranged_symbols == ('scalar', 'vector(3)', 'matrix(0:3, 0:3)')
 
 
 @pytest.mark.skipif(not HAVE_OMNI, reason='Test tequires OMNI frontend.')
@@ -72,10 +72,10 @@ end subroutine omni_array_indexing
     decls = FindNodes(ir.VariableDeclaration).visit(routine.spec)
     assert len(decls) == 5
     assert decls[0].symbols == ('n',)
-    assert decls[1].symbols == ('a(1:3)',)
-    assert decls[2].symbols == ('b(1:n)',)
-    assert decls[3].symbols == ('c(1:n, 1:n)',)
-    assert decls[4].symbols == ('d(1:n, 0:n)',)
+    assert decls[1].symbols == ('a(3)',)
+    assert decls[2].symbols == ('b(n)',)
+    assert decls[3].symbols == ('c(n, n)',)
+    assert decls[4].symbols == ('d(n, 0:n)',)
 
     assigns = FindNodes(ir.Assignment).visit(routine.body)
     assert len(assigns) == 4

--- a/loki/frontend/tests/test_omni.py
+++ b/loki/frontend/tests/test_omni.py
@@ -1,0 +1,85 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Specific test battery for the OMNI parser frontend.
+"""
+
+import pytest
+
+from loki import Module, Subroutine
+from loki.expression import FindVariables
+from loki.frontend import OMNI, HAVE_OMNI
+from loki.ir import nodes as ir, FindNodes
+
+
+@pytest.mark.skipif(not HAVE_OMNI, reason='Test tequires OMNI frontend.')
+def test_derived_type_definitions(tmp_path):
+    """ Test correct parsing of derived type declarations. """
+    fcode = """
+module omni_derived_type_mod
+  type explicit
+      real(kind=8) :: scalar, vector(3), matrix(3, 3)
+  end type explicit
+
+  type deferred
+      real(kind=8), allocatable :: scalar, vector(:), matrix(:, :)
+  end type deferred
+
+  type ranged
+      real(kind=8) :: scalar, vector(1:3), matrix(0:3, 0:3)
+  end type ranged
+end module omni_derived_type_mod
+"""
+    # Parse the source and validate the IR
+    module = Module.from_source(fcode, frontend=OMNI, xmods=[tmp_path])
+
+    assert len(module.typedefs) == 3
+    explicit_symbols = FindVariables(unique=False).visit(module['explicit'].body)
+    assert explicit_symbols == ('scalar', 'vector(1:3)', 'matrix(1:3, 1:3)')
+
+    deferred_symbols = FindVariables(unique=False).visit(module['deferred'].body)
+    assert deferred_symbols == ('scalar', 'vector(:)', 'matrix(:, :)')
+
+    ranged_symbols = FindVariables(unique=False).visit(module['ranged'].body)
+    assert ranged_symbols == ('scalar', 'vector(1:3)', 'matrix(0:3, 0:3)')
+
+
+@pytest.mark.skipif(not HAVE_OMNI, reason='Test tequires OMNI frontend.')
+def test_array_dimensions(tmp_path):
+    """ Test correct parsing of derived type declarations. """
+    fcode = """
+subroutine omni_array_indexing(n, a, b)
+  integer, intent(in) :: n
+  real(kind=8), intent(inout) :: a(3), b(n)
+  real(kind=8) :: c(n, n)
+  real(kind=8) :: d(1:n, 0:n)
+
+  a(:) = 11.
+  b(1:n) = 42.
+  c(2:n, 0:n) = 66.
+  d(:, 0:n) = 68.
+end subroutine omni_array_indexing
+"""
+    # Parse the source and validate the IR
+    routine = Subroutine.from_source(fcode, frontend=OMNI, xmods=[tmp_path])
+
+    # OMNI separate declarations per variable
+    decls = FindNodes(ir.VariableDeclaration).visit(routine.spec)
+    assert len(decls) == 5
+    assert decls[0].symbols == ('n',)
+    assert decls[1].symbols == ('a(1:3)',)
+    assert decls[2].symbols == ('b(1:n)',)
+    assert decls[3].symbols == ('c(1:n, 1:n)',)
+    assert decls[4].symbols == ('d(1:n, 0:n)',)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    assert len(assigns) == 4
+    assert assigns[0].lhs == 'a(:)'
+    assert assigns[1].lhs == 'b(1:n)'
+    assert assigns[2].lhs == 'c(2:n, 0:n)'
+    assert assigns[3].lhs == 'd(:, 0:n)'

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -290,9 +290,9 @@ class RangeIndexTransformer(Transformer):
         for v in self.retriever.retrieve(o.symbols):
             dimensions = tuple(d.upper if self.is_one_index(d) else d for d in v.dimensions)
             _type = v.type
-            if v.shape:
-                shape = tuple(d.upper if self.is_one_index(d) else d for d in v.shape)
-                _type = v.type.clone(shape=shape)
+            if _type.shape:
+                shape = tuple(d.upper if self.is_one_index(d) else d for d in _type.shape)
+                _type = _type.clone(shape=shape)
             vmap[v] = v.clone(dimensions=dimensions, type=_type)
 
         mapper = SubstituteExpressionsMapper(vmap, invalidate_source=self.invalidate_source)

--- a/loki/tests/test_derived_types.py
+++ b/loki/tests/test_derived_types.py
@@ -1173,12 +1173,8 @@ def test_derived_type_rescope_symbols_shadowed(tmp_path, shadowed_typedef_symbol
     assert istate in ('istate(nmaxstreams)', 'istate(1:nmaxstreams)')
     assert istate.scope is rng_type
 
-    if frontend == OMNI:
-        assert istate.dimensions[0] == '1:nmaxstreams'
-        assert istate.dimensions[0].stop.scope
-    else:
-        assert istate.dimensions[0] == 'nmaxstreams'
-        assert istate.dimensions[0].scope
+    assert istate.dimensions[0] == 'nmaxstreams'
+    assert istate.dimensions[0].scope
 
     # FIXME: Use of NMaxStreams from parent scope is in the wrong scope (LOKI-52)
     #assert istate.dimensions[0].scope is module

--- a/loki/tests/test_modules.py
+++ b/loki/tests/test_modules.py
@@ -90,7 +90,7 @@ end module a_module
     pt_ext = routine.variables[0]
 
     # OMNI resolves explicit shape parameters in the frontend parser
-    exptected_array_shape = '(1:2, 1:3)' if frontend == OMNI else '(x, y)'
+    exptected_array_shape = '(2, 3)' if frontend == OMNI else '(x, y)'
 
     # Check that the `array` variable in the `ext` type is found and
     # has correct type and shape info
@@ -187,7 +187,7 @@ end module a_module
     assert isinstance(module['other_routine'].symbol_attrs['pt'].dtype.typedef, TypeDef)
 
     # OMNI resolves explicit shape parameters in the frontend parser
-    exptected_array_shape = '(1:2, 1:3)' if frontend == OMNI else '(x, y)'
+    exptected_array_shape = '(2, 3)' if frontend == OMNI else '(x, y)'
 
     # Check that the `array` variable in the `ext` type is found and
     # has correct type and shape info
@@ -234,7 +234,7 @@ module type_mod
 end module type_mod
 """
     # OMNI resolves explicit shape parameters in the frontend parser
-    exptected_array_shape = '(1:2, 1:3)' if frontend == OMNI else '(x, y)'
+    exptected_array_shape = '(2, 3)' if frontend == OMNI else '(x, y)'
 
     module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     parent = module.typedef_map['parent_type']

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -15,8 +15,7 @@ from loki import (
     Array, Scalar, Variable,
     SymbolAttributes, StringLiteral, fgen, fexprgen,
     VariableDeclaration, Transformer, FindTypedSymbols,
-    ProcedureSymbol, StatementFunction,
-    normalize_range_indexing, DeferredTypeSymbol
+    ProcedureSymbol, StatementFunction, DeferredTypeSymbol
 )
 from loki.build import jit_compile, jit_compile_lib, clean_test
 from loki.frontend import available_frontends, OFP, OMNI, REGEX
@@ -1787,8 +1786,6 @@ end subroutine my_routine
     assert all(isinstance(arg, DeferredTypeSymbol) for arg in routine.arguments)
 
     routine.make_complete(frontend=frontend)
-    if frontend == OMNI:
-        normalize_range_indexing(routine)
     assert not routine._incomplete
     assert routine.arguments == ('n', 'a(n)', 'b(n)', 'd(n)')
     assert routine.argnames == ['n', 'a', 'b', 'd']
@@ -1879,8 +1876,6 @@ END SUBROUTINE CLOUDSC
     assert all(isinstance(arg, DeferredTypeSymbol) for arg in routine.arguments)
 
     routine.make_complete(frontend=frontend)
-    if frontend == OMNI:
-        normalize_range_indexing(routine)
     assert not routine._incomplete
     assert routine.arguments == argnames_with_dim
     assert [arg.upper() for arg in routine.argnames] == [arg.upper() for arg in argnames]

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -882,8 +882,7 @@ def test_scc_demotion_parameter(frontend, horizontal, tmp_path):
 
     assert len(routine.symbol_map['work'].shape) == 2
     if frontend == OMNI:
-        assert routine.symbol_map['work'].shape == (RangeIndex(children=(IntLiteral(1), IntLiteral(36))),
-                                                    IntLiteral(2))
+        assert routine.symbol_map['work'].shape == (IntLiteral(36), IntLiteral(2))
     else:
         assert routine.symbol_map['work'].shape == ('nang_param', IntLiteral(2))
 

--- a/loki/transformations/tests/test_data_offload.py
+++ b/loki/transformations/tests/test_data_offload.py
@@ -379,10 +379,10 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
 
     # Validate the analysis trafo_data
 
-    # OMNI handles array indices and parameters differently
+    # OMNI handles array indices and parameters differently
     if frontend == OMNI:
-        nfld_dim = '1:3'
-        nval_dim = '1:5'
+        nfld_dim = '3'
+        nval_dim = '5'
         nfld_data = set()
         nval_data = set()
     else:
@@ -449,10 +449,10 @@ def test_global_variable_offload(frontend, key, config, global_variable_analysis
         'driver': {'role': 'driver'}
     }
 
-    # OMNI handles array indices and parameters differently
+    # OMNI handles array indices and parameters differently
     if frontend == OMNI:
-        nfld_dim = '1:3'
-        nval_dim = '1:5'
+        nfld_dim = '3'
+        nval_dim = '5'
     else:
         nfld_dim = 'nfld'
         nval_dim = 'nval'

--- a/loki/transformations/tests/test_extract.py
+++ b/loki/transformations/tests/test_extract.py
@@ -559,8 +559,9 @@ def test_extract_contained_procedures_basic_scalar_function(frontend):
     call = list(FindInlineCalls().visit(outer.body))[0]
     assert 'x' in call.kw_parameters
 
-@pytest.mark.parametrize('frontend',
-                         available_frontends(xfail=(OFP, "ofp fails for unknown reason, likely frontend issue")))
+@pytest.mark.parametrize(
+    'frontend', available_frontends(skip=(OFP, "ofp fails for unknown reason, likely frontend issue"))
+)
 def test_extract_contained_procedures_basic_scalar_function_both(frontend):
     """
     Basic test for scalars highlighting that the outer and inner procedure may be functions.

--- a/loki/transformations/tests/test_extract.py
+++ b/loki/transformations/tests/test_extract.py
@@ -110,10 +110,7 @@ def test_extract_contained_procedures_basic_array(frontend):
     inner = routines[0]
     outer = src.routines[0]
     assert 'x' in inner.arguments
-    if frontend == OMNI:
-        assert 'arr(1:3)' in inner.arguments
-    else:
-        assert 'arr(3)' in inner.arguments
+    assert 'arr(3)' in inner.arguments
 
     call = FindNodes(CallStatement).visit(outer.body)[0]
     kwargdict = dict(call.kwarguments)

--- a/loki/transformations/tests/test_hoist_variables.py
+++ b/loki/transformations/tests/test_hoist_variables.py
@@ -13,8 +13,7 @@ import pytest
 import numpy as np
 
 from loki import (
-    Scheduler, SchedulerConfig, is_iterable,
-    normalize_range_indexing, FindInlineCalls
+    Scheduler, SchedulerConfig, is_iterable, FindInlineCalls
 )
 from loki.build import jit_compile_lib, Builder
 from loki.frontend import available_frontends, OMNI
@@ -636,11 +635,6 @@ end subroutine another_kernel
     scheduler = Scheduler(
         paths=[tmp_path], config=SchedulerConfig.from_dict(config), frontend=frontend, xmods=[tmp_path]
     )
-
-    if frontend == OMNI:
-        for item in scheduler.items:
-            normalize_range_indexing(item.ir)
-
     scheduler.process(transformation=HoistTemporaryArraysAnalysis(dim_vars=('klev',)))
     scheduler.process(transformation=HoistTemporaryArraysTransformationAllocatable())
 

--- a/loki/transformations/tests/test_inline.py
+++ b/loki/transformations/tests/test_inline.py
@@ -1191,9 +1191,9 @@ end module inline_declarations
     inline_marked_subroutines(routine=outer, adjust_imports=True)
 
     # Check that all declarations are using the ``bnds`` symbol
-    assert outer.symbols[0] == 'a(1:bnds%end)' if frontend == OMNI else 'a(bnds%end)'
-    assert outer.symbols[2] == 'b(1:bnds%end)' if frontend == OMNI else 'b(bnds%end)'
-    assert outer.symbols[3] == 'd(1:bnds%end)' if frontend == OMNI else 'd(bnds%end)'
+    assert outer.symbols[0] == 'a(bnds%end)'
+    assert outer.symbols[2] == 'b(bnds%end)'
+    assert outer.symbols[3] == 'd(bnds%end)'
     assert all(
         a.shape == ('bnds%end',) for a in outer.symbols if isinstance(a, sym.Array)
     )

--- a/loki/transformations/tests/test_parametrise.py
+++ b/loki/transformations/tests/test_parametrise.py
@@ -15,7 +15,7 @@ import numpy as np
 from loki import Scheduler, fgen
 from loki.build import jit_compile
 from loki.expression import symbols as sym
-from loki.frontend import available_frontends, OMNI
+from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
 
 from loki.transformations.parametrise import ParametriseTransformation
@@ -279,56 +279,30 @@ def test_parametrise_simple_replace_by_value(tmp_path, testdir, frontend, config
     check_arguments_and_parameter(scheduler=scheduler, subroutine_arguments=subroutine_arguments,
                                   call_arguments=call_arguments, parameter_variables=parameter_variables)
 
-    if frontend == OMNI:
-        routine_spec_str = fgen(scheduler['parametrise#driver'].ir.spec)
-        assert f'c(1:{a}, 1:{b})' in routine_spec_str
-        assert f'd(1:{b})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#another_driver'].ir.spec)
-        assert f'c(1:{a}, 1:{b})' in routine_spec_str
-        assert f'x(1:{a})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#kernel1'].ir.spec)
-        assert f'c(1:{a}, 1:{b})' in routine_spec_str
-        assert f'x(1:{a})' in routine_spec_str
-        assert f'y(1:{a}, 1:{b})' in routine_spec_str
-        assert f'k1_tmp(1:{a}, 1:{b})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#kernel2'].ir.spec)
-        assert f'd(1:{b})' in routine_spec_str
-        assert f'x(1:{a})' in routine_spec_str
-        assert f'k2_tmp(1:{a}, 1:{a})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#device1'].ir.spec)
-        assert f'd(1:{b})' in routine_spec_str
-        assert f'x(1:{a})' in routine_spec_str
-        assert f'y(1:{a}, 1:{a})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#device2'].ir.spec)
-        assert f'd(1:{b})' in routine_spec_str
-        assert f'x(1:{a})' in routine_spec_str
-        assert f'z(1:{b})' in routine_spec_str
-        assert f'd2_tmp(1:{b})' in routine_spec_str
-    else:
-        routine_spec_str = fgen(scheduler['parametrise#driver'].ir.spec)
-        assert f'c({a}, {b})' in routine_spec_str
-        assert f'd({b})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#another_driver'].ir.spec)
-        assert f'c({a}, {b})' in routine_spec_str
-        assert f'x({a})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#kernel1'].ir.spec)
-        assert f'c({a}, {b})' in routine_spec_str
-        assert f'x({a})' in routine_spec_str
-        assert f'y({a}, {b})' in routine_spec_str
-        assert f'k1_tmp({a}, {b})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#kernel2'].ir.spec)
-        assert f'd({b})' in routine_spec_str
-        assert f'x({a})' in routine_spec_str
-        assert f'k2_tmp({a}, {a})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#device1'].ir.spec)
-        assert f'd({b})' in routine_spec_str
-        assert f'x({a})' in routine_spec_str
-        assert f'y({a}, {a})' in routine_spec_str
-        routine_spec_str = fgen(scheduler['parametrise#device2'].ir.spec)
-        assert f'd({b})' in routine_spec_str
-        assert f'x({a})' in routine_spec_str
-        assert f'z({b})' in routine_spec_str
-        assert f'd2_tmp({b})' in routine_spec_str
+    routine_spec_str = fgen(scheduler['parametrise#driver'].ir.spec)
+    assert f'c({a}, {b})' in routine_spec_str
+    assert f'd({b})' in routine_spec_str
+    routine_spec_str = fgen(scheduler['parametrise#another_driver'].ir.spec)
+    assert f'c({a}, {b})' in routine_spec_str
+    assert f'x({a})' in routine_spec_str
+    routine_spec_str = fgen(scheduler['parametrise#kernel1'].ir.spec)
+    assert f'c({a}, {b})' in routine_spec_str
+    assert f'x({a})' in routine_spec_str
+    assert f'y({a}, {b})' in routine_spec_str
+    assert f'k1_tmp({a}, {b})' in routine_spec_str
+    routine_spec_str = fgen(scheduler['parametrise#kernel2'].ir.spec)
+    assert f'd({b})' in routine_spec_str
+    assert f'x({a})' in routine_spec_str
+    assert f'k2_tmp({a}, {a})' in routine_spec_str
+    routine_spec_str = fgen(scheduler['parametrise#device1'].ir.spec)
+    assert f'd({b})' in routine_spec_str
+    assert f'x({a})' in routine_spec_str
+    assert f'y({a}, {a})' in routine_spec_str
+    routine_spec_str = fgen(scheduler['parametrise#device2'].ir.spec)
+    assert f'd({b})' in routine_spec_str
+    assert f'x({a})' in routine_spec_str
+    assert f'z({b})' in routine_spec_str
+    assert f'd2_tmp({b})' in routine_spec_str
 
     compile_and_test(scheduler=scheduler, tmp_path=tmp_path, a=a, b=b)
 

--- a/loki/transformations/tests/test_pool_allocator.py
+++ b/loki/transformations/tests/test_pool_allocator.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from loki import Dimension, normalize_range_indexing
+from loki import Dimension
 from loki.batch import Scheduler, SchedulerConfig, SFilter, ProcedureItem
 from loki.expression import (
     FindVariables, FindInlineCalls, InlineCall, simplify
@@ -256,10 +256,6 @@ end module kernel_mod
         paths=[tmp_path], config=SchedulerConfig.from_dict(config),
         frontend=frontend, xmods=[tmp_path]
     )
-
-    if frontend == OMNI:
-        for item in SFilter(scheduler.sgraph, item_filter=ProcedureItem):
-            normalize_range_indexing(item.ir)
 
     transformation = TemporariesPoolAllocatorTransformation(
         block_dim=block_dim, check_bounds=check_bounds,
@@ -602,9 +598,6 @@ end module kernel_mod
         paths=[tmp_path], config=SchedulerConfig.from_dict(config),
         frontend=frontend, xmods=[tmp_path]
     )
-    if frontend == OMNI:
-        for item in SFilter(scheduler.sgraph, item_filter=ProcedureItem):
-            normalize_range_indexing(item.ir)
 
     transformation = TemporariesPoolAllocatorTransformation(
         block_dim=block_dim, directive=directive, cray_ptr_loc_rhs=cray_ptr_loc_rhs
@@ -902,9 +895,6 @@ end module kernel_mod
         paths=[tmp_path], config=SchedulerConfig.from_dict(config),
         frontend=frontend, xmods=[tmp_path]
     )
-    if frontend == OMNI:
-        for item in SFilter(scheduler.sgraph, item_filter=ProcedureItem):
-            normalize_range_indexing(item.ir)
 
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim, directive=directive,
             cray_ptr_loc_rhs=cray_ptr_loc_rhs)
@@ -1150,9 +1140,6 @@ def test_pool_allocator_more_call_checks(tmp_path, frontend, block_dim, caplog, 
     scheduler = Scheduler(
         paths=[tmp_path], config=SchedulerConfig.from_dict(config), frontend=frontend, xmods=[tmp_path]
     )
-    if frontend == OMNI:
-        for item in SFilter(scheduler.sgraph, item_filter=ProcedureItem):
-            normalize_range_indexing(item.ir)
 
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim, cray_ptr_loc_rhs=cray_ptr_loc_rhs)
     scheduler.process(transformation=transformation)
@@ -1325,11 +1312,6 @@ end module kernel_mod
         paths=[tmp_path], config=SchedulerConfig.from_dict(config),
         frontend=frontend, xmods=[tmp_path]
     )
-
-    if frontend == OMNI:
-        for item in scheduler.items:
-            if isinstance(item, ProcedureItem):
-                normalize_range_indexing(item.ir)
 
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim_alt,
             cray_ptr_loc_rhs=cray_ptr_loc_rhs)

--- a/loki/transformations/tests/test_raw_stack_allocator.py
+++ b/loki/transformations/tests/test_raw_stack_allocator.py
@@ -16,7 +16,6 @@ from loki.ir import FindNodes, CallStatement, Assignment, Pragma
 from loki.sourcefile import Sourcefile
 from loki.types import BasicType
 
-from loki.transformations.array_indexing import normalize_range_indexing
 from loki.transformations.raw_stack_allocator import TemporariesRawStackTransformation
 
 
@@ -263,11 +262,6 @@ end module kernel3_mod
 
     scheduler = Scheduler(paths=[tmp_path], config=SchedulerConfig.from_dict(config), frontend=frontend,
                           definitions=definitions, xmods=[tmp_path])
-
-    if frontend == OMNI:
-        for item in scheduler.items:
-            if isinstance(item, ProcedureItem):
-                normalize_range_indexing(item.ir)
 
     transformation = TemporariesRawStackTransformation(block_dim=block_dim, horizontal=horizontal, directive=directive)
     scheduler.process(transformation=transformation)

--- a/loki/transformations/tests/test_transform_derived_types.py
+++ b/loki/transformations/tests/test_transform_derived_types.py
@@ -325,10 +325,7 @@ end module transform_derived_type_arguments_mod
         'm', 'n', 't_io%a', 't_io%b', 't_in(i)%a', 't_in(i)%b',
         't_out(i)%a', 't_out(i)%b'
     )
-    if frontend == OMNI:
-        kernel_args = ('m', 'n', 'p_a(1:n)', 'p_b(1:m, 1:n)', 'q_a(:)', 'q_b(:, :)', 'r_a(:)', 'r_b(:, :)')
-    else:
-        kernel_args = ('m', 'n', 'P_a(n)', 'P_b(m, n)', 'Q_a(:)', 'Q_b(:, :)', 'R_a(:)', 'R_b(:, :)')
+    kernel_args = ('m', 'n', 'P_a(n)', 'P_b(m, n)', 'Q_a(:)', 'Q_b(:, :)', 'R_a(:)', 'R_b(:, :)')
 
     call = FindNodes(CallStatement).visit(source['caller'].ir)[0]
     assert call.name == 'kernel'
@@ -755,14 +752,9 @@ end subroutine caller
     )
 
     # Check arguments of kernel
-    if frontend == OMNI:
-        assert items['kernel'].ir.arguments == (
-            'm', 'n', 'p_a(1:n)', 'p_b(1:m, 1:n)', 'q_a(:)', 'q_b(:, :)', 'r_a(:)', 'r_b(:, :)', 'c'
-        )
-    else:
-        assert items['kernel'].ir.arguments == (
-            'm', 'n', 'P_a(n)', 'P_b(m, n)', 'Q_a(:)', 'Q_b(:, :)', 'R_a(:)', 'R_b(:, :)', 'c'
-        )
+    assert items['kernel'].ir.arguments == (
+        'm', 'n', 'P_a(n)', 'P_b(m, n)', 'Q_a(:)', 'Q_b(:, :)', 'R_a(:)', 'R_b(:, :)', 'c'
+    )
 
     # Check call arguments in layer
     calls = FindNodes(CallStatement).visit(items['layer'].ir.ir)
@@ -776,16 +768,10 @@ end subroutine caller
     )
 
     # Check arguments of layer
-    if frontend == OMNI:
-        assert items['layer'].ir.arguments == (
-            'm', 'n', 'p_a_a(:)', 'p_a_b(:, :)', 'p_b(1:5)', 'q_a_a(:)', 'q_a_b(:, :)', 'q_b(:)', 'q_constants(:)',
-            'r_a_a(:)', 'r_a_b(:, :)', 'r_b(:)'
-        )
-    else:
-        assert items['layer'].ir.arguments == (
-            'm', 'n', 'p_a_a(:)', 'p_a_b(:, :)', 'p_b(5)', 'q_a_a(:)', 'q_a_b(:, :)', 'q_b(:)', 'q_constants(:)',
-            'r_a_a(:)', 'r_a_b(:, :)', 'r_b(:)'
-        )
+    assert items['layer'].ir.arguments == (
+        'm', 'n', 'p_a_a(:)', 'p_a_b(:, :)', 'p_b(5)', 'q_a_a(:)', 'q_a_b(:, :)', 'q_b(:)', 'q_constants(:)',
+        'r_a_a(:)', 'r_a_b(:, :)', 'r_b(:)'
+    )
 
     # Check imports
     assert 'constants_type' in items['layer'].ir.imported_symbols

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -1275,10 +1275,7 @@ end subroutine transform_loop_fission_promote_array
     assert len(loops) == 3
     assert all(loop.bounds.start == '1' for loop in loops)
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 2
-    if frontend == OMNI:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['1:klon', 'klev']
-    else:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['klon', 'klev']
+    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
     fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
@@ -1331,11 +1328,8 @@ end subroutine transform_loop_fission_promote_multiple
     assert len(loops) == 3
     assert all(loop.bounds.start == '1' for loop in loops)
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 2
-    if frontend == OMNI:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['1:klon', 'klev']
-    else:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['klon', 'klev']
-    assert [str(d) for d in routine.variable_map['tmp'].shape] == ['klev']
+    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
+    assert routine.variable_map['tmp'].shape == ('klev',)
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
     fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
@@ -1402,12 +1396,8 @@ end subroutine transform_loop_fission_multiple_promote
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 4
     assert sum(loop.bounds.stop == 'klon' for loop in loops) == 2
     assert sum(loop.bounds.stop == 'nclv' for loop in loops) == 2
-    if frontend == OMNI:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['1:klon', 'klev']
-        assert [str(d) for d in routine.variable_map['zqxn'].shape] == ['1:klon', '1:nclv', 'klev']
-    else:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['klon', 'klev']
-        assert [str(d) for d in routine.variable_map['zqxn'].shape] == ['klon', 'nclv', 'klev']
+    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
+    assert routine.variable_map['zqxn'].shape == ('klon', 'nclv', 'klev')
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
     fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
@@ -1463,11 +1453,8 @@ end subroutine transform_loop_fission_promote_read_after_write
     assert len(loops) == 3
     assert all(loop.bounds.start == '1' for loop in loops)
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 2
-    if frontend == OMNI:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['1:klon', 'klev']
-    else:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['klon', 'klev']
-    assert [str(d) for d in routine.variable_map['tmp'].shape] == ['klev']
+    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
+    assert routine.variable_map['tmp'].shape == ('klev',)
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
     fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
@@ -1535,12 +1522,8 @@ end subroutine transform_loop_fission_promote_mult_r_a_w
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 4
     assert sum(loop.bounds.stop == 'klon' for loop in loops) == 2
     assert sum(loop.bounds.stop == 'nclv' for loop in loops) == 2
-    if frontend == OMNI:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['1:klon', 'klev']
-        assert [str(d) for d in routine.variable_map['zqxn'].shape] == ['1:nclv', '1:klon', 'klev']
-    else:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['klon', 'klev']
-        assert [str(d) for d in routine.variable_map['zqxn'].shape] == ['nclv', 'klon', 'klev']
+    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
+    assert routine.variable_map['zqxn'].shape == ('nclv', 'klon', 'klev')
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
     fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
@@ -1607,10 +1590,7 @@ end subroutine transform_loop_fusion_fission
     assert all(loop.bounds.start == '1' for loop in loops)
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 2
     assert sum(loop.bounds.stop == 'klon' for loop in loops) == 2
-    if frontend == OMNI:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['1:klon', 'klev']
-    else:
-        assert [str(d) for d in routine.variable_map['zsupsat'].shape] == ['klon', 'klev']
+    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
     fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -19,7 +19,6 @@ from loki.ir import (
     Assignment
 )
 
-from loki.transformations.array_indexing import normalize_range_indexing
 from loki.transformations.transform_loop import (
     loop_interchange, loop_fusion, loop_fission, loop_unroll
 )
@@ -964,7 +963,6 @@ subroutine transform_loop_fission_nested_promote(a, b, n)
 end subroutine transform_loop_fission_nested_promote
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    normalize_range_indexing(routine)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname=routine.name)
 

--- a/loki/transformations/tests/test_transform_region.py
+++ b/loki/transformations/tests/test_transform_region.py
@@ -16,7 +16,6 @@ from loki.build import jit_compile, jit_compile_lib, Builder, Obj
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends
 
-from loki.transformations.array_indexing import normalize_range_indexing
 from loki.transformations.transform_region import (
     region_hoist, region_to_call
 )
@@ -556,7 +555,6 @@ subroutine reg_to_call_arr(a, b, n)
 end subroutine reg_to_call_arr
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    normalize_range_indexing(routine)
 
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname=routine.name)
@@ -646,7 +644,6 @@ end module reg_to_call_imps_mod
 """
     ext_module = Module.from_source(fcode_module, frontend=frontend, xmods=[tmp_path])
     module = Module.from_source(fcode, frontend=frontend, definitions=ext_module, xmods=[tmp_path])
-    normalize_range_indexing(module.subroutines[0])
     refname = f'ref_{module.name}_{frontend}'
     reference = jit_compile_lib([module, ext_module], path=tmp_path, name=refname, builder=builder)
     function = getattr(getattr(reference, module.name), module.subroutines[0].name)

--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -507,7 +507,7 @@ end module test_get_local_arrays_mod
     # Test for component arrays on arguments in spec
     locals = get_local_arrays(routine, routine.spec, unique=True)
     assert len(locals) == 1
-    assert locals[0] == 'local(1:n)' if frontend == OMNI else 'local(n)'
+    assert locals[0] == 'local(n)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/transpile/fortran_maxeler.py
+++ b/loki/transformations/transpile/fortran_maxeler.py
@@ -25,7 +25,7 @@ from loki.tools import as_tuple, flatten
 
 from loki.transformations.array_indexing import (
     shift_to_zero_indexing, invert_array_indices,
-    resolve_vector_notation, normalize_range_indexing
+    resolve_vector_notation
 )
 from loki.transformations.utilities import replace_intrinsics
 from loki.types import SymbolAttributes, BasicType, DerivedType
@@ -191,7 +191,6 @@ class FortranMaxTransformation(Transformation):
 
         # Some vector notation sanitation
         resolve_vector_notation(max_kernel)
-        normalize_range_indexing(max_kernel)
 
         # Remove dataflow loops
         loop_map = {}

--- a/loki/transformations/transpile/fortran_python.py
+++ b/loki/transformations/transpile/fortran_python.py
@@ -16,7 +16,7 @@ from loki.ir import nodes as ir, FindNodes, Transformer, pragmas_attached
 from loki.sourcefile import Sourcefile
 
 from loki.transformations.array_indexing import (
-    shift_to_zero_indexing, invert_array_indices, normalize_range_indexing
+    shift_to_zero_indexing, invert_array_indices
 )
 from loki.transformations.sanitise import resolve_associates
 from loki.transformations.utilities import (
@@ -72,7 +72,6 @@ class FortranPythonTransformation(Transformation):
         resolve_associates(routine)
 
         # Do some vector and indexing transformations
-        normalize_range_indexing(routine)
         if self.with_dace or self.invert_indices:
             invert_array_indices(routine)
         shift_to_zero_indexing(routine)

--- a/loki/transformations/transpile/tests/test_transpile.py
+++ b/loki/transformations/transpile/tests/test_transpile.py
@@ -15,7 +15,6 @@ import loki.expression.symbols as sym
 from loki.frontend import available_frontends, OFP
 import loki.ir as ir
 
-from loki.transformations.array_indexing import normalize_range_indexing
 from loki.transformations.transpile import FortranCTransformation
 
 
@@ -98,7 +97,6 @@ end subroutine simple_loops
 
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    normalize_range_indexing(routine) # Fix OMNI nonsense
     filepath = tmp_path/(f'simple_loops{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='simple_loops')
 
@@ -197,7 +195,6 @@ end subroutine transpile_arguments
 
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    normalize_range_indexing(routine) # Fix OMNI nonsense
     filepath = tmp_path/(f'transpile_arguments{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
     function = jit_compile(routine, filepath=filepath, objname='transpile_arguments')
     a, b, c = function(n, array, array_io, a_io, b_io, c_io)

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -25,9 +25,7 @@ from loki.batch import Transformation, Pipeline, Scheduler, SchedulerConfig
 from loki.transformations.argument_shape import (
     ArgumentArrayShapeAnalysis, ExplicitArgumentArrayShapeTransformation
 )
-from loki.transformations.array_indexing import (
-        normalize_range_indexing, LowerConstantArrayIndices
-)
+from loki.transformations.array_indexing import LowerConstantArrayIndices
 from loki.transformations.build_system import (
     DependencyTransformation, ModuleWrapTransformation, FileWriteTransformation
 )
@@ -242,15 +240,6 @@ def convert(
         )
         scheduler.process(offload_transform)
         use_claw_offload = not offload_transform.has_data_regions
-
-    if frontend == Frontend.OMNI and mode in ['idem-stack', 'scc-stack']:
-        # To make the pool allocator size derivation work correctly, we need
-        # to normalize the 1:end-style index ranges that OMNI introduces
-        class NormalizeRangeIndexingTransformation(Transformation):
-            def transform_subroutine(self, routine, **kwargs):
-                normalize_range_indexing(routine)
-
-        scheduler.process( NormalizeRangeIndexingTransformation() )
 
     if global_var_offload:
         scheduler.process(transformation=GlobalVariableAnalysis())


### PR DESCRIPTION
~Just testing for now ...~

This change adds a frontend sanitisation step to remove the forced lower bounds on array declaration dimensions in OMNI. This is done via a custom sanitisation `Transformer`. 

As a result, we can remove a lot of the special-casing for OMNI's array dimension notation and, importantly, remove the use of the `normalize_range_indexing` utility across the `loki.transformation` sub-package tests. Consequently, we can also remove the OMNI special-casing in `loki_transform.py` - the problem that triggered this entire endeavour.

Please note, the `normalize_range_indexing` tool has not been removed, as it has a legitimate use in another sanitisation utility, which is part of the C-transpilation toolchain. However, all OMNI-specific workarounds using this utility have been removed.