### PR TITLE
Module: Fix enrichment of type info via `Module` imports

### DIFF
--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -327,7 +327,8 @@ class ProgramUnit(Scope):
         """
         definitions_map = CaseInsensitiveDict((r.name, r) for r in as_tuple(definitions))
 
-        for imprt in self.imports:
+        # Enrich type info from all known imports (including parent scopes)
+        for imprt in self.all_imports:
             if not (module := definitions_map.get(imprt.module)):
                 # Skip modules that are not available in the definitions list
                 continue


### PR DESCRIPTION
This addresses issue #428 . Many thanks to @wertysas for the excellent reproducer and test

The problem was essentially that we would drop type info for subroutines if the info enrichment came though type imports on the parent `Module`. This is easily fixed by including parent imports in the enrichment loop over Imports.

I took the opportunity to also clean up the import on `test_module.py` in the process.