### PR TITLE
Allow for optional case-sensitive 'recursive_expression_map_update'

### DIFF
--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -131,7 +131,7 @@ subroutine my_NOT_ALL_lowercase_ROUTINE(VAR1, another_VAR, lower_case, MiXeD_Cas
     end do
 
     do K=1,ANOTHER_VAR
-        LOWER_CASE(K) = K - 1
+        LOWER_CASE(MIXEd_cASE(1, K)) = K - 1
     end do
 end subroutine my_NOT_ALL_lowercase_ROUTINE
     """.strip()

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -526,7 +526,7 @@ def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=Subs
 
         # Check for early termination opportunities, either with case-sensitivity
         #  being the default (`{}`) or with the provided value (`case-sensitive`)
-        _case_sensitive = {'case-sensitive': case_sensitive} or {}
+        _case_sensitive = {'case-sensitive': case_sensitive} if case_sensitive is not None else {}
         with config_override(_case_sensitive):
             if prev_map == expr_map:
                 break

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -498,7 +498,7 @@ def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=Subs
         nesting that can be replaced.
     mapper_cls: :any:`SubstituteExpressionsMapper`
        The underlying mapper to be used (default: :any:`SubstituteExpressionsMapper`).
-    case_senstivie: None, bool
+    case_sensitive: bool (optional)
         Whether to check w/o case-sensitiviy for early termination opportunities
         (default: None, use the default/global case-sensitivy setting).
     """

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -26,6 +26,7 @@ from loki.module import Module
 from loki.subroutine import Subroutine
 from loki.tools import CaseInsensitiveDict, as_tuple
 from loki.types import SymbolAttributes, BasicType, DerivedType, ProcedureType
+from loki.config import config_override
 
 
 __all__ = [
@@ -98,7 +99,7 @@ def convert_to_lower_case(routine):
     }
 
     # Capture nesting by applying map to itself before applying to the routine
-    vmap = recursive_expression_map_update(vmap)
+    vmap = recursive_expression_map_update(vmap, case_sensitive=True)
     routine.body = SubstituteExpressions(vmap).visit(routine.body)
     routine.spec = SubstituteExpressions(vmap).visit(routine.spec)
 
@@ -472,7 +473,8 @@ def replace_selected_kind(routine):
             routine.spec.prepend(imprt)
 
 
-def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=SubstituteExpressionsMapper):
+def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=SubstituteExpressionsMapper,
+                                    case_sensitive=None):
     """
     Utility function to apply a substitution map for expressions to itself
 
@@ -496,6 +498,9 @@ def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=Subs
         nesting that can be replaced.
     mapper_cls: :any:`SubstituteExpressionsMapper`
        The underlying mapper to be used (default: :any:`SubstituteExpressionsMapper`).
+    case_senstivie: None, bool
+        Whether to check w/o case-sensitiviy for early termination opportunities
+        (default: None, use the default/global case-sensitivy setting).
     """
     def apply_to_init_arg(name, arg, expr, mapper):
         # Helper utility to apply the mapper only to expression arguments and
@@ -519,9 +524,12 @@ def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=Subs
             for expr, replacement in expr_map.items()
         }
 
-        # Check for early termination opportunities
-        if prev_map == expr_map:
-            break
+        # Check for early termination opportunities, either with case-sensitivity
+        #  being the default (`{}`) or with the provided value (`case-sensitive`)
+        _case_sensitive = {'case-sensitive': case_sensitive} or {}
+        with config_override(_case_sensitive):
+            if prev_map == expr_map:
+                break
 
     return expr_map
 


### PR DESCRIPTION
necessary for 'convert_to_lower_case' functionality.

@reuterbal it is unfortunately not possible without further changes to move the `with config_override` out of `recursive_expression_map_update` since the case-sensitivity produces problems within that function beyond the check for early termination.