### PR TITLE
Loki-transform: Pass `cuf` option to FilewriteTrafo

### DIFF
--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -175,7 +175,7 @@ def convert(
         # Write out all modified source files into the build directory
         file_write_trafo = scheduler.config.transformations.get('FileWriteTransformation', None)
         if not file_write_trafo:
-            file_write_trafo = FileWriteTransformation(builddir=build, mode=mode)
+            file_write_trafo = FileWriteTransformation(builddir=build, mode=mode, cuf='cuf' in mode)
         scheduler.process(transformation=file_write_trafo)
 
         return


### PR DESCRIPTION
This is a small workaround for enabling SCC-CUF pipelines from config file in CLOUDSC. As we still push static config info alongside dynamic build system settings, this is needed for now if we don't want to preprocess the loki config via cmake.