### PR TITLE
Skip privatization of arrays with existing data declarations

### DIFF
--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -232,7 +232,7 @@ class SCCDevectorTransformation(Transformation):
         """
 
         with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
-            driver_loops = find_driver_loops(routine=routine, targets=targets)
+            driver_loops = find_driver_loops(section=routine.body, targets=targets)
 
         # remove vector loops
         driver_loop_map = {}
@@ -435,7 +435,7 @@ class SCCRevectorTransformation(Transformation):
 
         if role == 'driver':
             with pragmas_attached(routine, ir.Loop):
-                driver_loops = find_driver_loops(routine=routine, targets=targets)
+                driver_loops = find_driver_loops(section=routine.body, targets=targets)
 
                 for loop in driver_loops:
                     # Revector all marked sections within the driver loop body

--- a/loki/transformations/tests/test_loop_blocking.py
+++ b/loki/transformations/tests/test_loop_blocking.py
@@ -44,7 +44,7 @@ end subroutine test_1d_splitting
     num_loops = len(loops)
     num_vars = len(routine.variable_map)
     with pragmas_attached(routine, Loop):
-        loops = find_driver_loops(routine,
+        loops = find_driver_loops(routine.body,
                                   targets=None)
     splitting_vars, inner_loop, outer_loop = split_loop(routine, loops[0], block_size)
     loops = FindNodes(ir.Loop).visit(routine.ir)
@@ -94,7 +94,7 @@ end subroutine test_1d_splitting_multi_var
     num_loops = len(loops)
     num_vars = len(routine.variable_map)
     with pragmas_attached(routine, Loop):
-        loops = find_driver_loops(routine,
+        loops = find_driver_loops(routine.body,
                                   targets=None)
     splitting_vars, inner_loop, outer_loop = split_loop(routine, loops[0], block_size)
     loops = FindNodes(ir.Loop).visit(routine.ir)
@@ -142,7 +142,7 @@ def test_2d_splitting(tmp_path, frontend, block_size, n):
     num_loops = len(loops)
     num_vars = len(routine.variable_map)
     with pragmas_attached(routine, Loop):
-        loops = find_driver_loops(routine,
+        loops = find_driver_loops(routine.body,
                                   targets=None)
     splitting_vars, inner_loop, outer_loop = split_loop(routine, loops[0], block_size)
     loops = FindNodes(ir.Loop).visit(routine.ir)
@@ -192,7 +192,7 @@ def test_3d_splitting(tmp_path, frontend, block_size, n):
     num_loops = len(loops)
     num_vars = len(routine.variable_map)
     with pragmas_attached(routine, Loop):
-        loops = find_driver_loops(routine,
+        loops = find_driver_loops(routine.body,
                                   targets=None)
     splitting_vars, inner_loop, outer_loop = split_loop(routine, loops[0], block_size)
     loops = FindNodes(ir.Loop).visit(routine.ir)
@@ -250,7 +250,7 @@ end subroutine test_1d_blocking
     routine = Subroutine.from_source(fcode, frontend=frontend)
     loops = FindNodes(ir.Loop).visit(routine.ir)
     with pragmas_attached(routine, Loop):
-        loops = find_driver_loops(routine,
+        loops = find_driver_loops(routine.body,
                                   targets=None)
 
     num_loops = len(loops)
@@ -309,7 +309,7 @@ end subroutine test_1d_blocking_multi_intent
     routine = Subroutine.from_source(fcode, frontend=frontend)
     loops = FindNodes(ir.Loop).visit(routine.ir)
     with pragmas_attached(routine, Loop):
-        loops = find_driver_loops(routine,
+        loops = find_driver_loops(routine.body,
                                   targets=None)
 
     num_loops = len(loops)
@@ -372,7 +372,7 @@ def test_2d_blocking(tmp_path, frontend, block_size, n):
     num_loops = len(loops)
     num_vars = len(routine.variable_map)
     with pragmas_attached(routine, Loop):
-        loops = find_driver_loops(routine,
+        loops = find_driver_loops(routine.body,
                                   targets=None)
     splitting_vars, inner_loop, outer_loop = split_loop(routine, loops[0], block_size)
     loops = FindNodes(ir.Loop).visit(routine.ir)
@@ -432,7 +432,7 @@ def test_3d_blocking(tmp_path, frontend, block_size, n):
     num_loops = len(loops)
     num_vars = len(routine.variable_map)
     with pragmas_attached(routine, Loop):
-        loops = find_driver_loops(routine,
+        loops = find_driver_loops(routine.body,
                                   targets=None)
     splitting_vars, inner_loop, outer_loop = split_loop(routine, loops[0], block_size)
     loops = FindNodes(ir.Loop).visit(routine.ir)

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -595,16 +595,16 @@ def is_driver_loop(loop, targets):
     return False
 
 
-def find_driver_loops(routine, targets):
+def find_driver_loops(section, targets):
     """
-    Find and return all driver loops of a given `routine`.
+    Find and return all driver loops in a given `section`.
 
     A *driver loop* is specified either by a call to a routine within
     `targets` or by the pragma `!$loki driver-loop`.
 
     Parameters
     ----------
-    routine : :any:`Subroutine`
+    section : :any:`Section` or tuple
         The subroutine in which to find the driver loops.
     targets : list or string
         List of subroutines that are to be considered as part of
@@ -613,7 +613,7 @@ def find_driver_loops(routine, targets):
 
     driver_loops = []
     nested_driver_loops = []
-    for loop in FindNodes(ir.Loop).visit(routine.body):
+    for loop in FindNodes(ir.Loop).visit(section):
         if loop in nested_driver_loops:
             continue
 


### PR DESCRIPTION
Arrays with existing data declarations should not be privatized in the driver gang loop. This PR adds the functionality to gather information from encompassing `!$acc data` regions and filter out the relevant arrays.