### PR TITLE
C-like-backends: skip/don't write Fortran interfaces

### DIFF
--- a/loki/backend/cgen.py
+++ b/loki/backend/cgen.py
@@ -273,6 +273,9 @@ class CCodegen(Stringifier):
         footer = [self.format_line('}')]
         return footer
 
+    def visit_Interface(self, o, **kwargs):
+        return None
+
     def visit_Subroutine(self, o, **kwargs):
         """
         Format as:


### PR DESCRIPTION
For now: just don't generate code for Fortran interfaces when applying c-like-backends (`cgen`, `cppgen`, `cudagen`).