### PR TITLE
Change/fix pipeline for mode 'scc-raw-stack'

### DIFF
--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -302,7 +302,7 @@ def convert(
     if mode == 'scc-raw-stack':
         pipeline = scheduler.config.transformations.get('scc-raw-stack', None)
         if not pipeline:
-            pipeline = SCCStackPipeline(
+            pipeline = SCCRawStackPipeline(
                 horizontal=horizontal,
                 block_dim=block_dim, directive=directive,
                 check_bounds=False,


### PR DESCRIPTION
Not sure whether I am missing something, but shouldn't the `SCCRawStackPipeline` be called for mode `scc-raw-stack`?