### PR TITLE
Extend 'resolve_vector_notation' to look for available and appropriate loops

### DIFF
--- a/loki/transformations/array_indexing.py
+++ b/loki/transformations/array_indexing.py
@@ -159,7 +159,7 @@ def resolve_vector_notation(routine):
     vmap = {}
     # find available loops and create map {(lower, upper, step): loop_variable}
     loops = FindNodes(Loop).visit(routine.body)
-    loop_map = {(loop.bounds.lower, loop.bounds.upper, loop.bounds.step if loop.bounds.step is not None else 1):
+    loop_map = {(loop.bounds.lower, loop.bounds.upper, loop.bounds.step or 1):
                 loop.variable for loop in loops}
     for stmt in FindNodes(Assignment).visit(routine.body):
         # Loop over all variables and replace them with loop indices
@@ -177,15 +177,17 @@ def resolve_vector_notation(routine):
             ivar_basename = f'i_{stmt.lhs.basename}'
             for i, dim, s in zip(count(), v.dimensions, as_tuple(v.shape)):
                 if isinstance(dim, sym.RangeIndex):
-                    # Create new index variable
-                    vtype = SymbolAttributes(BasicType.INTEGER)
-                    ivar = sym.Variable(name=f'{ivar_basename}_{i}', type=vtype, scope=routine)
                     # create tuple to test whether an appropriate loop is already available
                     test_range = (sym.IntLiteral(1), s, 1) if not isinstance(s, sym.RangeIndex)\
                             else (s.lower, s.upper, 1)
                     # actually test for it
                     if test_range in loop_map:
+                        # Use index variable of available matching loop
                         ivar = loop_map[test_range]
+                    else:
+                        # Create new index variable
+                        vtype = SymbolAttributes(BasicType.INTEGER)
+                        ivar = sym.Variable(name=f'{ivar_basename}_{i}', type=vtype, scope=routine)
                     shape_index_map[(i, s)] = ivar
                     index_range_map[ivar] = s
 


### PR DESCRIPTION
Imagine having:

```fortran
integer :: arr1(n), arr2(n)
arr1(:) = 0
do j=1,n
  arr2(j) = 0
enddo
```

Instead of transforming this to:

```fortran
integer :: arr1(n), arr2(n)
do i_arr1_0=1,n
  arr1(j) = 0
enddo
do j=1,n
  arr2(j) = 0
enddo
```

transform it to:

```fortran
integer :: arr1(n), arr2(n)
do j=1,n
  arr1(j) = 0
enddo
do j=1,n
  arr2(j) = 0
enddo
```

If there is no loop with appropriate bounds introduce new loop variable (like it was before in general).