### PR TITLE
Frontend: Deprecate OFP and purge from test base

### DIFF
--- a/loki/backend/tests/test_fgen.py
+++ b/loki/backend/tests/test_fgen.py
@@ -10,7 +10,7 @@ import pytest
 from loki import Module, Subroutine, Sourcefile
 from loki.backend import fgen
 from loki.expression import symbols as sym
-from loki.frontend import available_frontends, OMNI, OFP
+from loki.frontend import available_frontends, OMNI
 from loki.ir import Intrinsic, DataDeclaration
 from loki.types import ProcedureType, BasicType
 
@@ -107,10 +107,7 @@ end subroutine data_stmt
     """.strip()
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    if frontend == OFP:
-        assert isinstance(routine.spec.body[-1], Intrinsic)
-    else:
-        assert isinstance(routine.spec.body[-1], DataDeclaration)
+    assert isinstance(routine.spec.body[-1], DataDeclaration)
     spec_code = fgen(routine.spec)
     assert spec_code.lower().count('data ') == 2
     assert spec_code.count('/') == 4

--- a/loki/backend/tests/test_pygen.py
+++ b/loki/backend/tests/test_pygen.py
@@ -15,7 +15,7 @@ import numpy as np
 from loki import Subroutine
 from loki.backend import pygen
 from loki.build import jit_compile, clean_test
-from loki.frontend import available_frontends, OFP, OMNI
+from loki.frontend import available_frontends, OMNI
 from loki.transformations.transpile import FortranPythonTransformation
 
 
@@ -452,7 +452,7 @@ end subroutine pygen_logical_statements
     f2p.py_path.unlink()
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'OFP cannot handle stmt functions')]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_pygen_downcasing(tmp_path, frontend):
     """
     A simple test routine to test the conversion to lower case.

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -68,7 +68,7 @@ from loki.batch import (
 )
 from loki.expression import Scalar, Array, Literal, ProcedureSymbol
 from loki.frontend import (
-    available_frontends, OMNI, OFP, FP, REGEX, HAVE_FP, HAVE_OFP, HAVE_OMNI
+    available_frontends, OMNI, FP, REGEX, HAVE_FP, HAVE_OMNI
 )
 from loki.ir import nodes as ir, FindNodes, FindInlineCalls
 from loki.transformations import (
@@ -76,7 +76,7 @@ from loki.transformations import (
 )
 
 
-pytestmark = pytest.mark.skipif(not HAVE_FP and not HAVE_OFP, reason='Fparser and OFP not available')
+pytestmark = pytest.mark.skipif(not HAVE_FP, reason='Fparser not available')
 
 
 @pytest.fixture(scope='module', name='here')
@@ -116,7 +116,7 @@ def fixture_frontend():
     independent from the specific frontend used. Cannot use OMNI for this
     as not all tests have dependencies fully resolved.
     """
-    return FP if HAVE_FP else OFP
+    return FP
 
 
 @pytest.fixture(name='driverA_dependencies')

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -22,7 +22,7 @@ from loki.backend import cgen, fgen
 from loki.build import jit_compile, clean_test
 from loki.expression import symbols as sym, parse_expr, AttachScopesMapper
 from loki.frontend import (
-    available_frontends, OFP, OMNI, FP, HAVE_FP, parse_fparser_expression
+    available_frontends, OMNI, FP, HAVE_FP, parse_fparser_expression
 )
 from loki.ir import (
     nodes as ir, FindNodes, FindVariables, FindExpressions,
@@ -208,9 +208,7 @@ end subroutine boz_literals
         assert stmts[5].rhs.parameters[0].value == 'z"babe"'
 
 
-@pytest.mark.parametrize('frontend', available_frontends(
-    skip={OFP: "Not implemented because too stupid in OFP parse tree"})
-)
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_complex_literals(tmp_path, frontend):
     """
     Test complex literal values.
@@ -310,9 +308,7 @@ end subroutine logical_array
     clean_test(filepath)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OFP, 'Not implemented')]
-))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_array_constructor(tmp_path, frontend):
     """
     Test various array constructor formats
@@ -796,9 +792,7 @@ end subroutine expression_masked_statements
     clean_test(filepath)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[
-    (OFP, 'Current implementation does not handle nested where constructs')
-]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_masked_statements_nested(tmp_path, frontend):
     """
     Nested masked statements (WHERE(...) ... [ELSEWHERE ...] ENDWHERE)
@@ -1607,7 +1601,7 @@ end module typebound_resolution_type_info_mod
 ))
 def test_stmt_func_heuristic(frontend, tmp_path):
     """
-    Our Fparser/OFP translation has a heuristic to detect statement function declarations,
+    Our Fparser translation has a heuristic to detect statement function declarations,
     but that falsely misinterpreted some assignments as statement functions due to
     missing shape information (reported in #326)
     """

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -58,6 +58,8 @@ def parse_ofp_file(filename):
     if not HAVE_OFP:
         error('OpenFortranParser is not available.')
 
+    warning('[DEPRECATION]: The OFP frontend is deprecated and will be removed soon!')
+
     filepath = Path(filename)
     info(f'[Loki::OFP] Parsing {filepath}')
     return open_fortran_parser.parse(filepath, raise_on_error=True)

--- a/loki/frontend/ofp.py
+++ b/loki/frontend/ofp.py
@@ -22,7 +22,7 @@ except ImportError:
 
 from loki.frontend.source import extract_source, extract_source_from_range
 from loki.frontend.preprocessing import sanitize_registry
-from loki.frontend.util import OFP, sanitize_ir
+from loki.frontend.util import sanitize_ir, Frontend
 
 from loki import ir
 from loki.ir import (
@@ -45,6 +45,9 @@ from loki.config import config
 
 
 __all__ = ['HAVE_OFP', 'parse_ofp_file', 'parse_ofp_source', 'parse_ofp_ast']
+
+
+OFP = Frontend.OFP
 
 
 @Timer(logger=debug, text=lambda s: f'[Loki::OFP] Executed parse_ofp_file in {s:.2f}s')

--- a/loki/frontend/preprocessing.py
+++ b/loki/frontend/preprocessing.py
@@ -19,10 +19,13 @@ from loki.logging import debug, detail
 from loki.config import config
 from loki.tools import as_tuple, gettempdir, filehash
 from loki.ir import VariableDeclaration, Intrinsic, FindNodes
-from loki.frontend.util import OMNI, OFP, FP, REGEX
+from loki.frontend.util import OMNI, FP, REGEX, Frontend
 
 
 __all__ = ['preprocess_cpp', 'sanitize_input', 'sanitize_registry', 'PPRule']
+
+
+OFP = Frontend.OFP
 
 
 def preprocess_cpp(source, filepath=None, includes=None, defines=None):

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -27,7 +27,7 @@ from loki import (
 )
 from loki.build import jit_compile, clean_test
 from loki.expression import symbols as sym
-from loki.frontend import available_frontends, OMNI, OFP, FP, REGEX
+from loki.frontend import available_frontends, OMNI, FP, REGEX
 from loki.ir import nodes as ir, FindNodes
 
 
@@ -364,9 +364,7 @@ end subroutine test_enum
     clean_test(filepath)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OFP, 'OFP fails to parse parameterized types')]
-))
+@pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.usefixtures('reset_frontend_mode')
 def test_frontend_strict_mode(frontend, tmp_path):
     """
@@ -1622,7 +1620,7 @@ END SUBROUTINE DOT_PROD_SP_2D
     assert 'dot_product_ecv' in routine.variables
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'No support for prefix implemented')]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_regex_prefix(frontend, tmp_path):
     fcode = """
 module some_mod
@@ -1842,12 +1840,9 @@ end subroutine test_inline_comments
     assert assigns[3].comment.text == '! wall !'
 
     comments = FindNodes(ir.Comment).visit(routine.body)
-    assert len(comments) == 1 if frontend == OFP else 4
-    if frontend == OFP:
-        assert comments[0].text == '! Who said that?'
-    else:
-        assert comments[1].text == '! Who said that?'
-        assert comments[0].text == comments[2].text == comments[3].text == ''
+    assert len(comments) == 4
+    assert comments[1].text == '! Who said that?'
+    assert comments[0].text == comments[2].text == comments[3].text == ''
 
 
 @pytest.mark.parametrize('from_file', (True, False))

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -113,6 +113,8 @@ def available_frontends(xfail=None, skip=None, include_regex=False):
     # Build the list of parameters
     params = []
     for f in Frontend:
+        if f == OFP:
+            continue  # OFP is now deprecated!
         if f in skip:
             params += [pytest.param(f, marks=pytest.mark.skip(reason=skip[f]))]
         elif f in xfail:

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -26,7 +26,7 @@ from loki.types import ProcedureType
 
 
 __all__ = [
-    'Frontend', 'OFP', 'OMNI', 'FP', 'REGEX', 'available_frontends',
+    'Frontend', 'OMNI', 'FP', 'REGEX', 'available_frontends',
     'read_file', 'InlineCommentTransformer',
     'ClusterCommentTransformer', 'CombineMultilinePragmasTransformer',
     'sanitize_ir'
@@ -50,7 +50,6 @@ class Frontend(IntEnum):
         return self.name.lower()  # pylint: disable=no-member
 
 OMNI = Frontend.OMNI
-OFP = Frontend.OFP
 FP = Frontend.FP
 REGEX = Frontend.REGEX
 
@@ -113,7 +112,7 @@ def available_frontends(xfail=None, skip=None, include_regex=False):
     # Build the list of parameters
     params = []
     for f in Frontend:
-        if f == OFP:
+        if f == Frontend.OFP:
             continue  # OFP is now deprecated!
         if f in skip:
             params += [pytest.param(f, marks=pytest.mark.skip(reason=skip[f]))]
@@ -383,10 +382,10 @@ def sanitize_ir(_ir, frontend, pp_registry=None, pp_info=None):
         # Revert OMNI's array dimension expansion from `a(n)` => `arr(1:n)`
         _ir = RangeIndexTransformer(invalidate_source=False).visit(_ir)
 
-    if frontend in (OMNI, OFP):
+    if frontend in (OMNI, Frontend.OFP):
         _ir = inline_labels(_ir)
 
-    if frontend in (FP, OFP):
+    if frontend in (FP, Frontend.OFP):
         _ir = CombineMultilinePragmasTransformer(inplace=True, invalidate_source=False).visit(_ir)
         _ir = RemoveDuplicateVariableDeclarationsForExternalProcedures(inplace=True, invalidate_source=False).visit(_ir)
 

--- a/loki/ir/tests/test_control_flow.py
+++ b/loki/ir/tests/test_control_flow.py
@@ -11,7 +11,7 @@ import numpy as np
 from loki import Subroutine
 from loki.backend import fgen
 from loki.build import jit_compile, clean_test
-from loki.frontend import available_frontends, OMNI, OFP
+from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes
 
 
@@ -610,7 +610,6 @@ end subroutine forall_masked_stmt
 
 @pytest.mark.parametrize('frontend', available_frontends(xfail=[
     (OMNI, 'Renames index variable to omnitmp000'),
-    (OFP, 'Parser fails to parse'),
 ]))
 def test_multi_line_forall_construct(tmp_path, frontend):
     fcode = """

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -15,7 +15,7 @@ from codetiming import Timer
 from loki.backend.fgen import fgen
 from loki.backend.cufgen import cufgen
 from loki.frontend import (
-    Frontend, OMNI, OFP, FP, REGEX, sanitize_input, Source, read_file, preprocess_cpp,
+    Frontend, OMNI, FP, REGEX, sanitize_input, Source, read_file, preprocess_cpp,
     parse_omni_source, parse_ofp_source, parse_fparser_source,
     parse_omni_ast, parse_ofp_ast, parse_fparser_ast, parse_regex_source,
     RegexParserClass
@@ -30,6 +30,9 @@ from loki.tools import flatten, as_tuple
 
 
 __all__ = ['Sourcefile']
+
+
+OFP = Frontend.OFP
 
 
 class Sourcefile:

--- a/loki/tests/test_derived_types.py
+++ b/loki/tests/test_derived_types.py
@@ -21,7 +21,7 @@ from loki import (
     FindVariables
 )
 from loki.build import jit_compile, jit_compile_lib, clean_test, Obj
-from loki.frontend import available_frontends, OMNI, OFP
+from loki.frontend import available_frontends, OMNI
 
 
 @pytest.fixture(name='builder')
@@ -1204,9 +1204,7 @@ def test_derived_type_rescope_symbols_shadowed(tmp_path, shadowed_typedef_symbol
         clean_test(filepath)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[
-    (OFP, 'OFP cannot parse the Fortran')
-]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_derived_types_character_array_subscript(frontend, tmp_path):
     fcode = """
 module derived_type_char_arr_mod

--- a/loki/tests/test_modules.py
+++ b/loki/tests/test_modules.py
@@ -14,7 +14,7 @@ from loki import (
     Scalar, DeferredTypeSymbol, FindVariables, SubstituteExpressions, Literal
 )
 from loki.build import jit_compile, clean_test
-from loki.frontend import available_frontends, OFP, OMNI
+from loki.frontend import available_frontends, OMNI
 from loki.sourcefile import Sourcefile
 
 
@@ -933,9 +933,7 @@ end module some_mod
         assert use_name is None or f'{s} => {use_name}' in fcode
 
 
-@pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OFP, 'hasModuleNature on use-stmt but without conveying actual nature')]
-))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_module_use_module_nature(frontend, tmp_path):
     """
     Test module natures attributes in ``USE`` statements

--- a/loki/tests/test_sourcefile.py
+++ b/loki/tests/test_sourcefile.py
@@ -16,7 +16,7 @@ from loki import (
     StatementFunction, Comment, CommentBlock, RawSource, Scalar
 )
 from loki.build import jit_compile, clean_test
-from loki.frontend import available_frontends, OFP, OMNI, FP, REGEX
+from loki.frontend import available_frontends, OMNI, FP, REGEX
 
 
 @pytest.fixture(scope='module', name='here')
@@ -120,7 +120,7 @@ def test_sourcefile_pp_macros(here, frontend):
 
 
 @pytest.mark.parametrize('frontend', available_frontends(xfail=[
-    (OFP, 'Cannot handle directives'), (OMNI, 'Files are preprocessed')
+    (OMNI, 'Files are preprocessed')
 ]))
 def test_sourcefile_pp_directives(here, frontend):
     filepath = here/'sources/sourcefile_pp_directives.F90'
@@ -193,7 +193,7 @@ def test_sourcefile_cpp_preprocessing(here, frontend):
     assert 'b = 6' in fgen(routine)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'No support for statement functions')]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_sourcefile_cpp_stmt_func(here, frontend, tmp_path):
     """
     Test the correct identification of statement functions

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -18,7 +18,7 @@ from loki import (
     ProcedureSymbol, StatementFunction, DeferredTypeSymbol
 )
 from loki.build import jit_compile, jit_compile_lib, clean_test
-from loki.frontend import available_frontends, OFP, OMNI, REGEX
+from loki.frontend import available_frontends, OMNI, REGEX
 from loki.types import BasicType, DerivedType, ProcedureType
 from loki.ir import nodes as ir
 
@@ -1465,7 +1465,7 @@ end subroutine test_subroutine_rescope_clone
         )
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'No support for statement functions')]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_subroutine_stmt_func(tmp_path, frontend):
     """
     Test the correct identification of statement functions
@@ -1537,7 +1537,7 @@ end subroutine valid_fortran
     assert "Declarations must have intents" in str(error.value)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'Prefix support not implemented')]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_subroutine_prefix(frontend):
     """
     Test various prefixes that can occur in function/subroutine definitions
@@ -1852,7 +1852,7 @@ END SUBROUTINE CLOUDSC
     assert all(isinstance(arg, Array) for arg in routine.arguments[4:])
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP, 'Prefix support not implemented')]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_subroutine_lazy_prefix(frontend):
     """
     Test that prefixes for functions are correctly captured when the object is made

--- a/loki/tests/test_types.py
+++ b/loki/tests/test_types.py
@@ -15,7 +15,7 @@ from loki import (
     FindNodes, ProcedureDeclaration
 )
 from loki.expression import symbols as sym
-from loki.frontend import available_frontends, OFP, OMNI
+from loki.frontend import available_frontends, OMNI
 
 
 @pytest.fixture(scope='module', name='here')

--- a/loki/transformations/build_system/tests/test_dependency.py
+++ b/loki/transformations/build_system/tests/test_dependency.py
@@ -9,7 +9,7 @@ import pytest
 
 from loki import Sourcefile
 from loki.batch import Scheduler, SchedulerConfig
-from loki.frontend import available_frontends, OMNI, OFP
+from loki.frontend import available_frontends, OMNI
 from loki.ir import (
     FindNodes, CallStatement, Import, Interface, Intrinsic, FindInlineCalls
 )
@@ -445,8 +445,7 @@ END SUBROUTINE kernel
         assert intfs[0].symbols == ('kernel_test',)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(
-                         xfail=[(OFP, 'OFP does not correctly handle result variable declaration.')]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_dependency_transformation_inline_call(frontend):
     """
     Test injection of suffixed kernel, accessed through inline function call.

--- a/loki/transformations/extract/tests/test_extract_internal.py
+++ b/loki/transformations/extract/tests/test_extract_internal.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from loki.frontend import available_frontends, OMNI, OFP
+from loki.frontend import available_frontends, OMNI
 from loki.ir import CallStatement, Import, FindNodes, FindInlineCalls
 from loki.sourcefile import Sourcefile
 from loki.subroutine import Subroutine
@@ -558,9 +558,7 @@ def test_extract_internal_procedures_basic_scalar_function(frontend):
     call = list(FindInlineCalls().visit(outer.body))[0]
     assert 'x' in call.kw_parameters
 
-@pytest.mark.parametrize(
-    'frontend', available_frontends(skip=(OFP, "ofp fails for unknown reason, likely frontend issue"))
-)
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_extract_internal_procedures_basic_scalar_function_both(frontend):
     """
     Basic test for scalars highlighting that the outer and inner procedure may be functions.

--- a/loki/transformations/inline/tests/test_functions.py
+++ b/loki/transformations/inline/tests/test_functions.py
@@ -9,7 +9,7 @@ import pytest
 
 from loki import Module, Subroutine
 from loki.build import jit_compile_lib, Builder, Obj
-from loki.frontend import available_frontends, OMNI, OFP
+from loki.frontend import available_frontends, OMNI
 from loki.ir import (
     nodes as ir, FindNodes, FindVariables, FindInlineCalls
 )
@@ -195,8 +195,7 @@ end subroutine transform_inline_elemental_functions_extended
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    skip={OFP: "OFP apparently has problems dealing with those Statement Functions",
-          OMNI: "OMNI automatically inlines Statement Functions"}
+    skip={OMNI: "OMNI automatically inlines Statement Functions"}
 ))
 @pytest.mark.parametrize('stmt_decls', (True, False))
 def test_inline_statement_functions(frontend, stmt_decls):
@@ -242,8 +241,7 @@ end subroutine stmt_func
         assert FindInlineCalls().visit(routine.body)
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    skip={OFP: "OFP apparently has problems dealing with those Statement Functions",
-          OMNI: "OMNI automatically inlines Statement Functions"}
+    skip={OMNI: "OMNI automatically inlines Statement Functions"}
 ))
 @pytest.mark.parametrize('provide_myfunc', ('import', 'module', 'interface', 'intfb', 'routine'))
 def test_inline_statement_functions_inline_call(frontend, provide_myfunc, tmp_path):

--- a/loki/transformations/inline/tests/test_inline_transformation.py
+++ b/loki/transformations/inline/tests/test_inline_transformation.py
@@ -8,16 +8,14 @@
 import pytest
 
 from loki import Module, Subroutine
-from loki.frontend import available_frontends, OFP
+from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
 from loki.batch import Scheduler, SchedulerConfig
 
 from loki.transformations.inline import InlineTransformation
 
 
-@pytest.mark.parametrize('frontend', available_frontends(
-    (OFP, 'Prefix/elemental support not implemented'))
-)
+@pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('pass_as_kwarg', (False, True))
 def test_inline_transformation(tmp_path, frontend, pass_as_kwarg):
     """Test combining recursive inlining via :any:`InliningTransformation`."""

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -10,7 +10,7 @@ import pytest
 from loki import Subroutine, Sourcefile, Dimension, fgen
 from loki.batch import ProcedureItem
 from loki.expression import Scalar, Array, IntLiteral
-from loki.frontend import available_frontends, OMNI, OFP
+from loki.frontend import available_frontends, OMNI
 from loki.ir import (
     FindNodes, Assignment, CallStatement, Conditional, Loop,
     Pragma, PragmaRegion, pragmas_attached, is_loki_pragma,
@@ -633,8 +633,7 @@ def test_scc_variable_demotion(frontend, horizontal):
     assert isinstance(kernel.variable_map['c'], Scalar)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OFP,
-                         'OFP fails to parse multiconditional with embedded call.')]))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_scc_multicond(frontend, horizontal, blocking):
     """
     Test if horizontal loops in multiconditionals with CallStatements are

--- a/loki/transformations/tests/test_cloudsc.py
+++ b/loki/transformations/tests/test_cloudsc.py
@@ -16,7 +16,7 @@ import pytest
 from loki.tools import (
     execute, write_env_launch_script, local_loki_setup, local_loki_cleanup
 )
-from loki.frontend import available_frontends, OMNI, OFP, HAVE_FP
+from loki.frontend import available_frontends, OMNI, HAVE_FP
 from loki.logging import warning
 
 pytestmark = pytest.mark.skipif('CLOUDSC_DIR' not in os.environ, reason='CLOUDSC_DIR not set')
@@ -49,7 +49,6 @@ def fixture_bundle_create(here, local_loki_bundle):
 
 @pytest.mark.usefixtures('bundle_create')
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OFP, 'Lack of elemental support makes C-transpilation impossible')],
     skip=[(OMNI, 'OMNI needs FParser for parsing headers')] if not HAVE_FP else None
 ))
 def test_cloudsc(here, frontend):

--- a/loki/transformations/transpile/tests/test_transpile.py
+++ b/loki/transformations/transpile/tests/test_transpile.py
@@ -12,7 +12,7 @@ import numpy as np
 from loki import Subroutine, Module, cgen, cppgen, cudagen, FindNodes, Dimension, Scheduler, read_file
 from loki.build import jit_compile, jit_compile_lib, clean_test, Builder, Obj
 import loki.expression.symbols as sym
-from loki.frontend import available_frontends, OFP
+from loki.frontend import available_frontends
 from loki import ir
 
 from loki.transformations.transpile import FortranCTransformation
@@ -793,9 +793,7 @@ end subroutine multibody_cond
 
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
-@pytest.mark.parametrize('frontend', available_frontends(
-    skip=[(OFP, 'Prefix/elemental support not implemented')]
-))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_transpile_inline_elemental_functions(tmp_path, builder, frontend, use_c_ptr):
     """
     Test correct inlining of elemental functions in C transpilation.
@@ -854,9 +852,7 @@ end subroutine inline_elemental
 
 
 @pytest.mark.parametrize('use_c_ptr', (False, True))
-@pytest.mark.parametrize('frontend', available_frontends(
-    skip=[(OFP, 'Prefix/elemental support not implemented')]
-))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_transpile_inline_elementals_recursive(tmp_path, builder, frontend, use_c_ptr):
     """
     Test correct inlining of nested elemental functions.
@@ -1212,9 +1208,7 @@ end subroutine multi_cond_simple
         assert out_var == expected_results[i]
 
 
-@pytest.mark.parametrize('frontend', available_frontends(
-    skip=[(OFP, 'OFP got problems with RangeIndex as case value!')]
-))
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_transpile_multiconditional(tmp_path, builder, frontend):
     """
     A test to verify multiconditionals/select case statements.


### PR DESCRIPTION
~_Note: Just testing for now..._~

As described in #209 , this PR deprecates the OFP frontend and adds a warning to the central OFP parse method. It also purges the `OFP` symbol from the outward-facing API and the test base (including the `available_frontends()` utiltiy), leaving internal mechanics to rely on the explicit mention of `Frontend.OFP`.

Please note that the frontend itself is still present and functional, but it's use is now discouraged.