### PR TITLE
JoinableStringList: Do not break lines within quoted strings

### DIFF
--- a/cmake/loki_transform_helpers.cmake
+++ b/cmake/loki_transform_helpers.cmake
@@ -132,7 +132,7 @@ macro( _loki_transform_env_setup )
     set( _LOKI_TRANSFORM_ENV )
     set( _LOKI_TRANSFORM_PATH )
 
-    if( TARGET clawfc AND ${_PAR_FRONTEND} STREQUAL "omni" )
+    if( TARGET clawfc AND "${_PAR_FRONTEND}" STREQUAL "omni" )
         # Ugly hack but I don't have a better solution: We need to add F_FRONT
         # (which is installed in the same directory as clawfc) to the PATH, if
         # OMNI is used as a frontend. Hence we have to update the environment in the below
@@ -142,7 +142,7 @@ macro( _loki_transform_env_setup )
         list( APPEND _LOKI_TRANSFORM_PATH ${_CLAWFC_LOCATION} )
     endif()
 
-    if( _PAR_OUTPATH AND (${_PAR_FRONTEND} STREQUAL "omni" OR ${_PAR_FRONTEND} STREQUAL "ofp") )
+    if( _PAR_OUTPATH AND ("${_PAR_FRONTEND}" STREQUAL "omni" OR "${_PAR_FRONTEND}" STREQUAL "ofp") )
         # With pre-processing, we may end up having a race condition on the preprocessed
         # source files in parallel builds. Ensuring we use the outpath of the call to Loki
         # should ensure in most cases that parallel builds write to different directories

--- a/loki/backend/tests/test_fgen.py
+++ b/loki/backend/tests/test_fgen.py
@@ -91,6 +91,32 @@ end module some_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_character_list_linebreak(frontend, tmp_path):
+    fcode = """
+module some_mod
+  implicit none
+  character(len=*), parameter :: IceModelName(0:5) = (/ 'Monochromatic         ', &
+       &                                                'Fu-IFS                ', &
+       &                                                'Baran-EXPERIMENTAL    ', &
+       &                                                'Baran2016             ', &
+       &                                                'Baran2017-EXPERIMENTAL', &
+       &                                                'Yi                    ' /)
+end module some_mod
+    """
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    generated_fcode = module.to_fortran()
+    for ice_model_name in (
+        "'Monochromatic         '",
+        "'Fu-IFS                '",
+        "'Baran-EXPERIMENTAL    '",
+        "'Baran2016             '",
+        "'Baran2017-EXPERIMENTAL'",
+        "'Yi                    '"
+    ):
+        assert ice_model_name in generated_fcode
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_fgen_data_stmt(frontend):
     """
     Test correct formatting of data declaration statements

--- a/loki/tools/tests/test_tools.py
+++ b/loki/tools/tests/test_tools.py
@@ -126,6 +126,10 @@ def test_is_subset_raises(a, b):
      ' ', 8, '\n', 'Hello \nworld!'),
     (('Hello', JoinableStringList(['w', 'o', 'r', 'l', 'd', '!'], '', 8, '\n', separable=True)),
      ' ', 8, '\n', 'Hello w\norld!'),
+    (["'Long word   '", '"list with    "', '"several entries   "', "'that may have'",
+      "' trailing whitespace '", "'characters     '"], ', ', 20, '\n',
+     ("'Long word   ', \n\"list with    \", \n\"several entries   \"\n, 'that may have', \n"
+      "' trailing whitespace '\n, 'characters     '"))
 ])
 def test_joinable_string_list(items, sep, width, cont, ref):
     """


### PR DESCRIPTION
The line break heuristic in JoinableStringList did not account for quoted strings, sometimes putting line breaks into the middle of a string.
This caused issues with an initialiser list for a character array, where the list entries contained white spaces.

The fix is to search for quoted strings in the remainder string and treat them as unbreakable entities, while retaining the same splitting heuristic as before outside of quoted strings. This allowed to remove a four year old "TODO" comment that points out that the above problem might occur... 🤦 

Two tests are included to validate the behaviour directly on the class as well as in the original Fortran context where the problem first occured.

Piggy-backed is also a small hotfix to the CMake layer to fix an issue that occured if no frontend was chosen explicitly.