### PR TITLE
Transpilation: optional arguments

### DIFF
--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -203,8 +203,7 @@ class CCodegen(Stringifier):
 
     def _subroutine_optional_args(self, a):
         if a.type.optional:
-            warning(f'Argument "{a}" is optional, however, there is currently'
-                    f' no support for optional arguments for this backend!')
+            warning(f'Argument "{a}" is optional! No support for optional arguments in {self.__class__.__name__}.')
         return ''
 
     def _subroutine_declaration(self, o, **kwargs):

--- a/loki/backend/cppgen.py
+++ b/loki/backend/cppgen.py
@@ -32,8 +32,12 @@ class CppCodeMapper(CCodeMapper):
     A :class:`StringifyMapper`-derived visitor for Pymbolic expression trees that converts an
     expression to a string adhering to standardized C++.
     """
-    # pylint: disable=abstract-method, unused-argument, unnecessary-pass
-    pass
+    # pylint: disable=abstract-method, unused-argument
+
+    def map_inline_call(self, expr, enclosing_prec, *args, **kwargs):
+        if expr.function.name.lower() == 'present':
+            return self.format('%s', expr.parameters[0].name)
+        return super().map_inline_call(expr, enclosing_prec, *args, **kwargs)
 
 
 class CppCodegen(CCodegen):
@@ -68,6 +72,10 @@ class CppCodegen(CCodegen):
         footer += [self.format_line('\n} // extern')] if opt_extern else []
         return footer
 
+    def _subroutine_optional_args(self, a):
+        if a.type.optional:
+            return ' = nullptr'
+        return ''
 
 def cppgen(ir, **kwargs):
     """

--- a/loki/build/obj.py
+++ b/loki/build/obj.py
@@ -30,11 +30,11 @@ class Obj:
     A single source object representing a single C or Fortran source file.
     """
 
-    MODEMAP = {'.f90': 'f90', '.f': 'f', '.c': 'c', '.cc': 'c'}
+    MODEMAP = {'.f90': 'f90', '.f': 'f', '.c': 'c', '.cc': 'c', '.cpp': 'cpp'}
 
     # Default source and header extension recognized
     # TODO: Make configurable!
-    _ext = ['.f90', '.F90', '.f', '.F', '.c']
+    _ext = ['.f90', '.F90', '.f', '.F', '.c', '.cpp']
 
     def __new__(cls, *args, name=None, **kwargs):  # pylint: disable=unused-argument
         # Name is either provided or inferred from source_path

--- a/loki/build/obj.py
+++ b/loki/build/obj.py
@@ -30,11 +30,12 @@ class Obj:
     A single source object representing a single C or Fortran source file.
     """
 
-    MODEMAP = {'.f90': 'f90', '.f': 'f', '.c': 'c', '.cc': 'c', '.cpp': 'cpp'}
+    MODEMAP = {'.f90': 'f90', '.f': 'f', '.c': 'c', '.cc': 'c', '.cpp': 'cpp',
+               '.CC': 'cpp', '.cxx': 'cpp'}
 
     # Default source and header extension recognized
     # TODO: Make configurable!
-    _ext = ['.f90', '.F90', '.f', '.F', '.c', '.cpp']
+    _ext = ['.f90', '.F90', '.f', '.F', '.c', '.cpp', '.CC', '.cc', '.cxx']
 
     def __new__(cls, *args, name=None, **kwargs):  # pylint: disable=unused-argument
         # Name is either provided or inferred from source_path

--- a/loki/transformations/transpile/fortran_c.py
+++ b/loki/transformations/transpile/fortran_c.py
@@ -139,8 +139,6 @@ class FortranCTransformation(Transformation):
     def file_suffix(self):
         if self.language == 'cpp':
             return '.cpp'
-        # if self.language == 'cuda':
-        #     return '.cu'
         return '.c'
 
     def transform_module(self, module, **kwargs):

--- a/loki/transformations/transpile/fortran_c.py
+++ b/loki/transformations/transpile/fortran_c.py
@@ -139,8 +139,8 @@ class FortranCTransformation(Transformation):
     def file_suffix(self):
         if self.language == 'cpp':
             return '.cpp'
-        if self.language == 'cuda':
-            return '.cu'
+        # if self.language == 'cuda':
+        #     return '.cu'
         return '.c'
 
     def transform_module(self, module, **kwargs):


### PR DESCRIPTION
Allow/handle optional arguments for c-like-backends.
For 

* `cgen` - assume all optional arguments are passed (inherently unsafe, thus warn)
* `cppgen` (and all backends derived from that) - proper handling via optional argument with default value `nullptr`
    * arguments that would have been passed by value are instead passed as pointer if they are optional

Moreover, introduced capabilities to jit compile C++ files (in addition to C files).