### PR TITLE
Fix SccAnnotate when existing acc pragmas declare a copy category more than once

### DIFF
--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -226,6 +226,10 @@ class SCCAnnotateTransformation(Transformation):
                     if not driver_loops:
                         continue
 
+                    # When a key is given multiple times, get_pragma_parameters returns a list
+                    # We merge them here into single entries to make our life easier below
+                    parameters = {key: ', '.join(as_tuple(value)) for key, value in parameters.items()}
+
                     if (default := parameters.get('default', None)):
                         if not 'none' in [p.strip().lower() for p in default.split(',')]:
                             for loop in driver_loops:


### PR DESCRIPTION
PR #389 introduced a regression in ecphys. There we have an ACC statement like this:

```
!$acc data copyin(var_a, var_b) &
!$acc &    copyin(var_c) create(var_d)
```

Now, the ACC statements are checked for existing offload directives. For that, `get_pragma_parameters` is used to extract offload "categories". However, for situations where a key exists more than once, the values are provided as a list, i.e., for the above we obtain
```
{'copyin': ['var_a, var_b', 'var_c'], 'create': 'var_d'}
```

Where previously a simple `str.split(',')` was used to build a list of variables of each category, we need to be careful to accomodate for the above situation where not a simple string constitutes the value. This PR expands the test to include the above case and fixes the transformation accordingly.