### PR TITLE
Transformations: Remove routine pragmas when inlining functions

### DIFF
--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -601,7 +601,7 @@ def map_call_to_procedure_body(call, caller, callee=None):
         callee.body.body, scope=caller
     )
 
-    # Substitute 'loki routine' pragmas
+    # Remove 'loki routine' pragmas
     callee_body = Transformer(
         {pragma: None for pragma in FindNodes(Pragma).visit(callee_body)
          if is_loki_pragma(pragma, starts_with='routine')}

--- a/loki/transformations/inline.py
+++ b/loki/transformations/inline.py
@@ -17,7 +17,7 @@ from loki.ir import (
     Import, Comment, Assignment, VariableDeclaration, CallStatement,
     Transformer, FindNodes, pragmas_attached, is_loki_pragma, Interface,
     StatementFunction, FindVariables, FindInlineCalls, FindLiterals,
-    SubstituteExpressions, ExpressionFinder
+    SubstituteExpressions, ExpressionFinder, Pragma
 )
 from loki.expression import (
     symbols as sym, LokiIdentityMapper, ExpressionRetriever
@@ -600,6 +600,12 @@ def map_call_to_procedure_body(call, caller, callee=None):
     callee_body = SubstituteExpressions(argmap, rebuild_scopes=True).visit(
         callee.body.body, scope=caller
     )
+
+    # Substitute 'loki routine' pragmas
+    callee_body = Transformer(
+        {pragma: None for pragma in FindNodes(Pragma).visit(callee_body)
+         if is_loki_pragma(pragma, starts_with='routine')}
+    ).visit(callee_body)
 
     # Inline substituted body within a pair of marker comments
     comment = Comment(f'! [Loki] inlined child subroutine: {callee.name}')

--- a/loki/transformations/tests/test_inline.py
+++ b/loki/transformations/tests/test_inline.py
@@ -50,6 +50,7 @@ contains
     real(kind=real64) :: multiply
     real(kind=real64), intent(in) :: a, b
     real(kind=real64) :: temp
+    !$loki routine seq
 
     ! simulate multi-line function
     temp = a * b
@@ -93,6 +94,9 @@ end subroutine transform_inline_elemental_functions
 
     # Verify correct scope of inlined elements
     assert all(v.scope is routine for v in FindVariables().visit(routine.body))
+
+    # Ensure the !$loki routine pragma has been removed
+    assert not FindNodes(ir.Pragma).visit(routine.body)
 
     # Hack: rename routine to use a different filename in the build
     routine.name = f'{routine.name}_'


### PR DESCRIPTION
When inlining functions we need to remove any routine-level pragmas, such as `!$loki routine seq`, so as not to erroneously mark the caller body with them. This change adds a removal step and should hopefully fix ec-physics regression.