### PR TITLE
Fix representation of array return type in OMNI frontend

### DIFF
--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -579,6 +579,11 @@ class OMNI2IR(GenericVisitor):
                     # why we restore the return_type
                     _type = _type.dtype.return_type
 
+                    # If the return type has a shape, we need to apply this as a dimension to the
+                    # variable, otherwise it will be missing from the declaration
+                    if _type.shape:
+                        variable = variable.clone(dimensions=_type.shape)
+
         else:
             raise ValueError
 


### PR DESCRIPTION
The translation of the OMNI AST into the Loki IR dropped the shape information of the return type, representing the return value always as scalar. This PR fixes the behaviour and adds a test.

Small caveat is that with OMNI the dimension information will always be put on the variable, i.e., both
* `real, dimension(n) :: ret_val`
* `real :: ret_val(n)`
will always be represented as the latter. But since string-identical parse-unparse cycle is not achievable with OMNI anyway, I consider this not too important. Please shout if you disagree.

This PR should fix the problems that @MichaelSt98 encountered with OMNI in #378.