### PR TITLE
Logging: Small log-level sanitisation and CLI flags 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,37 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Local pytest plugin to add bespoke pytest extensions for Loki
+
+See the pytest documentation for more details:
+https://docs.pytest.org/en/stable/how-to/writing_plugins.html#local-conftest-plugins
+"""
+
+from loki.config import config as loki_config
+
+
+def pytest_addoption(parser, pluginmanager):  # pylint: disable=unused-argument
+    """
+    Add options to the pytest CLI
+
+    Additional options can be specified via ``parser.addoption`` using the same signature as
+    :any:`argparse.ArgumentParser.add_argument`.
+
+    For Loki, we add ``--loki-log-level`` to overwrite the log level in :any:`loki.logging`.
+    """
+    parser.addoption('--loki-log-level', dest='LOKI_LOG_LEVEL', default='INFO',
+                     help='Change the Loki log level (ERROR, WARNING, INFO, PERF, DETAIL, DEBUG)')
+
+
+def pytest_configure(config):
+    """
+    Apply configuration changes
+
+    This function is invoked after all command line options have been processed
+    """
+    loki_config['log-level'] = config.option.LOKI_LOG_LEVEL

--- a/loki/__init__.py
+++ b/loki/__init__.py
@@ -46,8 +46,7 @@ config.register('print-config', False, env_variable='LOKI_PRINT_CONFIG',
                 preprocess=lambda i: bool(i) if isinstance(i, int) else i)
 
 # Define Loki's global config options
-config.register('log-level', 'INFO', env_variable='LOKI_LOGGING',
-                callback=set_log_level, preprocess=lambda i: log_levels[i])
+config.register('log-level', 'INFO', callback=set_log_level, preprocess=lambda i: log_levels[i])
 
 config.register('debug', None, env_variable='LOKI_DEBUG',
                 callback=set_excepthook, preprocess=lambda i: auto_post_mortem_debugger if i else None)

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -283,7 +283,7 @@ class Scheduler:
         # Re-build the SGraph after parsing to pick up all new connections
         self._sgraph = SGraph.from_seed(self.seeds, self.item_factory, self.config)
 
-    @Timer(logger=info, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')
+    @Timer(logger=perf, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')
     def _enrich(self):
         """
         For items that have a specific enrichment list provided as part of their

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -15,7 +15,7 @@ from loki.batch.item import (
     InterfaceItem, ProcedureItem, ProcedureBindingItem, TypeDefItem
 )
 from loki.batch.sfilter import SFilter
-from loki.logging import info, warning, debug
+from loki.logging import debug, perf, warning
 from loki.tools import as_tuple
 
 
@@ -39,7 +39,7 @@ class SGraph:
         self._graph = nx.DiGraph()
 
     @classmethod
-    @Timer(logger=info, text='[Loki::Scheduler] Built SGraph from seed in {:.2f}s')
+    @Timer(logger=perf, text='[Loki::Scheduler] Built SGraph from seed in {:.2f}s')
     def from_seed(cls, seed, item_factory, config=None):
         """
         Create a new :any:`SGraph` using :data:`seed` as starting point.

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -36,7 +36,7 @@ from loki.expression.operations import (
     StringConcat, ParenthesisedAdd, ParenthesisedMul, ParenthesisedDiv, ParenthesisedPow
 )
 from loki.expression import ExpressionDimensionsMapper, AttachScopesMapper
-from loki.logging import debug, perf, info, warning, error
+from loki.logging import debug, detail, info, warning, error
 from loki.tools import (
     as_tuple, flatten, CaseInsensitiveDict, LazyNodeLookup, dict_override
 )
@@ -59,7 +59,7 @@ def parse_fparser_file(filename):
     return parse_fparser_source(source=fcode)
 
 
-@Timer(logger=perf, text=lambda s: f'[Loki::FP] Executed parse_fparser_source in {s:.2f}s')
+@Timer(logger=detail, text=lambda s: f'[Loki::FP] Executed parse_fparser_source in {s:.2f}s')
 def parse_fparser_source(source):
     """
     Generate a parse tree from string
@@ -81,7 +81,7 @@ def parse_fparser_source(source):
     return f2008_parser(reader)
 
 
-@Timer(logger=perf, text=lambda s: f'[Loki::FP] Executed parse_fparser_ast in {s:.2f}s')
+@Timer(logger=detail, text=lambda s: f'[Loki::FP] Executed parse_fparser_ast in {s:.2f}s')
 def parse_fparser_ast(ast, raw_source, pp_info=None, definitions=None, scope=None):
     """
     Generate an internal IR from fparser parse tree

--- a/loki/frontend/preprocessing.py
+++ b/loki/frontend/preprocessing.py
@@ -15,7 +15,7 @@ import re
 import pcpp
 from codetiming import Timer
 
-from loki.logging import debug, perf
+from loki.logging import debug, detail
 from loki.config import config
 from loki.tools import as_tuple, gettempdir, filehash
 from loki.ir import VariableDeclaration, Intrinsic, FindNodes
@@ -95,7 +95,7 @@ def preprocess_cpp(source, filepath=None, includes=None, defines=None):
     return s.getvalue()
 
 
-@Timer(logger=perf, text=lambda s: f'[Loki::Frontend] Executed sanitize_input in {s:.2f}s')
+@Timer(logger=detail, text=lambda s: f'[Loki::Frontend] Executed sanitize_input in {s:.2f}s')
 def sanitize_input(source, frontend):
     """
     Apply internal regex-based sanitisation rules to filter out known

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -20,7 +20,7 @@ from loki.ir import (
     ProcedureDeclaration, Loop, Intrinsic, Pragma
 )
 from loki.frontend.source import join_source_list
-from loki.logging import warning, perf, error
+from loki.logging import detail, warning, error
 from loki.tools import group_by_class, replace_windowed, as_tuple
 
 
@@ -299,7 +299,7 @@ class RangeIndexTransformer(Transformer):
         return o.clone(symbols=mapper(o.symbols, recurse_to_declaration_attributes=True))
 
 
-@Timer(logger=perf, text=lambda s: f'[Loki::Frontend] Executed sanitize_ir in {s:.2f}s')
+@Timer(logger=detail, text=lambda s: f'[Loki::Frontend] Executed sanitize_ir in {s:.2f}s')
 def sanitize_ir(_ir, frontend, pp_registry=None, pp_info=None):
     """
     Utility function to sanitize internal representation after creating it

--- a/loki/logging.py
+++ b/loki/logging.py
@@ -67,22 +67,26 @@ INFO = logging.INFO
 WARNING = logging.WARNING
 ERROR = logging.ERROR
 PERF = 15
+DETAIL = 12
 
 # Internally accepted log levels
 log_levels = {
     'DEBUG': DEBUG,
+    'DETAIL': DETAIL,
     'PERF': PERF,
     'INFO': INFO,
     'WARNING': WARNING,
     'ERROR': ERROR,
     # Lower case keywords for env variables
     'debug': DEBUG,
+    'detail': DETAIL,
     'perf': PERF,
     'info': INFO,
     'warning': WARNING,
     'error': ERROR,
     # Enum keys for idempotence
     DEBUG: DEBUG,
+    DETAIL: DETAIL,
     PERF: PERF,
     INFO: INFO,
     WARNING: WARNING,
@@ -96,6 +100,7 @@ BLUE = '\033[1;37;34m%s\033[0m'
 GREEN = '\033[1;37;32m%s\033[0m'
 colors = {
     DEBUG: NOCOLOR,
+    DETAIL: GREEN,
     PERF: GREEN,
     INFO: GREEN,
     WARNING: BLUE,
@@ -124,18 +129,82 @@ def log(msg, level, *args, **kwargs):
 
 
 def debug(msg, *args, **kwargs):
+    """
+    Logger method for most verbose level of output
+
+    Parameters
+    ----------
+    msg : str
+        Message to log at :any:`DEBUG` level.
+    """
     log(msg, DEBUG, *args, **kwargs)
 
+def detail(msg, *args, **kwargs):
+    """
+    Logger method for detailed, per-file information.
 
-def info(msg, *args, **kwargs):
-    log(msg, INFO, *args, **kwargs)
+    This level should be used for timing and detailed information at a
+    per-file level, which can get verbose.
+
+    Parameters
+    ----------
+    msg : str
+        Message to log at :any:`DETAIL` level.
+    """
+    log(msg, DETAIL, *args, **kwargs)
 
 def perf(msg, *args, **kwargs):
+    """
+    Logger method for performance information.
+
+    This level should be used for timing individual processes at a
+    global granularity during batch-processing.
+
+    Parameters
+    ----------
+    msg : str
+        Message to log at :any:`DETAIL` level.
+    """
     log(msg, PERF, *args, **kwargs)
 
+def info(msg, *args, **kwargs):
+    """
+    Logger method for high-level progress information.
+
+    This is the default output logging and should only be used at a
+    global granularity during batch-processing.
+
+    Parameters
+    ----------
+    msg : str
+        Message to log at :any:`INFO` level.
+    """
+    log(msg, INFO, *args, **kwargs)
+
 def warning(msg, *args, **kwargs):
+    """
+    Logger method for high-level progress information.
+
+    This level should be used for potentially dangerous, but not fatal
+    information.
+
+    Parameters
+    ----------
+    msg : str
+        Message to log at :any:`WARN` level.
+    """
     log(msg, WARNING, *args, **kwargs)
 
-
 def error(msg, *args, **kwargs):
+    """
+    Logger method for high-level progress information.
+
+    This level should be used to provide additional information in
+    case of failures.
+
+    Parameters
+    ----------
+    msg : str
+        Message to log at :any:`ERROR` level.
+    """
     log(msg, ERROR, *args, **kwargs)

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -22,7 +22,7 @@ from loki.frontend import (
 
 )
 from loki.ir import Section, RawSource, Comment, PreprocessorDirective
-from loki.logging import info, debug, perf
+from loki.logging import debug, detail, perf
 from loki.module import Module
 from loki.program_unit import ProgramUnit
 from loki.subroutine import Subroutine
@@ -110,9 +110,9 @@ class Sourcefile:
         if isinstance(frontend, str):
             frontend = Frontend[frontend.upper()]
 
-        # Log full parses at INFO and regex scans at PERF level
+        # Log full parses at INFO and regex scans at DETAIL level
         log = f'[Loki::Sourcefile] Constructed from {filename}' + ' in {:.2f}s'
-        with Timer(logger=perf if frontend is REGEX else info, text=log):
+        with Timer(logger=detail if frontend is REGEX else perf, text=log):
 
             filepath = Path(filename)
             raw_source = read_file(filepath)
@@ -365,7 +365,7 @@ class Sourcefile:
         frontend = frontend_args.pop('frontend', FP)
 
         log = f'[Loki::Sourcefile] Finished constructing from {self.path}' + ' in {:.2f}s'
-        with Timer(logger=debug if frontend == REGEX else info, text=log):
+        with Timer(logger=debug if frontend == REGEX else perf, text=log):
 
             # Sanitize frontend_args
             if isinstance(frontend, str):
@@ -583,7 +583,7 @@ class Sourcefile:
         """
         Same as :meth:`write` but can be called from a static context.
         """
-        info(f'[Loki::Sourcefile] Writing to {path}')
+        detail(f'[Loki::Sourcefile] Writing to {path}')
         with path.open('w') as f:
             f.write(source)
             if source[-1] != '\n':

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -16,11 +16,10 @@ from pathlib import Path
 import click
 
 from loki import (
-    Sourcefile, Frontend, as_tuple, set_excepthook,
-    auto_post_mortem_debugger, info
+    config as loki_config, Sourcefile, Frontend, as_tuple,
+    set_excepthook, auto_post_mortem_debugger, info
 )
 from loki.batch import Transformation, Pipeline, Scheduler, SchedulerConfig
-from loki.logging import set_log_level, log_levels
 
 # Get generalized transformations provided by Loki
 from loki.transformations.argument_shape import (
@@ -135,7 +134,7 @@ def convert(
     :any:`Transformation` objects to this call tree.
     """
 
-    set_log_level(log_levels[log_level])
+    loki_config['log-level'] = log_level
 
     info(f'[Loki] Batch-processing source files using config: {config} ')
 
@@ -447,7 +446,7 @@ def plan(
     given configuration.
     """
 
-    set_log_level(log_levels[log_level])
+    loki_config['log-level'] = log_level
 
     info(f'[Loki] Creating CMake plan file from config: {config}')
     config = SchedulerConfig.from_file(config)

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -20,6 +20,7 @@ from loki import (
     auto_post_mortem_debugger, info
 )
 from loki.batch import Transformation, Pipeline, Scheduler, SchedulerConfig
+from loki.logging import set_log_level, log_levels
 
 # Get generalized transformations provided by Loki
 from loki.transformations.argument_shape import (
@@ -113,12 +114,15 @@ def cli(debug):
               help="Recursively derive explicit shape dimension for argument arrays")
 @click.option('--eliminate-dead-code/--no-eliminate-dead-code', default=True,
               help='Perform dead code elimination, where unreachable branches are trimmed from the code.')
+@click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
+              type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
+              help='Log level to output during batch processing')
 def convert(
         mode, config, build, source, header, cpp, directive, include, define, omni_include, xmod,
         data_offload, remove_openmp, assume_deviceptr, frontend, trim_vector_sections,
         global_var_offload, remove_derived_args, inline_members, inline_marked,
         resolve_sequence_association, resolve_sequence_association_inlined_calls,
-        derive_argument_array_shape, eliminate_dead_code
+        derive_argument_array_shape, eliminate_dead_code, log_level
 ):
     """
     Batch-processing mode for Fortran-to-Fortran transformations that
@@ -130,6 +134,8 @@ def convert(
     automatic call-tree exploration and apply a set of
     :any:`Transformation` objects to this call tree.
     """
+
+    set_log_level(log_levels[log_level])
 
     info(f'[Loki] Batch-processing source files using config: {config} ')
 
@@ -429,11 +435,19 @@ def convert(
               help='Generate and display the subroutine callgraph.')
 @click.option('--plan-file', type=click.Path(),
               help='CMake "plan" file to generate.')
-def plan(mode, config, header, source, build, root, cpp, directive, frontend, callgraph, plan_file):
+@click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
+              type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
+              help='Log level to output during batch processing')
+def plan(
+         mode, config, header, source, build, root, cpp, directive,
+         frontend, callgraph, plan_file, log_level
+):
     """
     Create a "plan", a schedule of files to inject and transform for a
     given configuration.
     """
+
+    set_log_level(log_levels[log_level])
 
     info(f'[Loki] Creating CMake plan file from config: {config}')
     config = SchedulerConfig.from_file(config)


### PR DESCRIPTION
This PR brings a small clean-up and adjustments of our log-levels in preparation for some scheduler work. In particular it does:
* Introduce a new log-level DETAIL to capture per-file info in a batch processing context. This sits below PERF, so that PERF can be used for scheduler things without completely clobbering things with per-file output
* Docstrings for the specific log-levels to give some rough guidance on how to use them
* Adjustements to most of the frontend and scheduler timer logging; we now only output high-level timers for scheduler actions (no nested info!) and put the nested sub-components on PERF. Similarly, only the heavy IR parse stays at per-file level with PERF (as before with INFO), and all other frontend timers are put to DETAIL.
* The `--log-level` option is added to `loki-transform.py [convert | plan]` to expose log-levels explicitly. These then set the log_level, but can also be overridden with `LOKI_LOGGING` as before. The original central flag handling still works for debugging in the code base.

Last note: This is just a first attempt at improvements. There's a lot more we can do to improve logging in general, and I'm open for any pointers and/or opinions. Therefore posting as draft for initially for feedback.  