### PR TITLE
handle modulo operator/function for c-like-backends

### DIFF
--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -11,11 +11,13 @@ from pymbolic.mapper.stringifier import (
 )
 
 from loki.tools import as_tuple
-from loki.ir import Import, Stringifier, FindNodes
+from loki.ir import (
+        Import, Stringifier, FindNodes,
+        FindVariables, ExpressionFinder
+)
 from loki.expression import (
         LokiStringifyMapper, Array, symbolic_op, Literal,
-        symbols as sym, FindVariables, ExpressionFinder,
-        ExpressionRetriever
+        symbols as sym, ExpressionRetriever
 )
 from loki.types import BasicType, SymbolAttributes, DerivedType
 

--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -14,7 +14,8 @@ from loki.tools import as_tuple
 from loki.ir import Import, Stringifier, FindNodes
 from loki.expression import (
         LokiStringifyMapper, Array, symbolic_op, Literal,
-        symbols as sym
+        symbols as sym, FindVariables, ExpressionFinder,
+        ExpressionRetriever
 )
 from loki.types import BasicType, SymbolAttributes, DerivedType
 
@@ -139,6 +140,25 @@ class CCodeMapper(LokiStringifyMapper):
 
     def map_c_dereference(self, expr, enclosing_prec, *args, **kwargs):
         return self.format(' (*%s)', self.rec(expr.expression, PREC_NONE, *args, **kwargs))
+
+    def map_inline_call(self, expr, enclosing_prec, *args, **kwargs):
+
+        class FindFloatLiterals(ExpressionFinder):
+            retriever = ExpressionRetriever(lambda e: isinstance(e, sym.FloatLiteral))
+
+        if expr.function.name.lower() == 'mod':
+            parameters = [self.rec(param, PREC_NONE, *args, **kwargs) for param in expr.parameters]
+            # TODO: this check is not quite correct, as it should evaluate the
+            #  expression(s) of both arguments/parameters and choose the integer version of modulo ('%')
+            #  instead of the floating-point version ('fmod')
+            #  whenever the mentioned evaluations result in being of kind 'integer' ...
+            #  as an example: 'celing(3.1415)' got an floating point value in it, however it evaluates/returns
+            #  an integer, in that case the wrong modulo function/operation is chosen
+            if any(var.type.dtype != BasicType.INTEGER for var in FindVariables().visit(expr.parameters)) or\
+                    FindFloatLiterals().visit(expr.parameters):
+                return f'fmod({parameters[0]}, {parameters[1]})'
+            return f'({parameters[0]})%({parameters[1]})'
+        return super().map_inline_call(expr, enclosing_prec, *args, **kwargs)
 
 
 class CCodegen(Stringifier):

--- a/loki/ir/expr_visitors.py
+++ b/loki/ir/expr_visitors.py
@@ -25,8 +25,9 @@ from loki.expression.symbols import (
 
 __all__ = [
     'FindExpressions', 'FindVariables', 'FindTypedSymbols',
-    'FindInlineCalls', 'FindLiterals', 'SubstituteExpressions',
-    'SubstituteStringExpressions', 'ExpressionFinder', 'AttachScopes'
+    'FindInlineCalls', 'FindLiterals', 'FindRealLiterals',
+    'SubstituteExpressions', 'SubstituteStringExpressions',
+    'ExpressionFinder', 'AttachScopes'
 ]
 
 
@@ -200,6 +201,15 @@ class FindLiterals(ExpressionFinder):
     retriever = ExpressionRetriever(lambda e: isinstance(e, (
         FloatLiteral, IntLiteral, LogicLiteral, StringLiteral, IntrinsicLiteral
     )))
+
+class FindRealLiterals(ExpressionFinder):
+    """
+    A visitor to collect all real/float literals (which includes :any:`FloatLiteral`)
+    used in an IR tree.
+
+    See :class:`ExpressionFinder`
+    """
+    retriever = ExpressionRetriever(lambda e: isinstance(e, FloatLiteral))
 
 
 class SubstituteExpressions(Transformer):

--- a/loki/ir/tests/test_expr_visitors.py
+++ b/loki/ir/tests/test_expr_visitors.py
@@ -9,7 +9,7 @@ import pytest
 
 from loki import Sourcefile, Subroutine
 from loki.expression import symbols as sym, parse_expr
-from loki.frontend import available_frontends
+from loki.frontend import available_frontends, OMNI
 from loki.ir import (
     nodes as ir, FindNodes, FindVariables, FindTypedSymbols,
     SubstituteExpressions, SubstituteStringExpressions,
@@ -147,7 +147,8 @@ end subroutine test_find_literals
 """
     expected_int_literals = ('1', '5', '42')
     expected_real_literals = ('1.0', '10.5')
-    expected_intrinsic_literals = ("B'00000'",)
+    # Omni evaluates BOZ constants, so it creates IntegerLiteral instead...
+    expected_intrinsic_literals = ("B'00000'",) if frontend != OMNI else ('0',)
     expected_logic_literals = ('True',)
     expected_string_literals = ('string_kwarg',)
     expected_literals = expected_int_literals + expected_real_literals +\

--- a/loki/ir/tests/test_expr_visitors.py
+++ b/loki/ir/tests/test_expr_visitors.py
@@ -12,7 +12,8 @@ from loki.expression import symbols as sym, parse_expr
 from loki.frontend import available_frontends
 from loki.ir import (
     nodes as ir, FindNodes, FindVariables, FindTypedSymbols,
-    SubstituteExpressions, SubstituteStringExpressions
+    SubstituteExpressions, SubstituteStringExpressions,
+    FindLiterals, FindRealLiterals
 )
 
 
@@ -122,6 +123,43 @@ end module test_mod
     body_vars = FindVariables(unique=True).visit(routine.body)
     assert len(body_vars) == 10
     assert all(v in body_vars for v in expected)
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_find_literals(frontend):
+    """
+    Test that :any:`FindLiterals` finds all literals
+    and :any:`FindRealLiterals` all real/float literals.
+    """
+    fcode = """
+subroutine test_find_literals()
+  implicit none
+  integer :: n, n1
+  real(kind=8) :: x
+
+  n = 1 + 5 + 42
+  x = 1.0 / 10.5
+  n1 = int(B'00000')
+  if (.TRUE.) then
+    call some_func(x, some_string='string_kwarg')
+  endif
+
+end subroutine test_find_literals
+"""
+    expected_int_literals = ('1', '5', '42')
+    expected_real_literals = ('1.0', '10.5')
+    expected_intrinsic_literals = ("B'00000'",)
+    expected_logic_literals = ('True',)
+    expected_string_literals = ('string_kwarg',)
+    expected_literals = expected_int_literals + expected_real_literals +\
+            expected_intrinsic_literals + expected_logic_literals +\
+            expected_string_literals
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    literals = FindLiterals().visit(routine.body)
+    assert sorted(list(expected_literals)) == sorted([str(literal.value) for literal in literals])
+    real_literals = FindRealLiterals().visit(routine.body)
+    assert sorted(list(expected_real_literals)) == sorted([str(literal.value) for literal in real_literals])
+    real_literals_isinstance = [literal for literal in literals if isinstance(literal, sym.FloatLiteral)]
+    assert sorted(list(expected_real_literals)) == sorted([str(literal.value) for literal in real_literals_isinstance])
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
[TRANSPILATION] handle modulo operator/function for c-like-backends ...

convert

* `MOD(a, b)` to `a % b` for integer parameters/arguments
* `MOD(x, y)` to `fmod(x, y)` for floating point parameters/arguments