### PR TITLE
Fix function inlining when only interface is available (fixes #397)

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -394,6 +394,13 @@ class FParser2IR(GenericVisitor):
         # This should go away once fparser has a basic symbol table, see
         # https://github.com/stfc/fparser/issues/201 for some details
         _type = kwargs['scope'].symbol_attrs.lookup(name.name)
+        if _type is None and (definition := self.definitions.get(name.name)):
+            # We don't have any type information for this, which means it has
+            # not been declared locally. Check the definitions for enriched
+            # type information:
+            if isinstance(dtype := definition.procedure_type, ProcedureType):
+                _type = name.type.clone(dtype=dtype)
+                name = name.clone(type=_type)
         if _type and isinstance(_type.dtype, ProcedureType):
             name = name.clone(dimensions=None)
             call = sym.InlineCall(name, parameters=dimensions, kw_parameters=())

--- a/loki/logging.py
+++ b/loki/logging.py
@@ -13,7 +13,7 @@ import sys
 
 
 __all__ = ['logger', 'log_levels', 'set_log_level', 'FileLogger',
-           'debug', 'info', 'warning', 'error', 'log']
+           'debug', 'detail', 'perf', 'info', 'warning', 'error', 'log']
 
 
 def FileLogger(name, filename, level=None, file_level=None, fmt=None,


### PR DESCRIPTION
This adds the missing test for `InlineSubstitutionMapper`, expanded to four different cases:

1. Inline call provided as a module import, module available
2. Inline call provided as a module import, module not available
3. Inline call provided via an interface block
4. Inline call provided via an interface that is imported via c preprocessor (i.e., no interface available)

This includes a small fix to the mapper for the third case, where procedure information is available but that referes only to the interface, i.e., no body for inlining is present.

Let's see what codecov says...