### PR TITLE
Add option to install "plain OMNI" to install script and upgrade Github actions runners

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -17,7 +17,7 @@ jobs:
   regression_tests:
     name: Python ${{ matrix.python-version }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false  # false: try to complete all jobs
       matrix:
@@ -66,7 +66,9 @@ jobs:
 
       - name: Install Loki
         run: |
-          ./install --with-claw --with-ofp --with-tests --without-dace
+          export JAVA_HOME=${JAVA_HOME_11_X64}
+          ./install --with-omni --with-ofp --with-tests --without-dace
+          echo "export JAVA_HOME=${JAVA_HOME_11_X64}" >> loki-activate
 
       - name: Install up-to-date CMake
         run: |
@@ -81,7 +83,6 @@ jobs:
       - name: Run CLOUDSC and ECWAM regression tests
         env:
           CLOUDSC_DIR: ${{ github.workspace }}/cloudsc
-          CLOUDSC_ARCH: ${{ github.workspace }}/cloudsc/arch/github/ubuntu/gnu/9.4.0
           ECWAM_DIR: ${{ github.workspace }}/ecwam
           OMP_STACKSIZE: 4G
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,16 +29,16 @@ jobs:
 
         include:
           - name: linux python-3.8
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             python-version: '3.8'
           - name: linux python-3.9
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             python-version: '3.9'
           - name: linux python-3.10
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             python-version: '3.10'
           - name: linux python-3.11
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             python-version: '3.11'
           - name: macos python-3.11
             os: macos-14
@@ -84,7 +84,9 @@ jobs:
             echo "export F90=gfortran-13" >> loki-activate
             echo "export LD=gfortran-13" >> loki-activate
           else
-            ./install --with-claw --with-ofp --with-examples --with-tests --with-dace
+            export JAVA_HOME=${JAVA_HOME_11_X64}
+            ./install --with-omni --with-ofp --with-examples --with-tests --with-dace
+            echo "export JAVA_HOME=${JAVA_HOME_11_X64}" >> loki-activate
           fi
 
       - name: Install up-to-date CMake

--- a/install
+++ b/install
@@ -13,8 +13,8 @@ set -euo pipefail
 loki_ant_version=1.10.13
 
 hpc2020_java_version=11.0.6
-hpc2020_python_version=3.10.10-01
-hpc2020_cmake_version=3.25.2
+hpc2020_python_version=3.11.8-01
+hpc2020_cmake_version=3.28.3
 
 # Determine base path for loki
 # Either take the root of the current git tree or, if not inside a git repository, then
@@ -379,21 +379,21 @@ if [ "$with_claw" == true ]; then
   mkdir -p "${CLAW_INSTALL_DIR}"
   cd "${CLAW_INSTALL_DIR}"
   rm -rf claw-compiler
-  # git clone --recursive https://github.com/claw-project/claw-compiler.git claw-compiler
+  # git clone --recursive --single-branch https://github.com/claw-project/claw-compiler.git claw-compiler
 
-  # Note that our current regression tests (CLOUDSC) will fail due to faulty offload
+  # Note that the deprecated CLAW variants in CLOUDSC will fail due to faulty offload
   # directives with current CLAW-master. The fixes exist in this pinned branch:
+  # However, this branch fails to build with recent GNU versions (GNU 10+)
   git clone --recursive --single-branch --branch=mlange-dev https://github.com/mlange05/claw-compiler.git claw-compiler
   cd claw-compiler
 
   (
     set -a
     eval ${claw_install_env}
-    cmake -DCMAKE_INSTALL_PREFIX="${CLAW_INSTALL_DIR}" .
+    cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${CLAW_INSTALL_DIR}"
+    cmake --build build
+    cmake --install .
   )
-
-  make
-  make install
 fi
 
 #

--- a/install
+++ b/install
@@ -35,6 +35,7 @@ with_jdk=false
 with_ant=false
 with_claw=false
 claw_install_env=""
+with_omni=false
 with_ofp=false
 with_docs=false
 with_dace=true
@@ -61,6 +62,7 @@ print_usage_with_options() {
   echo "  --with[out]-jdk              Install JDK instead of using system version (default: use system version)"
   echo "  --with[out]-ant              Install ant instead of using system version (default: use system version)"
   echo "  --with[out]-claw             Install CLAW and OMNI Compiler (default: disabled)"
+  echo "  --with[out]-omni             Install OMNI Compiler; cannot be combined with --with-claw (default: disabled)"
   echo "  --with[out]-ofp              Install Open Fortran Parser (default: disabled)"
   echo "  --with[out]-dace             Install DaCe (default: enabled)"
   echo "  --with[out]-tests            Install dependencies to run tests (default: enabled)"
@@ -137,6 +139,12 @@ while getopts "$optspec" optchar; do
         without-claw) # Disable installation of OMNI+CLAW
           with_claw=false
           ;;
+        with-omni)   # Enable installation of OMNI
+          with_omni=true
+          ;;
+        without-omni) # Disable installation of OMNI
+          with_omni=false
+          ;;
         with-dace)    # Enable installation of DaCe
           with_dace=true
           ;;
@@ -189,6 +197,13 @@ while getopts "$optspec" optchar; do
   esac
 done
 
+if [ "$with_omni" == true ]; then
+  if [ "$with_claw" == true ]; then
+    echo "ERROR: Cannot combine --with-claw and --with-omni"
+    exit 1
+  fi
+fi
+
 # Print configuration
 if [ "$verbose" == true ]; then
   print_step "Installation configuration:"
@@ -198,6 +213,7 @@ if [ "$verbose" == true ]; then
   [[ "$with_jdk" == true ]]  && echo "    --with-jdk"
   [[ "$with_ant" == true ]]  && echo "    --with-ant"
   [[ "$with_claw" == true ]] && echo "    --with-claw"
+  [[ "$with_omni" == true ]] && echo "    --with-omni"
   [[ "$with_ofp" == false ]] && echo "    --without-ofp"
   [[ "$with_dace" == false ]] && echo "    --without-dace"
   [[ "$with_tests" == false ]] && echo "    --without-tests"
@@ -205,7 +221,6 @@ if [ "$verbose" == true ]; then
   [[ "$with_examples" == false ]] && echo "    --without-examples"
   [[ "$proxy_certificate" != "" ]] && echo "    --proxy-certificate='$proxy_certificate'"
   [[ "$jdk_certificate" != "" ]]   && echo "    --jdk-certificate='$jdk_certificate'"
-  [[ "$claw_install_env" != "" ]]  && echo "    --claw_install_env='$claw_install_env'"
 fi
 
 if [ "x$proxy_certificate" != "x" ]; then
@@ -397,6 +412,28 @@ if [ "$with_claw" == true ]; then
 fi
 
 #
+# Install OMNI
+#
+
+if [ "$with_omni" == true ]; then
+  print_step "Downloading and installing OMNI Compiler"
+
+  OMNI_INSTALL_DIR=${venv_path}/opt/omni
+  mkdir -p "${OMNI_INSTALL_DIR}"
+  cd "${OMNI_INSTALL_DIR}"
+  rm -rf xcodeml-tools
+  git clone --recursive --single-branch https://github.com/omni-compiler/xcodeml-tools.git xcodeml-tools
+
+  cd xcodeml-tools
+
+  omni_opts=()
+  [[ ! -z "${JAVA_HOME}" ]] && omni_opts+=("JAVA_HOME=${JAVA_HOME}")
+
+  ./configure --prefix="${OMNI_INSTALL_DIR}" "${omni_opts[@]}"
+  make && make install
+fi
+
+#
 # Install OFP
 #
 
@@ -494,6 +531,11 @@ fi
 # Inject CLAW into env
 if [ "$with_claw" == true ]; then
   path_var=${CLAW_INSTALL_DIR}/bin:$path_var
+fi
+
+# Inject OMNI into env
+if [ "$with_omni" == true ]; then
+  path_var=${OMNI_INSTALL_DIR}/bin:$path_var
 fi
 
 # Update path variable

--- a/loki/transformations/extract/tests/test_extract_transformation.py
+++ b/loki/transformations/extract/tests/test_extract_transformation.py
@@ -17,7 +17,7 @@ from loki.transformations.extract import ExtractTransformation
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('outline_regions', [False, True])
 @pytest.mark.parametrize('extract_internals', [False, True])
-def test_extract_transformation_module(extract_internals, outline_regions, frontend):
+def test_extract_transformation_module(extract_internals, outline_regions, frontend, tmp_path):
     """
     Test basic subroutine extraction from marker pragmas in modules.
     """
@@ -59,7 +59,7 @@ contains
 end subroutine outer
 end module test_extract_mod
 """
-    module = Module.from_source(fcode, frontend=frontend)
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
 
     ExtractTransformation(
         extract_internals=extract_internals, outline_regions=outline_regions

--- a/loki/transformations/tests/test_argument_shape.py
+++ b/loki/transformations/tests/test_argument_shape.py
@@ -365,7 +365,7 @@ def test_argument_shape_transformation(frontend):
 
 
 @pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
-def test_argument_shape_transformation_import(frontend, here):
+def test_argument_shape_transformation_import(frontend, here, tmp_path):
     """
     Test that ensures that explicit argument shapes are indeed inserted
     in a multi-layered call tree.
@@ -388,7 +388,7 @@ def test_argument_shape_transformation_import(frontend, here):
     headers = [Sourcefile.from_file(filename=h, frontend=frontend_type) for h in header]
     definitions = flatten(h.modules for h in headers)
     scheduler = Scheduler(paths=here/'sources/projArgShape', config=config, frontend=frontend,
-                          definitions=definitions)
+                          definitions=definitions, xmods=[tmp_path])
     scheduler.process(transformation=ArgumentArrayShapeAnalysis())
     scheduler.process(transformation=ExplicitArgumentArrayShapeTransformation())
 

--- a/loki/transformations/tests/test_cloudsc.py
+++ b/loki/transformations/tests/test_cloudsc.py
@@ -16,7 +16,7 @@ import pytest
 from loki.tools import (
     execute, write_env_launch_script, local_loki_setup, local_loki_cleanup
 )
-from loki.frontend import available_frontends, OMNI, OFP, HAVE_FP, HAVE_OMNI
+from loki.frontend import available_frontends, OMNI, OFP, HAVE_FP
 from loki.logging import warning
 
 pytestmark = pytest.mark.skipif('CLOUDSC_DIR' not in os.environ, reason='CLOUDSC_DIR not set')
@@ -59,9 +59,6 @@ def test_cloudsc(here, frontend):
         '--cloudsc-prototype1=OFF', '--cloudsc-fortran=OFF', '--cloudsc-c=OFF',
     ]
 
-    if HAVE_OMNI:
-        build_cmd += ['--with-claw']
-
     if 'CLOUDSC_ARCH' in os.environ:
         build_cmd += [f"--arch={os.environ['CLOUDSC_ARCH']}"]
     else:
@@ -89,13 +86,6 @@ def test_cloudsc(here, frontend):
         ('dwarf-cloudsc-loki-idem-stack', '2', '16000', '32'),
         ('dwarf-cloudsc-loki-scc-stack', '1', '16000', '32'),
     ]
-
-    if HAVE_OMNI:
-        # Skip CLAW binaries if we don't have OMNI installed
-        binaries += [
-            ('dwarf-cloudsc-loki-claw-cpu', '2', '16000', '64'),
-            ('dwarf-cloudsc-loki-claw-gpu', '1', '16000', '64'),
-        ]
 
     failures, warnings = {}, {}
     for binary, *args in binaries:

--- a/loki/transformations/transpile/tests/test_transpile.py
+++ b/loki/transformations/transpile/tests/test_transpile.py
@@ -1399,7 +1399,7 @@ def test_scc_cuda_parametrise(tmp_path, here, frontend, config, horizontal, vert
 
     proj = here / '../../tests/sources/projSccCuf/module'
 
-    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver'], frontend=frontend)
+    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver'], frontend=frontend, xmods=[tmp_path])
 
     dic2p = {'nz': 137}
     cuda_transform = SCCLowLevelParametrise(
@@ -1469,7 +1469,7 @@ def test_scc_cuda_hoist(tmp_path, here, frontend, config, horizontal, vertical, 
 
     proj = here / '../../tests/sources/projSccCuf/module'
 
-    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver'], frontend=frontend)
+    scheduler = Scheduler(paths=[proj], config=config, seed_routines=['driver'], frontend=frontend, xmods=[tmp_path])
 
     cuda_transform = SCCLowLevelHoist(
         horizontal=horizontal, vertical=vertical, block_dim=blocking,


### PR DESCRIPTION
This is partially in response to #406: It looks like we can keep OMNI alive for the time being (yay...?!) if we give up the specific version bundled with the CLAW, and instead update to the latest upstream. The way this is implemented does not yet remove CLAW entirely, instead a new `--with-omni` option is added to the `install` script and the existing `--with-claw` option is kept as is. The two cannot be combined but using `--with-omni` gives the newer F_Front version.

Notably, for our purpose it is even sufficient to use the [xcodeml-tools](https://github.com/omni-compiler/xcodeml-tools) component of the OMNI compiler, which provides the frontends.

With this we are able to use recent GNU versions to compile OMNI and thus can upgrade the Github runners to the latest Ubuntu image, which uses GNU 13.2.0 as default. This builds cleanly and all tests seem to work as expected. It should also resolve the spurious errors observed in #230, which I will rebase on top of this PR.

The one downside of these changes is that they means we are stopping the testing of the CLAW variants for CLOUDSC regression tests. But since they don't have any perspective anyway, I think this is acceptable - please shout if you disagree!

I used the opportunity to also update the module versions for HPC2020 to recent versions.
Piggy-backed are also a few fixes where no tmp_path was specified for xmods in tests.