### PR TITLE
SingleColumn: Fix vectorisation of nested else-if bodies

### DIFF
--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -704,6 +704,16 @@ class Conditional(InternalNode, _ConditionalBase):
             return f'Conditional:: {self.name}'
         return 'Conditional::'
 
+    @property
+    def else_bodies(self):
+        """
+        Return all nested node tuples in the ``ELSEIF``/``ELSE`` part
+        of the conditional chain.
+        """
+        if self.has_elseif:
+            return (self.else_body[0].body,) + self.else_body[0].else_bodies
+        return (self.else_body,)
+
 
 @dataclass_strict(frozen=True)
 class _PragmaRegionBase():

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -712,7 +712,7 @@ class Conditional(InternalNode, _ConditionalBase):
         """
         if self.has_elseif:
             return (self.else_body[0].body,) + self.else_body[0].else_bodies
-        return (self.else_body,)
+        return (self.else_body,) if self.else_body else ()
 
 
 @dataclass_strict(frozen=True)

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -179,6 +179,25 @@ def test_multi_conditional(scope, one, i, n, a_i):
     assert isinstance(else_bodies[2][0], ir.Assignment)
     assert else_bodies[2][0].lhs == 'a(i)' and else_bodies[2][0].rhs == '42.0'
 
+    # Not try without the final else
+    multicond = ir.Conditional(
+        condition=sym.Comparison(i, '==', sym.IntLiteral(1)),
+        body=ir.Assignment(lhs=a_i, rhs=sym.Literal(1.0)),
+    )
+    for idx in range(2, 4):
+        multicond = ir.Conditional(
+            condition=sym.Comparison(i, '==', sym.IntLiteral(idx)),
+            body=ir.Assignment(lhs=a_i, rhs=sym.Literal(float(idx))),
+            else_body=multicond, has_elseif=True
+        )
+    else_bodies = multicond.else_bodies
+    assert len(else_bodies) == 2
+    assert all(isinstance(b, tuple) for b in else_bodies)
+    assert isinstance(else_bodies[0][0], ir.Assignment)
+    assert else_bodies[0][0].lhs == 'a(i)' and else_bodies[0][0].rhs == '2.0'
+    assert isinstance(else_bodies[1][0], ir.Assignment)
+    assert else_bodies[1][0].lhs == 'a(i)' and else_bodies[1][0].rhs == '1.0'
+
 
 def test_section(scope, one, i, n, a_n, a_i):
     """

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -151,6 +151,35 @@ def test_conditional(scope, one, i, n, a_i):
     # TODO: Test inline, name, has_elseif
 
 
+def test_multi_conditional(scope, one, i, n, a_i):
+    """
+    Test nested chains of constructors of :any:`Conditional` to form
+    multi-conditional.
+    """
+    multicond = ir.Conditional(
+        condition=sym.Comparison(i, '==', sym.IntLiteral(1)),
+        body=ir.Assignment(lhs=a_i, rhs=sym.Literal(1.0)),
+        else_body=ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
+    )
+    for idx in range(2, 4):
+        multicond = ir.Conditional(
+            condition=sym.Comparison(i, '==', sym.IntLiteral(idx)),
+            body=ir.Assignment(lhs=a_i, rhs=sym.Literal(float(idx))),
+            else_body=multicond, has_elseif=True
+        )
+
+    # Check that we can recover all bodies from a nested else-if construct
+    else_bodies = multicond.else_bodies
+    assert len(else_bodies) == 3
+    assert all(isinstance(b, tuple) for b in else_bodies)
+    assert isinstance(else_bodies[0][0], ir.Assignment)
+    assert else_bodies[0][0].lhs == 'a(i)' and else_bodies[0][0].rhs == '2.0'
+    assert isinstance(else_bodies[1][0], ir.Assignment)
+    assert else_bodies[1][0].lhs == 'a(i)' and else_bodies[1][0].rhs == '1.0'
+    assert isinstance(else_bodies[2][0], ir.Assignment)
+    assert else_bodies[2][0].lhs == 'a(i)' and else_bodies[2][0].rhs == '42.0'
+
+
 def test_section(scope, one, i, n, a_n, a_i):
     """
     Test constructors and behaviour of :any:`Section` nodes.

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -140,12 +140,8 @@ class SCCDevectorTransformation(Transformation):
                 # we need to prevent that the whole 'else_body' is wrapped in a section,
                 # as 'Conditional's rely on the fact that the first element of the 'else_body'
                 # (if 'has_elseif') is a Conditional itself
-                if separator.has_elseif and separator.else_body:
-                    subsec_else = cls.extract_vector_sections(separator.else_body[0].body, horizontal)
-                else:
-                    subsec_else = cls.extract_vector_sections(separator.else_body, horizontal)
-                if subsec_else:
-                    subsections += subsec_else
+                for ebody in separator.else_bodies:
+                    subsections += cls.extract_vector_sections(ebody, horizontal)
 
             if isinstance(separator, ir.MultiConditional):
                 for body in separator.bodies:

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -137,8 +137,8 @@ class SCCDevectorTransformation(Transformation):
                 subsec_body = cls.extract_vector_sections(separator.body, horizontal)
                 if subsec_body:
                     subsections += subsec_body
-                # we need to prevent that the whole 'else_body' is wrapped in a section,
-                # as 'Conditional's rely on the fact that the first element of the 'else_body'
+                # we need to prevent that all (possibly nested) 'else_bodies' are completely wrapped as a section,
+                # as 'Conditional's rely on the fact that the first element of each 'else_body'
                 # (if 'has_elseif') is a Conditional itself
                 for ebody in separator.else_bodies:
                     subsections += cls.extract_vector_sections(ebody, horizontal)


### PR DESCRIPTION
The recent special-casing for else-if branches in the SCC vectorisation only works for single-level nesting, but skips any further nested else-ifs and the final else-branch. TO fix this, i've introduced a `else_bodies` property on `Conditional` nodes that returns the nested bodies for multi-conditionals. Using this, this we can then apply vector-section extraction for every else body in a deeply nested multi-conditional.