### PR TITLE
IR: Symbol management on scoped nodes

### DIFF
--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -22,10 +22,11 @@ from pymbolic.primitives import Expression
 from pydantic.dataclasses import dataclass as dataclass_validated
 from pydantic import model_validator
 
+from loki.expression import Variable
+from loki.frontend.source import Source
 from loki.scope import Scope
 from loki.tools import flatten, as_tuple, is_iterable, truncate_string, CaseInsensitiveDict
 from loki.types import DataType, BasicType, DerivedType, SymbolAttributes
-from loki.frontend.source import Source
 
 
 __all__ = [
@@ -342,6 +343,26 @@ class ScopedNode(Scope):
             Base name of the symbol to be retrieved
         """
         return self.get_symbol_scope(name).variable_map.get(name)  # pylint: disable=no-member
+
+    def Variable(self, **kwargs):
+        """
+        Factory method for :any:`TypedSymbol` or :any:`MetaSymbol` classes.
+
+        This invokes the :any:`Variable` with this node as the scope.
+
+        Parameters
+        ----------
+        name : str
+            The name of the variable.
+        type : optional
+            The type of that symbol. Defaults to :any:`BasicType.DEFERRED`.
+        parent : :any:`Scalar` or :any:`Array`, optional
+            The derived type variable this variable belongs to.
+        dimensions : :any:`ArraySubscript`, optional
+            The array subscript expression.
+        """
+        kwargs['scope'] = self
+        return Variable(**kwargs)
 
 
 # Intermediate node types

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -329,6 +329,21 @@ class ScopedNode(Scope):
         symbol_attrs = s.pop('symbol_attrs', None)
         self._update(**s, symbol_attrs=symbol_attrs, rescope_symbols=True)
 
+    def get_symbol(self, name):
+        """
+        Returns the symbol for a given name as defined in its declaration.
+
+        The returned symbol might include dimension symbols if it was
+        declared as an array.
+
+        Parameters
+        ----------
+        name : str
+            Base name of the symbol to be retrieved
+        """
+        return self.get_symbol_scope(name).variable_map.get(name)  # pylint: disable=no-member
+
+
 # Intermediate node types
 
 
@@ -430,6 +445,13 @@ class Associate(ScopedNode, Section, _AssociateBase):  # pylint: disable=too-man
     @property
     def variables(self):
         return tuple(v for _, v in self.associations)
+
+    @property
+    def variable_map(self):
+        """
+        Map of variable names to :any:`Variable` objects
+        """
+        return CaseInsensitiveDict((v.name, v) for v in self.variables)
 
     def __repr__(self):
         if self.associations:

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -22,7 +22,7 @@ from pymbolic.primitives import Expression
 from pydantic.dataclasses import dataclass as dataclass_validated
 from pydantic import model_validator
 
-from loki.expression import Variable
+from loki.expression import Variable, parse_expr
 from loki.frontend.source import Source
 from loki.scope import Scope
 from loki.tools import flatten, as_tuple, is_iterable, truncate_string, CaseInsensitiveDict
@@ -363,6 +363,31 @@ class ScopedNode(Scope):
         """
         kwargs['scope'] = self
         return Variable(**kwargs)
+
+    def parse_expr(self, expr_str, strict=False, evaluate=False, context=None):
+        """
+        Uses :meth:`parse_expr` to convert expression(s) represented
+        in a string to Loki expression(s)/IR.
+
+        Parameters
+        ----------
+        expr_str : str
+            The expression as a string
+        strict : bool, optional
+            Whether to raise exception for unknown variables/symbols when
+            evaluating an expression (default: `False`)
+        evaluate : bool, optional
+            Whether to evaluate the expression or not (default: `False`)
+        context : dict, optional
+            Symbol context, defining variables/symbols/procedures to help/support
+            evaluating an expression
+
+        Returns
+        -------
+        :any:`Expression`
+            The expression tree corresponding to the expression
+        """
+        return parse_expr(expr_str, scope=self, strict=strict, evaluate=evaluate, context=context)
 
 
 # Intermediate node types

--- a/loki/ir/tests/test_scoped_nodes.py
+++ b/loki/ir/tests/test_scoped_nodes.py
@@ -12,6 +12,8 @@ import pytest
 from loki import Module
 from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
+from loki.expression import symbols as sym
+from loki.types import BasicType
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -65,3 +67,57 @@ end module test_scoped_node_symbols_mod
     assert associate.get_symbol('jprb') == 'jprb'
     assert associate.get_symbol('jprb').scope == module
     assert associate.get_symbol('jprb').initial == 8
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_scoped_node_variable_constructor(frontend, tmp_path):
+    """ Test :any:`Variable` constrcutore on scoped nodes. """
+    fcode = """
+module test_scoped_nodes_mod
+implicit none
+integer, parameter :: jprb = 8
+
+contains
+  subroutine test_scoped_nodes(n, a, b, c)
+    integer, intent(in) :: n
+    real(kind=jprb), intent(inout) :: a(n), b(n), c
+    integer :: i
+
+    a(1) = 42.0_jprb
+
+    associate(d => a)
+    do i=1, n
+      b(i) = a(i) + c
+    end do
+    end associate
+  end subroutine test_scoped_nodes
+end module test_scoped_nodes_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['test_scoped_nodes']
+    associate = FindNodes(ir.Associate).visit(routine.body)[0]
+
+    # Build some symbiols and check their type
+    c = routine.Variable(name='c')
+    assert c.type.dtype == BasicType.REAL
+    assert c.type.kind in ('jprb', 8)
+    i = routine.Variable(name='i')
+    assert i.type.dtype == BasicType.INTEGER
+    jprb = routine.Variable(name='jprb')
+    assert jprb.type.dtype == BasicType.INTEGER
+    assert jprb.type.initial == 8
+
+    a_i = routine.Variable(name='a', dimensions=(i,))
+    assert a_i == 'a(i)'
+    assert isinstance(a_i, sym.Array)
+    assert a_i.dimensions == (i,)
+    assert a_i.type.dtype == BasicType.REAL
+    assert a_i.type.kind in ('jprb', 8)
+
+    # Build another, but from the associate node
+    b_i = associate.Variable(name='b', dimensions=(i,))
+    assert b_i == 'b(i)'
+    assert isinstance(b_i, sym.Array)
+    assert b_i.dimensions == (i,)
+    assert b_i.type.dtype == BasicType.REAL
+    assert b_i.type.kind in ('jprb', 8)

--- a/loki/ir/tests/test_scoped_nodes.py
+++ b/loki/ir/tests/test_scoped_nodes.py
@@ -1,0 +1,67 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# A set of tests for the symbol accessort and management API built into `ScopedNode`.
+
+import pytest
+
+from loki import Module
+from loki.frontend import available_frontends
+from loki.ir import nodes as ir, FindNodes
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_scoped_node_get_symbols(frontend, tmp_path):
+    """ Test :method:`get_symbol` functionality on scoped nodes. """
+    fcode = """
+module test_scoped_node_symbols_mod
+implicit none
+integer, parameter :: jprb = 8
+
+contains
+  subroutine test_scoped_node_symbols(n, a, b, c)
+    integer, intent(in) :: n
+    real(kind=jprb), intent(inout) :: a(n), b(n), c
+    integer :: i
+
+    a(1) = 42.0_jprb
+
+    associate(d => a)
+    do i=1, n
+      b(i) = a(i) + c
+    end do
+    end associate
+  end subroutine test_scoped_node_symbols
+end module test_scoped_node_symbols_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['test_scoped_node_symbols']
+    associate = FindNodes(ir.Associate).visit(routine.body)[0]
+
+    # Check symbol lookup from subroutine
+    assert routine.get_symbol('a') == 'a(n)'
+    assert routine.get_symbol('a').scope == routine
+    assert routine.get_symbol('b') == 'b(n)'
+    assert routine.get_symbol('b').scope == routine
+    assert routine.get_symbol('c') == 'c'
+    assert routine.get_symbol('c').scope == routine    
+    assert routine.get_symbol('jprb') == 'jprb'
+    assert routine.get_symbol('jprb').scope == module
+    assert routine.get_symbol('jprb').initial == 8
+
+    # Check passthrough from the Associate (ScopedNode)
+    assert associate.get_symbol('a') == 'a(n)'
+    assert associate.get_symbol('a').scope == routine
+    assert associate.get_symbol('b') == 'b(n)'
+    assert associate.get_symbol('b').scope == routine
+    assert associate.get_symbol('c') == 'c'
+    assert associate.get_symbol('c').scope == routine
+    assert associate.get_symbol('d') == 'd'
+    assert associate.get_symbol('d').scope == associate
+    assert associate.get_symbol('jprb') == 'jprb'
+    assert associate.get_symbol('jprb').scope == module
+    assert associate.get_symbol('jprb').initial == 8

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -652,6 +652,20 @@ class ProgramUnit(Scope):
             (s.name, s) for s in self.symbols
         )
 
+    def get_symbol(self, name):
+        """
+        Returns the symbol for a given name as defined in its declaration.
+
+        The returned symbol might include dimension symbols if it was
+        declared as an array.
+
+        Parameters
+        ----------
+        name : str
+            Base name of the symbol to be retrieved
+        """
+        return self.get_symbol_scope(name).variable_map.get(name)
+
     @property
     def subroutines(self):
         """

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -7,7 +7,7 @@
 
 from abc import abstractmethod
 
-from loki.expression import Variable
+from loki.expression import Variable, parse_expr
 from loki.frontend import (
     Frontend, parse_omni_source, parse_ofp_source, parse_fparser_source,
     RegexParserClass, preprocess_cpp, sanitize_input
@@ -685,6 +685,31 @@ class ProgramUnit(Scope):
         """
         kwargs['scope'] = self
         return Variable(**kwargs)
+
+    def parse_expr(self, expr_str, strict=False, evaluate=False, context=None):
+        """
+        Uses :meth:`parse_expr` to convert expression(s) represented
+        in a string to Loki expression(s)/IR.
+
+        Parameters
+        ----------
+        expr_str : str
+            The expression as a string
+        strict : bool, optional
+            Whether to raise exception for unknown variables/symbols when
+            evaluating an expression (default: `False`)
+        evaluate : bool, optional
+            Whether to evaluate the expression or not (default: `False`)
+        context : dict, optional
+            Symbol context, defining variables/symbols/procedures to help/support
+            evaluating an expression
+
+        Returns
+        -------
+        :any:`Expression`
+            The expression tree corresponding to the expression
+        """
+        return parse_expr(expr_str, scope=self, strict=strict, evaluate=evaluate, context=context)
 
     @property
     def subroutines(self):

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -666,6 +666,26 @@ class ProgramUnit(Scope):
         """
         return self.get_symbol_scope(name).variable_map.get(name)
 
+    def Variable(self, **kwargs):
+        """
+        Factory method for :any:`TypedSymbol` or :any:`MetaSymbol` classes.
+
+        This invokes the :any:`Variable` with this node as the scope.
+
+        Parameters
+        ----------
+        name : str
+            The name of the variable.
+        type : optional
+            The type of that symbol. Defaults to :any:`BasicType.DEFERRED`.
+        parent : :any:`Scalar` or :any:`Array`, optional
+            The derived type variable this variable belongs to.
+        dimensions : :any:`ArraySubscript`, optional
+            The array subscript expression.
+        """
+        kwargs['scope'] = self
+        return Variable(**kwargs)
+
     @property
     def subroutines(self):
         """


### PR DESCRIPTION
~_Note: This PR sits on top of #372, so I'm only filing a draft before anticipated rebase._~

This PR brings a set of convenience methods and expression constructors to the `ScopedNode` and `ProgramUnit` classes. The idea is that eventually, `Subroutine` and `Module` classes should become scoped nodes and the expression management API should be equivalent between them.

The idea is to add the following three utilities to the scope objects themselves, to enable quick(er) expression generation:
* `.get_symbol(name)` - utility to look up a symbol by it's name. This will first find it's true owning scope and attach the symbol.
* `.Variable(name, ....)` - a shortcut to the general `Variable` constructor that will attempt to build array and scalar symbols, depending on available type information
* `.parse_expr` - a shortcut to the general expression parser that can generate nested expression trees from pure strings.