### PR TITLE
Improve representation of procedure pointers (fix #393)

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -944,6 +944,13 @@ class FParser2IR(GenericVisitor):
         if return_type is None:
             interface = self.visit(o.children[0], **kwargs)
             interface = AttachScopesMapper()(interface, scope=scope)
+            if interface.type.dtype is BasicType.DEFERRED:
+                # This is (presumably!) an external function with explicit interface that we
+                # don't know because the type information is not available, e.g., because it's been
+                # imported from another module or sits in an intfb.h header file.
+                # So, we create a ProcedureType object with the interface name and use that
+                dtype = ProcedureType(interface.name)
+                interface = interface.clone(type=interface.type.clone(dtype=dtype))
             _type = interface.type.clone(**attrs)
         else:
             interface = return_type.dtype
@@ -978,7 +985,7 @@ class FParser2IR(GenericVisitor):
         * attribute name (`str`)
         * attribute value (such as ``IN``, ``OUT``, ``INOUT``) or `None`
         """
-        return (o.children[0].lower(), o.children[1].lower() if o.children[1] is not None else True)
+        return (o.children[0].lower(), str(o.children[1]).lower() if o.children[1] is not None else True)
 
     visit_Proc_Decl_List = visit_List
 

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1098,15 +1098,23 @@ class OFP2IR(GenericVisitor):
             # Update symbol table entries
             if isinstance(_type.dtype, ProcedureType):
                 scope.symbol_attrs.update({var.name: var.type.clone(**_type.__dict__) for var in symbols})
-            else:
-                # This is (presumably!) an external or dummy function with implicit interface,
-                # which is declared as `PROCEDURE(<return_type>) [::] <name>`. Easy, isn't it...?
-                # Great, now we have to update each symbol's type one-by-one...
-                assert o.find('procedure-declaration-stmt').get('hasProcInterface')
-                interface = _type.dtype
-                for var in symbols:
-                    dtype = ProcedureType(var.name, is_function=True, return_type=_type)
-                    scope.symbol_attrs[var.name] = var.type.clone(dtype=dtype)
+            elif o.find('procedure-declaration-stmt').get('hasProcInterface'):
+                if o.find('proc-interface').get('id'):
+                    # This is (presumably!) an external function with explicit interface that we
+                    # don't know because the type information is not available, e.g., because it's been
+                    # imported from another module or sits in an intfb.h header file.
+                    # So, we create a ProcedureType object with the proc-interface name and use that
+                    dtype = ProcedureType(o.find('proc-interface').get('id'))
+                    _type = _type.clone(dtype=dtype)
+                    scope.symbol_attrs.update({var.name: var.type.clone(**_type.__dict__) for var in symbols})
+                else:
+                    # This is (presumably!) an external or dummy function with implicit interface,
+                    # which is declared as `PROCEDURE(<return_type>) [::] <name>`. Easy, isn't it...?
+                    # Great, now we have to update each symbol's type one-by-one...
+                    interface = _type.dtype
+                    for var in symbols:
+                        dtype = ProcedureType(var.name, is_function=True, return_type=_type)
+                        scope.symbol_attrs[var.name] = var.type.clone(dtype=dtype)
 
             # Rescope variables so they know their type
             symbols = tuple(var.rescope(scope=scope) for var in symbols)

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -1114,7 +1114,7 @@ class OFP2IR(GenericVisitor):
                     interface = _type.dtype
                     for var in symbols:
                         dtype = ProcedureType(var.name, is_function=True, return_type=_type)
-                        scope.symbol_attrs[var.name] = var.type.clone(dtype=dtype)
+                        scope.symbol_attrs[var.name] = _type.clone(dtype=dtype)
 
             # Rescope variables so they know their type
             symbols = tuple(var.rescope(scope=scope) for var in symbols)

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -572,9 +572,12 @@ class OMNI2IR(GenericVisitor):
                     )
                     _type = _type.clone(dtype=dtype)
 
-                if tast.attrib.get('is_external') == 'true':
-                    _type.external = True
-                elif variable == kwargs['scope'].name and _type.dtype.return_type is not None:
+                if variable != kwargs['scope'].name:
+                    # Instantiate the symbol representing the procedure in the current scope to create
+                    # relevant symbol table entries, and then extract the dtype
+                    dtype = kwargs['scope'].Variable(name=_type.dtype.name).type.dtype
+                    _type = _type.clone(dtype=dtype)
+                elif _type.dtype.return_type is not None:
                     # This is the declaration of the return type inside a function, which is
                     # why we restore the return_type
                     _type = _type.dtype.return_type
@@ -583,6 +586,9 @@ class OMNI2IR(GenericVisitor):
                     # variable, otherwise it will be missing from the declaration
                     if _type.shape:
                         variable = variable.clone(dimensions=_type.shape)
+
+                if tast.attrib.get('is_external') == 'true':
+                    _type.external = True
 
         else:
             raise ValueError


### PR DESCRIPTION
This was triggered by the fgen issue reported in #393. This looked first like the issue was simply that we did not account for the case that procedure information might be missing when generating the code for procedure declarations.

However, while trying to sort this out across frontends, I noticed that it should be perfectly possible to recognize the interface as a procedure in this situation, and that the handling of procedure types for symbols declared in procedure declarations was very inconsistent and partially wrong. This should fix this discrepancy.