### PR TITLE
Inline: Fix rescoping of intrinsic procedure symbols in elementals

### DIFF
--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -816,8 +816,12 @@ class AttachScopesMapper(LokiIdentityMapper):
         return map_fn(new_expr, *args, **kwargs)
 
     map_deferred_type_symbol = map_variable_symbol
-    map_procedure_symbol = map_variable_symbol
 
+    def map_procedure_symbol(self, expr, *args, **kwargs):
+        if expr.type and expr.type.is_intrinsic:
+            # Always rescope intrinsics to the closest scope
+            return expr.clone(scope=kwargs['scope'])
+        return self.map_variable_symbol(expr, *args, **kwargs)
 
 class DetachScopesMapper(LokiIdentityMapper):
     """

--- a/loki/transformations/inline/procedures.py
+++ b/loki/transformations/inline/procedures.py
@@ -10,7 +10,7 @@ from collections import defaultdict, ChainMap
 from loki.ir import (
     Import, Comment, VariableDeclaration, CallStatement, Transformer,
     FindNodes, FindVariables, FindInlineCalls, SubstituteExpressions,
-    pragmas_attached, is_loki_pragma, Interface, Pragma
+    pragmas_attached, is_loki_pragma, Interface, Pragma, AttachScopes
 )
 from loki.expression import symbols as sym
 from loki.types import BasicType
@@ -161,6 +161,9 @@ def map_call_to_procedure_body(call, caller, callee=None):
         {pragma: None for pragma in FindNodes(Pragma).visit(callee_body)
          if is_loki_pragma(pragma, starts_with='routine')}
     ).visit(callee_body)
+
+    # Ensure all symbols are rescoped to the caller
+    AttachScopes().visit(callee_body, scope=caller)
 
     # Inline substituted body within a pair of marker comments
     comment = Comment(f'! [Loki] inlined child subroutine: {callee.name}')


### PR DESCRIPTION
This caused problems by a race condition, where the elemental scope that was the original scope of intrisincs could be re-build, making the scope weakref invalid before the final catch-all rescoping.

To fix this, I'm explicitly foxing the function body to be rescoped, before it gets inserted. This was problematic, as intrisic procedure symbols were not updated correctly, so I enforce indiscriminant rescoping for intrisic procedure symbols to the given, closest scope in `AttachScopesMapper`.