### PR TITLE
Sanitise: New transformation sub-package and some refactoring

### DIFF
--- a/lint_rules/lint_rules/debug_rules.py
+++ b/lint_rules/lint_rules/debug_rules.py
@@ -7,7 +7,7 @@
 
 import operator as _op
 from loki import (
-     FindNodes, CallStatement, Assignment, Scalar, RangeIndex, resolve_associates,
+     FindNodes, CallStatement, Assignment, Scalar, RangeIndex, do_resolve_associates,
      simplify, Sum, Product, IntLiteral, as_tuple, SubstituteExpressions, Array,
      symbolic_op, StringLiteral, is_constant, LogicLiteral, VariableDeclaration, flatten,
      FindInlineCalls, Conditional, FindExpressions, Comparison
@@ -113,7 +113,7 @@ class ArgSizeMismatchRule(GenericRule):
         max_indirections = config['max_indirections']
 
         # first resolve associates
-        resolve_associates(subroutine)
+        do_resolve_associates(subroutine)
 
         assign_map = {a.lhs: a.rhs for a in FindNodes(Assignment).visit(subroutine.body)}
         decl_symbols = flatten([decl.symbols for decl in FindNodes(VariableDeclaration).visit(subroutine.spec)])

--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -18,7 +18,7 @@ from loki.types import SymbolAttributes, BasicType
 from loki.expression import (
     symbols as sym, Variable, Array, RangeIndex
 )
-from loki.transformations.sanitise import resolve_associates
+from loki.transformations.sanitise import do_resolve_associates
 from loki.transformations.utilities import (
     recursive_expression_map_update, get_integer_variable,
     get_loop_bounds, check_routine_sequential
@@ -242,7 +242,7 @@ class BlockViewToFieldViewTransformation(Transformation):
     def process_kernel(self, routine, item, successors, targets, exclude_arrays):
 
         # Sanitize the subroutine
-        resolve_associates(routine)
+        do_resolve_associates(routine)
         v_index = get_integer_variable(routine, name=self.horizontal.index)
         SCCBaseTransformation.resolve_masked_stmts(routine, loop_variable=v_index)
 

--- a/loki/transformations/sanitise/__init__.py
+++ b/loki/transformations/sanitise/__init__.py
@@ -42,7 +42,7 @@ class SanitiseTransformation(Transformation):
         # Associates at the highest level, so they don't interfere
         # with the sections we need to do for detecting subroutine calls
         if self.resolve_associate_mappings:
-            resolve_associates(routine)
+            do_resolve_associates(routine)
 
         # Transform arrays passed with scalar syntax to array syntax
         if self.resolve_sequence_association:

--- a/loki/transformations/sanitise/__init__.py
+++ b/loki/transformations/sanitise/__init__.py
@@ -46,4 +46,4 @@ class SanitiseTransformation(Transformation):
 
         # Transform arrays passed with scalar syntax to array syntax
         if self.resolve_sequence_association:
-            transform_sequence_association(routine)
+            do_resolve_sequence_association(routine)

--- a/loki/transformations/sanitise/__init__.py
+++ b/loki/transformations/sanitise/__init__.py
@@ -1,0 +1,49 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+"""
+Sub-package with assorted utility :any:`Transformation` classes to
+harmonize the look-and-feel of input source code.
+"""
+from loki.batch import Transformation
+
+from loki.transformations.sanitise.associates import * # noqa
+from loki.transformations.sanitise.sequence_associations import * # noqa
+
+
+__all__ = ['SanitiseTransformation']
+
+
+class SanitiseTransformation(Transformation):
+    """
+    :any:`Transformation` object to apply several code sanitisation
+    steps when batch-processing large source trees via the :any:`Scheduler`.
+
+    Parameters
+    ----------
+    resolve_associate_mappings : bool
+        Resolve ASSOCIATE mappings in body of processed subroutines; default: True.
+    resolve_sequence_association : bool
+        Replace scalars that are passed to array arguments with array
+        ranges; default: False.
+    """
+
+    def __init__(
+            self, resolve_associate_mappings=True, resolve_sequence_association=False
+    ):
+        self.resolve_associate_mappings = resolve_associate_mappings
+        self.resolve_sequence_association = resolve_sequence_association
+
+    def transform_subroutine(self, routine, **kwargs):
+
+        # Associates at the highest level, so they don't interfere
+        # with the sections we need to do for detecting subroutine calls
+        if self.resolve_associate_mappings:
+            resolve_associates(routine)
+
+        # Transform arrays passed with scalar syntax to array syntax
+        if self.resolve_sequence_association:
+            transform_sequence_association(routine)

--- a/loki/transformations/sanitise/__init__.py
+++ b/loki/transformations/sanitise/__init__.py
@@ -8,14 +8,59 @@
 Sub-package with assorted utility :any:`Transformation` classes to
 harmonize the look-and-feel of input source code.
 """
-from loki.batch import Transformation
+from functools import partial
+
+from loki.batch import Transformation, Pipeline
 
 from loki.transformations.sanitise.associates import * # noqa
 from loki.transformations.sanitise.sequence_associations import * # noqa
 from loki.transformations.sanitise.substitute import * # noqa
 
 
-__all__ = ['SanitiseTransformation']
+"""
+:any:`Pipeline` class that provides combined access to the features
+provided by the following :any:`Transformation` classes, in sequence:
+1. :any:`SubstituteExpressionTransformation` - String-based generic
+expression substitution.
+2. :any:`AssociatesTransformation` - Full or partial resolution of
+nested :any:`Associate` nodes, including optional merging of
+independent association pairs.
+3. :any:`SequenceAssociationTransformation` - Resolves sequence
+association patterns in the call signature of :any:`CallStatement`
+nodes.
+
+Parameters
+----------
+substitute_expressions : bool
+    Flag to trigger or suppress expression substitution
+expression_map : dict of str to str
+    A string-to-string map detailing the substitutions to apply.
+substitute_spec : bool
+    Flag to trigger or suppress expression substitution in specs.
+substitute_body : bool
+    Flag to trigger or suppress expression substitution in bodies.
+resolve_associates : bool, default: True
+    Enable full or partial resolution of only :any:`Associate`
+    scopes.
+merge_associates : bool, default: False
+    Enable merging :any:`Associate` to the outermost possible
+    scope in nested associate blocks.
+start_depth : int, optional
+    Starting depth for partial resolution of :any:`Associate`
+    after merging.
+max_parents : int, optional
+    Maximum number of parent symbols for valid selector to have
+    when merging :any:`Associate` nodes.
+resolve_sequence_associations : bool
+    Flag to trigger or suppress resolution of sequence associations
+"""
+SanitisePipeline = partial(
+    Pipeline, classes=(
+        SubstituteExpressionTransformation,
+        AssociatesTransformation,
+        SequenceAssociationTransformation,
+    )
+)
 
 
 class SanitiseTransformation(Transformation):

--- a/loki/transformations/sanitise/__init__.py
+++ b/loki/transformations/sanitise/__init__.py
@@ -12,6 +12,7 @@ from loki.batch import Transformation
 
 from loki.transformations.sanitise.associates import * # noqa
 from loki.transformations.sanitise.sequence_associations import * # noqa
+from loki.transformations.sanitise.substitute import * # noqa
 
 
 __all__ = ['SanitiseTransformation']

--- a/loki/transformations/sanitise/associates.py
+++ b/loki/transformations/sanitise/associates.py
@@ -12,51 +12,16 @@ constructs to unify code structure and make reasoning about Fortran
 code easier.
 """
 
-from loki.batch import Transformation
-from loki.expression import Array, RangeIndex, LokiIdentityMapper
-from loki.ir import nodes as ir, FindNodes, Transformer, NestedTransformer
+from loki.expression import LokiIdentityMapper
+from loki.ir import nodes as ir, Transformer, NestedTransformer
 from loki.scope import SymbolTable
-from loki.tools import as_tuple, dict_override
-from loki.types import BasicType
+from loki.tools import dict_override
 
 
 __all__ = [
-    'SanitiseTransformation', 'resolve_associates', 'merge_associates',
-    'ResolveAssociatesTransformer', 'transform_sequence_association',
-    'transform_sequence_association_append_map'
+    'resolve_associates', 'merge_associates',
+    'ResolveAssociatesTransformer'
 ]
-
-
-class SanitiseTransformation(Transformation):
-    """
-    :any:`Transformation` object to apply several code sanitisation
-    steps when batch-processing large source trees via the :any:`Scheduler`.
-
-    Parameters
-    ----------
-    resolve_associate_mappings : bool
-        Resolve ASSOCIATE mappings in body of processed subroutines; default: True.
-    resolve_sequence_association : bool
-        Replace scalars that are passed to array arguments with array
-        ranges; default: False.
-    """
-
-    def __init__(
-            self, resolve_associate_mappings=True, resolve_sequence_association=False
-    ):
-        self.resolve_associate_mappings = resolve_associate_mappings
-        self.resolve_sequence_association = resolve_sequence_association
-
-    def transform_subroutine(self, routine, **kwargs):
-
-        # Associates at the highest level, so they don't interfere
-        # with the sections we need to do for detecting subroutine calls
-        if self.resolve_associate_mappings:
-            resolve_associates(routine)
-
-        # Transform arrays passed with scalar syntax to array syntax
-        if self.resolve_sequence_association:
-            transform_sequence_association(routine)
 
 
 def resolve_associates(routine, start_depth=0):
@@ -280,95 +245,3 @@ class MergeAssociatesTransformer(NestedTransformer):
         # that moved associations get the correct defining scope
         o._derive_local_symbol_types(parent_scope=o.parent)
         return o
-
-
-def check_if_scalar_syntax(arg, dummy):
-    """
-    Check if an array argument, arg,
-    is passed to an array dummy argument, dummy,
-    using scalar syntax. i.e. arg(1,1) -> d(m,n)
-
-    Parameters
-    ----------
-    arg:   variable
-    dummy: variable
-    """
-    if isinstance(arg, Array) and isinstance(dummy, Array):
-        if arg.dimensions:
-            if not any(isinstance(d, RangeIndex) for d in arg.dimensions):
-                return True
-    return False
-
-
-def transform_sequence_association(routine):
-    """
-    Housekeeping routine to replace scalar syntax when passing arrays as arguments
-    For example, a call like
-
-    .. code-block::
-
-        real :: a(m,n)
-
-        call myroutine(a(i,j))
-
-    where myroutine looks like
-
-    .. code-block::
-
-        subroutine myroutine(a)
-            real :: a(5)
-        end subroutine myroutine
-
-    should be changed to
-
-    .. code-block::
-
-        call myroutine(a(i:m,j)
-
-    Parameters
-    ----------
-    routine : :any:`Subroutine`
-        The subroutine where calls will be changed
-
-    """
-
-    #List calls in routine, but make sure we have the called routine definition
-    calls = (c for c in FindNodes(ir.CallStatement).visit(routine.body) if not c.procedure_type is BasicType.DEFERRED)
-    call_map = {}
-
-    # Check all calls and record changes to `call_map` if necessary.
-    for call in calls:
-        transform_sequence_association_append_map(call_map, call)
-
-    # Fix sequence association in all calls in one go.
-    if call_map:
-        routine.body = Transformer(call_map).visit(routine.body)
-
-def transform_sequence_association_append_map(call_map, call):
-    """
-    Check if `call` contains the sequence association pattern in one of the arguments,
-    and if so, add the necessary transform data to `call_map`.
-    """
-    new_args = []
-    found_scalar = False
-    for dummy, arg in call.arg_map.items():
-        if check_if_scalar_syntax(arg, dummy):
-            found_scalar = True
-
-            n_dims = len(dummy.shape)
-            new_dims = []
-            for s, lower in zip(arg.shape[:n_dims], arg.dimensions[:n_dims]):
-
-                if isinstance(s, RangeIndex):
-                    new_dims += [RangeIndex((lower, s.stop))]
-                else:
-                    new_dims += [RangeIndex((lower, s))]
-
-            if len(arg.dimensions) > n_dims:
-                new_dims += arg.dimensions[len(dummy.shape):]
-            new_args += [arg.clone(dimensions=as_tuple(new_dims)),]
-        else:
-            new_args += [arg,]
-
-    if found_scalar:
-        call_map[call] = call.clone(arguments = as_tuple(new_args))

--- a/loki/transformations/sanitise/sequence_associations.py
+++ b/loki/transformations/sanitise/sequence_associations.py
@@ -5,6 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from loki.batch import Transformation
 from loki.expression import Array, RangeIndex
 from loki.ir import Transformer
 from loki.tools import as_tuple
@@ -12,8 +13,29 @@ from loki.types import BasicType
 
 
 __all__ = [
-    'transform_sequence_association', 'SequenceAssociationTransformer'
+    'SequenceAssociationTransformation',
+    'do_resolve_sequence_association',
+    'SequenceAssociationTransformer'
 ]
+
+
+class SequenceAssociationTransformation(Transformation):
+    """
+    :any:`Transformation` that resolves sequence association patterns
+    in :any:`CallStatement` nodes.
+
+    Parameters
+    ----------
+    resolve_sequence_associations : bool
+        Flag to trigger or suppress resolution of sequence associations
+    """
+
+    def __init__(self, resolve_sequence_associations=True):
+        self.resolve_sequence_associations = resolve_sequence_associations
+
+    def transform_subroutine(self, routine, **kwargs):  # pylint: disable=unused-argument
+        if self.resolve_sequence_associations:
+            do_resolve_sequence_association(routine)
 
 
 def check_if_scalar_syntax(arg, dummy):
@@ -34,10 +56,10 @@ def check_if_scalar_syntax(arg, dummy):
     return False
 
 
-def transform_sequence_association(routine):
+def do_resolve_sequence_association(routine):
     """
-    Housekeeping routine to replace scalar syntax when passing arrays as arguments
-    For example, a call like
+    Housekeeping routine to replace scalar syntax when passing arrays
+    as arguments For example, a call like
 
     .. code-block::
 

--- a/loki/transformations/sanitise/sequence_associations.py
+++ b/loki/transformations/sanitise/sequence_associations.py
@@ -1,0 +1,109 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki.expression import Array, RangeIndex
+from loki.ir import nodes as ir, FindNodes, Transformer
+from loki.tools import as_tuple
+from loki.types import BasicType
+
+
+__all__ = [
+    'transform_sequence_association',
+    'transform_sequence_association_append_map'
+]
+
+
+def check_if_scalar_syntax(arg, dummy):
+    """
+    Check if an array argument, arg,
+    is passed to an array dummy argument, dummy,
+    using scalar syntax. i.e. arg(1,1) -> d(m,n)
+
+    Parameters
+    ----------
+    arg:   variable
+    dummy: variable
+    """
+    if isinstance(arg, Array) and isinstance(dummy, Array):
+        if arg.dimensions:
+            if not any(isinstance(d, RangeIndex) for d in arg.dimensions):
+                return True
+    return False
+
+
+def transform_sequence_association(routine):
+    """
+    Housekeeping routine to replace scalar syntax when passing arrays as arguments
+    For example, a call like
+
+    .. code-block::
+
+        real :: a(m,n)
+
+        call myroutine(a(i,j))
+
+    where myroutine looks like
+
+    .. code-block::
+
+        subroutine myroutine(a)
+            real :: a(5)
+        end subroutine myroutine
+
+    should be changed to
+
+    .. code-block::
+
+        call myroutine(a(i:m,j)
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine where calls will be changed
+
+    """
+
+    #List calls in routine, but make sure we have the called routine definition
+    calls = (c for c in FindNodes(ir.CallStatement).visit(routine.body) if not c.procedure_type is BasicType.DEFERRED)
+    call_map = {}
+
+    # Check all calls and record changes to `call_map` if necessary.
+    for call in calls:
+        transform_sequence_association_append_map(call_map, call)
+
+    # Fix sequence association in all calls in one go.
+    if call_map:
+        routine.body = Transformer(call_map).visit(routine.body)
+
+def transform_sequence_association_append_map(call_map, call):
+    """
+    Check if `call` contains the sequence association pattern in one of the arguments,
+    and if so, add the necessary transform data to `call_map`.
+    """
+    new_args = []
+    found_scalar = False
+    for dummy, arg in call.arg_map.items():
+        if check_if_scalar_syntax(arg, dummy):
+            found_scalar = True
+
+            n_dims = len(dummy.shape)
+            new_dims = []
+            for s, lower in zip(arg.shape[:n_dims], arg.dimensions[:n_dims]):
+
+                if isinstance(s, RangeIndex):
+                    new_dims += [RangeIndex((lower, s.stop))]
+                else:
+                    new_dims += [RangeIndex((lower, s))]
+
+            if len(arg.dimensions) > n_dims:
+                new_dims += arg.dimensions[len(dummy.shape):]
+            new_args += [arg.clone(dimensions=as_tuple(new_dims)),]
+        else:
+            new_args += [arg,]
+
+    if found_scalar:
+        call_map[call] = call.clone(arguments = as_tuple(new_args))

--- a/loki/transformations/sanitise/substitute.py
+++ b/loki/transformations/sanitise/substitute.py
@@ -1,0 +1,56 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki.batch import Transformation
+from loki.ir import SubstituteStringExpressions
+
+
+__all__ = ['SubstituteExpressionTransformation']
+
+
+class SubstituteExpressionTransformation(Transformation):
+    """
+    A :any:`Transformation` that allows individual expressions to be
+    substituted in :any:`Subroutine` objects.
+
+    The expressions should be provided as a dictionary map of strings,
+    which will be parsed in the local :any:`Subroutine` scope to
+    determine the respective symbols.
+
+    Parameters
+    ----------
+    substitute_expressions : bool
+        Flag to trigger or suppress expression substitution
+    expression_map : dict of str to str
+        A string-to-string map detailing the substitutions to apply.
+    substitute_spec : bool
+        Flag to trigger or suppress expression substitution in specs.
+    substitute_body : bool
+        Flag to trigger or suppress expression substitution in bodies.
+    """
+
+    def __init__(
+            self, substitute_expressions=True, expression_map=None,
+            substitute_body=True, substitute_spec=True
+    ):
+        self.substitute_expressions = substitute_expressions
+        self.expression_map = expression_map or {}
+        self.substitute_spec = substitute_spec
+        self.substitute_body = substitute_body
+
+    def transform_subroutine(self, routine, **kwargs):
+
+        if self.substitute_expressions:
+            substitute = SubstituteStringExpressions(
+                self.expression_map, scope=routine
+            )
+
+            if self.substitute_spec:
+                routine.spec = substitute.visit(routine.spec)
+
+            if self.substitute_body:
+                routine.body = substitute.visit(routine.body)

--- a/loki/transformations/sanitise/tests/test_associates.py
+++ b/loki/transformations/sanitise/tests/test_associates.py
@@ -18,7 +18,7 @@ from loki.transformations.sanitise import (
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_transform_associates_simple(frontend):
     """
@@ -58,7 +58,7 @@ end subroutine transform_associates_simple
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_transform_associates_nested(frontend):
     """
@@ -98,7 +98,7 @@ end subroutine transform_associates_nested
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_transform_associates_array_call(frontend):
     """
@@ -148,7 +148,7 @@ end subroutine transform_associates_simple
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_transform_associates_nested_conditional(frontend):
     """
@@ -205,7 +205,7 @@ end subroutine transform_associates_nested_conditional
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_transform_associates_partial_body(frontend):
     """
@@ -252,7 +252,7 @@ end subroutine transform_associates_partial
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_transform_associates_start_depth(frontend):
     """
@@ -301,7 +301,7 @@ end subroutine transform_associates_partial
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_merge_associates_nested(frontend):
     """

--- a/loki/transformations/sanitise/tests/test_sanitise.py
+++ b/loki/transformations/sanitise/tests/test_sanitise.py
@@ -11,7 +11,9 @@ from loki import Module
 from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
 
-from loki.transformations.sanitise import SanitiseTransformation
+from loki.transformations.sanitise import (
+    SanitiseTransformation, SanitisePipeline
+)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -73,3 +75,72 @@ end module test_transformation_sanitise_mod
     calls = FindNodes(ir.CallStatement).visit(routine.body)
     assert len(calls) == 1
     assert calls[0].arguments[0] == 'a(1:3)' if resolve_sequence else 'a(1)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('substitute_expressions', [True, False])
+@pytest.mark.parametrize('resolve_associates', [True, False])
+@pytest.mark.parametrize('resolve_sequence_associations', [True, False])
+def test_sanitise_pipeline(
+        tmp_path, frontend, substitute_expressions,
+        resolve_associates, resolve_sequence_associations
+):
+    """
+    Test the agglomerated :any:`SanitisePipeline` with different settings.
+    """
+    fcode = """
+module test_sanitise_pipeline_mod
+  implicit none
+
+  type rick
+    real :: scalar
+  end type rick
+contains
+
+  subroutine test_pipeline_sanitise(n, a, dave)
+    integer, intent(in) :: n
+    real, intent(inout) :: a(n+1)
+    type(rick), intent(inout) :: dave
+
+    associate(scalar => dave%scalar)
+      scalar = a(1) + a(2)
+
+      call vadd(a(1), 2.0, n+1)
+    end associate
+
+  contains
+    subroutine vadd(x, y, n)
+      real, intent(inout) :: x(n)
+      real, intent(inout) :: y
+      integer, intent(in) :: n
+
+      x = x + 2.0
+    end subroutine vadd
+  end subroutine test_pipeline_sanitise
+end module test_sanitise_pipeline_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['test_pipeline_sanitise']
+
+    assoc = FindNodes(ir.Associate).visit(routine.body)
+    assert len(assoc) == 1
+    calls = FindNodes(ir.CallStatement).visit(routine.body)
+    assert len(calls) == 1
+
+    pipeline = SanitisePipeline(
+        substitute_expressions=substitute_expressions,
+        expression_map={'n + 1': 'n'},
+        resolve_associates=resolve_associates,
+        resolve_sequence_associations=resolve_sequence_associations
+    )
+    pipeline.apply(routine)
+
+    assoc = FindNodes(ir.Associate).visit(routine.body)
+    assert len(assoc) == 0 if resolve_associates else 1
+
+    calls = FindNodes(ir.CallStatement).visit(routine.body)
+    assert len(calls) == 1
+    if resolve_sequence_associations:
+        assert calls[0].arguments[0] == 'a(1:n)' if substitute_expressions else 'a(1:n+1)'
+    else:
+        assert calls[0].arguments[0] == 'a(1)'

--- a/loki/transformations/sanitise/tests/test_sanitise.py
+++ b/loki/transformations/sanitise/tests/test_sanitise.py
@@ -1,0 +1,75 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from loki import Module
+from loki.frontend import available_frontends
+from loki.ir import nodes as ir, FindNodes
+
+from loki.transformations.sanitise import SanitiseTransformation
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('resolve_associate', [True, False])
+@pytest.mark.parametrize('resolve_sequence', [True, False])
+def test_transformation_sanitise(frontend, resolve_associate, resolve_sequence, tmp_path):
+    """
+    Test that the selective dispatch of the sanitisations works.
+    """
+
+    fcode = """
+module test_transformation_sanitise_mod
+  implicit none
+
+  type rick
+    real :: scalar
+  end type rick
+contains
+
+  subroutine test_transformation_sanitise(a, dave)
+    real, intent(inout) :: a(3)
+    type(rick), intent(inout) :: dave
+
+    associate(scalar => dave%scalar)
+      scalar = a(1) + a(2)
+
+      call vadd(a(1), 2.0, 3)
+    end associate
+
+  contains
+    subroutine vadd(x, y, n)
+      real, intent(inout) :: x(n)
+      real, intent(inout) :: y
+      integer, intent(in) :: n
+
+      x = x + 2.0
+    end subroutine vadd
+  end subroutine test_transformation_sanitise
+end module test_transformation_sanitise_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['test_transformation_sanitise']
+
+    assoc = FindNodes(ir.Associate).visit(routine.body)
+    assert len(assoc) == 1
+    calls = FindNodes(ir.CallStatement).visit(routine.body)
+    assert len(calls) == 1
+    assert calls[0].arguments[0] == 'a(1)'
+
+    trafo = SanitiseTransformation(
+        resolve_associate_mappings=resolve_associate,
+        resolve_sequence_association=resolve_sequence,
+    )
+    trafo.apply(routine)
+
+    assoc = FindNodes(ir.Associate).visit(routine.body)
+    assert len(assoc) == 0 if resolve_associate else 1
+
+    calls = FindNodes(ir.CallStatement).visit(routine.body)
+    assert len(calls) == 1
+    assert calls[0].arguments[0] == 'a(1:3)' if resolve_sequence else 'a(1)'

--- a/loki/transformations/sanitise/tests/test_sequence_associations.py
+++ b/loki/transformations/sanitise/tests/test_sequence_associations.py
@@ -7,8 +7,8 @@
 
 import pytest
 
-from loki import Module, fgen
-from loki.frontend import available_frontends
+from loki import Module, Subroutine
+from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes
 
 from loki.transformations.sanitise import (
@@ -21,42 +21,47 @@ from loki.transformations.sanitise import (
 def test_resolve_sequence_assocaition_scalar_notation(tmp_path, frontend, use_trafo):
     fcode = """
 module mod_a
-    implicit none
+  implicit none
 
-    type type_b
-        integer :: c
-        integer :: d
-    end type type_b
+  type type_b
+    integer :: c
+    integer :: d
+  end type type_b
 
-    type type_a
-        type(type_b) :: b
-    end type type_a
+  type type_a
+    type(type_b) :: b
+  end type type_a
 
 contains
 
-    subroutine main()
+  subroutine main()
+    type(type_a) :: a
+    integer :: k, m, n
 
-        type(type_a) :: a
-        integer :: k, m, n
+    real :: array(10,10)
+    real :: another(1:8, 2)
 
-        real    :: array(10,10)
+    ! Test array with scalar dimension
+    call sub_x(array(1, 1), 1)
+    call sub_x(array(2, 2), 2)
+    call sub_x(array(m, 1), k)
+    call sub_x(array(m-1, 1), k-1)
+    call sub_x(array(a%b%c, 1), a%b%d)
 
-        call sub_x(array(1, 1), 1)
-        call sub_x(array(2, 2), 2)
-        call sub_x(array(m, 1), k)
-        call sub_x(array(m-1, 1), k-1)
-        call sub_x(array(a%b%c, 1), a%b%d)
+    ! Test array with range dimension
+    call sub_x(another(1, 1), 1)
+    call sub_x(another(2, 2), 2)
+    call sub_x(another(m, 1), k)
 
-    contains
+  contains
 
-        subroutine sub_x(array, k)
+    subroutine sub_x(array, k)
+      integer, intent(in) :: k
+      real, intent(in)    :: array(k:n)
 
-            integer, intent(in) :: k
-            real, intent(in)    :: array(k:n)
+    end subroutine sub_x
 
-        end subroutine sub_x
-
-    end subroutine main
+  end subroutine main
 
 end module mod_a
     """.strip()
@@ -72,9 +77,52 @@ end module mod_a
         do_resolve_sequence_association(routine)
 
     calls = FindNodes(ir.CallStatement).visit(routine.body)
+    assert all(c.name == 'sub_x' for c in calls)
 
-    assert fgen(calls[0]).lower() == 'call sub_x(array(1:10, 1), 1)'
-    assert fgen(calls[1]).lower() == 'call sub_x(array(2:10, 2), 2)'
-    assert fgen(calls[2]).lower() == 'call sub_x(array(m:10, 1), k)'
-    assert fgen(calls[3]).lower() == 'call sub_x(array(m - 1:10, 1), k - 1)'
-    assert fgen(calls[4]).lower() == 'call sub_x(array(a%b%c:10, 1), a%b%d)'
+    assert calls[0].arguments == ('array(1:10, 1)', 1)
+    assert calls[1].arguments == ('array(2:10, 2)', 2)
+    assert calls[2].arguments == ('array(m:10, 1)', 'k')
+    assert calls[3].arguments == ('array(m - 1:10, 1)', 'k - 1')
+    assert calls[4].arguments == ('array(a%b%c:10, 1)', 'a%b%d')
+
+    assert calls[5].arguments == ('another(1:8, 1)', 1)
+    assert calls[6].arguments == ('another(2:8, 2)', 2)
+    assert calls[7].arguments == ('another(m:8, 1)', 'k')
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI does not like not knowing shapes!')]
+))
+def test_resolve_sequence_assocaition_missing_shape(frontend):
+    fcode = """
+subroutine test_resolve_seq_assoc_no_shape(a, n)
+  use ricks_module, only: my_type
+  implicit none
+
+  type(my_type), intent(inout) :: a
+  integer, intent(in) :: n
+
+  ! Test array with no known shape
+  call sub_x(a%a(1, 1), 1)
+  call sub_x(a%b(1), 1)
+  call sub_x(a%c, 1)
+
+contains
+
+  subroutine sub_x(array, k)
+    integer, intent(in) :: k
+    real, intent(in)    :: array(k:n)
+
+  end subroutine sub_x
+end subroutine test_resolve_seq_assoc_no_shape
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    do_resolve_sequence_association(routine)
+
+    calls = FindNodes(ir.CallStatement).visit(routine.body)
+    assert all(c.name == 'sub_x' for c in calls)
+
+    assert calls[0].arguments == ('a%a(:, 1)', 1)
+    assert calls[1].arguments == ('a%b(:)', 1)
+    assert calls[2].arguments == ('a%c', 1)

--- a/loki/transformations/sanitise/tests/test_sequence_associations.py
+++ b/loki/transformations/sanitise/tests/test_sequence_associations.py
@@ -1,0 +1,72 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from loki import Module, fgen
+from loki.frontend import available_frontends
+from loki.ir import nodes as ir, FindNodes
+
+from loki.transformations.sanitise import transform_sequence_association
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_sequence_assocaition_scalar_notation(frontend, tmp_path):
+    fcode = """
+module mod_a
+    implicit none
+
+    type type_b
+        integer :: c
+        integer :: d
+    end type type_b
+
+    type type_a
+        type(type_b) :: b
+    end type type_a
+
+contains
+
+    subroutine main()
+
+        type(type_a) :: a
+        integer :: k, m, n
+
+        real    :: array(10,10)
+
+        call sub_x(array(1, 1), 1)
+        call sub_x(array(2, 2), 2)
+        call sub_x(array(m, 1), k)
+        call sub_x(array(m-1, 1), k-1)
+        call sub_x(array(a%b%c, 1), a%b%d)
+
+    contains
+
+        subroutine sub_x(array, k)
+
+            integer, intent(in) :: k
+            real, intent(in)    :: array(k:n)
+
+        end subroutine sub_x
+
+    end subroutine main
+
+end module mod_a
+    """.strip()
+
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['main']
+
+    transform_sequence_association(routine)
+
+    calls = FindNodes(ir.CallStatement).visit(routine.body)
+
+    assert fgen(calls[0]).lower() == 'call sub_x(array(1:10, 1), 1)'
+    assert fgen(calls[1]).lower() == 'call sub_x(array(2:10, 2), 2)'
+    assert fgen(calls[2]).lower() == 'call sub_x(array(m:10, 1), k)'
+    assert fgen(calls[3]).lower() == 'call sub_x(array(m - 1:10, 1), k - 1)'
+    assert fgen(calls[4]).lower() == 'call sub_x(array(a%b%c:10, 1), a%b%d)'

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -13,7 +13,7 @@ from loki.ir import (
 )
 from loki.tools import as_tuple
 
-from loki.transformations.sanitise import resolve_associates
+from loki.transformations.sanitise import do_resolve_associates
 from loki.transformations.utilities import (
     get_integer_variable, get_loop_bounds, check_routine_sequential
 )
@@ -180,7 +180,7 @@ class SCCBaseTransformation(Transformation):
 
         # Associates at the highest level, so they don't interfere
         # with the sections we need to do for detecting subroutine calls
-        resolve_associates(routine)
+        do_resolve_associates(routine)
 
         # Resolve WHERE clauses
         self.resolve_masked_stmts(routine, loop_variable=v_index)
@@ -202,4 +202,4 @@ class SCCBaseTransformation(Transformation):
         # Resolve associates, since the PGI compiler cannot deal with
         # implicit derived type component offload by calling device
         # routines.
-        resolve_associates(routine)
+        do_resolve_associates(routine)

--- a/loki/transformations/single_column/scc_cuf.py
+++ b/loki/transformations/single_column/scc_cuf.py
@@ -21,7 +21,7 @@ from loki.types import BasicType, DerivedType
 from loki.scope import SymbolAttributes
 
 from loki.transformations.hoist_variables import HoistVariablesTransformation
-from loki.transformations.sanitise import resolve_associates
+from loki.transformations.sanitise import do_resolve_associates
 from loki.transformations.single_column.base import SCCBaseTransformation
 from loki.transformations.single_column.vector import SCCDevectorTransformation
 from loki.transformations.utilities import single_variable_declaration
@@ -622,7 +622,7 @@ class SccLowLevelDataOffload(Transformation):
         """
 
         v_index = get_integer_variable(routine, name=self.horizontal.index)
-        resolve_associates(routine)
+        do_resolve_associates(routine)
         SCCBaseTransformation.resolve_masked_stmts(routine, loop_variable=v_index)
         SCCBaseTransformation.resolve_vector_dimension(routine, loop_variable=v_index, bounds=self.horizontal.bounds)
         SCCDevectorTransformation.kernel_remove_vector_loops(routine, self.horizontal)

--- a/loki/transformations/tests/test_transform_derived_types.py
+++ b/loki/transformations/tests/test_transform_derived_types.py
@@ -23,7 +23,7 @@ from loki.transformations.transform_derived_types import (
     DerivedTypeArgumentsTransformation,
     TypeboundProcedureCallTransformation
 )
-from loki.transformations.sanitise import resolve_associates
+from loki.transformations.sanitise import do_resolve_associates
 #pylint: disable=too-many-lines
 
 @pytest.fixture(scope='module', name='here')
@@ -1266,7 +1266,7 @@ end module some_mod
     assert variable_map['t'].type.intent == 'inout'
     assert variable_map['arr'].type.intent is None
 
-    resolve_associates(source['some_routine'])
+    do_resolve_associates(source['some_routine'])
     variables = FindVariables().visit(source['some_routine'].body)
     assert variables == {'t', 't%arr(:)'}
     variable_map = CaseInsensitiveDict((v.name, v) for v in variables)

--- a/loki/transformations/transpile/fortran_c.py
+++ b/loki/transformations/transpile/fortran_c.py
@@ -35,7 +35,7 @@ from loki.transformations.array_indexing import (
 from loki.transformations.utilities import (
     convert_to_lower_case, replace_intrinsics, sanitise_imports
 )
-from loki.transformations.sanitise import resolve_associates
+from loki.transformations.sanitise import do_resolve_associates
 from loki.transformations.inline import (
     inline_constant_parameters, inline_elemental_functions
 )
@@ -608,7 +608,7 @@ class FortranCTransformation(Transformation):
         kernel.spec = Transformer(intrinsic_map).visit(kernel.spec)
 
         # Resolve implicit struct mappings through "associates"
-        resolve_associates(kernel)
+        do_resolve_associates(kernel)
 
         # Force all variables to lower-caps, as C/C++ is case-sensitive
         convert_to_lower_case(kernel)

--- a/loki/transformations/transpile/fortran_python.py
+++ b/loki/transformations/transpile/fortran_python.py
@@ -19,7 +19,7 @@ from loki.sourcefile import Sourcefile
 from loki.transformations.array_indexing import (
     shift_to_zero_indexing, invert_array_indices
 )
-from loki.transformations.sanitise import resolve_associates
+from loki.transformations.sanitise import do_resolve_associates
 from loki.transformations.utilities import (
     convert_to_lower_case, replace_intrinsics
 )
@@ -70,7 +70,7 @@ class FortranPythonTransformation(Transformation):
         convert_to_lower_case(routine)
 
         # Resolve implicit struct mappings through "associates"
-        resolve_associates(routine)
+        do_resolve_associates(routine)
 
         # Do some vector and indexing transformations
         if self.with_dace or self.invert_indices:


### PR DESCRIPTION
This PR creates a new transformation sub-package for sanitisation and then refactors and improves several of the existing utilities for easier inclusion in external pipelines.

 In particular it separate associate-handling from sequence-association resolution, and adds a new utility for user-driven expression substitution. Each of those are now available as a single `Transformation` object and have been combined into a combined `SanitisePipeline`, each of which can now be used via external config constructors. The existing `SanitiseTransformation` is retained for backward compatibility.

In some more detail:
* Created a new sub-package `loki.transformations.sanitise` and moved according tests. In this sub-package, existing utilities for associates and sequence association have been separated
* Refactored sequence association resolver as an in-place `Transformer` to avoid awkward map handling. This requires some sub-classing in specific further use-case in `transformations.inline`.
* Provide `AssociateTransformation` to offer full or partial associate resolution together with the new associate-merging capabilities.
* Provide sequence association resolution as a standalone `Transformation`, which entails some method renaming
* Provide new `SubstituteExpressionTransformation` to expose string-based expression replacement
* Combine all of the above into a `SanitisePipeline`, which is intended as the long-term replacement for `SanitiseTransformation` - the latter, however, is retained for external backward compatibility
* Small tweaks to test (skip OMNI instead of xfail; it's faster and less messy in logs)
