### PR TITLE
Batch: Process-parallel directory scan and initial file read

### DIFF
--- a/loki/batch/__init__.py
+++ b/loki/batch/__init__.py
@@ -15,6 +15,7 @@ configuration utilities for large call tree traversals.
 """
 
 from loki.batch.configure import * # noqa
+from loki.batch.executor import * # noqa
 from loki.batch.item import * # noqa
 from loki.batch.item_factory import * # noqa
 from loki.batch.pipeline import * # noqa

--- a/loki/batch/executor.py
+++ b/loki/batch/executor.py
@@ -1,0 +1,44 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+A dummy "executor" utility that allows parallel non-threaded execution
+under the same API as thread or ProcessPoolExecutors.
+"""
+
+from concurrent.futures import Executor, Future
+
+__all__ = ['SerialExecutor']
+
+
+class SerialExecutor(Executor):
+    """
+    A dummy "executor" utility that allows parallel non-threaded
+    execution with the same API as a ``ProcessPoolExecutors``.
+    """
+
+    def submit(self, fn, *args, **kwargs):  # pylint: disable=arguments-differ
+        """
+        Executes the callable, *fn* as ``fn(*args, **kwargs)``
+        and wraps the return value in a *Future* object.
+        """
+        f = Future()
+        try:
+            # Execute function on given args
+            result = fn(*args, **kwargs)
+        except BaseException as e:
+            f.set_exception(e)
+        else:
+            f.set_result(result)
+
+        return f
+
+    def map(self, fn, *args, **kwargs):
+        """
+        Maps the callable *fn* via ``map(fn, *args, **kwargs)``.
+        """
+        return map(fn, *args, **kwargs)

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -15,7 +15,6 @@ from loki.ir import nodes as ir
 from loki.logging import warning
 from loki.module import Module
 from loki.subroutine import Subroutine
-from loki.sourcefile import Sourcefile
 from loki.tools import CaseInsensitiveDict, as_tuple
 from loki.types import BasicType
 
@@ -312,39 +311,6 @@ class ItemFactory:
             return self.create_from_ir(scope[local_name], scope, config=config)
 
         raise RuntimeError(f'Failed to clone item {item.name} as {name}')
-
-    def get_or_create_file_item_from_path(self, path, config, frontend_args=None):
-        """
-        Utility method to create a :any:`FileItem` for a given path
-
-        This is used to instantiate items for the first time during the scheduler's
-        discovery phase. It will use a cached item if it exists, or parse the source
-        file using the given :data:`frontend_args`.
-
-        Parameters
-        ----------
-        path : str or pathlib.Path
-            The file path of the source file
-        config : :any:`SchedulerConfig`
-            The config object from which the item configuration will be derived
-        frontend_args : dict, optional
-            Frontend arguments that are given to :any:`Sourcefile.from_file` when
-            parsing the file
-        """
-        item_name = str(path).lower()
-        if file_item := self.item_cache.get(item_name):
-            return file_item
-
-        if not frontend_args:
-            frontend_args = {}
-        if config:
-            frontend_args = config.create_frontend_args(path, frontend_args)
-
-        source = Sourcefile.from_file(path, **frontend_args)
-        item_conf = config.create_item_config(item_name) if config else None
-        file_item = FileItem(item_name, source=source, config=item_conf)
-        self.item_cache[item_name] = file_item
-        return file_item
 
     def get_or_create_file_item_from_source(self, source, config):
         """

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -22,6 +22,7 @@ from loki.batch.sgraph import SGraph
 from loki.batch.transformation import Transformation
 
 from loki.frontend import FP, REGEX, RegexParserClass
+from loki.sourcefile import Sourcefile
 from loki.tools import as_tuple, CaseInsensitiveDict, flatten
 
 from loki.logging import info, perf, warning, error
@@ -223,8 +224,14 @@ class Scheduler:
         path_list = list(set(flatten(path_list)))  # Filter duplicates and flatten
 
         # Instantiate FileItem instances for all files in the search path
-        for path in path_list:
-            self.item_factory.get_or_create_file_item_from_path(path, self.config, frontend_args)
+        path_fargs = tuple(
+            (path, self.config.create_frontend_args(path, frontend_args)) for path in path_list
+        )
+        sources = tuple(
+            Sourcefile.from_file(filename=path, **fargs) for path, fargs in path_fargs
+        )
+        for source in sources:
+            self.item_factory.get_or_create_file_item_from_source(source, self.config)
 
         # Instantiate the basic list of items for files and top-level program units
         #  in each file, i.e., modules and subroutines

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -6,6 +6,7 @@
 # nor does it submit to any jurisdiction.
 
 from enum import Enum, auto
+from concurrent.futures import ProcessPoolExecutor
 from os.path import commonpath
 from pathlib import Path
 from codetiming import Timer
@@ -160,9 +161,12 @@ class Scheduler:
     # TODO: Should be user-definable!
     source_suffixes = ['.f90', '.F90', '.f', '.F']
 
-    def __init__(self, paths, config=None, seed_routines=None, preprocess=False,
-                 includes=None, defines=None, definitions=None, xmods=None,
-                 omni_includes=None, full_parse=True, frontend=FP, output_dir=None):
+    def __init__(
+            self, paths, config=None, seed_routines=None, preprocess=False,
+            includes=None, defines=None, definitions=None, xmods=None,
+            omni_includes=None, full_parse=True, num_workers=1,
+            frontend=FP, output_dir=None
+    ):
         # Derive config from file or dict
         if isinstance(config, SchedulerConfig):
             self.config = config
@@ -172,6 +176,7 @@ class Scheduler:
             self.config = SchedulerConfig.from_dict(config or {})
 
         self.full_parse = full_parse
+        self.num_workers = num_workers
 
         # Build-related arguments to pass to the sources
         self.paths = [Path(p) for p in as_tuple(paths)]
@@ -224,12 +229,16 @@ class Scheduler:
         path_list = list(set(flatten(path_list)))  # Filter duplicates and flatten
 
         # Instantiate FileItem instances for all files in the search path
+        # TODO: This is essentially item-cache creation, and should live on ItemFactory
         path_fargs = tuple(
             (path, self.config.create_frontend_args(path, frontend_args)) for path in path_list
         )
-        sources = tuple(
-            Sourcefile.from_file(filename=path, **fargs) for path, fargs in path_fargs
-        )
+        with ProcessPoolExecutor(max_workers=self.num_workers) as executor:
+            src_futures = tuple(
+                executor.submit(Sourcefile.from_file, path, **fargs)
+                for path, fargs in path_fargs
+            )
+            sources = [src.result() for src in src_futures]
         for source in sources:
             self.item_factory.get_or_create_file_item_from_source(source, self.config)
 

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -381,7 +381,7 @@ class Scheduler:
         # Re-build the SGraph after parsing to pick up all new connections
         self._sgraph = SGraph.from_seed(self.seeds, self.item_factory, self.config)
 
-    @Timer(logger=perf, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')
+    @Timer(logger=info, text='[Loki::Scheduler] Enriched call tree in {:.2f}s')
     def _enrich(self):
         """
         For items that have a specific enrichment list provided as part of their

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -214,6 +214,23 @@ class Scheduler:
         # Shut down the parallel process pool
         self.executor.shutdown()
 
+    @staticmethod
+    def _parse_source(source, frontend_args):
+        """
+        Utility function that exposes the parsing step for one
+        :any:`SourceFile` as a pure function for the parallel
+        executor.
+
+        Parameters
+        ----------
+        source : :any:`Sourcefile`
+            The sourcefile object to trigger full parse on
+        frontend_args : dict
+            Dict of arguments to pass to :meth:`make_complete`
+        """
+        source.make_complete(**frontend_args)
+        return source
+
     @Timer(logger=info, text='[Loki::Scheduler] Performed initial source scan in {:.2f}s')
     def _discover(self):
         """
@@ -336,9 +353,22 @@ class Scheduler:
         # Force the parsing of the routines
         default_frontend_args = self.build_args.copy()
         default_frontend_args['definitions'] = as_tuple(default_frontend_args['definitions']) + self.definitions
-        for item in SFilter(self.file_graph, reverse=True):
-            frontend_args = self.config.create_frontend_args(item.name, default_frontend_args)
-            item.source.make_complete(**frontend_args)
+
+        # Get the iteration order from the Sfilter
+        items = SFilter(self.file_graph, reverse=True)
+
+        # Build the arguments for the parser function and call parallel map
+        with Timer(logger=perf, text='[Loki::Scheduler] Performed the actual parse loop in {:.2f}s'):
+            sources = tuple(item.source for item in items)
+            fargs = tuple(
+                self.config.create_frontend_args(item.name, default_frontend_args)
+                for item in items
+            )
+            f_sources = self.executor.map(self._parse_source, sources, fargs)
+
+        # Set the "completed" Sourcefile on the item
+        for item, source in zip(items, f_sources):
+            item.source = source
 
         # Re-build the SGraph after parsing to pick up all new connections
         self._sgraph = SGraph.from_seed(self.seeds, self.item_factory, self.config)

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from codetiming import Timer
 
 from loki.batch.configure import SchedulerConfig
+from loki.batch.executor import SerialExecutor
 from loki.batch.item import (
     FileItem, ModuleItem, ProcedureItem, ProcedureBindingItem,
     InterfaceItem, TypeDefItem, ExternalItem
@@ -152,6 +153,9 @@ class Scheduler:
     full_parse: bool, optional
         Flag indicating whether a full parse of all sourcefiles is required.
         By default a full parse is executed, use this flag to suppress.
+    num_workers : int, default: 0
+        Number of processes to use for parallel processing. Use the default
+        value ``0`` to bypass parallel processing and process serially.
     frontend : :any:`Frontend`, optional
         Frontend to use for full parse of source files (default :any:`FP`).
     output_dir : str or path
@@ -164,7 +168,7 @@ class Scheduler:
     def __init__(
             self, paths, config=None, seed_routines=None, preprocess=False,
             includes=None, defines=None, definitions=None, xmods=None,
-            omni_includes=None, full_parse=True, num_workers=1,
+            omni_includes=None, full_parse=True, num_workers=0,
             frontend=FP, output_dir=None
     ):
         # Derive config from file or dict
@@ -177,8 +181,12 @@ class Scheduler:
 
         self.full_parse = full_parse
 
-        # Create the parallel pool executor for parallel processing
-        self.executor = ProcessPoolExecutor(max_workers=num_workers)
+        if num_workers > 0:
+            # Create the parallel pool executor for parallel processing
+            self.executor = ProcessPoolExecutor(max_workers=num_workers)
+        else:
+            # Create a dummy executor that mimics the concurrent Exectuor API
+            self.executor = SerialExecutor()
 
         # Build-related arguments to pass to the sources
         self.paths = [Path(p) for p in as_tuple(paths)]

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -176,7 +176,9 @@ class Scheduler:
             self.config = SchedulerConfig.from_dict(config or {})
 
         self.full_parse = full_parse
-        self.num_workers = num_workers
+
+        # Create the parallel pool executor for parallel processing
+        self.executor = ProcessPoolExecutor(max_workers=num_workers)
 
         # Build-related arguments to pass to the sources
         self.paths = [Path(p) for p in as_tuple(paths)]
@@ -208,6 +210,10 @@ class Scheduler:
             # Attach interprocedural call-tree information
             self._enrich()
 
+    def __del__(self):
+        # Shut down the parallel process pool
+        self.executor.shutdown()
+
     @Timer(logger=info, text='[Loki::Scheduler] Performed initial source scan in {:.2f}s')
     def _discover(self):
         """
@@ -233,14 +239,14 @@ class Scheduler:
         path_fargs = tuple(
             (path, self.config.create_frontend_args(path, frontend_args)) for path in path_list
         )
-        with ProcessPoolExecutor(max_workers=self.num_workers) as executor:
+        with Timer(logger=info, text='[Loki::Scheduler] Scheduler:: Initial file parse in {:.2f}s'):
             src_futures = tuple(
-                executor.submit(Sourcefile.from_file, path, **fargs)
+                self.executor.submit(Sourcefile.from_file, path, **fargs)
                 for path, fargs in path_fargs
             )
-            sources = [src.result() for src in src_futures]
-        for source in sources:
-            self.item_factory.get_or_create_file_item_from_source(source, self.config)
+            sources = tuple(src.result() for src in src_futures)
+            for source in sources:
+                self.item_factory.get_or_create_file_item_from_source(source, self.config)
 
         # Instantiate the basic list of items for files and top-level program units
         #  in each file, i.e., modules and subroutines

--- a/loki/batch/tests/test_batch.py
+++ b/loki/batch/tests/test_batch.py
@@ -713,7 +713,8 @@ def test_procedure_item_from_item1(testdir, default_config):
     # A file with a single subroutine definition that calls a routine via interface block
     item_factory = ItemFactory()
     scheduler_config = SchedulerConfig.from_dict(default_config)
-    file_item = item_factory.get_or_create_file_item_from_path(proj/'source/comp1.F90', config=scheduler_config)
+    source = Sourcefile.from_file(proj/'source/comp1.F90')
+    file_item = item_factory.get_or_create_file_item_from_source(source, config=scheduler_config)
     item = file_item.create_definition_items(item_factory=item_factory, config=scheduler_config)[0]
     assert item.name == '#comp1'
     assert isinstance(item, ProcedureItem)
@@ -746,7 +747,8 @@ def test_procedure_item_from_item2(testdir, default_config):
     # where the type is imported via an import statement in the module scope
     item_factory = ItemFactory()
     scheduler_config = SchedulerConfig.from_dict(default_config)
-    file_item = item_factory.get_or_create_file_item_from_path(proj/'module/other_mod.F90', config=scheduler_config)
+    source = Sourcefile.from_file(proj/'module/other_mod.F90')
+    file_item = item_factory.get_or_create_file_item_from_source(source, config=scheduler_config)
     mod_item = file_item.create_definition_items(item_factory=item_factory, config=scheduler_config)[0]
     assert mod_item.name == 'other_mod'
     assert isinstance(mod_item, ModuleItem)

--- a/loki/cli/loki_transform.py
+++ b/loki/cli/loki_transform.py
@@ -39,8 +39,10 @@ from loki.transformations.build_system import FileWriteTransformation
 @click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
               type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
               help='Log level to output during batch processing')
+@click.option('--num-workers', type=int, default=1, envvar='LOKI_NUM_WORKERS',
+              help='Number of worker processes to use for parallel processing steps.')
 def convert(
-        frontend_opts, scheduler_opts, mode, config, plan_file, callgraph, root, log_level
+        frontend_opts, scheduler_opts, mode, config, plan_file, callgraph, root, log_level, num_workers
 ):
     """
     Batch-processing mode for Fortran-to-Fortran transformations that
@@ -85,7 +87,8 @@ def convert(
     full_parse = processing_strategy == ProcessingStrategy.DEFAULT
     scheduler = Scheduler(
         paths=paths, config=config, full_parse=full_parse,
-        definitions=definitions, output_dir=scheduler_opts.build, **frontend_opts.asdict
+        definitions=definitions, output_dir=scheduler_opts.build,
+        num_workers=num_workers, **frontend_opts.asdict
     )
 
     # If requested, apply a custom pipeline from the scheduler config
@@ -132,6 +135,8 @@ def convert(
 @click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
               type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
               help='Log level to output during batch processing')
+@click.option('--num-workers', type=int, default=1, envvar='LOKI_NUM_WORKERS',
+              help='Number of worker processes to use for parallel processing steps.')
 @click.pass_context
 def plan(ctx, *_args, **_kwargs):
     """

--- a/loki/cli/loki_transform.py
+++ b/loki/cli/loki_transform.py
@@ -39,7 +39,7 @@ from loki.transformations.build_system import FileWriteTransformation
 @click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
               type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
               help='Log level to output during batch processing')
-@click.option('--num-workers', type=int, default=1, envvar='LOKI_NUM_WORKERS',
+@click.option('--num-workers', type=int, default=0, envvar='LOKI_NUM_WORKERS',
               help='Number of worker processes to use for parallel processing steps.')
 def convert(
         frontend_opts, scheduler_opts, mode, config, plan_file, callgraph, root, log_level, num_workers
@@ -135,7 +135,7 @@ def convert(
 @click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
               type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
               help='Log level to output during batch processing')
-@click.option('--num-workers', type=int, default=1, envvar='LOKI_NUM_WORKERS',
+@click.option('--num-workers', type=int, default=0, envvar='LOKI_NUM_WORKERS',
               help='Number of worker processes to use for parallel processing steps.')
 @click.pass_context
 def plan(ctx, *_args, **_kwargs):

--- a/loki/expression/operations.py
+++ b/loki/expression/operations.py
@@ -134,15 +134,17 @@ class Cast(StrCompareMixin, pmbl.Call):
     Internal representation of a data type cast.
     """
 
-    init_arg_names = ('name', 'expression', 'kind')
-
-    def __init__(self, name, expression, kind=None, **kwargs):
-        assert kind is None or isinstance(kind, pmbl.Expression)
-        self.kind = kind
-        super().__init__(pmbl.make_variable(name), as_tuple(expression), **kwargs)
+    init_arg_names = ('function', 'expression', 'kind')
 
     def __getinitargs__(self):
-        return (self.name, self.expression, self.kind)
+        return (self.function, self.expression, self.kind)
+
+    def __init__(self, function, expression, kind=None, **kwargs):
+        if not isinstance(function, pmbl.Expression):
+            function = pmbl.make_variable(function)
+        assert kind is None or isinstance(kind, pmbl.Expression)
+        self.kind = kind
+        super().__init__(function, as_tuple(expression), **kwargs)
 
     mapper_method = intern('map_cast')
 
@@ -153,6 +155,10 @@ class Cast(StrCompareMixin, pmbl.Call):
     @property
     def expression(self):
         return self.parameters
+
+    @expression.setter
+    def expression(self, expr):
+        self.parameters = expr
 
 
 class Reference(StrCompareMixin, pmbl.Expression):

--- a/loki/expression/tests/test_symbols.py
+++ b/loki/expression/tests/test_symbols.py
@@ -179,7 +179,7 @@ def test_symbol_recreation():
     exprs.append( sym.LoopRange((sym.IntLiteral(1), i)) )
     exprs.append( sym.RangeIndex((sym.IntLiteral(1), i)) )
 
-    exprs.append( sym.Cast(name='int', expression=b, kind=i) )
+    exprs.append( sym.Cast(function='int', expression=b, kind=i) )
     exprs.append( sym.Reference(expression=b) )
     exprs.append( sym.Dereference(expression=b) )
 

--- a/loki/module.py
+++ b/loki/module.py
@@ -249,7 +249,8 @@ class Module(ProgramUnit):
         s = self.__dict__.copy()
         # TODO: We need to remove the AST, as certain AST types
         # (eg. FParser) are not pickle-safe.
-        del s['_ast']
+        if '_ast' in s:
+            del s['_ast']
         return s
 
     def __setstate__(self, s):

--- a/loki/tests/test_pickle.py
+++ b/loki/tests/test_pickle.py
@@ -306,3 +306,30 @@ def test_pickle_scheduler_item(here, frontend, tmp_path):
     assert loads(dumps(item_a.source.ir)) == item_a.source.ir
     assert loads(dumps(item_a.source)) == item_a.source
     assert loads(dumps(item_a)) == item_a
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_pickle_expressions(frontend):
+
+    fcode = """
+  subroutine my_routine(n, a, b, c)
+    integer, intent(in) :: n
+    real, intent(in) :: a(n), b(n), c(n)
+    real :: x, y, z
+    integer :: i, j
+
+    a(:) = b(:) + c(:) ! Test arrays
+    x = max(x, a(1))   ! Test scalar and intrinsic
+
+    i = real(x, 4)  ! Test casts
+  end subroutine my_routine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    # Ensure equivalence after pickle-cyle with scope-level replication
+    routine_new = loads(dumps(routine))
+    assert routine_new.spec == routine.spec
+    assert routine_new.body == routine.body
+    assert routine_new.contains == routine.contains
+    assert routine_new.symbol_attrs == routine.symbol_attrs
+    assert routine_new == routine

--- a/loki/transformations/single_column/scc_cuf.py
+++ b/loki/transformations/single_column/scc_cuf.py
@@ -472,13 +472,14 @@ class SccLowLevelLaunchConfiguration(Transformation):
 
                 # GRIDDIM
                 lhs = routine.variable_map["griddim"]
-                rhs = sym.InlineCall(function=func_dim3, parameters=(sym.IntLiteral(1), sym.IntLiteral(1),
-                                                                    sym.InlineCall(function=func_ceiling,
-                                                                                    parameters=as_tuple(
-                                                                                        sym.Cast(name="REAL",
-                                                                                                expression=upper) /
-                                                                                        sym.Cast(name="REAL",
-                                                                                                expression=step)))))
+                rhs = sym.InlineCall(
+                    function=func_dim3, parameters=(
+                        sym.IntLiteral(1), sym.IntLiteral(1),
+                        sym.InlineCall(function=func_ceiling, parameters=as_tuple(
+                            sym.Cast("REAL", expression=upper) / sym.Cast("REAL", expression=step)
+                        ))
+                    )
+                )
                 griddim_assignment = ir.Assignment(lhs=lhs, rhs=rhs)
                 mapper[call] = (blockdim_assignment, griddim_assignment, ir.Comment(""),
                         call.clone(chevron=(routine.variable_map["GRIDDIM"], routine.variable_map["BLOCKDIM"]),),
@@ -493,11 +494,12 @@ class SccLowLevelLaunchConfiguration(Transformation):
                 blockdim_assignment = ir.Assignment(lhs=lhs, rhs=rhs)
                 # GRIDDIM
                 lhs = griddim_var
-                rhs = sym.InlineCall(function=func_dim3, parameters=(sym.InlineCall(function=func_ceiling,
-                    parameters=as_tuple(
-                        sym.Cast(name="REAL", expression=upper) /
-                        sym.Cast(name="REAL", expression=step))),
-                    sym.IntLiteral(1), sym.IntLiteral(1)))
+                rhs = sym.InlineCall(function=func_dim3, parameters=(
+                    sym.InlineCall(function=func_ceiling, parameters=as_tuple(
+                        sym.Cast("REAL", expression=upper) / sym.Cast("REAL", expression=step)
+                    )),
+                    sym.IntLiteral(1), sym.IntLiteral(1))
+                )
                 griddim_assignment = ir.Assignment(lhs=lhs, rhs=rhs)
 
         routine.body = Transformer(mapper=mapper).visit(routine.body)

--- a/loki/transformations/temporaries/pool_allocator.py
+++ b/loki/transformations/temporaries/pool_allocator.py
@@ -439,7 +439,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             _kind = routine.symbol_map.get('REAL64', None) or Variable(name='REAL64')
 
             # Convert stack_size from bytes to integer
-            stack_type_bytes = Cast(name='REAL', expression=Literal(1), kind=_kind)
+            stack_type_bytes = Cast('REAL', expression=Literal(1), kind=_kind)
             stack_type_bytes = InlineCall(Variable(name='C_SIZEOF'),
                                           parameters=as_tuple(stack_type_bytes))
             stack_size_assign = Assignment(lhs=stack_size_var, rhs=stack_size)
@@ -577,15 +577,15 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         """
 
         if arr.type.dtype == BasicType.REAL:
-            param = Cast(name='REAL', expression=IntLiteral(1))
+            param = Cast('REAL', expression=IntLiteral(1))
         elif arr.type.dtype == BasicType.INTEGER:
-            param = Cast(name='INT', expression=IntLiteral(1))
+            param = Cast('INT', expression=IntLiteral(1))
         elif arr.type.dtype == BasicType.CHARACTER:
-            param = Cast(name='CHAR', expression=IntLiteral(1))
+            param = Cast('CHAR', expression=IntLiteral(1))
         elif arr.type.dtype == BasicType.LOGICAL:
-            param = Cast(name='LOGICAL', expression=LogicLiteral('.TRUE.'))
+            param = Cast('LOGICAL', expression=LogicLiteral('.TRUE.'))
         elif arr.type.dtype == BasicType.COMPLEX:
-            param = Cast(name='CMPLX', expression=(IntLiteral(1), IntLiteral(1)))
+            param = Cast('CMPLX', expression=(IntLiteral(1), IntLiteral(1)))
 
         param.kind = getattr(arr.type, 'kind', None) # pylint: disable=possibly-used-before-assignment
 
@@ -871,7 +871,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                     lhs=stack_end, rhs=Sum((stack_ptr, stack_size_var))
                 )
             else:
-                _real_size_bytes = Cast(name='REAL', expression=Literal(1), kind=_kind)
+                _real_size_bytes = Cast('REAL', expression=Literal(1), kind=_kind)
                 _real_size_bytes = InlineCall(Variable(name='C_SIZEOF'),
                                               parameters=as_tuple(_real_size_bytes))
                 stack_incr = Assignment(


### PR DESCRIPTION
Initial implementation of simple parallelism in the batch-processing scheduler. This PR refactors the two "trivially parallel" steps of the Scheduler initialisation (scanning the source directories and parsing the full `Sourcefile` into IR) using Python's builtin `ProcessPoolExecutor`. It also adds a dummy `SerialExecutor` implementation that exposes the same interface, but works serially on the original process, thus keeping existing functionality available.

In a little more detail:
* Strictly separate `Sourcefile` creation from Item creation and remove `get_or_create_file_item_from_path`
* Add an `executor` object to the Scheduler that dummies to the provided `SerialExecutor` if `num_workers=0` is selected, and otherwise creates a `ProcessPoolExecutor(max_workers=num_workers)`.
* Invoke the `Sourcefile.from_path` on the executor by passing assembled `frontend_args`
* Perform the full file parse (`Sourcefile.make_complete`) using the `executor.map` functionality over source objects and parser-args, before updating the returned copy of source on the according `Item`
* Pickle-safety fixes for `sym.Cast` objects and `Module` AST objects
* Increase log-level for Scheduler enrichment to INFO, as it can now become quite dominant during the setup phase

### Performance
To test performance, I've mimicked the H24-dev Plan-generation (without explicitly provided header paths), but locally enabled full source parses in the plan step. When adding the new `ProcessPoolExecutor` but keeping the number of processors low, we can see a significant overhead of the process-pipe-and-serialisation mechanics, but increasing the number of process somewhat we can still get to a reasonable quality-of-life improvement.

Sequential, equivalent to previous:
```
$ loki-transform.py plan --mode idem --config arpifs/loki_physics.config -s arpifs/phys_ec/ -s surf/external/ -s surf/module --plan-file=../../my_plan.cmake --num-workers=0
[Loki] Creating CMake plan file from config: arpifs/loki_physics.config
[Loki::Scheduler] Scheduler:: Initial file parse in 14.63s
...
[Loki::Scheduler] Performed initial source scan in 21.46s
[Loki::Scheduler] Performed full source parse in 79.78s
[Loki::Scheduler] Enriched call tree in 0.53s
[Loki] Scheduler writing CMake plan: ../../my_plan.cmake
```

Sequential, but through `ProcessPoolExecutor`:
```
$ loki-transform.py plan --mode idem --config arpifs/loki_physics.config -s arpifs/phys_ec/ -s surf/external/ -s surf/module --plan-file=../../my_plan.cmake --num-workers=1
[Loki] Creating CMake plan file from config: arpifs/loki_physics.config
[Loki::Scheduler] Scheduler:: Initial file parse in 13.06s
...
[Loki::Scheduler] Performed initial source scan in 20.50s
[Loki::Scheduler] Performed full source parse in 204.73s
[Loki::Scheduler] Enriched call tree in 20.53s
[Loki] Scheduler writing CMake plan: ../../my_plan.cmake
```

And with 12 build processes:
```
(loki_env) [naml@ac6-102 ifs-source]$ loki-transform.py plan --mode idem --config arpifs/loki_physics.config -s arpifs/phys_ec/ -s surf/external/ -s surf/module --plan-file=../../my_plan.cmake --num-workers=12
[Loki] Creating CMake plan file from config: arpifs/loki_physics.config
[Loki::Scheduler] Scheduler:: Initial file parse in 2.11s
...
[Loki::Scheduler] Performed initial source scan in 9.57s
[Loki::Scheduler] Performed full source parse in 36.45s
[Loki::Scheduler] Enriched call tree in 20.57s
[Loki] Scheduler writing CMake plan: ../../my_plan.cmake
```