### PR TITLE
CMake plan and enrichment bugfix

### DIFF
--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -635,8 +635,15 @@ class Scheduler:
         sources_to_transform = []
 
         # Filter the SGraph to get a pure call-tree
-        item_filter = None if self.config.enable_imports else ProcedureItem
-        for item in SFilter(self.sgraph, item_filter=item_filter):
+        item_filter = ProcedureItem
+        if self.config.enable_imports:
+            item_filter = as_tuple(item_filter) + (ModuleItem,)
+        graph = self.sgraph.as_filegraph(
+            self.item_factory, self.config, item_filter=item_filter,
+            exclude_ignored=True
+        )
+        traversal = SFilter(graph, reverse=False, include_external=False)
+        for item in traversal:
             if item.is_ignored:
                 continue
 

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -223,10 +223,21 @@ class SGraph:
             if file_item not in self._graph:
                 self.add_node(file_item)
 
-        # Update the "is_ignored" attribute for file items
+        # Update the "is_ignored" and "replicate" attributes for file items
         for items in file_item_2_item_map.values():
+            file_item = item_2_file_item_map[items[0]]
             is_ignored = all(item.is_ignored for item in items)
-            item_2_file_item_map[items[0]].config['is_ignored'] = is_ignored
+            file_item.config['is_ignored'] = is_ignored
+
+            replicate = any(item.replicate for item in items)
+            if replicate:
+                non_replicate_items = [item for item in items if not item.replicate]
+                if non_replicate_items:
+                    warning((
+                        f'File {file_item.name} will be replicated but contains items '
+                        f'that are marked as non-replicated: {", ".join(non_replicate_items)}'
+                    ))
+            file_item.config['replicate'] = replicate
 
         # Insert edges to the file items corresponding to the successors of the items
         for item in SFilter(sgraph, item_filter, exclude_ignored=exclude_ignored):

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -235,7 +235,7 @@ class SGraph:
                 if non_replicate_items:
                     warning((
                         f'File {file_item.name} will be replicated but contains items '
-                        f'that are marked as non-replicated: {", ".join(non_replicate_items)}'
+                        f'that are marked as non-replicated: {", ".join(item.name for item in non_replicate_items)}'
                     ))
             file_item.config['replicate'] = replicate
 

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -349,14 +349,17 @@ class ProgramUnit(Scope):
                 # Take care of renaming upon import
                 local_name = symbol.name
                 remote_name = symbol.type.use_name or local_name
-                remote_node = module[remote_name]
+                try:
+                    remote_node = module[remote_name]
+                except KeyError:
+                    remote_node = None
 
-                if hasattr(remote_node, 'procedure_type'):
+                if remote_node and hasattr(remote_node, 'procedure_type'):
                     # This is a subroutine/function defined in the remote module
                     updated_symbol_attrs[local_name] = symbol.type.clone(
                         dtype=remote_node.procedure_type, imported=True, module=module
                     )
-                elif hasattr(remote_node, 'dtype'):
+                elif remote_node and hasattr(remote_node, 'dtype'):
                     # This is a derived type defined in the remote module
                     updated_symbol_attrs[local_name] = symbol.type.clone(
                         dtype=remote_node.dtype, imported=True, module=module
@@ -368,7 +371,7 @@ class ProgramUnit(Scope):
                         if getattr(type_.dtype, 'name') == remote_node.dtype.name
                     }
                     updated_symbol_attrs.update(variables_with_this_type)
-                elif hasattr(remote_node, 'type'):
+                elif remote_node and hasattr(remote_node, 'type'):
                     # This is a global variable or interface import
                     updated_symbol_attrs[local_name] = remote_node.type.clone(
                         imported=True, module=module, use_name=symbol.type.use_name

--- a/loki/transformations/build_system/file_write.py
+++ b/loki/transformations/build_system/file_write.py
@@ -51,7 +51,7 @@ class FileWriteTransformation(Transformation):
         imports are honoured in the :any:`Scheduler` traversal.
         """
         if self.include_module_var_imports:
-            return (ProcedureItem, ModuleItem) #GlobalVariableItem)
+            return (ProcedureItem, ModuleItem)
         return ProcedureItem
 
     def transform_file(self, sourcefile, **kwargs):

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -59,11 +59,11 @@ end module b_mod
     else:
         import_stmt = "use a_mod\n    use b_mod"
 
+    module_import_stmt = ""
+    routine_import_stmt = ""
     if import_level == 'module':
         module_import_stmt = import_stmt
-        routine_import_stmt = ""
     elif import_level == 'subroutine':
-        module_import_stmt = ""
         routine_import_stmt = import_stmt
 
     fcode_mod_c = f"""
@@ -82,7 +82,7 @@ contains
 end module c_mod
 """
 
-    fcode_mod_d = f"""
+    fcode_mod_d = """
 module d_mod
     implicit none
 contains

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -1,0 +1,206 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Tests for build system interaction
+"""
+
+from pathlib import Path
+import re
+from subprocess import CalledProcessError
+
+import pytest
+
+from loki.batch import Scheduler, SchedulerConfig
+from loki.frontend import available_frontends, OMNI
+from loki.transformations.build_system import FileWriteTransformation
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('enable_imports', [False, True])
+@pytest.mark.parametrize('import_level', ['module', 'subroutine'])
+@pytest.mark.parametrize('qualified_imports', [False, True])
+@pytest.mark.parametrize('use_rootpath', [False, True])
+@pytest.mark.parametrize('suffix', [None, '.F90', '.Fstar'])
+def test_file_write_module_imports(frontend, tmp_path, enable_imports, import_level,
+                                   qualified_imports, use_rootpath, suffix):
+    """
+    Set up a four file mini-project with some edge cases around
+    import behaviour (see in-source comments for details) and verify
+    that the generated CMake plan matches the list of files we expect
+    to transform, and that the FileWriteTransformation writes exactly these
+    files
+    """
+    fcode_mod_a = """
+module a_mod
+    implicit none
+    public
+    integer :: global_a = 1
+end module a_mod
+"""
+
+    fcode_mod_b = """
+module b_mod
+    implicit none
+    public
+    type type_b
+        integer :: val
+    end type type_b
+end module b_mod
+"""
+
+    if qualified_imports:
+        import_stmt = "use a_mod, only: global_a\n    use b_mod, only: type_b"
+    else:
+        import_stmt = "use a_mod\n    use b_mod"
+
+    if import_level == 'module':
+        module_import_stmt = import_stmt
+        routine_import_stmt = ""
+    elif import_level == 'subroutine':
+        module_import_stmt = ""
+        routine_import_stmt = import_stmt
+
+    fcode_mod_c = f"""
+module c_mod
+    {module_import_stmt}
+    implicit none
+contains
+    subroutine c(val)
+        {routine_import_stmt}
+        implicit none
+        integer, intent(inout) :: val
+        type(type_b) :: b
+        b%val = global_a
+        val = b%val
+    end subroutine c
+end module c_mod
+"""
+
+    fcode_mod_d = f"""
+module d_mod
+    implicit none
+contains
+    subroutine d
+        use c_mod, only: c
+        implicit none
+        integer :: v
+        call c(v)
+    end subroutine d
+end module d_mod
+"""
+
+    # Set-up paths and write sources
+    src_path = tmp_path/'src'
+    src_path.mkdir()
+    out_path = tmp_path/'build'
+    out_path.mkdir()
+
+    (src_path/'a.F90').write_text(fcode_mod_a)
+    (src_path/'b.F90').write_text(fcode_mod_b)
+    (src_path/'c.F90').write_text(fcode_mod_c)
+    (src_path/'d.F90').write_text(fcode_mod_d)
+
+    # Expected items in the dependency graph
+    expected_items = {'c_mod#c', 'd_mod#d'}
+
+    if import_level == 'subroutine':
+        if qualified_imports:
+            # With qualified imports, we do not have a dependency
+            # on 'b_mod' but directly on 'b_mod#type_b'
+            expected_items |= {'a_mod', 'b_mod#type_b'}
+        else:
+            # Without qualified imports, we assume a dependency
+            # for the subroutine on the imported module
+            expected_items |= {'a_mod', 'b_mod'}
+
+    elif import_level == 'module':
+        if qualified_imports:
+            # If we have a qualified import for the derived type
+            # then we will recognize the dependency
+            expected_items |= {'b_mod#type_b'}
+
+    # Create the Scheduler
+    config = SchedulerConfig.from_dict({
+        'default': {
+            'role': 'kernel',
+            'expand': True,
+            'strict': True,
+            'enable_imports': enable_imports,
+            'mode': 'foobar'
+        },
+        'routines': {'d': {'role': 'driver'}}
+    })
+    try:
+        scheduler = Scheduler(
+            paths=[src_path], config=config, frontend=frontend,
+            output_dir=out_path, xmods=[tmp_path]
+        )
+    except CalledProcessError as e:
+        all_modules_expected = 'a_mod' in expected_items and (expected_items | {'b_mod', 'b_mod#type_b'})
+        if frontend == OMNI and not (enable_imports and all_modules_expected):
+            # If not all header modules appear in the dependency graph, then these
+            # will not be parsed by OMNI and therefore the required xmod files will
+            # not be generated, thus making modules 'c' and 'd' fail at parsing
+            pytest.xfail('Without parsing imports, OMNI does not have the xmod for imported modules')
+        raise e
+
+    # Check the dependency graph
+    assert expected_items == {item.name for item in scheduler.items}
+
+    # Generate the CMake plan
+    plan_file = tmp_path/'plan.cmake'
+    root_path = tmp_path if use_rootpath else None
+    scheduler.write_cmake_plan(
+        filepath=plan_file, mode=config.default['mode'], buildpath=out_path,
+        rootpath=root_path
+    )
+
+    # Validate the plan file content
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+
+    loki_plan = plan_file.read_text()
+    plan_dict = {k: v.split() for k, v in plan_pattern.findall(loki_plan)}
+    plan_dict = {k: {Path(s).stem for s in v} for k, v in plan_dict.items()}
+
+    if enable_imports:
+        # We expect to write all files that correspond to items in the graph
+        expected_files = {item[0] for item in expected_items}
+
+        if qualified_imports:
+            # ...but we want to never write 'b' if we have fully qualified imports
+            # because that only contains a type definition
+            expected_files -= {'b'}
+    else:
+        # We expect to only write the subroutine files
+        expected_files = {'c', 'd'}
+
+    assert 'LOKI_SOURCES_TO_TRANSFORM' in plan_dict
+    assert plan_dict['LOKI_SOURCES_TO_TRANSFORM'] == expected_files
+
+    assert 'LOKI_SOURCES_TO_REMOVE' in plan_dict
+    assert plan_dict['LOKI_SOURCES_TO_REMOVE'] == expected_files
+
+    assert 'LOKI_SOURCES_TO_APPEND' in plan_dict
+    assert plan_dict['LOKI_SOURCES_TO_APPEND'] == {
+        f'{name}.foobar' for name in expected_files
+    }
+
+    # Write the outputs
+    transformation = FileWriteTransformation(
+        suffix=suffix,
+        include_module_var_imports=enable_imports
+    )
+    scheduler.process(transformation)
+
+    # Validate the list of written files
+    if suffix is None:
+        suffix = '.F90'
+    written_files = {f.name for f in out_path.glob('*')}
+    assert written_files == {
+        f'{name}.foobar{suffix}' for name in expected_files
+    }

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -19,13 +19,12 @@ from loki import (
     config as loki_config, Sourcefile, Frontend, as_tuple,
     set_excepthook, auto_post_mortem_debugger, info, warning
 )
-from loki.batch import Transformation, Pipeline, Scheduler, SchedulerConfig
+from loki.batch import Pipeline, Scheduler, SchedulerConfig
 
 # Get generalized transformations provided by Loki
 from loki.transformations.argument_shape import (
     ArgumentArrayShapeAnalysis, ExplicitArgumentArrayShapeTransformation
 )
-from loki.transformations.array_indexing import LowerConstantArrayIndices
 from loki.transformations.build_system import (
     DependencyTransformation, ModuleWrapTransformation, FileWriteTransformation
 )
@@ -34,7 +33,6 @@ from loki.transformations.data_offload import (
 )
 from loki.transformations.transform_derived_types import DerivedTypeArgumentsTransformation
 from loki.transformations.drhook import DrHookTransformation
-from loki.transformations.hoist_variables import HoistTemporaryArraysAnalysis
 from loki.transformations.idempotence import IdemTransformation
 from loki.transformations.inline import InlineTransformation
 from loki.transformations.pool_allocator import TemporariesPoolAllocatorTransformation
@@ -43,7 +41,6 @@ from loki.transformations.sanitise import SanitiseTransformation
 from loki.transformations.single_column import (
     ExtractSCATransformation, CLAWTransformation, SCCVectorPipeline,
     SCCHoistPipeline, SCCStackPipeline, SCCRawStackPipeline,
-    HoistTemporaryArraysDeviceAllocatableTransformation,
 )
 from loki.transformations.transpile import FortranCTransformation
 from loki.transformations.block_index_transformations import (


### PR DESCRIPTION
This fixes two errors spotted with complex Fortran module dependencies:

1. When including module files in transformations, we had inconsistent behaviour between the files in a dependency graph that are going to be written, and those that are listed in the CMake plan. 74409002d6bd05e83504804806a92ae393e17186 applies the methodology that is used to derive the file graph for the `FileWriteTransformation` also when deriving the file list in the CMake plan writing, thus ensuring consistent behaviour.
2. For indirect imports, e.g., when importing a symbol from a module, where the symbol itself is only available because of an import from a third module, enrichment failed non-gracefully because we had the presumed origin module available but that module didn't have the symbol information available. e9a77f425bbc884fff26f0e3b3533c4c5edd60ed fixes the failure by not enriching the symbol, which is the correct approach if the information is not available. A corresponding test is supplied.