### PR TITLE
Expression: Expression cloning and mapper tests

### DIFF
--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -749,7 +749,7 @@ class SubstituteExpressionsMapper(LokiIdentityMapper):
         otherwise continue tree traversal
         """
         if expr in self.expr_map:
-            return self.expr_map[expr]
+            return self._rebuild(self.expr_map[expr])
         map_fn = getattr(super(), expr.mapper_method)
         return map_fn(expr, *args, **kwargs)
 

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -9,7 +9,7 @@
 Mappers for traversing and transforming the
 :ref:`internal_representation:Expression tree`.
 """
-from copy import deepcopy
+
 import re
 from itertools import zip_longest
 import pymbolic.primitives as pmbl
@@ -522,7 +522,10 @@ class LokiIdentityMapper(IdentityMapper):
         """ Utility to safely rebuild any symbol """
         if hasattr(expr, 'clone'):
             return expr.clone()
-        return deepcopy(expr)
+
+        # Re-create symbol Pymbolic-style
+        cargs = dict(zip(expr.init_arg_names, expr.__getinitargs__()))
+        return type(expr)(**cargs)
 
     def __call__(self, expr, *args, **kwargs):
         if expr is None:

--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -515,18 +515,7 @@ class LokiIdentityMapper(IdentityMapper):
     This can serve as basis for any transformation mappers
     that apply changes to the expression tree. Expression nodes that
     are unchanged are returned as is.
-
-    Parameters
-    ----------
-    invalidate_source : bool, optional
-        By default the :attr:`source` property of nodes is discarded
-        when rebuilding the node, setting this to `False` allows to
-        retain that information
     """
-
-    def __init__(self, invalidate_source=True):
-        super().__init__()
-        self.invalidate_source = invalidate_source
 
     @staticmethod
     def _rebuild(expr):
@@ -539,20 +528,7 @@ class LokiIdentityMapper(IdentityMapper):
         if expr is None:
             return None
         kwargs.setdefault('recurse_to_declaration_attributes', False)
-        new_expr = super().__call__(expr, *args, **kwargs)
-        if getattr(expr, 'source', None):
-            if isinstance(new_expr, tuple):
-                for e in new_expr:
-                    if self.invalidate_source:
-                        e.source = None
-                    else:
-                        e.source = deepcopy(expr.source)
-            else:
-                if self.invalidate_source:
-                    new_expr.source = None
-                else:
-                    new_expr.source = deepcopy(expr.source)
-        return new_expr
+        return super().__call__(expr, *args, **kwargs)
 
     rec = __call__
 
@@ -757,15 +733,11 @@ class SubstituteExpressionsMapper(LokiIdentityMapper):
     ----------
     expr_map : dict
         Expression mapping to apply to the expression tree.
-    invalidate_source : bool, optional
-        By default the :attr:`source` property of nodes is discarded
-        when rebuilding the node, setting this to `False` allows to
-        retain that information
     """
     # pylint: disable=abstract-method
 
-    def __init__(self, expr_map, invalidate_source=True):
-        super().__init__(invalidate_source=invalidate_source)
+    def __init__(self, expr_map):
+        super().__init__()
 
         self.expr_map = expr_map
         for expr in self.expr_map.keys():
@@ -796,7 +768,7 @@ class AttachScopesMapper(LokiIdentityMapper):
     """
 
     def __init__(self, fail=False):
-        super().__init__(invalidate_source=False)
+        super().__init__()
         self.fail = fail
 
     def _update_symbol_scope(self, expr, scope):
@@ -853,9 +825,6 @@ class DetachScopesMapper(LokiIdentityMapper):
     itself, which is useful when storing information for inter-procedural
     analysis passes.
     """
-
-    def __init__(self):
-        super().__init__(invalidate_source=False)
 
     def map_variable_symbol(self, expr, *args, **kwargs):
         new_expr = super().map_variable_symbol(expr, *args, **kwargs)

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -518,8 +518,8 @@ class SimplifyMapper(LokiIdentityMapper):
     """
     # pylint: disable=abstract-method
 
-    def __init__(self, enabled_simplifications=Simplification.ALL, invalidate_source=True):
-        super().__init__(invalidate_source=invalidate_source)
+    def __init__(self, enabled_simplifications=Simplification.ALL):
+        super().__init__()
 
         self.enabled_simplifications = enabled_simplifications
 

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1236,6 +1236,8 @@ class LiteralList(pmbl.AlgebraicLeaf):
     A list of constant literals, e.g., as used in Array Initialization Lists.
     """
 
+    init_arg_names = ('values', 'dtype')
+
     def __init__(self, values, dtype=None, **kwargs):
         self.elements = values
         self.dtype = dtype
@@ -1424,16 +1426,25 @@ class Cast(pmbl.Call):
     Internal representation of a data type cast.
     """
 
+    init_arg_names = ('name', 'expression', 'kind')
+
     def __init__(self, name, expression, kind=None, **kwargs):
         assert kind is None or isinstance(kind, pmbl.Expression)
         self.kind = kind
         super().__init__(pmbl.make_variable(name), as_tuple(expression), **kwargs)
+
+    def __getinitargs__(self):
+        return (self.name, self.expression, self.kind)
 
     mapper_method = intern('map_cast')
 
     @property
     def name(self):
         return self.function.name
+
+    @property
+    def expression(self):
+        return self.parameters
 
 
 class Range(StrCompareMixin, pmbl.Slice):

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -12,7 +12,6 @@ import pytest
 import numpy as np
 
 import pymbolic.primitives as pmbl
-import pymbolic.mapper as pmbl_mapper
 
 from loki import (
     Sourcefile, Subroutine, Module, Scope, BasicType,

--- a/loki/expression/tests/test_mapper.py
+++ b/loki/expression/tests/test_mapper.py
@@ -8,8 +8,9 @@
 import pytest
 
 from loki import Subroutine, Scope
-from loki.expression import (
-    symbols as sym, parse_expr, ExpressionRetriever
+from loki.expression import symbols as sym, parse_expr
+from loki.expression.mappers import (
+    ExpressionRetriever, LokiIdentityMapper
 )
 from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
@@ -57,3 +58,36 @@ end subroutine test_expr_retriever
     # Cannot determine Scalar without declarations, so check for deferred
     assert ExpressionRetriever(q_deferred).retrieve(expr) == ['a', 'c', 'a']
     assert ExpressionRetriever(q_literal).retrieve(expr) == [5, 4]
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_identity_mapper(frontend):
+    """
+    Test for :any:`LokiIdentityMapper`, in particular deep-copying
+    expression nodes.
+    """
+
+    fcode = """
+subroutine test_expr_retriever(n, a, b, c)
+  integer, intent(inout) :: n, a, b(n), c
+
+  a = 5 * a + 4 * b(c) + a
+end subroutine test_expr_retriever
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    expr = FindNodes(ir.Assignment).visit(routine.body)[0].rhs
+
+    # Run the identity mapper over the expression
+    new_expr = LokiIdentityMapper()(expr)
+
+    # Check that symbols and literals are equivalent, but distinct objects!
+    get_symbols = ExpressionRetriever(lambda e: isinstance(e, sym.TypedSymbol)).retrieve
+    get_literals = ExpressionRetriever(lambda e: isinstance(e, sym.IntLiteral)).retrieve
+
+    for old, new in zip(get_symbols(expr), get_symbols(new_expr)):
+        assert old == new
+        assert not old is new
+
+    for old, new in zip(get_literals(expr), get_literals(new_expr)):
+        assert old == new
+        assert not old is new

--- a/loki/expression/tests/test_mapper.py
+++ b/loki/expression/tests/test_mapper.py
@@ -1,0 +1,59 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from loki import Subroutine, Scope
+from loki.expression import (
+    symbols as sym, parse_expr, ExpressionRetriever
+)
+from loki.frontend import available_frontends
+from loki.ir import nodes as ir, FindNodes
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_expression_retriever(frontend):
+    """ Test for :any:`ExpressionRetriever` (a :any:`LokiWalkMapper`) """
+
+    fcode = """
+subroutine test_expr_retriever(n, a, b, c)
+  integer, intent(inout) :: n, a, b(n), c
+
+  a = 5 * a + 4 * b(c) + a
+end subroutine test_expr_retriever
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    expr = FindNodes(ir.Assignment).visit(routine.body)[0].rhs
+
+    def q_symbol(n):
+        return isinstance(n, sym.TypedSymbol)
+
+    def q_array(n):
+        return isinstance(n, sym.Array)
+
+    def q_scalar(n):
+        return isinstance(n, sym.Scalar)
+
+    def q_deferred(n):
+        return isinstance(n, sym.DeferredTypeSymbol)
+
+    def q_literal(n):
+        return isinstance(n, sym.IntLiteral)
+
+    assert ExpressionRetriever(q_symbol).retrieve(expr) == ['a', 'b', 'c', 'a']
+    assert ExpressionRetriever(q_array).retrieve(expr) == ['b(c)']
+    assert ExpressionRetriever(q_scalar).retrieve(expr) == ['a', 'c', 'a']
+    assert ExpressionRetriever(q_literal).retrieve(expr) == [5, 4]
+
+    scope = Scope()
+    expr = parse_expr('5 * a + 4 * b(c) + a', scope=scope)
+
+    assert ExpressionRetriever(q_symbol).retrieve(expr) == ['a', 'b', 'c', 'a']
+    assert ExpressionRetriever(q_array).retrieve(expr) == ['b(c)']
+    # Cannot determine Scalar without declarations, so check for deferred
+    assert ExpressionRetriever(q_deferred).retrieve(expr) == ['a', 'c', 'a']
+    assert ExpressionRetriever(q_literal).retrieve(expr) == [5, 4]

--- a/loki/expression/tests/test_parser.py
+++ b/loki/expression/tests/test_parser.py
@@ -13,7 +13,7 @@ import pymbolic.mapper as pmbl_mapper
 from loki import Subroutine, Module, Scope
 from loki.expression import symbols as sym, parse_expr
 from loki.frontend import (
-    available_frontends, OMNI, HAVE_FP, parse_fparser_expression
+    available_frontends, HAVE_FP, parse_fparser_expression
 )
 from loki.ir import FindVariables
 

--- a/loki/expression/tests/test_symbolic.py
+++ b/loki/expression/tests/test_symbolic.py
@@ -252,8 +252,7 @@ def test_is_dimension_constant(frontend):
     assert not is_const[3]
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
-def test_normalized_loop_range(tmp_path, frontend):
+def test_normalized_loop_range():
     """
     Tests the num_iterations and normalized_loop_range functions.
     """
@@ -270,12 +269,11 @@ def test_normalized_loop_range(tmp_path, frontend):
                 assert normalized_start == 1, "LoopRange.start should be equal to 1 in a normalized range"
 
                 normalized_stop = floor(LokiEvaluationMapper()(normalized_range.stop))
-                assert normalized_stop == len(
-                    pyrange), "LoopRange.stop should be equal to the total number of iterations of the original LoopRange"
+                assert normalized_stop == len(pyrange), \
+                    "LoopRange.stop should be equal to the total number of iterations of the original LoopRange"
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
-def test_iteration_number(tmp_path, frontend):
+def test_iteration_number():
     for start in range(-10, 11):
         for stop in range(start + 1, 50, 4):
             for step in itertools.chain([None], range(1, stop - start)):
@@ -290,8 +288,7 @@ def test_iteration_number(tmp_path, frontend):
                            zip(pyrange, normalized_range))
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
-def test_iteration_index(tmp_path, frontend):
+def test_iteration_index():
     for start in range(-10, 11):
         for stop in range(start + 1, 50, 4):
             for step in range(1, stop - start):
@@ -304,6 +301,3 @@ def test_iteration_index(tmp_path, frontend):
                 LEM = LokiEvaluationMapper()
                 assert all(i == LEM(iteration_index(sym.IntLiteral(n), loop_range)) for i, n in
                            zip(pyrange, normalized_range))
-
-
-

--- a/loki/expression/tests/test_symbols.py
+++ b/loki/expression/tests/test_symbols.py
@@ -1,0 +1,77 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki.expression import symbols as sym
+from loki.scope import Scope
+from loki.types import BasicType, ProcedureType, SymbolAttributes
+
+
+def test_symbol_recreation():
+    """ 
+    Test the correct construction and re-construction of our symbol objects.
+    """
+    scope = Scope()
+    int_type = SymbolAttributes(BasicType.INTEGER, parameter=True)
+    real_type = SymbolAttributes(BasicType.REAL, kind='rick')
+    log_type = SymbolAttributes(BasicType.LOGICAL)
+    proc_type = SymbolAttributes(
+        ProcedureType(name='f', is_function=True, return_type=real_type)
+    )
+
+    i = sym.Scalar(name='i', type=int_type, scope=scope)
+    a = sym.Array(name='a', type=real_type, scope=scope)
+    b = sym.Variable(
+        name='b', dimensions=(i,), type=int_type, scope=scope
+    )
+    t = sym.Scalar(name='t', type=log_type, scope=scope)
+    f = sym.ProcedureSymbol(name='f', type=proc_type, scope=scope)
+
+    # Basic variables and symbols
+    exprs = [i, a, b, t, f]
+
+    # Literals
+    exprs.append( sym.FloatLiteral(66.6) )
+    exprs.append( sym.IntLiteral(42) )
+    exprs.append( sym.LogicLiteral(True) )
+    exprs.append( sym.StringLiteral('Dave') )
+    exprs.append( sym.LiteralList(
+        values=(sym.Literal(1), sym.IntLiteral(2)), dtype=int_type
+    ) )
+
+    # Operations
+    exprs.append( sym.Sum((b, a)) )  # b(i) + a
+    exprs.append( sym.Product((b, a)) )  # b(i) +* a
+    exprs.append( sym.Sum((b, sym.Product((-1, a)))))  # b(i) - a
+    exprs.append( sym.Quotient(numerator=b, denominator=a) )  # b(i) / a
+
+    exprs.append( sym.Comparison(b, '==', a) )  # b(i) == a
+    exprs.append( sym.LogicalNot(t) )
+    exprs.append( sym.LogicalAnd((t, sym.LogicalNot(t))) )
+    exprs.append( sym.LogicalOr((t, sym.LogicalNot(t))) )
+
+    # Slightly special symbol types
+    exprs.append( sym.InlineCall(function=f, parameters=(a, b)) )
+    exprs.append( sym.Range((sym.IntLiteral(1), i)) )
+    exprs.append( sym.LoopRange((sym.IntLiteral(1), i)) )
+    exprs.append( sym.RangeIndex((sym.IntLiteral(1), i)) )
+
+    exprs.append( sym.Cast(name='int', expression=b, kind=i) )
+    exprs.append( sym.Reference(expression=b) )
+    exprs.append( sym.Dereference(expression=b) )
+
+    for expr in exprs:
+        # Check that Pymbolic-style re-generation works for all
+        # TODO: Should we introduce a Mixin "Cloneable" to makes these sane?
+        cargs = dict(zip(expr.init_arg_names, expr.__getinitargs__()))
+        clone = type(expr)(**cargs)
+        assert clone == expr
+
+        if isinstance(expr, sym.TypedSymbol):
+            # Check that TypedSymbols replicate scope via .clone()
+            scoped_clone = expr.clone()
+            assert scoped_clone == expr
+            assert scoped_clone.scope == expr.scope

--- a/loki/expression/tests/test_symbols.py
+++ b/loki/expression/tests/test_symbols.py
@@ -69,9 +69,11 @@ def test_symbol_recreation():
         cargs = dict(zip(expr.init_arg_names, expr.__getinitargs__()))
         clone = type(expr)(**cargs)
         assert clone == expr
+        assert clone is not expr
 
         if isinstance(expr, sym.TypedSymbol):
             # Check that TypedSymbols replicate scope via .clone()
             scoped_clone = expr.clone()
             assert scoped_clone == expr
-            assert scoped_clone.scope == expr.scope
+            assert scoped_clone is not expr
+            assert scoped_clone.scope is expr.scope

--- a/loki/frontend/util.py
+++ b/loki/frontend/util.py
@@ -297,7 +297,7 @@ class RangeIndexTransformer(Transformer):
                 _type = _type.clone(shape=shape)
             vmap[v] = v.clone(dimensions=dimensions, type=_type)
 
-        mapper = SubstituteExpressionsMapper(vmap, invalidate_source=self.invalidate_source)
+        mapper = SubstituteExpressionsMapper(vmap)
         return o.clone(symbols=mapper(o.symbols, recurse_to_declaration_attributes=True))
 
 

--- a/loki/ir/expr_visitors.py
+++ b/loki/ir/expr_visitors.py
@@ -246,8 +246,7 @@ class SubstituteExpressions(Transformer):
     def __init__(self, expr_map, invalidate_source=True, **kwargs):
         super().__init__(invalidate_source=invalidate_source, **kwargs)
 
-        self.expr_mapper = SubstituteExpressionsMapper(expr_map,
-                                                       invalidate_source=invalidate_source)
+        self.expr_mapper = SubstituteExpressionsMapper(expr_map)
 
     def visit_Expression(self, o, **kwargs):
         """

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -510,7 +510,11 @@ def recursive_expression_map_update(expr_map, max_iterations=10, mapper_cls=Subs
         # We update the expression map by applying it to the children of each replacement
         # node, thus making sure node replacements are also applied to nested attributes,
         # e.g. call arguments or array subscripts etc.
-        mapper = mapper_cls(expr_map)
+        if issubclass(mapper_cls, SubstituteExpressionsMapper):
+            # Need to check if we should pass the `expr_map` argument
+            mapper = mapper_cls(expr_map)
+        else:
+            mapper = mapper_cls()
         prev_map, expr_map = expr_map, {
             expr: type(replacement)(**{
                 name: apply_to_init_arg(name, arg, expr, mapper)


### PR DESCRIPTION
~_Note: Only for testing so far ..._~

The primary intention behind this PR is to increase test coverage of the expression mappers and rigorously duplicate symbols when expression mappers (`LokiIdentityMapper` and `SubstituteExpressionMapper`). It also fixes a bunch of other issues along the way that this threw up and now fixes #379 .

In a little more detail:
* Add dedicated tests for expression walker (via `ExpressionRetriever`) and the mappers `LokitIdentityMapper` and `SubstituteExrpressionMapper`
* Lint-clean the expression tests directory
* Remove the now redundant `invalidate_source` argument from Loki mappers (we do not store source on expressions anymore)
  * Fix the resulting issue in `recursive_expression_map_update` by checking for ancestry of `SubstituteExpressionMapper` before handing the map to constructors
* Duplicate symbols in `LokiIdentityMapper` and `SubstotuteExpressionMapper`
  * Add a local `_rebuild()` method the base class that check for scope-carrying and scope-free symbols
  * Add a dedicated symbols test for correct re-instatiation of all our symbols types and fix the ones that do not behave
  * Always update the symbol after enrichment, to ensure that `DeferredTypeSymbols` are replaced with `ProcedureTypeSymbols` in `CallStatement.name` after the type updates.