### PR TITLE
DataOffload: fix generation of offload pragmas

### DIFF
--- a/loki/transformations/data_offload.py
+++ b/loki/transformations/data_offload.py
@@ -484,7 +484,7 @@ class GlobalVarOffloadTransformation(Transformation):
         offload_variables = offload_variables - declared_variables
         if offload_variables:
             module.spec.append(
-                Pragma(keyword='acc', content=f'declare create({",".join(v.name for v in offload_variables)})')
+                Pragma(keyword='acc', content=f'declare create({", ".join(v.name for v in offload_variables)})')
             )
 
     def transform_subroutine(self, routine, **kwargs):
@@ -575,11 +575,11 @@ class GlobalVarOffloadTransformation(Transformation):
             copyin_variables = {v for v, _ in uses_symbols if v.parent}
             if update_variables:
                 update_device += (
-                    Pragma(keyword='acc', content=f'update device({",".join(v.name for v in update_variables)})'),
+                    Pragma(keyword='acc', content=f'update device({", ".join(v.name for v in update_variables)})'),
                 )
             if copyin_variables:
                 update_device += (
-                    Pragma(keyword='acc', content=f'enter data copyin({",".join(v.name for v in copyin_variables)})'),
+                    Pragma(keyword='acc', content=f'enter data copyin({", ".join(v.name for v in copyin_variables)})'),
                 )
 
         # All variables that are written in a kernel need a device-to-host transfer
@@ -592,15 +592,15 @@ class GlobalVarOffloadTransformation(Transformation):
             }
             if update_variables:
                 update_host += (
-                    Pragma(keyword='acc', content=f'update self({",".join(v.name for v in update_variables)})'),
+                    Pragma(keyword='acc', content=f'update self({", ".join(v.name for v in update_variables)})'),
                 )
             if copyout_variables:
                 update_host += (
-                    Pragma(keyword='acc', content=f'exit data copyout({",".join(v.name for v in copyout_variables)})'),
+                    Pragma(keyword='acc', content=f'exit data copyout({", ".join(v.name for v in copyout_variables)})'),
                 )
             if create_variables:
                 update_device += (
-                    Pragma(keyword='acc', content=f'enter data create({",".join(v.name for v in create_variables)})'),
+                    Pragma(keyword='acc', content=f'enter data create({", ".join(v.name for v in create_variables)})'),
                 )
 
         # Replace Loki pragmas with acc data/update pragmas

--- a/loki/transformations/tests/test_data_offload.py
+++ b/loki/transformations/tests/test_data_offload.py
@@ -570,11 +570,11 @@ def test_global_variable_offload(frontend, key, config, global_variable_analysis
     for pragma in acc_pragmas[:len(expected_h2d_pragmas)]:
         command, variables = pragma.content.lower().split('(')
         assert command.strip() in expected_h2d_pragmas
-        assert set(variables.strip()[:-1].strip().split(',')) == expected_h2d_pragmas[command.strip()]
+        assert set(variables.strip()[:-1].strip().split(', ')) == expected_h2d_pragmas[command.strip()]
     for pragma in acc_pragmas[len(expected_h2d_pragmas):]:
         command, variables = pragma.content.lower().split('(')
         assert command.strip() in expected_d2h_pragmas
-        assert set(variables.strip()[:-1].strip().split(',')) == expected_d2h_pragmas[command.strip()]
+        assert set(variables.strip()[:-1].strip().split(', ')) == expected_d2h_pragmas[command.strip()]
 
     # Verify declarations have been added to the header modules
     expected_declarations = {
@@ -591,7 +591,7 @@ def test_global_variable_offload(frontend, key, config, global_variable_analysis
         variables = {
             v.strip()
             for pragma in acc_pragmas
-            for v in pragma.content.lower().split('(')[-1].strip()[:-1].split(',')
+            for v in pragma.content.lower().split('(')[-1].strip()[:-1].split(', ')
         }
         assert variables == expected_declarations[name]
 


### PR DESCRIPTION
A small fix to how the global variable offload pragmas are generated which allows them to be split into multiple lines by `fgen`.