### PR TITLE
Prevent superfluous clone of loki in ecwam regression test

### DIFF
--- a/loki/transformations/tests/test_ecwam.py
+++ b/loki/transformations/tests/test_ecwam.py
@@ -35,7 +35,7 @@ def fixture_local_loki_bundle(here):
 def fixture_bundle_create(here, local_loki_bundle):
     """Inject ourselves into the ECWAM bundle"""
     env = os.environ.copy()
-    env['ECWAM_CONCEPT_BUNDLE_LOKI_DIR'] = local_loki_bundle
+    env['ECWAM_BUNDLE_LOKI_DIR'] = local_loki_bundle
 
     # Run ecbundle to fetch dependencies
     execute(


### PR DESCRIPTION
The ecwam-bundle project name in the regression test is outdated, which lead to the tagged loki release in the ewam bundle being cloned everytime the test was run. Since `--without-loki-install` is specified, that version is never built and the local copy of loki is indeed used. Nevertheless it would be good to prevent an unnecessary clone of loki during the regression test.