### PR TITLE
SGraph (re-)build optimisations

### DIFF
--- a/loki/batch/configure.py
+++ b/loki/batch/configure.py
@@ -5,7 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from fnmatch import fnmatch
+import fnmatch
 from itertools import accumulate
 from pathlib import Path
 import re
@@ -183,10 +183,10 @@ class SchedulerConfig:
                 }
 
         # Match against keys
-        keys = as_tuple(keys)
+        keys = tuple(key.lower() for key in as_tuple(keys))
         if use_pattern_matching:
-            return tuple(key for key in keys or () if any(fnmatch(name, key.lower()) for name in item_names))
-        return tuple(key for key in keys or () if key.lower() in item_names)
+            return tuple(key for key in keys if fnmatch.filter(item_names, key))
+        return tuple(key for key in keys if key in item_names)
 
     def create_item_config(self, name):
         """
@@ -233,7 +233,7 @@ class SchedulerConfig:
         frontend_args = default_args.copy()
         for key, args in (self.frontend_args or {}).items():
             pattern = key.lower() if key[0] == '/' else f'*{key}'.lower()
-            if fnmatch(path, pattern):
+            if fnmatch.fnmatch(path, pattern):
                 frontend_args.update(args)
                 return frontend_args
         return frontend_args
@@ -242,7 +242,7 @@ class SchedulerConfig:
         """
         Check if the item with the given :data:`name` is marked as `disabled`
         """
-        return len(self.match_item_keys(name, self.disable, use_pattern_matching=True, match_item_parents=True)) > 0
+        return bool(self.match_item_keys(name, self.disable, use_pattern_matching=True, match_item_parents=True))
 
 
 class TransformationConfig:

--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -623,10 +623,7 @@ class ModuleItem(Item):
         global variables.
         """
         self.concretize_definitions()
-        definitions = tuple(
-            d for d in self.ir.definitions
-            if not isinstance(d, (MetaSymbol, TypedSymbol)) or isinstance(d, ProcedureSymbol)
-        )
+        definitions = self.ir.subroutines + as_tuple(FindNodes((TypeDef, Interface)).visit(self.ir.spec))
         return definitions
 
     @property

--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -1118,8 +1118,6 @@ class ItemFactory:
         :any:`Item` or None
             The item object or `None` if disabled or impossible to create
         """
-        if config and config.is_disabled(item_name):
-            return None
         if item_name in self.item_cache:
             return self.item_cache[item_name]
 

--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -1489,7 +1489,7 @@ class ItemFactory:
             ``True`` if matched successfully via :data:`config` or :data:`ignore` list,
             otherwise ``False``
         """
-        return (
-            (config and config.is_disabled(name)) or
-            (ignore and SchedulerConfig.match_item_keys(name, ignore, use_pattern_matching=True))
+        keys = as_tuple(config.disable if config else ()) + as_tuple(ignore)
+        return keys and SchedulerConfig.match_item_keys(
+            name, keys, use_pattern_matching=True, match_item_parents=True
         )

--- a/loki/batch/tests/test_batch.py
+++ b/loki/batch/tests/test_batch.py
@@ -347,7 +347,7 @@ def test_module_item4(testdir):
     # Make sure interfaces are correctly identified as definitions
     item = get_item(ModuleItem, proj/'some_module.F90', 'some_module', RegexParserClass.ProgramUnitClass)
     definitions = item.definitions
-    assert len(definitions) == 8
+    assert len(definitions) == 6
     assert len(item.ir.interfaces) == 1
     assert item.ir.interfaces[0] in definitions
 
@@ -355,7 +355,7 @@ def test_module_item4(testdir):
     item_factory.item_cache[item.name] = item
 
     items = item.create_definition_items(item_factory=item_factory)
-    assert len(items) == 10
+    assert len(items) == 8
     assert len(set(items)) == 6
     assert 'some_module#add_args' in item_factory.item_cache
     assert isinstance(item_factory.item_cache['some_module#add_args'], InterfaceItem)


### PR DESCRIPTION
While profiling the building of the SGraph, I noticed two things:

1. A non-negligible amount of time was spent on checking if items are part of any of the exclusion lists. The reason that this is costly is the pattern support, which incurs some overhead for repeatedly compiling search patterns. This can be partially reduced by using `fnmatch.filter` instead of a comprehension with `any`. On top of that, I tried reducing the amount of pattern compilations overall via some reordering or caching, however, since `fnmatch` already comes with a built-in pattern cache, this did worsen performance in all cases.
2. The `Module` class includes module variables in the list of definitions, which is correct from a Fortran point-of-view but not required for the Scheduler, where we don't capture explicitly the dependency on individual variables but only the module itself. Hence, searching directly only for procedures, interfaces and typedefs brings the search effort down considerably.

Depending on the structure of the graph, this dropped graph building time by 10-20% for me. Much bigger gains could be achieved by caching definitions or dependencies, but this seems a little trickier to do.