### PR TITLE
Utilities to merge associate blocks and restrict depth of associate resolution

### DIFF
--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -501,14 +501,14 @@ class Associate(ScopedNode, Section, _AssociateBase):  # pylint: disable=too-man
         """
         An :any:`collections.OrderedDict` of associated expressions.
         """
-        return CaseInsensitiveDict((str(k), v) for k, v in self.associations)
+        return CaseInsensitiveDict((k, v) for k, v in self.associations)
 
     @property
     def inverse_map(self):
         """
         An :any:`collections.OrderedDict` of associated expressions.
         """
-        return CaseInsensitiveDict((str(v), k) for k, v in self.associations)
+        return CaseInsensitiveDict((v, k) for k, v in self.associations)
 
     @property
     def variables(self):

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -23,7 +23,10 @@ from pymbolic.primitives import Expression
 from pydantic.dataclasses import dataclass as dataclass_validated
 from pydantic import model_validator
 
-from loki.expression import Variable, parse_expr
+from loki.expression import (
+    symbols as sym, Variable, parse_expr, AttachScopesMapper,
+    ExpressionDimensionsMapper
+)
 from loki.frontend.source import Source
 from loki.scope import Scope
 from loki.tools import flatten, as_tuple, is_iterable, truncate_string, CaseInsensitiveDict
@@ -513,6 +516,36 @@ class Associate(ScopedNode, Section, _AssociateBase):  # pylint: disable=too-man
     @property
     def variables(self):
         return tuple(v for _, v in self.associations)
+
+    def _derive_local_symbol_types(self, parent_scope):
+        """ Derive the types of locally defined symbols from their associations. """
+
+        rescoped_associations = ()
+        for expr, name in self.associations:
+            # Put symbols in associated expression into the right scope
+            expr = AttachScopesMapper()(expr, scope=parent_scope)
+
+            # Determine type of new names
+            if isinstance(expr, (sym.TypedSymbol, sym.MetaSymbol)):
+                # Use the type of the associated variable
+                _type = expr.type.clone(parent=None)
+                if isinstance(expr, sym.Array) and expr.dimensions is not None:
+                    shape = ExpressionDimensionsMapper()(expr)
+                    if shape == (sym.IntLiteral(1),):
+                        # For a scalar expression, we remove the shape
+                        shape = None
+                    _type = _type.clone(shape=shape)
+            else:
+                # TODO: Handle data type and shape of complex expressions
+                shape = ExpressionDimensionsMapper()(expr)
+                if shape == (sym.IntLiteral(1),):
+                    # For a scalar expression, we remove the shape
+                    shape = None
+                _type = SymbolAttributes(BasicType.DEFERRED, shape=shape)
+            name = name.clone(scope=self, type=_type)
+            rescoped_associations += ((expr, name),)
+
+        self._update(associations=rescoped_associations)
 
     def __repr__(self):
         if self.associations:

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -313,14 +313,14 @@ def test_associate(scope, a_i):
     # TODO: Check constructor failures, auto-casting and frozen status
 
     # Check provided symbol maps
-    assert 'B%a' in assoc.association_map and assoc.association_map['B%a'] == a
-    assert b_a in assoc.association_map and assoc.association_map[b_a] == a
-    assert 'a' in assoc.inverse_map and assoc.inverse_map['a'] == b_a
-    assert a in assoc.inverse_map and assoc.inverse_map[a] == b_a
+    assert 'B%a' in assoc.association_map and assoc.association_map['B%a'] is a
+    assert b_a in assoc.association_map and assoc.association_map[b_a] is a
+    assert 'a' in assoc.inverse_map and assoc.inverse_map['a'] is b_a
+    assert a in assoc.inverse_map and assoc.inverse_map[a] is b_a
 
     # Check rescoping facility
-    assert assign.lhs.scope == scope
-    assert assign2.lhs.scope == scope
+    assert assign.lhs.scope is scope
+    assert assign2.lhs.scope is scope
     assoc.rescope_symbols()
-    assert assign.lhs.scope == assoc
-    assert assign2.lhs.scope == scope
+    assert assign.lhs.scope is assoc
+    assert assign2.lhs.scope is scope

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -239,16 +239,20 @@ class CaseInsensitiveDict(OrderedDict):
     https://stackoverflow.com/questions/2082152/case-insensitive-dictionary
     """
     def __setitem__(self, key, value):
-        super().__setitem__(key.lower(), value)
+        key = key.lower() if isinstance(key, str) else key
+        super().__setitem__(key, value)
 
     def __getitem__(self, key):
-        return super().__getitem__(key.lower())
+        key = key.lower() if isinstance(key, str) else key
+        return super().__getitem__(key)
 
     def get(self, key, default=None):
-        return super().get(key.lower(), default)
+        key = key.lower() if isinstance(key, str) else key
+        return super().get(key, default)
 
     def __contains__(self, key):
-        return super().__contains__(key.lower())
+        key = key.lower() if isinstance(key, str) else key
+        return super().__contains__(key)
 
 
 class CaseInsensitiveDefaultDict(defaultdict):
@@ -256,16 +260,20 @@ class CaseInsensitiveDefaultDict(defaultdict):
     Variant of :any:`collections.defaultdict` that ignores the casing of string keys.
     """
     def __setitem__(self, key, value):
-        super().__setitem__(key.lower(), value)
+        key = key.lower() if isinstance(key, str) else key
+        super().__setitem__(key, value)
 
     def __getitem__(self, key):
-        return super().__getitem__(key.lower())
+        key = key.lower() if isinstance(key, str) else key
+        return super().__getitem__(key)
 
     def get(self, key, default=None):
-        return super().get(key.lower(), default)
+        key = key.lower() if isinstance(key, str) else key
+        return super().get(key, default)
 
     def __contains__(self, key):
-        return super().__contains__(key.lower())
+        key = key.lower() if isinstance(key, str) else key
+        return super().__contains__(key)
 
 
 def strip_inline_comments(source, comment_char='!', str_delim='"\''):

--- a/loki/transformations/sanitise.py
+++ b/loki/transformations/sanitise.py
@@ -244,7 +244,7 @@ class MergeAssociatesTransformer(NestedTransformer):
         body = self.visit(o.body, **kwargs)
 
         if not o.parent or not isinstance(o.parent, ir.Associate):
-            return o._rebuild(body=body)
+            return o._rebuild(body=body, rescope_symbols=True)
 
         # Find all associate mapping that can be moved up
         to_move = tuple(
@@ -271,7 +271,7 @@ class MergeAssociatesTransformer(NestedTransformer):
             (expr, name) for expr, name in o.associations
             if (expr, name) not in to_move
         )
-        return o._rebuild(body=body, associations=new_assocs)
+        return o._rebuild(body=body, associations=new_assocs, rescope_symbols=True)
 
 
 def check_if_scalar_syntax(arg, dummy):

--- a/loki/transformations/sanitise.py
+++ b/loki/transformations/sanitise.py
@@ -14,13 +14,13 @@ code easier.
 
 from loki.batch import Transformation
 from loki.expression import Array, RangeIndex, LokiIdentityMapper
-from loki.ir import nodes as ir, FindNodes, Transformer
+from loki.ir import nodes as ir, FindNodes, Transformer, NestedTransformer
 from loki.tools import as_tuple, dict_override
 from loki.types import BasicType
 
 
 __all__ = [
-    'SanitiseTransformation', 'resolve_associates',
+    'SanitiseTransformation', 'resolve_associates', 'merge_associates',
     'ResolveAssociatesTransformer', 'transform_sequence_association',
     'transform_sequence_association_append_map'
 ]
@@ -192,6 +192,86 @@ class ResolveAssociatesTransformer(Transformer):
         arguments = self.visit(o.arguments, **kwargs)
         kwarguments = tuple((k, self.visit(v, **kwargs)) for k, v in o.kwarguments)
         return o._rebuild(arguments=arguments, kwarguments=kwarguments)
+
+
+def merge_associates(routine, max_parents=None):
+    """
+    Moves associate mappings in :any:`Associate` within a
+    :any:`Subroutine` to the outermost parent scope.
+
+    Please see :any:`MergeAssociatesTransformer` for mode details.
+
+    Note
+    ----
+    This method can be combined with :any:`resolve_associates` to
+    create a more unified look-and-feel for nested ASSOCIATE blocks.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine for which to resolve all associate blocks.
+    max_parents : int, optional
+        Maximum number of parent symbols for valid selector to have.
+    """
+    transformer = MergeAssociatesTransformer(max_parents=max_parents)
+    routine.body = transformer.visit(routine.body)
+
+
+class MergeAssociatesTransformer(NestedTransformer):
+    """
+    :any:`NestedTransformer` that moves associate mappings in
+    :any:`Associate` to parent nodes.
+
+    If a selector expression depends on a symbol from a parent
+    :any:`Associate` exists, it does not get moved.
+
+    Additionally, a maximum parent-depth can be specified for the
+    selector to prevent overly long symbols to be moved up.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine for which to resolve all associate blocks.
+    max_parents : int, optional
+        Maximum number of parent symbols for valid selector to have.
+    """
+
+    def __init__(self, max_parents=None, **kwargs):
+        self.max_parents = max_parents
+        super().__init__(**kwargs)
+
+    def visit_Associate(self, o, **kwargs):
+        body = self.visit(o.body, **kwargs)
+
+        if not o.parent or not isinstance(o.parent, ir.Associate):
+            return o._rebuild(body=body)
+
+        # Find all associate mapping that can be moved up
+        to_move = tuple(
+            (expr, name) for expr, name in o.associations
+            if not expr.scope == o.parent
+        )
+
+        if self.max_parents:
+            # Optionally filter by depth of symbol-parentage
+            to_move = tuple(
+                (expr, name) for expr, name in to_move
+                if not len(expr.parents) > self.max_parents
+            )
+
+        # Move up to parent ...
+        parent_assoc = tuple(
+            (expr, name) for expr, name in to_move
+            if (expr, name) not in o.parent.associations
+        )
+        o.parent._update(associations=o.parent.associations + parent_assoc)
+
+        # ... and remove from this associate node
+        new_assocs = tuple(
+            (expr, name) for expr, name in o.associations
+            if (expr, name) not in to_move
+        )
+        return o._rebuild(body=body, associations=new_assocs)
 
 
 def check_if_scalar_syntax(arg, dummy):

--- a/loki/transformations/tests/test_sanitise.py
+++ b/loki/transformations/tests/test_sanitise.py
@@ -14,8 +14,9 @@ from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes
 
 from loki.transformations.sanitise import (
-    resolve_associates, transform_sequence_association,
-    ResolveAssociatesTransformer, SanitiseTransformation
+    resolve_associates, merge_associates,
+    transform_sequence_association, ResolveAssociatesTransformer,
+    SanitiseTransformation
 )
 
 
@@ -300,6 +301,59 @@ end subroutine transform_associates_partial
     assert assigns[1].rhs == 'a%b(i) + 1.'
     assert assigns[2].lhs == 'b%d(i)'
     assert assigns[2].rhs == 'b%d(i) + 1.'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+))
+def test_merge_associates_nested(frontend):
+    """
+    Test association merging for nested mappings.
+    """
+    fcode = """
+subroutine merge_associates_simple(base)
+  use some_module, only: some_type
+  implicit none
+
+  type(some_type), intent(inout) :: base
+  integer :: i
+  real :: local_var
+
+  associate(a => base%a)
+  associate(b => base%other%symbol, c => a%more)
+  associate(d => base%other%symbol%really%deep, &
+   &        a => base%a)
+    do i=1, 5
+      call another_routine(i, n=b(c)%n)
+
+      d(i) = 42.0
+    end do
+  end associate
+  end associate
+  end associate
+end subroutine merge_associates_simple
+"""
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    assocs = FindNodes(ir.Associate).visit(routine.body)
+    assert len(assocs) == 3
+    assert len(assocs[0].associations) == 1
+    assert len(assocs[1].associations) == 2
+    assert len(assocs[2].associations) == 2
+
+    # Move associate mapping around
+    merge_associates(routine, max_parents=2)
+
+    assocs = FindNodes(ir.Associate).visit(routine.body)
+    assert len(assocs) == 3
+    assert len(assocs[0].associations) == 2
+    assert assocs[0].associations[0] == ('base%a', 'a')
+    assert assocs[0].associations[1] == ('base%other%symbol', 'b')
+    assert len(assocs[1].associations) == 1
+    assert assocs[1].associations[0] == ('a%more', 'c')
+    assert len(assocs[2].associations) == 1
+    assert assocs[2].associations[0] == ('base%other%symbol%really%deep', 'd')
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/tests/test_sanitise.py
+++ b/loki/transformations/tests/test_sanitise.py
@@ -320,9 +320,9 @@ subroutine merge_associates_simple(base)
   real :: local_var
 
   associate(a => base%a)
-  associate(b => base%other%symbol, c => a%more)
+  associate(b => base%other%symbol)
   associate(d => base%other%symbol%really%deep, &
-   &        a => base%a)
+   &        a => base%a, c => a%more)
     do i=1, 5
       call another_routine(i, n=b(c)%n)
 
@@ -339,8 +339,8 @@ end subroutine merge_associates_simple
     assocs = FindNodes(ir.Associate).visit(routine.body)
     assert len(assocs) == 3
     assert len(assocs[0].associations) == 1
-    assert len(assocs[1].associations) == 2
-    assert len(assocs[2].associations) == 2
+    assert len(assocs[1].associations) == 1
+    assert len(assocs[2].associations) == 3
 
     # Move associate mapping around
     merge_associates(routine, max_parents=2)

--- a/loki/transformations/tests/test_sanitise.py
+++ b/loki/transformations/tests/test_sanitise.py
@@ -358,9 +358,7 @@ end subroutine merge_associates_simple
     # Check that body symbols have been rescoped correctly
     call = FindNodes(ir.CallStatement).visit(routine.body)[0]
     b_c_n = call.kwarguments[0][1]  # b(c)%n
-    c = b_c_n.parent.dimensions[0]  # c
     assert b_c_n.scope == assocs[0]
-    assert c.scope == assocs[1]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/tests/test_sanitise.py
+++ b/loki/transformations/tests/test_sanitise.py
@@ -253,6 +253,55 @@ end subroutine transform_associates_partial
     assert assigns[2].rhs == 'some_obj%b(i) + 1.'
 
 
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+))
+def test_transform_associates_start_depth(frontend):
+    """
+    Test resolving associated symbols, but only for a part of an
+    associate's body.
+    """
+    fcode = """
+subroutine transform_associates_partial
+  use some_module, only: some_obj
+  implicit none
+
+  integer :: i
+  real :: local_var
+
+  associate (a=>some_obj%a, b=>some_obj%b)
+  associate (c=>a%b, d=>b%d)
+    local_var = a(1)
+
+    do i=1, some_obj%n
+      c(i) = c(i) + 1.
+      d(i) = d(i) + 1.
+    end do
+  end associate
+  end associate
+end subroutine transform_associates_partial
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    assert len(FindNodes(ir.Assignment).visit(routine.body)) == 3
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    # Resolve all expect the outermost associate block
+    resolve_associates(routine, start_depth=1)
+
+    # Check that associated symbols have been resolved in loop body only
+    assert len(FindNodes(ir.Loop).visit(routine.body)) == 1
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    assert len(assigns) == 3
+    assert assigns[0].lhs == 'local_var'
+    assert assigns[0].rhs == 'a(1)'
+    assert assigns[1].lhs == 'a%b(i)'
+    assert assigns[1].rhs == 'a%b(i) + 1.'
+    assert assigns[2].lhs == 'b%d(i)'
+    assert assigns[2].rhs == 'b%d(i) + 1.'
+
+
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_transform_sequence_assocaition_scalar_notation(frontend, tmp_path):
     fcode = """

--- a/loki/transformations/tests/test_sanitise.py
+++ b/loki/transformations/tests/test_sanitise.py
@@ -355,6 +355,13 @@ end subroutine merge_associates_simple
     assert len(assocs[2].associations) == 1
     assert assocs[2].associations[0] == ('base%other%symbol%really%deep', 'd')
 
+    # Check that body symbols have been rescoped correctly
+    call = FindNodes(ir.CallStatement).visit(routine.body)[0]
+    b_c_n = call.kwarguments[0][1]  # b(c)%n
+    c = b_c_n.parent.dimensions[0]  # c
+    assert b_c_n.scope == assocs[0]
+    assert c.scope == assocs[1]
+
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_transform_sequence_assocaition_scalar_notation(frontend, tmp_path):


### PR DESCRIPTION
~_Note: This sits on top of PR #387 and requires this to be merged first._~

This PR adds a new utility to merge `Associate` blocks and adds a feature to the existing `resolve_associations` method to restrict the starting depth of the association resolution. Combining the two allows for a neat look and feel, where all except the first layer of (non-nested) associations get resolved after all non-nested ones have been merged into the outermost associate block. Tests have been added for both features.

Edit: This one took on a life of its own after the interior mechanics of `ResolveAssociates` were changed ( PR #387 ). As the new resolver relies very strictly on identifying the "depth" via finding the defining scope, the new merge mechanism needs to carefully update the changes scopes to re-build the local symbol table of the `Associate` nodes. This is done by moving the derivation mechanics from the frontend into the IR node and triggering it specifically (comment and suggestions welcome). 

I've also added a rudimentary node-level test for `Associate` nodes and improved the associate mappings to allow symbols as keys, as well as strings. 