### PR TITLE
Loki: Pin pymbolic version to 2022.2 due to upstream incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = {text = "Apache-2.0"}
 dynamic = ["version", "readme"]
 dependencies = [
   "numpy",  # essential for tests, loop transformations and other dependencies
-  "pymbolic>=2022.1",  # essential for expression tree
+  "pymbolic==2022.2",  # essential for expression tree
   "PyYAML",  # essential for loki-lint
   "pcpp",  # essential for preprocessing
   "more-itertools",  # essential for SCC transformation


### PR DESCRIPTION
Upstream update to Pymbolic `v2024.1` is causing issues in ecWAM regression suite that need separate investigation. Pinning to known-good version with this. 