### PR TITLE
IR: Fix false "end" matches in pragma_regions_attached utility

### DIFF
--- a/loki/ir/pragma_utils.py
+++ b/loki/ir/pragma_utils.py
@@ -487,12 +487,12 @@ def get_matching_region_pragmas(pragmas):
     matches = []
     stack = []
     for i, p in enumerate(pragmas):
-        if 'end' not in p.content.lower():
+        if 'end' not in p.content.lower().split(' '):
             # If we encounter one that does have a match, stack it
             if any(_matches_starting_pragma(p, p2) for p2 in pragmas[i:]):
                 stack.append(p)
 
-        elif 'end' in p.content.lower() and stack:
+        elif 'end' in p.content.lower().split(' ') and stack:
             # If we and end that matches our last stacked, keep it!
             if _matches_starting_pragma(stack[-1], p):
                 p1 = stack.pop()

--- a/loki/ir/tests/test_pragma_utils.py
+++ b/loki/ir/tests/test_pragma_utils.py
@@ -513,7 +513,7 @@ subroutine test_tools_pragmas_attached_region (in, out, n)
 
   out(0) = -2.0
 
-  !$loki data nofoo
+  !$loki data nofoo endfoo
   do i=1,n
     !$loki do_nothing
     out(i) = 0.0


### PR DESCRIPTION
The problem are false matches if "end" appears in pragma content after the initial `end` keyword.

This should also fix issue #427 