### PR TITLE
DataOffload: Add new FieldOffloadTransformation for FIELD API boilerplate injection

### DIFF
--- a/loki/transformations/data_offload.py
+++ b/loki/transformations/data_offload.py
@@ -953,13 +953,13 @@ def get_field_type(a: sym.Array) -> sym.DerivedType:
 
 
 def field_new(field_ptr, data, scope):
-    return ir.CallStatement(sym.ProcedureSymbol('FIELD_NEW', scope=scope),
-                            (field_ptr,), (('DATA', data),))
+    return ir.CallStatement(name=sym.ProcedureSymbol('FIELD_NEW', scope=scope),
+                            arguments=(field_ptr,), kwarguments=(('DATA', data),))
 
 
 def field_delete(field_ptr, scope):
-    return ir.CallStatement(sym.ProcedureSymbol('FIELD_DELETE', scope=scope),
-                            (field_ptr,))
+    return ir.CallStatement(name=sym.ProcedureSymbol('FIELD_DELETE', scope=scope),
+                            arguments=(field_ptr,))
 
 
 class FieldAPITransferType(Enum):
@@ -977,13 +977,13 @@ def field_get_device_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferTyp
     if transfer_type == FieldAPITransferType.WRITE_ONLY:
         suffix = 'WRONLY'
     procedure_name = 'GET_DEVICE_DATA_' + suffix
-    return ir.CallStatement(sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope),
-                            (dev_ptr.clone(dimensions=None),))
+    return ir.CallStatement(name=sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope),
+                            arguments=(dev_ptr.clone(dimensions=None),), )
 
 
 def field_sync_host(field_ptr, scope):
     procedure_name = 'SYNC_HOST_RDWR'
-    return ir.CallStatement(sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope), ())
+    return ir.CallStatement(name=sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope), arguments=())
 
 
 def find_array_arguments(routine, calls):

--- a/loki/transformations/data_offload.py
+++ b/loki/transformations/data_offload.py
@@ -1074,10 +1074,10 @@ class FieldOffloadTransformation(Transformation):
                 yield outarg, self.devptrs[i+start]
 
 
-    def __init__(self, devptr_prefix='LOKI_DEVPTR_', **kwargs):
+    def __init__(self, **kwargs):
         self.devptr_prefix = kwargs.get('devptr_prefix', 'loki_devptr')
-        field_group_types = kwargs.get('field_group_types', ['CLOUDSC_STATE_TYPE', 'CLOUDSC_AUX_TYPE', 'CLOUDSC_FLUX_TYPE'])
         self.assume_deviceptr = kwargs.get('assume_deviceptr', False)
+        field_group_types = kwargs.get('field_group_types', ['CLOUDSC_STATE_TYPE', 'CLOUDSC_AUX_TYPE', 'CLOUDSC_FLUX_TYPE'])
         self.field_group_types = tuple(typename.lower() for typename in field_group_types)
 
     def transform_subroutine(self, routine, **kwargs):

--- a/loki/transformations/data_offload.py
+++ b/loki/transformations/data_offload.py
@@ -1011,8 +1011,7 @@ class FieldOffloadTransformation(Transformation):
 
 
     def __init__(self, **kwargs):
-        self.devptr_prefix = kwargs.get('devptr_prefix', 'loki_devptr')
-        self.assume_deviceptr = kwargs.get('assume_deviceptr', False)
+        self.deviceptr_prefix = kwargs.get('devptr_prefix', 'loki_devptr_')
         field_group_types = kwargs.get('field_group_types', ['CLOUDSC_STATE_TYPE', 'CLOUDSC_AUX_TYPE', 'CLOUDSC_FLUX_TYPE'])
         self.field_group_types = tuple(typename.lower() for typename in field_group_types)
 
@@ -1086,14 +1085,14 @@ class FieldOffloadTransformation(Transformation):
         driver.variables += device_ptrs
         return device_ptrs
 
-    def _devptr_from_array(self, driver, a: sym.Array) -> sym.Variable:
+    def _devptr_from_array(self, driver, a: sym.Array):
         """
         Returns a contiguous pointer :any:`Variable` with types matching the array a
         """
         shape = (sym.RangeIndex((None, None)),) * (len(a.shape)+1)
         devptr_type = a.type.clone(pointer=True, contiguous=True, shape=shape, intent=None)
         base_name = a.name if a.parent is None else '_'.join(a.name.split('%'))
-        devptr_name = self.devptr_prefix + base_name
+        devptr_name = self.deviceptr_prefix + base_name
         try:
             driver.variable_map[devptr_name]
             warning(f'[Loki] Field data offload: The routine {driver.name} already has a' +

--- a/loki/transformations/data_offload.py
+++ b/loki/transformations/data_offload.py
@@ -996,7 +996,7 @@ class FieldOffloadTransformation(Transformation):
             ______
             :any:`Array`
                 Original kernel call argument
-            :any: `Array`
+            :any:`Array`
                 Corresponding device pointer added by the transformation.
             """
             for i, inarg in enumerate(self.inargs):
@@ -1143,8 +1143,12 @@ class FieldOffloadTransformation(Transformation):
         change_map = {}
         offload_idx_expr = driver.variable_map[self.offload_index]
         for arg, devptr in chain(offload_map.in_pairs, offload_map.inout_pairs, offload_map.out_pairs):
-            dims = (sym.RangeIndex((None, None)),) * (len(devptr.shape)-1) + (offload_idx_expr,)
+            if len(arg.dimensions) != 0:
+                dims = arg.dimensions + (offload_idx_expr,)
+            else:
+                dims = (sym.RangeIndex((None, None)),) * (len(devptr.shape)-1) + (offload_idx_expr,)
             change_map[arg] = devptr.clone(dimensions=dims)
+
         arg_transformer = SubstituteExpressions(change_map, inplace=True)
         for call in kernel_calls:
             arg_transformer.visit(call)

--- a/loki/transformations/parallel/field_api.py
+++ b/loki/transformations/parallel/field_api.py
@@ -9,16 +9,19 @@
 Transformation utilities to manage and inject FIELD-API boilerplate code.
 """
 
+from enum import Enum
 from loki.expression import symbols as sym
 from loki.ir import (
     nodes as ir, FindNodes, FindVariables, Transformer
 )
+from loki.scope import Scope
 from loki.logging import warning
 from loki.tools import as_tuple
 
-
 __all__ = [
-    'remove_field_api_view_updates', 'add_field_api_view_updates'
+    'remove_field_api_view_updates', 'add_field_api_view_updates', 'get_field_type',
+    'field_new', 'field_delete', 'field_get_device_data', 'field_sync_host',
+    'FieldAPITransferType'
 ]
 
 
@@ -26,9 +29,7 @@ def remove_field_api_view_updates(routine, field_group_types, dim_object=None):
     """
     Remove FIELD API boilerplate calls for view updates of derived types.
 
-    This utility is intended to remove the IFS-specific group type
-    objects that provide block-scope view pointers to deep kernel
-    trees. It will remove all calls to ``UPDATE_VIEW`` on derive-type
+    This utility is intended to remove the IFS-specific group type objects that provide block-scope view pointers to deep kernel trees. It will remove all calls to ``UPDATE_VIEW`` on derive-type
     objects with the respective types.
 
     Parameters
@@ -150,3 +151,66 @@ def add_field_api_view_updates(routine, dimension, field_group_types, dim_object
             return loop
 
     routine.body = InsertFieldAPIViewsTransformer().visit(routine.body, scope=routine)
+
+
+def get_field_type(a: sym.Array) -> sym.DerivedType:
+    """
+    Returns the corresponding FIELD API type for an array.
+
+    This transformation is IFS specific and assumes that the
+    type is an array declared with one of the IFS type specifiers, e.g. KIND=JPRB
+    """
+    type_map = ["jprb",
+                "jpit",
+                "jpis",
+                "jpim",
+                "jpib",
+                "jpia",
+                "jprt",
+                "jprs",
+                "jprm",
+                "jprd",
+                "jplm"]
+
+    type_name = a.type.kind.name
+    assert type_name.lower() in type_map, ('Error array type kind is: '
+                                           f'"{type_name}" which is not a valid IFS type specifier')
+    rank = len(a.shape)
+    field_type = sym.DerivedType(name="field_" + str(rank) + type_name[2:4])
+    return field_type
+
+
+def field_new(field_ptr, data, scope):
+    return ir.CallStatement(name=sym.ProcedureSymbol('FIELD_NEW', scope=scope),
+                            arguments=(field_ptr,), kwarguments=(('DATA', data),))
+
+
+def field_delete(field_ptr, scope):
+    return ir.CallStatement(name=sym.ProcedureSymbol('FIELD_DELETE', scope=scope),
+                            arguments=(field_ptr,))
+
+
+class FieldAPITransferType(Enum):
+    READ_ONLY = 1
+    READ_WRITE = 2
+    WRITE_ONLY = 3
+
+
+def field_get_device_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferType, scope: Scope):
+    assert isinstance(transfer_type, FieldAPITransferType)
+    if transfer_type == FieldAPITransferType.READ_ONLY:
+        suffix = 'RDONLY'
+    if transfer_type == FieldAPITransferType.READ_WRITE:
+        suffix = 'RDWR'
+    if transfer_type == FieldAPITransferType.WRITE_ONLY:
+        suffix = 'WRONLY'
+    procedure_name = 'GET_DEVICE_DATA_' + suffix
+    return ir.CallStatement(name=sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope),
+                            arguments=(dev_ptr.clone(dimensions=None),), )
+
+
+def field_sync_host(field_ptr, scope):
+    procedure_name = 'SYNC_HOST_RDWR'
+    return ir.CallStatement(name=sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope), arguments=())
+
+

--- a/loki/transformations/parallel/field_api.py
+++ b/loki/transformations/parallel/field_api.py
@@ -171,12 +171,12 @@ def get_field_type(a: sym.Array) -> sym.DerivedType:
                 "jprm",
                 "jprd",
                 "jplm"]
-
     type_name = a.type.kind.name
+
     assert type_name.lower() in type_map, ('Error array type kind is: '
                                            f'"{type_name}" which is not a valid IFS type specifier')
     rank = len(a.shape)
-    field_type = sym.DerivedType(name="field_" + str(rank) + type_name[2:4])
+    field_type = sym.DerivedType(name="field_" + str(rank) + type_name[2:4].lower())
     return field_type
 
 
@@ -197,7 +197,8 @@ class FieldAPITransferType(Enum):
 
 
 def field_get_device_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferType, scope: Scope):
-    assert isinstance(transfer_type, FieldAPITransferType)
+    if not isinstance(transfer_type, FieldAPITransferType):
+        raise TypeError(f"transfer_type must be of type FieldAPITransferType, but is of type {type(transfer_type)}")
     if transfer_type == FieldAPITransferType.READ_ONLY:
         suffix = 'RDONLY'
     if transfer_type == FieldAPITransferType.READ_WRITE:

--- a/loki/transformations/parallel/field_api.py
+++ b/loki/transformations/parallel/field_api.py
@@ -20,8 +20,7 @@ from loki.tools import as_tuple
 
 __all__ = [
     'remove_field_api_view_updates', 'add_field_api_view_updates', 'get_field_type',
-    'field_new', 'field_delete', 'field_get_device_data', 'field_sync_host',
-    'FieldAPITransferType'
+    'field_get_device_data', 'field_sync_host', 'FieldAPITransferType'
 ]
 
 
@@ -181,15 +180,6 @@ def get_field_type(a: sym.Array) -> sym.DerivedType:
     field_type = sym.DerivedType(name="field_" + str(rank) + type_name[2:4].lower())
     return field_type
 
-
-def field_new(field_ptr, data, scope):
-    return ir.CallStatement(name=sym.ProcedureSymbol('FIELD_NEW', scope=scope),
-                            arguments=(field_ptr,), kwarguments=(('DATA', data),))
-
-
-def field_delete(field_ptr, scope):
-    return ir.CallStatement(name=sym.ProcedureSymbol('FIELD_DELETE', scope=scope),
-                            arguments=(field_ptr,))
 
 
 class FieldAPITransferType(Enum):

--- a/loki/transformations/parallel/field_api.py
+++ b/loki/transformations/parallel/field_api.py
@@ -29,7 +29,9 @@ def remove_field_api_view_updates(routine, field_group_types, dim_object=None):
     """
     Remove FIELD API boilerplate calls for view updates of derived types.
 
-    This utility is intended to remove the IFS-specific group type objects that provide block-scope view pointers to deep kernel trees. It will remove all calls to ``UPDATE_VIEW`` on derive-type
+    This utility is intended to remove the IFS-specific group type
+    objects that provide block-scope view pointers to deep kernel
+    trees. It will remove all calls to ``UPDATE_VIEW`` on derive-type
     objects with the respective types.
 
     Parameters
@@ -201,10 +203,12 @@ def field_get_device_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferTyp
         raise TypeError(f"transfer_type must be of type FieldAPITransferType, but is of type {type(transfer_type)}")
     if transfer_type == FieldAPITransferType.READ_ONLY:
         suffix = 'RDONLY'
-    if transfer_type == FieldAPITransferType.READ_WRITE:
+    elif transfer_type == FieldAPITransferType.READ_WRITE:
         suffix = 'RDWR'
-    if transfer_type == FieldAPITransferType.WRITE_ONLY:
+    elif transfer_type == FieldAPITransferType.WRITE_ONLY:
         suffix = 'WRONLY'
+    else:
+        suffix = ''
     procedure_name = 'GET_DEVICE_DATA_' + suffix
     return ir.CallStatement(name=sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope),
                             arguments=(dev_ptr.clone(dimensions=None),), )
@@ -213,5 +217,3 @@ def field_get_device_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferTyp
 def field_sync_host(field_ptr, scope):
     procedure_name = 'SYNC_HOST_RDWR'
     return ir.CallStatement(name=sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope), arguments=())
-
-

--- a/loki/transformations/parallel/field_api.py
+++ b/loki/transformations/parallel/field_api.py
@@ -158,7 +158,7 @@ def get_field_type(a: sym.Array) -> sym.DerivedType:
     """
     Returns the corresponding FIELD API type for an array.
 
-    This transformation is IFS specific and assumes that the
+    This function is IFS specific and assumes that the
     type is an array declared with one of the IFS type specifiers, e.g. KIND=JPRB
     """
     type_map = ["jprb",
@@ -189,6 +189,21 @@ class FieldAPITransferType(Enum):
 
 
 def field_get_device_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferType, scope: Scope):
+    """
+    Utility function to generate a :any:`CallStatement` corresponding to a Field API
+    ``GET_DEVICE_DATA`` call.
+    
+    Parameters
+    ----------
+    field_ptr: pointer to field object
+        Pointer to the field to call ``GET_DEVICE_DATA`` from.
+    dev_ptr: :any:`Array`
+        Device pointer array
+    transfer_type: :any:`FieldAPITransferType`
+        Field API transfer type to determine which ``GET_DEVICE_DATA`` method to call.
+    scope: :any:`Scope`
+        Scope of the created :any:`CallStatement`
+    """
     if not isinstance(transfer_type, FieldAPITransferType):
         raise TypeError(f"transfer_type must be of type FieldAPITransferType, but is of type {type(transfer_type)}")
     if transfer_type == FieldAPITransferType.READ_ONLY:
@@ -205,5 +220,17 @@ def field_get_device_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferTyp
 
 
 def field_sync_host(field_ptr, scope):
+    """
+    Utility function to generate a :any:`CallStatement` corresponding to a Field API
+    ``SYNC_HOST`` call.
+    
+    Parameters
+    ----------
+    field_ptr: pointer to field object
+        Pointer to the field to call ``SYNC_HOST`` from.
+    scope: :any:`Scope`
+        Scope of the created :any:`CallStatement`
+    """
+
     procedure_name = 'SYNC_HOST_RDWR'
     return ir.CallStatement(name=sym.ProcedureSymbol(procedure_name, parent=field_ptr, scope=scope), arguments=())

--- a/loki/transformations/parallel/tests/test_field_api.py
+++ b/loki/transformations/parallel/tests/test_field_api.py
@@ -10,11 +10,13 @@ import pytest
 from loki import Subroutine, Module, Dimension
 from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes
-from loki.logging import WARNING
-
+from loki.expression import symbols as sym
+from loki.scope import Scope
 from loki.transformations.parallel import (
-    remove_field_api_view_updates, add_field_api_view_updates
+    remove_field_api_view_updates, add_field_api_view_updates, get_field_type
 )
+from loki.types import BasicType, SymbolAttributes
+from loki.logging import WARNING
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
@@ -136,3 +138,52 @@ end subroutine test_remove_block_loop
     assert calls[3].name == 'STATE%UPDATE_VIEW' and calls[3].arguments == ('IBL',)
 
     assert len(FindNodes(ir.Loop).visit(routine.body)) == 1
+
+
+def test_get_field_type():
+    type_map = ["jprb",
+                "jpit",
+                "jpis",
+                "jpim",
+                "jpib",
+                "jpia",
+                "jprt",
+                "jprs",
+                "jprm",
+                "jprd",
+                "jplm"]
+    field_types = [
+                    "field_1rb", "field_2rb", "field_3rb",
+                    "field_1it", "field_2it", "field_3it",
+                    "field_1is", "field_2is", "field_3is",
+                    "field_1im", "field_2im", "field_3im",
+                    "field_1ib", "field_2ib", "field_3ib",
+                    "field_1ia", "field_2ia", "field_3ia",
+                    "field_1rt", "field_2rt", "field_3rt",
+                    "field_1rs", "field_2rs", "field_3rs",
+                    "field_1rm", "field_2rm", "field_3rm",
+                    "field_1rd", "field_2rd", "field_3rd",
+                    "field_1lm", "field_2lm", "field_3lm",
+                  ]
+
+    def generate_fields(types):
+        generated = []
+        for type_name in types:
+            for dim in range(1, 4):
+                shape = tuple(None for _ in range(dim))
+                a = sym.Variable(name='test_array',
+                                 type=SymbolAttributes(BasicType.REAL,
+                                                       shape=shape,
+                                                       kind=sym.Variable(name=type_name)))
+                generated.append(get_field_type(a))
+        return generated
+
+    generated = generate_fields(type_map)
+    for field, field_name in zip(generated, field_types):
+        assert isinstance(field, sym.DerivedType) and field.name == field_name
+
+    generated = generate_fields([t.upper() for t in type_map])
+    for field, field_name in zip(generated, field_types):
+        assert isinstance(field, sym.DerivedType) and field.name == field_name
+
+

--- a/loki/transformations/parallel/tests/test_field_api.py
+++ b/loki/transformations/parallel/tests/test_field_api.py
@@ -13,7 +13,8 @@ from loki.ir import nodes as ir, FindNodes
 from loki.expression import symbols as sym
 from loki.scope import Scope
 from loki.transformations.parallel import (
-    remove_field_api_view_updates, add_field_api_view_updates, get_field_type
+    remove_field_api_view_updates, add_field_api_view_updates, get_field_type, 
+    field_get_device_data, FieldAPITransferType
 )
 from loki.types import BasicType, SymbolAttributes
 from loki.logging import WARNING
@@ -186,4 +187,15 @@ def test_get_field_type():
     for field, field_name in zip(generated, field_types):
         assert isinstance(field, sym.DerivedType) and field.name == field_name
 
+
+def test_field_get_device_data():
+    scope = Scope()
+    fptr = sym.Variable(name='fptr_var')
+    dev_ptr = sym.Variable(name='data_var')
+    for fttype in FieldAPITransferType:
+        get_dev_data_call = field_get_device_data(fptr, dev_ptr, fttype, scope)
+        assert isinstance(get_dev_data_call, ir.CallStatement)
+        assert get_dev_data_call.name.parent == fptr
+    with pytest.raises(TypeError):
+        _ = field_get_device_data(fptr, dev_ptr, "none_transfer_type", scope)
 

--- a/loki/transformations/tests/test_data_offload.py
+++ b/loki/transformations/tests/test_data_offload.py
@@ -914,6 +914,7 @@ def test_field_offload(frontend):
     driver = driver_mod['driver_routine']
     deviceptr_prefix = 'loki_devptr_prefix_'
     driver.apply(FieldOffloadTransformation(devptr_prefix=deviceptr_prefix,
+                                            offload_index='i', 
                                             field_group_types=['state_type']),
                  role='driver',
                  targets=['kernel_routine'])
@@ -1000,6 +1001,7 @@ def test_field_offload_multiple_calls(frontend):
     driver = driver_mod['driver_routine']
     deviceptr_prefix = 'loki_devptr_prefix_'
     driver.apply(FieldOffloadTransformation(devptr_prefix=deviceptr_prefix,
+                                            offload_index='i', 
                                             field_group_types=['state_type']),
                  role='driver',
                  targets=['kernel_routine'])
@@ -1084,6 +1086,7 @@ def test_field_offload_no_targets(frontend):
     driver = driver_mod['driver_routine']
     deviceptr_prefix = 'loki_devptr_prefix_'
     driver.apply(FieldOffloadTransformation(devptr_prefix=deviceptr_prefix,
+                                            offload_index='i', 
                                             field_group_types=['state_type']),
                  role='driver',
                  targets=['kernel_routine'])

--- a/loki/transformations/tests/test_data_offload.py
+++ b/loki/transformations/tests/test_data_offload.py
@@ -21,7 +21,6 @@ from loki.transformations import (
     DataOffloadTransformation, GlobalVariableAnalysis,
     GlobalVarOffloadTransformation, GlobalVarHoistTransformation, FieldOffloadTransformation
 )
-from loki.transformations.data_offload import find_array_arguments, find_target_calls
 
 
 @pytest.fixture(scope='module', name='here')
@@ -807,59 +806,6 @@ def test_transformation_global_var_derived_type_hoist(here, config, frontend, ho
     assert kernel.variable_map['p'].type.dtype.name == 'point'
     assert kernel.variable_map['p0'].type.intent == 'in'
     assert kernel.variable_map['p0'].type.dtype.name == 'point'
-
-
-
-@pytest.mark.parametrize('frontend', available_frontends())
-def test_find_array_arguments(frontend):
-        fcode_driver = """
-      SUBROUTINE driver_routine(nlon, nlev, a, b, c, d, e, f)
-        INTEGER, INTENT(INOUT)  :: nlon, nlev
-        REAL, INTENT(INOUT)     :: a(nlon,nlev)
-        REAL, INTENT(INOUT)     :: b(nlon)
-        REAL, INTENT(INOUT)     :: c(nlon,nlev,nlon)
-        REAL, INTENT(INOUT)     :: d
-        REAL, INTENT(INOUT)     :: e
-        REAL, INTENT(INOUT)     :: f
-        INTEGER                 :: nlon_copy, nlev_copy
-        REAL                    :: a_copy(nlon,nlev)
-        REAL                    :: b_copy(nlon)
-        REAL                    :: c_copy(nlon,nlev,nlon)
-        REAL                    :: d_copy
-        REAL                    :: e_copy
-        REAL                    :: f_copy
-
-        call kernel_routine(nlon_copy, nlev_copy, a_copy, b_copy, c_copy, d_copy, e_copy, f_copy)
-
-      END SUBROUTINE driver_routine
-    """
-        fcode_kernel = """
-      SUBROUTINE kernel_routine(nlon, nlev, a, b, c, d, e, f)
-        INTEGER, INTENT(IN)     :: nlon, nlev
-        REAL, INTENT(IN)        :: a(nlon,nlev)
-        REAL, INTENT(INOUT)     :: b(nlon)
-        REAL, INTENT(OUT)       :: c(nlon,nlev,nlon)
-        REAL, INTENT(IN)        :: d
-        REAL, INTENT(IN)        :: e
-        REAL, INTENT(IN)        :: f
-
-        do j=1, nlon
-          do i=1, nlev
-            b_copy(i) = a(i,j) + 0.1
-            c(i,j,i) = 0.1
-          end do
-        end do
-      END SUBROUTINE kernel_routine
-    """
-        driver = Sourcefile.from_source(fcode_driver, frontend=frontend)['driver_routine']
-        kernel = Sourcefile.from_source(fcode_kernel, frontend=frontend)['kernel_routine']
-        driver.enrich(kernel)
-        targets = find_target_calls(driver.body, [kernel.name])
-        in_vars, inout_vars, out_vars = find_array_arguments(driver, targets)
-
-        assert len(in_vars) == 1 and in_vars[0].name == 'a_copy'
-        assert len(inout_vars) == 1 and inout_vars[0].name == 'b_copy'
-        assert len(out_vars) == 1 and out_vars[0].name == 'c_copy'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
This adds a new transformation, ``FieldOffloadTransformation``,   for offloading F-API fields to GPU. Specifically this transformation is meant to operate on CPU driver code that passes view pointers to the kernels. The transformation

1. Removes the view update calls
2. Adds new device pointers for the arrays to offload
3. Adds F-API data offload and sync calls
4. Replaces the old *view-based* arguments in kernel calls with device pointer slices

The corresponding ``dwarf-p-cloudsc`` implementation is on the branch [dwarf-p-cloudsc/je-field-api-offload-v2](https://github.com/ecmwf-ifs/dwarf-p-cloudsc/tree/je-field-api-offload-v2). This adds a new transformation pipeline for converting view based CPU driver code to GPU offloaded F-API code,  ``[pipelines.scc-field]``, and a new Loki target ``dwarf-cloudsc-loki-scc-field``.
