### PR TITLE
Continued: F2C/CUDA transpilation

### DIFF
--- a/loki/backend/cudagen.py
+++ b/loki/backend/cudagen.py
@@ -78,6 +78,8 @@ class CudaCodegen(CppCodegen):
         prefix = ''
         if o.prefix and "global" in o.prefix[0].lower():
             prefix = '__global__ '
+        if o.prefix and "device" in o.prefix[0].lower():
+            prefix = '__device__ '
         if o.is_function:
             return_type = self.symgen.intrinsic_type_mapper(o.return_type)
         else:

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1432,14 +1432,14 @@ class InlineCall(pmbl.CallWithKwargs):
         new_kwarguments = tuple((arg_name, kwargs[arg_name]) for arg_name in r_arg_names)
         return new_kwarguments
 
-    def check_kwarguments_order(self):
+    def is_kwargs_order_correct(self):
         """
         Check whether kwarguments/kw_parameters are correctly ordered
         in respect to the arguments (``self.routine.arguments``).
         """
         return self.kwarguments == self._sort_kwarguments()
 
-    def sort_kwarguments(self):
+    def clone_with_sorted_kwargs(self):
         """
         Sort and update the kwarguments/kw_parameters according to the order of the
         arguments (``self.routine.arguments``) and return the
@@ -1448,7 +1448,7 @@ class InlineCall(pmbl.CallWithKwargs):
         new_kwarguments = self._sort_kwarguments()
         return self.clone(kw_parameters=new_kwarguments)
 
-    def convert_kwargs_to_args(self):
+    def clone_with_kwargs_as_args(self):
         """
         Convert all kwarguments/kw_parameters to arguments and
         return the converted clone/copy of the inline call.

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1420,6 +1420,42 @@ class InlineCall(pmbl.CallWithKwargs):
         kw_parameters = kwargs.get('kw_parameters', self.kw_parameters)
         return InlineCall(function, parameters, kw_parameters)
 
+    def _sort_kwarguments(self):
+        """
+        Helper routine to sort the kwarguments/kw_parameters according to the order of the
+        arguments (``self.routine.arguments``)`.
+        """
+        routine = self.routine
+        assert routine is not BasicType.DEFERRED
+        kwargs = CaseInsensitiveDict(self.kwarguments)
+        r_arg_names = [arg.name for arg in routine.arguments if arg.name in kwargs]
+        new_kwarguments = tuple((arg_name, kwargs[arg_name]) for arg_name in r_arg_names)
+        return new_kwarguments
+
+    def check_kwarguments_order(self):
+        """
+        Check whether kwarguments/kw_parameters are correctly ordered
+        in respect to the arguments (``self.routine.arguments``).
+        """
+        return self.kwarguments == self._sort_kwarguments()
+
+    def sort_kwarguments(self):
+        """
+        Sort and update the kwarguments/kw_parameters according to the order of the
+        arguments (``self.routine.arguments``) and return the
+        conveted clone/copy of the inline call.
+        """
+        new_kwarguments = self._sort_kwarguments()
+        return self.clone(kw_parameters=new_kwarguments)
+
+    def convert_kwargs_to_args(self):
+        """
+        Convert all kwarguments/kw_parameters to arguments and
+        return the converted clone/copy of the inline call.
+        """
+        new_kwarguments = self._sort_kwarguments()
+        new_args = tuple(arg[1] for arg in new_kwarguments)
+        return self.clone(parameters=self.arguments + new_args, kw_parameters=())
 
 class Cast(pmbl.Call):
     """

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -691,10 +691,10 @@ end subroutine my_kwargs_routine
 
     # Sort the kwargs and test the transformed code
     inline_call = list(FindInlineCalls().visit(routine.body))[0]
-    call_map = {inline_call: inline_call.sort_kwarguments()}
+    call_map = {inline_call: inline_call.clone_with_sorted_kwargs()}
     routine.body = SubstituteExpressions(call_map).visit(routine.body)
     inline_call = list(FindInlineCalls().visit(routine.body))[0]
-    assert inline_call.check_kwarguments_order()
+    assert inline_call.is_kwargs_order_correct()
     assert not inline_call.arguments
     assert inline_call.kwarguments == (('a', 'v_a'), ('b', 'v_b'), ('c', 'v_c'), ('d', 'v_d'))
     filepath = tmp_path/(f'sorted_expression_kwargs_call_{frontend}.f90')
@@ -703,7 +703,7 @@ end subroutine my_kwargs_routine
     assert res_sorted == 83
 
     # Convert kwargs to args and test the transformed code
-    call_map = {inline_call: inline_call.convert_kwargs_to_args()}
+    call_map = {inline_call: inline_call.clone_with_kwargs_as_args()}
     routine.body = SubstituteExpressions(call_map).visit(routine.body)
     inline_call = list(FindInlineCalls().visit(routine.body))[0]
     assert not inline_call.kwarguments

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -663,6 +663,57 @@ end subroutine my_routine
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_kwargs_inline_call(frontend, tmp_path):
+    """
+    Test inline call with kwargs and correct sorting as well
+    as correct conversion to args.
+    """
+    fcode_routine = """
+subroutine my_kwargs_routine(var, v_a, v_b, v_c, v_d)
+  implicit none
+  integer, intent(out) :: var
+  integer, intent(in) :: v_a, v_b, v_c, v_d
+  var = my_kwargs_func(c=v_c, b=v_b, a=v_a, d=v_d)
+contains
+  function my_kwargs_func(a, b, c, d)
+    integer, intent(in) :: a, b, c, d
+    integer :: my_kwargs_func
+    my_kwargs_func = a - b - c - d 
+  end function my_kwargs_func
+end subroutine my_kwargs_routine
+    """
+    # Test the original implementation
+    filepath = tmp_path/(f'orig_expression_kwargs_call_{frontend}.f90')
+    routine = Subroutine.from_source(fcode_routine, frontend=frontend, xmods=[tmp_path])
+    function = jit_compile(routine, filepath=filepath, objname='my_kwargs_routine')
+    res_orig = function(100, 10, 5, 2)
+    assert res_orig == 83
+
+    # Sort the kwargs and test the transformed code
+    inline_call = list(FindInlineCalls().visit(routine.body))[0]
+    call_map = {inline_call: inline_call.sort_kwarguments()}
+    routine.body = SubstituteExpressions(call_map).visit(routine.body)
+    inline_call = list(FindInlineCalls().visit(routine.body))[0]
+    assert inline_call.check_kwarguments_order()
+    assert not inline_call.arguments
+    assert inline_call.kwarguments == (('a', 'v_a'), ('b', 'v_b'), ('c', 'v_c'), ('d', 'v_d'))
+    filepath = tmp_path/(f'sorted_expression_kwargs_call_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname='my_kwargs_routine')
+    res_sorted = function(100, 10, 5, 2)
+    assert res_sorted == 83
+
+    # Convert kwargs to args and test the transformed code
+    call_map = {inline_call: inline_call.convert_kwargs_to_args()}
+    routine.body = SubstituteExpressions(call_map).visit(routine.body)
+    inline_call = list(FindInlineCalls().visit(routine.body))[0]
+    assert not inline_call.kwarguments
+    filepath = tmp_path/(f'converted_expression_kwargs_call_{frontend}.f90')
+    function = jit_compile(routine, filepath=filepath, objname='my_kwargs_routine')
+    res_args = function(100, 10, 5, 2)
+    assert res_args == 83
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_inline_call_derived_type_arguments(frontend, tmp_path):
     """
     Check that derived type arguments are correctly represented in

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -1110,7 +1110,7 @@ class CallStatement(LeafNode, _CallStatementBase):
         new_kwarguments = tuple((arg_name, kwargs[arg_name]) for arg_name in r_arg_names)
         return new_kwarguments
 
-    def check_kwarguments_order(self):
+    def is_kwargs_order_correct(self):
         """
         Check whether kwarguments are correctly ordered
         in respect to the arguments (``self.routine.arguments``).

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -2190,7 +2190,7 @@ def test_call_args_kwargs_conversion(frontend):
 
     # sort kwargs
     for i_call, call in enumerate(FindNodes(ir.CallStatement).visit(driver.body)):
-        assert call.check_kwarguments_order() == kwargs_in_order[i_call]
+        assert call.is_kwargs_order_correct() == kwargs_in_order[i_call]
         call.sort_kwarguments()
 
     # check calls with sorted kwargs

--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -521,8 +521,8 @@ class LowerBlockIndexTransformation(Transformation):
         """
         processed_routines = ()
         variable_map = routine.variable_map
-        block_dim_index = variable_map[self.block_dim.index]
-        block_dim_size = variable_map[self.block_dim.size]
+        block_dim_index = get_integer_variable(routine, self.block_dim.index)
+        block_dim_size = get_integer_variable(routine, self.block_dim.size)
         for call in FindNodes(ir.CallStatement).visit(routine.body):
             if str(call.name).lower() not in targets:
                 continue

--- a/loki/transformations/single_column/scc_cuf.py
+++ b/loki/transformations/single_column/scc_cuf.py
@@ -342,14 +342,15 @@ class SccLowLevelLaunchConfiguration(Transformation):
                     if horizontal_index.name in call.routine.variables:
                         call.routine.symbol_attrs.update({horizontal_index.name:\
                                 call.routine.variable_map[horizontal_index.name].type.clone(intent='in')})
-                    additional_args += (horizontal_index.clone(),)
+                    additional_args += (horizontal_index.clone(type=horizontal_index.type.clone(intent='in'),
+                                                               scope=call.routine),)
                 if horizontal_index.name not in call.arg_map:
-                    additional_kwargs += ((horizontal_index.name, horizontal_index.clone()),)
+                    additional_kwargs += ((horizontal_index.name, horizontal_index.clone(scope=routine)),)
 
                 if block_dim_index.name not in call.routine.arguments:
                     additional_args += (block_dim_index.clone(type=block_dim_index.type.clone(intent='in',
                         scope=call.routine)),)
-                    additional_kwargs += ((block_dim_index.name, block_dim_index.clone()),)
+                    additional_kwargs += ((block_dim_index.name, block_dim_index.clone(scope=routine)),)
                 if additional_kwargs:
                     call._update(kwarguments=call.kwarguments+additional_kwargs)
                 if additional_args:

--- a/loki/transformations/tests/sources/projSccCuf/module/kernel.f90
+++ b/loki/transformations/tests/sources/projSccCuf/module/kernel.f90
@@ -10,7 +10,7 @@ MODULE KERNEL_MOD
         INTEGER :: jl, jk
         REAL :: c
 
-        c = 5.345
+        c = SOME_FUNC(A=5.345)
         DO jk = 2, nz
           DO jl = start, iend
             call ELEMENTAL_DEVICE(z(jl, jk))
@@ -53,5 +53,12 @@ MODULE KERNEL_MOD
             END DO
         END DO
     END SUBROUTINE DEVICE
+
+    FUNCTION SOME_FUNC(A)
+        REAL, INTENT(IN) :: A
+        REAL :: SOME_FUNC
+        !$loki routine seq
+        SOME_FUNC = A
+    END FUNCTION SOME_FUNC
 
 END MODULE KERNEL_MOD

--- a/loki/transformations/transpile/fortran_c.py
+++ b/loki/transformations/transpile/fortran_c.py
@@ -239,7 +239,7 @@ class FortranCTransformation(Transformation):
         inline_call_map = {}
         for inline_call in as_tuple(FindInlineCalls().visit(routine.body)):
             if str(inline_call.name).lower() in as_tuple(targets) and inline_call.routine is not BasicType.DEFERRED:
-                inline_call_map[inline_call] = inline_call.convert_kwargs_to_args()
+                inline_call_map[inline_call] = inline_call.clone_with_kwargs_as_args()
         if inline_call_map:
             routine.body = SubstituteExpressions(inline_call_map).visit(routine.body)
 

--- a/loki/transformations/transpile/fortran_c.py
+++ b/loki/transformations/transpile/fortran_c.py
@@ -18,7 +18,7 @@ from loki.expression import (
 from loki.ir import (
     Section, Import, Intrinsic, Interface, CallStatement,
     VariableDeclaration, TypeDef, Assignment, Transformer, FindNodes,
-    Pragma, Comment, SubstituteExpressions
+    Pragma, Comment, SubstituteExpressions, FindInlineCalls
 )
 from loki.logging import debug
 from loki.module import Module
@@ -188,9 +188,8 @@ class FortranCTransformation(Transformation):
             if isinstance(arg.type.dtype, DerivedType):
                 self.c_structs[arg.type.dtype.name.lower()] = self.c_struct_typedef(arg.type)
 
-        for call in FindNodes(CallStatement).visit(routine.body):
-            if str(call.name).lower() in as_tuple(targets):
-                call.convert_kwargs_to_args()
+        # for calls and inline calls: convert kwarguments to arguments
+        self.convert_kwargs_to_args(routine, targets)
 
         if role == 'kernel':
             # Generate Fortran wrapper module
@@ -230,6 +229,19 @@ class FortranCTransformation(Transformation):
                                path=self.c_path)
             header_path = (path/c_kernel.name.lower()).with_suffix('.h')
             Sourcefile.to_file(source=self.codegen(c_kernel, header=True), path=header_path)
+
+    def convert_kwargs_to_args(self, routine, targets):
+        # calls (to subroutines)
+        for call in as_tuple(FindNodes(CallStatement).visit(routine.body)):
+            if str(call.name).lower() in as_tuple(targets):
+                call.convert_kwargs_to_args()
+        # inline calls (to functions)
+        inline_call_map = {}
+        for inline_call in as_tuple(FindInlineCalls().visit(routine.body)):
+            if str(inline_call.name).lower() in as_tuple(targets) and inline_call.routine is not BasicType.DEFERRED:
+                inline_call_map[inline_call] = inline_call.convert_kwargs_to_args()
+        if inline_call_map:
+            routine.body = SubstituteExpressions(inline_call_map).visit(routine.body)
 
     def c_struct_typedef(self, derived):
         """
@@ -627,6 +639,9 @@ class FortranCTransformation(Transformation):
         # apply dereference and reference where necessary
         self.apply_de_reference(kernel)
 
+        # adapt call and inline call names -> '<call name>_c'
+        self.convert_call_names(kernel, targets)
+
         symbol_map = {'epsilon': 'DBL_EPSILON'}
         function_map = {'min': 'fmin', 'max': 'fmax', 'abs': 'fabs',
                         'exp': 'exp', 'sqrt': 'sqrt', 'sign': 'copysign'}
@@ -636,6 +651,20 @@ class FortranCTransformation(Transformation):
         sanitise_imports(kernel)
 
         return kernel
+
+    def convert_call_names(self, routine, targets):
+        # calls (to subroutines)
+        calls = FindNodes(CallStatement).visit(routine.body)
+        for call in calls:
+            if call.name not in as_tuple(targets):
+                continue
+            call._update(name=Variable(name=f'{call.name}_c'.lower()))
+        # inline calls (to functions)
+        callmap = {}
+        for call in FindInlineCalls(unique=False).visit(routine.body):
+            if call.routine is not BasicType.DEFERRED and (targets is None or call.name in as_tuple(targets)):
+                callmap[call.function] = call.function.clone(name=f'{call.name}_c')
+        routine.body = SubstituteExpressions(callmap).visit(routine.body)
 
     def generate_c_kernel_launch(self, kernel_launch, kernel, **kwargs):
         import_map = {}


### PR DESCRIPTION
Mostly related to nested/multi-level kernel calls:

* `__device__` prefix
* kwargs to args (also for inline calls)
* call name adaptation -> `<call/function name>_c`
* ...