### PR TITLE
Filter out globals in `get_local_arrays`

### DIFF
--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -462,6 +462,13 @@ end subroutine test_find_driver_loops
 def test_transform_utilites_get_local_arrays(frontend, tmp_path):
     """ Test :any:`get_local_arrays` utility. """
 
+    fcode_mod = """
+module global_var_mod
+    integer, parameter :: arr_size = 20
+    real :: myarray(arr_size)
+end module global_var_mod
+"""
+
     fcode = """
 module test_get_local_arrays_mod
 implicit none
@@ -471,6 +478,7 @@ end type my_dim
 contains
 
 subroutine test_get_local_arrays(n, dims, start, end, arr)
+  use global_var_mod, only: myarray
   integer, intent(in) :: n, start, end
   type(my_dim), intent(in) :: dims
   real, intent(inout) :: arr(dims%a(2))
@@ -489,7 +497,8 @@ subroutine test_get_local_arrays(n, dims, start, end, arr)
 end subroutine test_get_local_arrays
 end module test_get_local_arrays_mod
 """
-    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    global_mod = Module.from_source(fcode_mod, frontend=frontend, xmods=[tmp_path])
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path], definitions=(global_mod,))
     routine = module['test_get_local_arrays']
 
     locals = get_local_arrays(routine, routine.body, unique=True)

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -639,12 +639,14 @@ def get_local_arrays(routine, section, unique=True):
         Flag whether to return unique instances of each symbol;
         default: ``False``
     """
+    imported_symbols = routine.imported_symbols
     arg_names = tuple(a.lower() for a in routine._dummies)
     variables = FindVariables(unique=unique).visit(section)
 
     # Filter all variables by argument name to get local arrays
     arrays = [v for v in variables if isinstance(v, sym.Array) and not v.parent]
     arrays = [v for v in arrays if str(v.name).lower() not in arg_names]
+    arrays = [v for v in arrays if v.name not in imported_symbols]
 
     return arrays
 


### PR DESCRIPTION
A small PR to filter out global variables from `get_local_arrays`; these may be included if `get_local_arrays` is applied to `routine.spec`.