### PR TITLE
[F2C transpilation] (driver level) convert interface to import

### DIFF
--- a/loki/transformations/transpile/fortran_c.py
+++ b/loki/transformations/transpile/fortran_c.py
@@ -182,6 +182,7 @@ class FortranCTransformation(Transformation):
             depth = depths[item]
 
         if role == 'driver':
+            self.interface_to_import(routine, targets)
             return
 
         for arg in routine.arguments:
@@ -242,6 +243,30 @@ class FortranCTransformation(Transformation):
                 inline_call_map[inline_call] = inline_call.clone_with_kwargs_as_args()
         if inline_call_map:
             routine.body = SubstituteExpressions(inline_call_map).visit(routine.body)
+
+    def interface_to_import(self, routine, targets):
+        """
+        Convert interface to import.
+        """
+        for call in FindNodes(CallStatement).visit(routine.body):
+            if str(call.name).lower() in as_tuple(targets):
+                call.convert_kwargs_to_args()
+        intfs = FindNodes(Interface).visit(routine.spec)
+        removal_map = {}
+        for i in intfs:
+            for b in i.body:
+                if isinstance(b, Subroutine):
+                    if targets and b.name.lower() in targets:
+                        # Create a new module import with explicitly qualified symbol
+                        modname = f'{b.name}_FC_MOD'
+                        new_symbol = Variable(name=f'{b.name}_FC', scope=routine)
+                        new_import = Import(module=modname, c_import=False, symbols=(new_symbol,))
+                        routine.spec.prepend(new_import)
+                        # Mark current import for removal
+                        removal_map[i] = None
+        # Apply any scheduled interface removals to spec
+        if removal_map:
+            routine.spec = Transformer(removal_map).visit(routine.spec)
 
     def c_struct_typedef(self, derived):
         """

--- a/loki/transformations/transpile/fortran_c.py
+++ b/loki/transformations/transpile/fortran_c.py
@@ -254,16 +254,15 @@ class FortranCTransformation(Transformation):
         intfs = FindNodes(Interface).visit(routine.spec)
         removal_map = {}
         for i in intfs:
-            for b in i.body:
-                if isinstance(b, Subroutine):
-                    if targets and b.name.lower() in targets:
-                        # Create a new module import with explicitly qualified symbol
-                        modname = f'{b.name}_FC_MOD'
-                        new_symbol = Variable(name=f'{b.name}_FC', scope=routine)
-                        new_import = Import(module=modname, c_import=False, symbols=(new_symbol,))
-                        routine.spec.prepend(new_import)
-                        # Mark current import for removal
-                        removal_map[i] = None
+            for s in i.symbols:
+                if targets and s in targets:
+                    # Create a new module import with explicitly qualified symbol
+                    new_symbol = s.clone(name=f'{s.name}_FC', scope=routine)
+                    modname = f'{new_symbol.name}_MOD'
+                    new_import = Import(module=modname, c_import=False, symbols=(new_symbol,))
+                    routine.spec.prepend(new_import)
+                    # Mark current import for removal
+                    removal_map[i] = None
         # Apply any scheduled interface removals to spec
         if removal_map:
             routine.spec = Transformer(removal_map).visit(routine.spec)

--- a/loki/transformations/transpile/tests/test_transpile.py
+++ b/loki/transformations/transpile/tests/test_transpile.py
@@ -1410,11 +1410,11 @@ END SUBROUTINE driver_interface_to_module
     f2c = FortranCTransformation()
     f2c.apply(source=routine, path=tmp_path, targets=('kernel',), role='driver')
 
-    interfaces = FindNodes(ir.Interface).visit(routine.spec)
-    imports = FindNodes(ir.Import).visit(routine.spec)
-    assert len(interfaces) == 2
+    assert len(routine.interfaces) == 2
+    imports = routine.imports
     assert len(imports) == 1
     assert imports[0].module.upper() == 'KERNEL_FC_MOD'
+    assert imports[0].symbols == ('KERNEL_FC',)
 
 
 @pytest.fixture(scope='module', name='horizontal')

--- a/loki/transformations/transpile/tests/test_transpile.py
+++ b/loki/transformations/transpile/tests/test_transpile.py
@@ -1372,6 +1372,50 @@ end subroutine transpile_special_functions
         fc_function(in_var, out_var)
         assert int(out_var) == expected_results[i]
 
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transpile_interface_to_module(tmp_path, frontend):
+    driver_fcode = """
+SUBROUTINE driver_interface_to_module(a, b, c)
+  IMPLICIT NONE
+  INTERFACE
+    SUBROUTINE KERNEL(a, b, c)
+      INTEGER, INTENT(INOUT) :: a, b, c
+    END SUBROUTINE KERNEL
+  END INTERFACE
+  INTERFACE
+    SUBROUTINE KERNEL2(a, b)
+      INTEGER, INTENT(INOUT) :: a, b
+    END SUBROUTINE KERNEL2
+  END INTERFACE
+  INTERFACE
+    SUBROUTINE KERNEL3(a)
+      INTEGER, INTENT(INOUT) :: a
+    END SUBROUTINE KERNEL3
+  END INTERFACE
+
+  INTEGER, INTENT(INOUT) :: a, b, c
+
+  CALL kernel(a, b ,c)
+  CALL kernel2(a, b)
+END SUBROUTINE driver_interface_to_module
+    """.strip()
+
+    routine = Subroutine.from_source(driver_fcode, frontend=frontend)
+
+    interfaces = FindNodes(ir.Interface).visit(routine.spec)
+    imports = FindNodes(ir.Import).visit(routine.spec)
+    assert len(interfaces) == 3
+    assert not imports
+
+    f2c = FortranCTransformation()
+    f2c.apply(source=routine, path=tmp_path, targets=('kernel',), role='driver')
+
+    interfaces = FindNodes(ir.Interface).visit(routine.spec)
+    imports = FindNodes(ir.Import).visit(routine.spec)
+    assert len(interfaces) == 2
+    assert len(imports) == 1
+    assert imports[0].module.upper() == 'KERNEL_FC_MOD'
+
 
 @pytest.fixture(scope='module', name='horizontal')
 def fixture_horizontal():


### PR DESCRIPTION
Convert interface to kernel calls (e.g., `interface kernel ...`) to the appropriate import (e.g., `kernel_fc_mod, only: kernel_fc`).