### PR TITLE
Sanitise: Update scope on unchanged expressions in remove_associates

### DIFF
--- a/loki/transformations/sanitise/associates.py
+++ b/loki/transformations/sanitise/associates.py
@@ -139,7 +139,8 @@ class ResolveAssociateMapper(LokiIdentityMapper):
             expr = scope.inverse_map[expr.basename]
             return self.rec(expr, *args, **kwargs)
 
-        return expr
+        # Update the scope, as this one will be removed
+        return expr.clone(scope=scope.parent)
 
     def map_array(self, expr, *args, **kwargs):
         """ Special case for arrys: we need to preserve the dimensions """


### PR DESCRIPTION
The default case is the one, where the symbol is associates by the closest associate, but that associates is about to be removed. So we simply update the scope to ensure nothing becomes unscoped.

Note, I believe this should fix issue #438 . The PR includes a much simplified test case.