### PR TITLE
Handle Loki dimension pragmas for modules (and not only routines) for FP

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2061,6 +2061,11 @@ class FParser2IR(GenericVisitor):
             spec = self.visit(spec_ast, **kwargs)
             spec = sanitize_ir(spec, FP, pp_registry=sanitize_registry[FP], pp_info=self.pp_info)
 
+            # Infer any additional shape information from `!$loki dimension` pragmas
+            spec = attach_pragmas(spec, ir.VariableDeclaration)
+            spec = process_dimension_pragmas(spec)
+            spec = detach_pragmas(spec, ir.VariableDeclaration)
+
             # Another big hack: fparser allocates all comments before and after the
             # spec to the spec. We remove them from the beginning to get the docstring.
             comment_map = {}


### PR DESCRIPTION
Infer shape via Loki dimension pragmas, e.g.,

```fortran
!$loki dimension(x/2, x**2, (x+y)/x)
real(kind=jprb), dimension(:, :, :), pointer :: v6 
```

not only for routines but also for modules (FP only).