### PR TITLE
Expressions: Handle intrinsic function calls

### DIFF
--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -685,7 +685,7 @@ class ProcedureItem(Item):
         inline_calls = tuple({
             call.function.name: call.function
             for call in FindInlineCalls().visit(self.ir.ir)
-            if isinstance(call.function, ProcedureSymbol)
+            if isinstance(call.function, ProcedureSymbol) and not call.function.type.dtype.is_intrinsic
         }.values())
         imports = tuple(
             imprt for imprt in self.ir.imports

--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -685,7 +685,7 @@ class ProcedureItem(Item):
         inline_calls = tuple({
             call.function.name: call.function
             for call in FindInlineCalls().visit(self.ir.ir)
-            if isinstance(call.function, ProcedureSymbol) and not call.function.type.dtype.is_intrinsic
+            if isinstance(call.function, ProcedureSymbol) and not call.function.type.is_intrinsic
         }.values())
         imports = tuple(
             imprt for imprt in self.ir.imports

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -559,6 +559,7 @@ class LokiIdentityMapper(IdentityMapper):
         new_type = expr.type
         if recurse_to_declaration_attributes:
             old_type = expr.type
+            assert expr.type is not None
             kind = self.rec(old_type.kind, *args, **kwargs)
 
             if expr.scope and expr.name == old_type.initial:

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2553,7 +2553,7 @@ class FParser2IR(GenericVisitor):
         proc_type = ProcedureType(
             name=pname, is_function=True, is_intrinsic=True, procedure=None
         )
-        kwargs['scope'].symbol_attrs[pname] = SymbolAttributes(dtype=proc_type)
+        kwargs['scope'].symbol_attrs[pname] = SymbolAttributes(dtype=proc_type, is_intrinsic=True)
 
         # Look up the function symbol
         name = self.visit(o.children[0], **kwargs)

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2550,10 +2550,13 @@ class FParser2IR(GenericVisitor):
 
         # Register the ProcedureType in the scope before the name lookup
         pname = o.children[0].string
-        proc_type = ProcedureType(
-            name=pname, is_function=True, is_intrinsic=True, procedure=None
-        )
-        kwargs['scope'].symbol_attrs[pname] = SymbolAttributes(dtype=proc_type, is_intrinsic=True)
+        scope = kwargs['scope']
+        if not scope.get_symbol_scope(pname):
+            # No known alternative definition; register a true intrinsic procedure type
+            proc_type = ProcedureType(
+                name=pname, is_function=True, is_intrinsic=True, procedure=None
+            )
+            kwargs['scope'].symbol_attrs[pname] = SymbolAttributes(dtype=proc_type, is_intrinsic=True)
 
         # Look up the function symbol
         name = self.visit(o.children[0], **kwargs)

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2547,7 +2547,17 @@ class FParser2IR(GenericVisitor):
 
 
     def visit_Intrinsic_Function_Reference(self, o, **kwargs):
+
+        # Register the ProcedureType in the scope before the name lookup
+        pname = o.children[0].string
+        proc_type = ProcedureType(
+            name=pname, is_function=True, is_intrinsic=True, procedure=None
+        )
+        kwargs['scope'].symbol_attrs[pname] = SymbolAttributes(dtype=proc_type)
+
+        # Look up the function symbol
         name = self.visit(o.children[0], **kwargs)
+
         if o.children[1] is not None:
             arguments = self.visit(o.children[1], **kwargs)
             kwarguments = tuple(arg for arg in arguments if isinstance(arg, tuple))

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -1217,7 +1217,7 @@ class OMNI2IR(GenericVisitor):
             proc_type = ProcedureType(
                 name=pname, is_function=True, is_intrinsic=True, procedure=None
             )
-            kwargs['scope'].symbol_attrs[pname] = SymbolAttributes(dtype=proc_type)
+            kwargs['scope'].symbol_attrs[pname] = SymbolAttributes(dtype=proc_type, is_intrinsic=True)
 
         if o.find('name') is not None:
             name = self.visit(o.find('name'), **kwargs)

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -1210,6 +1210,15 @@ class OMNI2IR(GenericVisitor):
         return sym.LiteralList(values=values, dtype=dtype)
 
     def visit_functionCall(self, o, **kwargs):
+
+        if 'is_intrinsic' in o.attrib:
+            # Register the ProcedureType in the scope before the name lookup
+            pname = o.find('name').text
+            proc_type = ProcedureType(
+                name=pname, is_function=True, is_intrinsic=True, procedure=None
+            )
+            kwargs['scope'].symbol_attrs[pname] = SymbolAttributes(dtype=proc_type)
+
         if o.find('name') is not None:
             name = self.visit(o.find('name'), **kwargs)
         elif o.find('FmemberRef') is not None:

--- a/loki/ir/tests/test_visitor.py
+++ b/loki/ir/tests/test_visitor.py
@@ -369,7 +369,7 @@ end subroutine find_variables_associates
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
     variables = FindVariables(unique=False).visit(routine.body)
-    assert len(variables) == 29
+    assert len(variables) == 27 if frontend == OMNI else 28
     assert len([v for v in variables if v.name == 'v']) == 1
     assert len([v for v in variables if v.name == 'm']) == 2
 

--- a/loki/tests/test_modules.py
+++ b/loki/tests/test_modules.py
@@ -1330,11 +1330,11 @@ module foo
   integer, parameter :: j = 16
 
   contains
-    integer function SUM(v)
+    integer function plus_one(v)
       implicit none
       integer, intent(in) :: v
-      SUM = v + 1
-    end function SUM
+      plus_one = v + 1
+    end function plus_one
 end module foo
 
 module test
@@ -1348,7 +1348,7 @@ contains
         real(kind=rk), intent(inout) :: res
         integer(kind=ik) :: i
         do i = 1, n
-            res = res + SUM(j)
+            res = res + plus_one(j)
         end do
     end subroutine calc
 end module test
@@ -1358,10 +1358,10 @@ end module test
     routine = source['calc']
     calls = list(FindInlineCalls().visit(routine.body))
     assert len(calls) == 1
-    assert calls[0].function == 'sum'
+    assert calls[0].function == 'plus_one'
     assert calls[0].function.type.imported
     assert calls[0].function.type.module is source['foo']
-    assert calls[0].function.type.dtype.procedure is source['sum']
+    assert calls[0].function.type.dtype.procedure is source['plus_one']
     if frontend != OMNI:
         # OMNI inlines parameters
         assert calls[0].arguments[0].type.dtype == BasicType.INTEGER

--- a/loki/transformations/tests/test_raw_stack_allocator.py
+++ b/loki/transformations/tests/test_raw_stack_allocator.py
@@ -10,7 +10,7 @@ import pytest
 from loki.backend import fgen
 from loki.batch import Scheduler, SchedulerConfig
 from loki.dimension import Dimension
-from loki.expression import DeferredTypeSymbol, InlineCall, IntLiteral
+from loki.expression import DeferredTypeSymbol, InlineCall, IntLiteral, ProcedureSymbol
 from loki.frontend import available_frontends, OMNI
 from loki.ir import FindNodes, CallStatement, Assignment, Pragma
 from loki.sourcefile import Sourcefile
@@ -282,7 +282,7 @@ end module kernel3_mod
     real = BasicType.REAL
     logical = BasicType.LOGICAL
     jprb = DeferredTypeSymbol('JPRB')
-    srk = InlineCall(function = DeferredTypeSymbol(name = 'SELECTED_REAL_KIND'),
+    srk = InlineCall(function = ProcedureSymbol(name = 'SELECTED_REAL_KIND'),
                      parameters = (IntLiteral(13), IntLiteral(300)))
 
     stack_dict = kernel1_item.trafo_data[transformation._key]['stack_dict']

--- a/loki/types.py
+++ b/loki/types.py
@@ -168,16 +168,22 @@ class ProcedureType(DataType):
         Indicate that this is a function
     is_generic : bool, optional
         Indicate that this is a generic function
+    is_intrinsic : bool, optional
+        Indicate that this is an intrinsic function
     procedure : :any:`Subroutine` or :any:`StatementFunction` or :any:`LazyNodeLookup`, optional
         The procedure this type represents
     """
 
-    def __init__(self, name=None, is_function=None, is_generic=False, procedure=None, return_type=None):
+    def __init__(
+            self, name=None, is_function=None, is_generic=False,
+            is_intrinsic=False, procedure=None, return_type=None
+    ):
         from loki.subroutine import Subroutine  # pylint: disable=import-outside-toplevel,cyclic-import
         super().__init__()
         assert name or isinstance(procedure, Subroutine)
-        assert isinstance(return_type, SymbolAttributes) or procedure or not is_function
+        assert isinstance(return_type, SymbolAttributes) or procedure or not is_function or is_intrinsic
         self.is_generic = is_generic
+        self.is_intrinsic = is_intrinsic
         if procedure is None or isinstance(procedure, LazyNodeLookup):
             self._procedure = procedure
             self._name = name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "coloredlogs",  # optional for loki-build utility
   "junit_xml",  # optional for JunitXML output in loki-lint
   "codetiming",  # essential for scheduler and sourcefile timings
-  "pydantic>=2.0",  # type checking for IR nodes
+  "pydantic>=2.0,<2.10.0",  # type checking for IR nodes
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR adds handling of intrinsic function calls by adding an `is_intrinsic` property to `ProcedureType` and adding the procedure type to the parsing scope in frontends before creating the respective `ProcedureSymbol`.

We also add the new `is_intrinsic` flag to the symbol attributes table for quick lookup in scheduler items, as we never want to chase intrinsics.

EDIT: This also needs the fix from #439 and needs a rebase once that is merged.