### PR TITLE
CMake/python_venv: Do not request COMPONENT Development

### DIFF
--- a/cmake/python_venv.cmake
+++ b/cmake/python_venv.cmake
@@ -50,7 +50,7 @@ function( find_python_venv VENV_PATH PYTHON_VERSION )
     set( Python3_ROOT_DIR "${VENV_PATH}" )
 
     # Launch a new search
-    find_package( Python3 ${PYTHON_VERSION} COMPONENTS Interpreter Development REQUIRED )
+    find_package( Python3 ${PYTHON_VERSION} COMPONENTS Interpreter REQUIRED )
 
     # Find the binary directory of the virtual environment
     execute_process(


### PR DESCRIPTION
A small hotfix PR that removes the "Development" component from the find_package for Python in a CMake installation.

This component is intended to allow applications to use Python headers - but Loki, as a pure Python package, doesn't need this. However, the find_package will fail if Python headers cannot be found, thus preventing installation.