### PR TITLE
Loki: Turn test sub-directories into sub-pacakges

### DIFF
--- a/loki/analyse/tests/__init__.py
+++ b/loki/analyse/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/loki/backend/tests/__init__.py
+++ b/loki/backend/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/loki/backend/tests/test_fgen.py
+++ b/loki/backend/tests/test_fgen.py
@@ -11,7 +11,7 @@ from loki import Module, Subroutine, Sourcefile
 from loki.backend import fgen
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI
-from loki.ir import Intrinsic, DataDeclaration
+from loki.ir import DataDeclaration
 from loki.types import ProcedureType, BasicType
 
 

--- a/loki/batch/tests/__init__.py
+++ b/loki/batch/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/loki/batch/tests/test_batch.py
+++ b/loki/batch/tests/test_batch.py
@@ -402,6 +402,7 @@ def test_procedure_item1(testdir):
 
     # To ensure any existing items from the item_cache are re-used, we instantiate one for
     # the procedure binding
+    # pylint: disable=unsupported-binary-operation
     t_mod_t_proc = get_item(
         ProcedureBindingItem, proj/'module/t_mod.F90', 't_mod#t%proc',
         RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass | RegexParserClass.DeclarationClass
@@ -805,6 +806,7 @@ def test_interface_item_in_subroutine(testdir):
 
 def test_procedure_binding_item1(testdir):
     proj = testdir/'sources/projBatch'
+    # pylint: disable=unsupported-binary-operation
     parser_classes = (
         RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass | RegexParserClass.DeclarationClass
     )
@@ -830,6 +832,7 @@ def test_procedure_binding_item1(testdir):
 
 def test_procedure_binding_item2(testdir, default_config):
     proj = testdir/'sources/projBatch'
+    # pylint: disable=unsupported-binary-operation
     parser_classes = (
         RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass | RegexParserClass.DeclarationClass
     )
@@ -871,6 +874,7 @@ def test_procedure_binding_item2(testdir, default_config):
 
 def test_procedure_binding_item3(testdir):
     proj = testdir/'sources/projBatch'
+    # pylint: disable=unsupported-binary-operation
     parser_classes = (
         RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass | RegexParserClass.DeclarationClass
     )
@@ -909,6 +913,7 @@ def test_procedure_binding_item3(testdir):
 ])
 def test_procedure_binding_with_config(testdir, config, expected_dependencies):
     proj = testdir/'sources/projBatch'
+    # pylint: disable=unsupported-binary-operation
     parser_classes = (
         RegexParserClass.ProgramUnitClass | RegexParserClass.TypeDefClass | RegexParserClass.DeclarationClass
     )

--- a/loki/batch/tests/test_transformation.py
+++ b/loki/batch/tests/test_transformation.py
@@ -629,8 +629,8 @@ end subroutine test_pipeline_compose
     assert comments[4].text == '! No !'
 
     # Check that the string representation is sane
-    assert '<YesTrafo  [test_transformation]' in str(pipe)
-    assert '<MaybeTrafo  [test_transformation]' in str(pipe)
-    assert '<MaybeNotTrafo  [test_transformation]' in str(pipe)
-    assert '<YesTrafo  [test_transformation]' in str(pipe)
-    assert '<NoTrafo  [test_transformation]' in str(pipe)
+    assert '<YesTrafo  [loki.batch.tests.test_transformation]' in str(pipe)
+    assert '<MaybeTrafo  [loki.batch.tests.test_transformation]' in str(pipe)
+    assert '<MaybeNotTrafo  [loki.batch.tests.test_transformation]' in str(pipe)
+    assert '<YesTrafo  [loki.batch.tests.test_transformation]' in str(pipe)
+    assert '<NoTrafo  [loki.batch.tests.test_transformation]' in str(pipe)

--- a/loki/build/tests/__init__.py
+++ b/loki/build/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/loki/build/tests/test_build.py
+++ b/loki/build/tests/test_build.py
@@ -8,9 +8,10 @@
 from pathlib import Path
 import pytest
 
-from loki.build import (
-    Obj, Lib, Builder,
-    Compiler, GNUCompiler, NvidiaCompiler, get_compiler_from_env, _default_compiler
+from loki.build import Obj, Lib, Builder
+from loki.build.compiler import  (
+    Compiler, GNUCompiler, NvidiaCompiler, get_compiler_from_env,
+    _default_compiler
 )
 
 

--- a/loki/expression/tests/__init__.py
+++ b/loki/expression/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/loki/frontend/tests/__init__.py
+++ b/loki/frontend/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/loki/ir/tests/__init__.py
+++ b/loki/ir/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/loki/ir/tests/test_control_flow.py
+++ b/loki/ir/tests/test_control_flow.py
@@ -583,7 +583,6 @@ end subroutine forall_masked_stmt
     assert bound_var == "j"
     assert bound_range == '1:n'
     # Check the array mask
-    mask = statements[0].mask
     assert statements[0].mask == 'a(i, j) != 0.0'
     # Quickly check assignment
     assignments = FindNodes(ir.Assignment).visit(statements[0])

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -5,9 +5,9 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import pytest
-
 from dataclasses import FrozenInstanceError
+
+import pytest
 from pymbolic.primitives import Expression
 from pydantic import ValidationError
 
@@ -52,17 +52,17 @@ def test_assignment(scope, a_i):
     assert assign.comment is None
 
     # Ensure "frozen" status of node objects
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         assign.lhs = sym.Scalar('b', scope=scope)
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         assign.rhs = sym.Scalar('b', scope=scope)
 
     # Test errors for wrong contructor usage
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.Assignment(lhs='a', rhs=sym.Literal(42.0))
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.Assignment(lhs=a_i, rhs='42.0 + 6.0')
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0), comment=a_i)
 
 
@@ -81,11 +81,11 @@ def test_loop(scope, one, i, n, a_i):
     assert loop.children == ( i, bounds, (assign,) )
 
     # Ensure "frozen" status of node objects
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         loop.variable = sym.Scalar('j', scope=scope)
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         loop.bounds = sym.Range((n, sym.Scalar('k', scope=scope)))
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         loop.body = (assign, assign, assign)
 
     # Test auto-casting of the body to tuple
@@ -97,17 +97,17 @@ def test_loop(scope, one, i, n, a_i):
     assert loop.body == (assign, assign, assign)
 
     # Test errors for wrong contructor usage
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.Loop(variable=i, bounds=bounds, body=n)
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.Loop(variable=None, bounds=bounds, body=(assign,))
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.Loop(variable=i, bounds=None, body=(assign,))
 
     # TODO: Test pragmas, names and labels
 
 
-def test_conditional(scope, one, i, n, a_i):
+def test_conditional(scope, n, a_i):
     """
     Test constructors of :any:`Conditional`.
     """
@@ -124,34 +124,34 @@ def test_conditional(scope, one, i, n, a_i):
     assert all(isinstance(n, ir.Node) for n in cond.else_body)
     assert cond.children == ( condition, (assign, assign), (assign,) )
 
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         cond.condition = parse_expr('k == 0', scope=scope)
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         cond.body = (assign, assign, assign)
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         cond.else_body = (assign, assign, assign)
 
     # Test auto-casting of the body / else_body to tuple
     cond = ir.Conditional(condition=condition, body=assign)
-    assert cond.body == (assign,) and cond.else_body == ()
+    assert cond.body == (assign,) and not cond.else_body
     cond = ir.Conditional(condition=condition, body=( (assign,), ))
-    assert cond.body == (assign,) and cond.else_body == ()
+    assert cond.body == (assign,) and not cond.else_body
     cond = ir.Conditional(condition=condition, body=( assign, (assign,), assign, None))
-    assert cond.body == (assign, assign, assign) and cond.else_body == ()
+    assert cond.body == (assign, assign, assign) and not cond.else_body
 
     cond = ir.Conditional(condition=condition, body=(), else_body=assign)
-    assert cond.body == () and cond.else_body == (assign,)
+    assert not cond.body and cond.else_body == (assign,)
     cond = ir.Conditional(condition=condition, body=(), else_body=( (assign,), ))
-    assert cond.body == () and cond.else_body == (assign,)
+    assert not cond.body and cond.else_body == (assign,)
     cond = ir.Conditional(
         condition=condition, body=(), else_body=( assign, (assign,), assign, None)
     )
-    assert cond.body == () and cond.else_body == (assign, assign, assign)
+    assert not cond.body and cond.else_body == (assign, assign, assign)
 
     # TODO: Test inline, name, has_elseif
 
 
-def test_multi_conditional(scope, one, i, n, a_i):
+def test_multi_conditional(i, a_i):
     """
     Test nested chains of constructors of :any:`Conditional` to form
     multi-conditional.
@@ -199,7 +199,7 @@ def test_multi_conditional(scope, one, i, n, a_i):
     assert else_bodies[1][0].lhs == 'a(i)' and else_bodies[1][0].rhs == '1.0'
 
 
-def test_section(scope, one, i, n, a_n, a_i):
+def test_section(n, a_n, a_i):
     """
     Test constructors and behaviour of :any:`Section` nodes.
     """
@@ -213,13 +213,13 @@ def test_section(scope, one, i, n, a_n, a_i):
     sec = ir.Section(body=(assign, assign))
     assert isinstance(sec.body, tuple) and len(sec.body) == 2
     assert all(isinstance(n, ir.Node) for n in sec.body)
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         sec.body = (assign, assign)
 
     sec = ir.Section(body=(func, func))
     assert isinstance(sec.body, tuple) and len(sec.body) == 2
     assert all(isinstance(n, Scope) for n in sec.body)
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         sec.body = (func, func)
 
     sec = ir.Section((assign, assign))
@@ -264,29 +264,29 @@ def test_callstatement(scope, one, i, n, a_i):
     )
 
     # Ensure "frozen" status of node objects
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         call.name = sym.ProcedureSymbol('dave', scope=scope)
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         call.arguments = (a_i, n, one)
-    with pytest.raises(FrozenInstanceError) as error:
+    with pytest.raises(FrozenInstanceError):
         call.kwarguments = (('i', one), ('j', i))
 
     # Test auto-casting of the body to tuple
     call = ir.CallStatement(name=cname, arguments=[a_i, one])
-    assert call.arguments == (a_i, one) and call.kwarguments == ()
+    assert call.arguments == (a_i, one) and not call.kwarguments
     call = ir.CallStatement(name=cname, arguments=None)
-    assert call.arguments == () and call.kwarguments == ()
+    assert not call.arguments and not call.kwarguments
     call = ir.CallStatement(name=cname, kwarguments=[('i', i), ('j', one)])
-    assert call.arguments == () and call.kwarguments == (('i', i), ('j', one))
+    assert not call.arguments and call.kwarguments == (('i', i), ('j', one))
     call = ir.CallStatement(name=cname, kwarguments=None)
-    assert call.arguments == () and call.kwarguments == ()
+    assert not call.arguments and not call.kwarguments
 
     # Test errors for wrong contructor usage
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.CallStatement(name='a', arguments=(sym.Literal(42.0),))
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.CallStatement(name=cname, arguments=('a',))
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(ValidationError):
         ir.Assignment(
             name=cname, arguments=(sym.Literal(42.0),), kwarguments=('i', 'i')
         )
@@ -304,7 +304,7 @@ def test_associate(scope, a_i):
     assign = ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
     assign2 = ir.Assignment(lhs=a_i.clone(parent=b), rhs=sym.Literal(66.6))
 
-    assoc = ir.Associate(associations=((b_a, a),), body=(assign, assign2), parent=scope)
+    assoc = ir.Associate(associations=((b_a, a),), body=(assign, assign2), parent=scope)  # pylint: disable=unexpected-keyword-arg
     assert isinstance(assoc.associations, tuple)
     assert all(isinstance(n, tuple) and len(n) == 2 for n in assoc.associations)
     assert isinstance(assoc.body, tuple)

--- a/loki/ir/tests/test_pragma_utils.py
+++ b/loki/ir/tests/test_pragma_utils.py
@@ -95,7 +95,7 @@ end subroutine test_pragmas_map
     assert pragmas[0].keyword == 'OMP'
     params = get_pragma_parameters(pragmas[0], only_loki_pragmas=False)
     assert len(params) == 3
-    assert params['PARALLEL'] == None
+    assert params['PARALLEL'] is None
     assert params['PRIVATE'].strip() == 'i, j'
     assert params['FIRSTPRIVATE'].strip() == 'n, a, b'
 
@@ -656,7 +656,7 @@ END SUBROUTINE TEST
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
-    pragma = Pragma(keyword='acc', content=f'kernels num_gangs ( 1 ) async wait')
+    pragma = Pragma(keyword='acc', content='kernels num_gangs ( 1 ) async wait')
     assert get_pragma_parameters(pragma, only_loki_pragmas=False) == {
         'kernels': None,
         'num_gangs': ' 1 ',

--- a/loki/ir/tests/test_scoped_nodes.py
+++ b/loki/ir/tests/test_scoped_nodes.py
@@ -50,7 +50,7 @@ end module test_scoped_node_symbols_mod
     assert routine.get_symbol('b') == 'b(n)'
     assert routine.get_symbol('b').scope == routine
     assert routine.get_symbol('c') == 'c'
-    assert routine.get_symbol('c').scope == routine    
+    assert routine.get_symbol('c').scope == routine
     assert routine.get_symbol('jprb') == 'jprb'
     assert routine.get_symbol('jprb').scope == module
     assert routine.get_symbol('jprb').initial == 8

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -78,7 +78,7 @@ class ProgramUnit(Scope):
             if not isinstance(contains, ir.Section):
                 contains = ir.Section(body=as_tuple(contains))
             for node in contains.body:
-                if isinstance(node, ir.Intrinsic) and 'contains' in node.text.lower():
+                if isinstance(node, ir.Intrinsic) and 'contains' in node.text.lower():  # pylint: disable=no-member
                     break
                 if isinstance(node, ProgramUnit):
                     contains.prepend(ir.Intrinsic(text='CONTAINS'))

--- a/loki/tests/__init__.py
+++ b/loki/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/loki/tests/test_dimension.py
+++ b/loki/tests/test_dimension.py
@@ -154,5 +154,5 @@ def test_dimension_config(tmp_path):
     assert dim_b.size == nblocks
     assert dim_b.index == ibl
     assert dim_b.bounds == (sym.IntLiteral(1), nblocks)
-    assert dim_b.lower == (one, start, start.clone(parent=dim))
-    assert dim_b.upper == (nblocks, end, end.clone(parent=dim))
+    assert dim_b.lower == (one, start, start.clone(parent=dim))  # pylint: disable=no-member
+    assert dim_b.upper == (nblocks, end, end.clone(parent=dim))  # pylint: disable=no-member

--- a/loki/tests/test_modules.py
+++ b/loki/tests/test_modules.py
@@ -872,8 +872,8 @@ module test_other_rename_mod
 end module test_other_rename_mod
     """.strip()
 
-    mod1 = Module.from_source(fcode_mod1, frontend=frontend, xmods=[tmp_path])
-    mod2 = Module.from_source(fcode_mod2, frontend=frontend, xmods=[tmp_path])
+    _ = Module.from_source(fcode_mod1, frontend=frontend, xmods=[tmp_path])
+    _ = Module.from_source(fcode_mod2, frontend=frontend, xmods=[tmp_path])
 
     fcode_mod3 = """
 module some_mod
@@ -1306,7 +1306,9 @@ end module module_all_imports_routine_mod
 
     header_a = Module.from_source(fcode['header_a'], frontend=frontend, xmods=[tmp_path])
     header_b = Module.from_source(fcode['header_b'], frontend=frontend, xmods=[tmp_path])
-    routine_mod = Module.from_source(fcode['routine'], definitions=(header_a, header_b), frontend=frontend, xmods=[tmp_path])
+    routine_mod = Module.from_source(
+        fcode['routine'], definitions=(header_a, header_b), frontend=frontend, xmods=[tmp_path]
+    )
     routine = routine_mod['routine']
 
     assert routine_mod.parents == ()

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -2274,8 +2274,8 @@ end subroutine
     # Instead, we can creatae a deferred type variable in the scope and
     # resolve members relative to it
     not_tt = Variable(name='not_tt', scope=routine)
-    assert not_tt.type.dtype == BasicType.DEFERRED
-    not_tt_invalid = not_tt.get_derived_type_member('invalid')
+    assert not_tt.type.dtype == BasicType.DEFERRED  # pylint: disable=no-member
+    not_tt_invalid = not_tt.get_derived_type_member('invalid')  # pylint: disable=no-member
     assert not_tt_invalid == 'not_tt%invalid'
     assert not_tt_invalid.type.dtype == BasicType.DEFERRED
 

--- a/loki/tools/tests/__init__.py
+++ b/loki/tools/tests/__init__.py
@@ -1,0 +1,6 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.


### PR DESCRIPTION
This make test integration cleaner and avoids eventual namespace clashes in the future. It also now runs the linter over tests, without exporting test symbols as part of `from loki import *` (please double-check this). 

Note, the other half of this is hidden in PR #446 , where this was necessary to avoid namespace clashes in tests.

EDIT: Looks like I have to leave `loki.lint.tests` untouched, as the introduction of the test sub-packages makes the dynamic `rules` imports go haywire. I leave that for a follow-on PR.