### PR TITLE
CMake Plan: Pipeline dry-run and transformation-based plan creation

### DIFF
--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -610,7 +610,7 @@ class Scheduler:
                 warning(f'[Loki] Failed to render filegraph due to graphviz error:\n  {e}')
 
     @Timer(logger=perf, text='[Loki::Scheduler] Wrote CMake plan file in {:.2f}s')
-    def write_cmake_plan(self, filepath, mode, buildpath, rootpath):
+    def write_cmake_plan(self, filepath, rootpath=None):
         """
         Generate the "plan file" for CMake
 

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -5,6 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from enum import Enum, auto
 from os.path import commonpath
 from pathlib import Path
 from codetiming import Timer
@@ -21,10 +22,40 @@ from loki.batch.transformation import Transformation
 
 from loki.frontend import FP, REGEX, RegexParserClass
 from loki.tools import as_tuple, CaseInsensitiveDict, flatten
-from loki.logging import info, perf, warning, debug, error
+
+from loki.logging import info, perf, warning, error
+
+__all__ = ['ProcessingStrategy', 'Scheduler']
 
 
-__all__ = ['Scheduler']
+class ProcessingStrategy(Enum):
+    """
+    List of available processing types for :any:`Scheduler.process`
+
+    Multiple options exist how the :any:`Scheduler.process` method can
+    apply a provided :any:`Transformation` or :any:`Pipeline` object to the
+    items in a :any:`Scheduler` graph. The permissible options and default
+    values are provided by this class.
+    """
+
+    SEQUENCE = auto()
+    """Sequential processing of transformations
+
+    For each transformation in a pipeline, the :any:`Transformation.apply`
+    method is called for every item in the graph, following the graph traversal
+    mode specified in the transformation's manifest, before repeating the
+    same for the next transformation in the pipeline.
+    """
+
+    PLAN = auto()
+    """Planning mode using :any:`ProcessingStrategy.SEQUENCE` strategy.
+
+    This calls :any:`Transformation.plan` (instead of :any:`Transformation.apply`)
+    for each transformation.
+    """
+
+    DEFAULT = SEQUENCE
+    """Default processing strategy, currently :any:`ProcessingStrategy.SEQUENCE`"""
 
 
 class Scheduler:
@@ -382,7 +413,7 @@ class Scheduler:
             if item.name not in deleted_keys
         )
 
-    def process(self, transformation, plan=False):
+    def process(self, transformation, proc_strategy=ProcessingStrategy.DEFAULT):
         """
         Process all :attr:`items` in the scheduler's graph with either
         a :any:`Pipeline` or a single :any:`Transformation`.
@@ -396,18 +427,21 @@ class Scheduler:
         ----------
         transformation : :any:`Transformation` or :any:`Pipeline`
             The transformation or transformation pipeline to apply
+        proc_strategy : :any:`ProcessingStrategy`
+            The processing strategy to use when applying the given
+            :data:`transformation` to the scheduler's graph.
         """
         if isinstance(transformation, Transformation):
-            self.process_transformation(transformation=transformation, plan=plan)
+            self.process_transformation(transformation=transformation, proc_strategy=proc_strategy)
 
         elif isinstance(transformation, Pipeline):
-            self.process_pipeline(pipeline=transformation, plan=plan)
+            self.process_pipeline(pipeline=transformation, proc_strategy=proc_strategy)
 
         else:
             error('[Loki::Scheduler] Batch processing requires Transformation or Pipeline object')
-            raise RuntimeError('[Loki] Could not batch process {transformation_or_pipeline}')
+            raise RuntimeError(f'Could not batch process {transformation}')
 
-    def process_pipeline(self, pipeline, plan=False):
+    def process_pipeline(self, pipeline, proc_strategy=ProcessingStrategy.DEFAULT):
         """
         Process a given :any:`Pipeline` by applying its assocaited
         transformations in turn.
@@ -416,11 +450,14 @@ class Scheduler:
         ----------
         transformation : :any:`Pipeline`
             The transformation pipeline to apply
+        proc_strategy : :any:`ProcessingStrategy`
+            The processing strategy to use when applying the given
+            :data:`pipeline` to the scheduler's graph.
         """
         for transformation in pipeline.transformations:
-            self.process_transformation(transformation, plan=plan)
+            self.process_transformation(transformation, proc_strategy=proc_strategy)
 
-    def process_transformation(self, transformation, plan=False):
+    def process_transformation(self, transformation, proc_strategy=ProcessingStrategy.DEFAULT):
         """
         Process all :attr:`items` in the scheduler's graph
 
@@ -445,6 +482,9 @@ class Scheduler:
         ----------
         transformation : :any:`Transformation`
             The transformation to apply over the dependency tree
+        proc_strategy : :any:`ProcessingStrategy`
+            The processing strategy to use when applying the given
+            :data:`transformation` to the scheduler's graph.
         """
         def _get_definition_items(_item, sgraph_items):
             # For backward-compatibility with the DependencyTransform and LinterTransformation
@@ -463,6 +503,10 @@ class Scheduler:
                     if transformation.process_ignored_items or not item.is_ignored:
                         items += (item,) + child_items
             return items
+
+        if proc_strategy not in (ProcessingStrategy.SEQUENCE, ProcessingStrategy.PLAN):
+            error(f'[Loki::Scheduler] Processing {proc_strategy} is not implemented!')
+            raise RuntimeError(f'Could not batch process {transformation}')
 
         trafo_name = transformation.__class__.__name__
         log = f'[Loki::Scheduler] Applied transformation <{trafo_name}>' + ' in {:.2f}s'
@@ -499,7 +543,7 @@ class Scheduler:
                     item=_item, targets=_item.targets, items=_get_definition_items(_item, sgraph_items),
                     successors=graph.successors(_item, item_filter=item_filter),
                     depths=graph.depths, build_args=self.build_args,
-                    plan=plan
+                    plan_mode=proc_strategy == ProcessingStrategy.PLAN
                 )
 
         if transformation.renames_items:
@@ -614,22 +658,18 @@ class Scheduler:
         """
         Generate the "plan file" for CMake
 
-        The plan file is a CMake file defining three lists:
+        See :any:`CMakePlanTransformation` for the specification of that file.
 
-        * ``LOKI_SOURCES_TO_TRANSFORM``: The list of files that are
-          processed in the dependency graph
-        * ``LOKI_SOURCES_TO_APPEND``: The list of files that are created
-          and have to be added to the build target as part of the processing
-        * ``LOKI_SOURCES_TO_REMOVE``: The list of files that are no longer
-          required (because they have been replaced by transformed files) and
-          should be removed from the build target.
-
-        These lists are used by the CMake wrappers to schedule the source
-        updates and update the source lists of the CMake target object accordingly.
+        Parameters
+        ----------
+        filepath : str or Path
+            The path of the CMake file to write.
+        rootpath : str or Path (optional)
+            If given, all paths in the CMake file will be made relative to this root directory
         """
         info(f'[Loki] Scheduler writing CMake plan: {filepath}')
 
-        from loki.transformations.build_system.plan import CMakePlanTransformation
+        from loki.transformations.build_system.plan import CMakePlanTransformation  # pylint: disable=import-outside-toplevel
         planner = CMakePlanTransformation(rootpath=rootpath)
-        self.process(planner, plan=True)
+        self.process(planner, proc_strategy=ProcessingStrategy.PLAN)
         planner.write_plan(filepath)

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -1001,10 +1001,13 @@ def test_scheduler_missing_files(testdir, config, frontend, strict, tmp_path):
     # Check processing with missing items
     class CheckApply(Transformation):
 
-        def apply(self, source, post_apply_rescope_symbols=False, **kwargs):
+        def apply(self, source, post_apply_rescope_symbols=False, plan_mode=False, **kwargs):
             assert 'item' in kwargs
             assert not isinstance(kwargs['item'], ExternalItem)
-            super().apply(source, post_apply_rescope_symbols=post_apply_rescope_symbols, **kwargs)
+            super().apply(
+                source, post_apply_rescope_symbols=post_apply_rescope_symbols,
+                plan_mode=plan_mode, **kwargs
+            )
 
     if strict:
         with pytest.raises(RuntimeError):

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -64,7 +64,7 @@ from loki import (
 from loki.batch import (
     Scheduler, SchedulerConfig, Item, ProcedureItem,
     ProcedureBindingItem, InterfaceItem, TypeDefItem, SFilter,
-    ExternalItem, Transformation, Pipeline
+    ExternalItem, Transformation, Pipeline, ProcessingStrategy
 )
 from loki.expression import Scalar, Array, Literal, ProcedureSymbol
 from loki.frontend import (
@@ -1183,7 +1183,7 @@ def test_scheduler_cmake_planner(tmp_path, testdir, frontend):
     # Apply the transformation
     planfile = builddir/'loki_plan.cmake'
 
-    scheduler.process(FileWriteTransformation(), plan=True)
+    scheduler.process(FileWriteTransformation(), proc_strategy=ProcessingStrategy.PLAN)
     scheduler.write_cmake_plan(filepath=planfile, rootpath=sourcedir)
 
     # Validate the plan file content

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -74,7 +74,7 @@ from loki.ir import (
     nodes as ir, FindNodes, FindInlineCalls, FindVariables
 )
 from loki.transformations import (
-    DependencyTransformation, ModuleWrapTransformation
+    DependencyTransformation, ModuleWrapTransformation, FileWriteTransformation
 )
 
 
@@ -1156,35 +1156,35 @@ def test_scheduler_cmake_planner(tmp_path, testdir, frontend):
     proj_b = sourcedir/'projB'
 
     config = SchedulerConfig.from_dict({
-        'default': {'role': 'kernel', 'expand': True, 'strict': True, 'ignore': ('header_mod',)},
+        'default': {
+            'role': 'kernel',
+            'expand': True,
+            'strict': True,
+            'ignore': ('header_mod',),
+            'mode': 'foobar'
+        },
         'routines': {
             'driverB': {'role': 'driver'},
             'kernelB': {'ignore': ['ext_driver']},
         }
     })
+    builddir = tmp_path/'scheduler_cmake_planner_dummy_dir'
+    builddir.mkdir(exist_ok=True)
 
     # Populate the scheduler
     # (this is the same as SchedulerA in test_scheduler_dependencies_ignore, so no need to
     # check scheduler set-up itself)
     scheduler = Scheduler(
         paths=[proj_a, proj_b], includes=proj_a/'include',
-        config=config, frontend=frontend, xmods=[tmp_path]
+        config=config, frontend=frontend, xmods=[tmp_path],
+        output_dir=builddir
     )
 
     # Apply the transformation
-    builddir = tmp_path/'scheduler_cmake_planner_dummy_dir'
-    builddir.mkdir(exist_ok=True)
     planfile = builddir/'loki_plan.cmake'
 
-    scheduler.write_cmake_plan(
-        filepath=planfile, mode='foobar', buildpath=builddir, rootpath=sourcedir
-    )
-
-    # Validate the generated lists
-    expected_files = {
-        proj_a/'module/driverB_mod.f90', proj_a/'module/kernelB_mod.F90',
-        proj_a/'module/compute_l1_mod.f90', proj_a/'module/compute_l2_mod.f90'
-    }
+    scheduler.process(FileWriteTransformation(), plan=True)
+    scheduler.write_cmake_plan(filepath=planfile, rootpath=sourcedir)
 
     # Validate the plan file content
     plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)

--- a/loki/batch/transformation.py
+++ b/loki/batch/transformation.py
@@ -275,7 +275,7 @@ class Transformation:
         if plan_mode:
             self.plan_file(sourcefile, item=item, role=role, targets=targets, items=items, **kwargs)
         else:
-            if not plan_mode and sourcefile._incomplete:
+            if sourcefile._incomplete:
                 raise RuntimeError('Transformation.apply_file requires Sourcefile to be complete')
 
             self.transform_file(sourcefile, item=item, role=role, targets=targets, items=items, **kwargs)

--- a/loki/batch/transformation.py
+++ b/loki/batch/transformation.py
@@ -130,7 +130,19 @@ class Transformation:
 
     def plan_subroutine(self, routine, **kwargs):
         """
-        ...
+        Define the planning steps to apply for :any:`Subroutine` items.
+
+        For transformations that modify the dependencies of :data:`routine`
+        (e.g., adding new procedure calls, inlining calls, renaming the interface)
+        this should be implemented. It gets called via the dispatch method :meth:`apply`
+        if the optional ``plan_mode`` argument is set to `True`.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The subroutine to be transformed.
+        **kwargs : optional
+            Keyword arguments for the transformation.
         """
 
     def transform_module(self, module, **kwargs):
@@ -151,7 +163,19 @@ class Transformation:
 
     def plan_module(self, module, **kwargs):
         """
-        ...
+        Define the planning steps to apply for :any:`Module` items.
+
+        For transformations that modify the dependencies or definitions of :data:`module`
+        (e.g., renaming the module, adding new subroutines, adding or removing imports)
+        this should be implemented. It gets called via the dispatch method :meth:`apply`
+        if the optional ``plan_mode`` argument is set to `True`.
+
+        Parameters
+        ----------
+        module : :any:`Module`
+            The module to be transformed.
+        **kwargs : optional
+            Keyword arguments for the transformation.
         """
 
     def transform_file(self, sourcefile, **kwargs):
@@ -172,10 +196,21 @@ class Transformation:
 
     def plan_file(self, sourcefile, **kwargs):
         """
-        ...
+        Define the planning steps to apply for :any:`Sourcefile` items.
+
+        For transformations that modify the definitions or dependencies of :data:`sourcefile`
+        this should be implemented. It gets called via the dispatch method :meth:`apply`
+        if the optional ``plan_mode`` argument is set to `True`.
+
+        Parameters
+        ----------
+        sourcefile : :any:`Sourcefile`
+            The sourcefile to be transformed.
+        **kwargs : optional
+            Keyword arguments for the transformation.
         """
 
-    def apply(self, source, post_apply_rescope_symbols=False, plan=False, **kwargs):
+    def apply(self, source, post_apply_rescope_symbols=False, plan_mode=False, **kwargs):
         """
         Dispatch method to apply transformation to :data:`source`.
 
@@ -194,22 +229,23 @@ class Transformation:
             actual transformation.
         """
         if isinstance(source, Sourcefile):
-            self.apply_file(source, plan=plan, **kwargs)
+            self.apply_file(source, plan_mode=plan_mode, **kwargs)
 
         if isinstance(source, Subroutine):
-            self.apply_subroutine(source, plan=plan, **kwargs)
+            self.apply_subroutine(source, plan_mode=plan_mode, **kwargs)
 
         if isinstance(source, Module):
-            self.apply_module(source, plan=plan, **kwargs)
+            self.apply_module(source, plan_mode=plan_mode, **kwargs)
 
-        if not plan:
+        if not plan_mode:
             self.post_apply(source, rescope_symbols=post_apply_rescope_symbols)
 
-    def apply_file(self, sourcefile, plan=False, **kwargs):
+    def apply_file(self, sourcefile, plan_mode=False, **kwargs):
         """
         Apply transformation to all items in :data:`sourcefile`.
 
-        This calls :meth:`transform_file`.
+        This calls :meth:`transform_file` or, if :data:`plan_mode` is enabled,
+        calls :meth:`plan_file`.
 
         If the :attr:`recurse_to_modules` class property is set, it
         will also invoke :meth:`apply` on all :any:`Module` objects in
@@ -222,6 +258,8 @@ class Transformation:
         ----------
         sourcefile : :any:`Sourcefile`
             The file to transform.
+        plan_mode : bool, optional
+            If enabled, apply planning mode.
         **kwargs : optional
             Keyword arguments that are passed on to transformation methods.
         """
@@ -234,10 +272,10 @@ class Transformation:
         targets = kwargs.pop('targets', None)
 
         # Apply file-level transformations
-        if plan:
+        if plan_mode:
             self.plan_file(sourcefile, item=item, role=role, targets=targets, items=items, **kwargs)
         else:
-            if not plan and sourcefile._incomplete:
+            if not plan_mode and sourcefile._incomplete:
                 raise RuntimeError('Transformation.apply_file requires Sourcefile to be complete')
 
             self.transform_file(sourcefile, item=item, role=role, targets=targets, items=items, **kwargs)
@@ -262,7 +300,7 @@ class Transformation:
                         # Provide the list of items that belong to this module
                         item_items = tuple(_it for _it in items if _it.scope is item.ir)
 
-                        if plan:
+                        if plan_mode:
                             self.plan_module(
                                 item.ir, item=item, role=item_role, targets=item.targets, items=item_items, **kwargs
                             )
@@ -272,7 +310,7 @@ class Transformation:
                             )
             else:
                 for module in sourcefile.modules:
-                    if plan:
+                    if plan_mode:
                         self.plan_module(module, item=item, role=role, targets=targets, items=items, **kwargs)
                     else:
                         self.transform_module(module, item=item, role=role, targets=targets, items=items, **kwargs)
@@ -283,7 +321,7 @@ class Transformation:
                 # Recursion into all subroutine items in the current file
                 for item in items:
                     if isinstance(item, ProcedureItem):
-                        if plan:
+                        if plan_mode:
                             self.plan_subroutine(
                                 item.ir, item=item, role=item.role, targets=item.targets, **kwargs
                             )
@@ -293,16 +331,17 @@ class Transformation:
                             )
             else:
                 for routine in sourcefile.all_subroutines:
-                    if plan:
+                    if plan_mode:
                         self.plan_subroutine(routine, item=item, role=role, targets=targets, **kwargs)
                     else:
                         self.transform_subroutine(routine, item=item, role=role, targets=targets, **kwargs)
 
-    def apply_subroutine(self, subroutine, plan=False, **kwargs):
+    def apply_subroutine(self, subroutine, plan_mode=False, **kwargs):
         """
         Apply transformation to a given :any:`Subroutine` object and its members.
 
-        This calls :meth:`transform_subroutine`.
+        This calls :meth:`transform_subroutine` or, if :data:`plan_mode` is enabled,
+        calls :meth:`plan_subroutine`.
 
         If the :attr:`recurse_to_member_procedures` class property is
         set, it will also invoke :meth:`apply` on all
@@ -313,6 +352,8 @@ class Transformation:
         ----------
         subroutine : :any:`Subroutine`
             The subroutine to transform.
+        plan_mode : bool, optional
+            If enabled, apply planning mode.
         **kwargs : optional
             Keyword arguments that are passed on to transformation methods.
         """
@@ -320,7 +361,7 @@ class Transformation:
             raise TypeError('Transformation.apply_subroutine can only be applied to Subroutine object')
 
         # Apply the actual transformation for subroutines
-        if plan:
+        if plan_mode:
             self.plan_subroutine(subroutine, **kwargs)
         else:
             if subroutine._incomplete:
@@ -331,13 +372,14 @@ class Transformation:
         # Recurse to internal procedures
         if self.recurse_to_internal_procedures:
             for routine in subroutine.subroutines:
-                self.apply_subroutine(routine, plan=plan, **kwargs)
+                self.apply_subroutine(routine, plan_mode=plan_mode, **kwargs)
 
-    def apply_module(self, module, plan=False, **kwargs):
+    def apply_module(self, module, plan_mode=False, **kwargs):
         """
         Apply transformation to a given :any:`Module` object and its members.
 
-        This calls :meth:`transform_module`.
+        This calls :meth:`transform_module` or, if :data:`plan_mode` is enabled,
+        calls :meth:`plan_module`.
 
         If the :attr:`recurse_to_procedures` class property is set,
         it will also invoke :meth:`apply` on all :any:`Subroutine`
@@ -347,6 +389,8 @@ class Transformation:
         ----------
         module : :any:`Module`
             The module to transform.
+        plan_mode : bool, optional
+            If enabled, apply planning mode.
         **kwargs : optional
             Keyword arguments that are passed on to transformation methods.
         """
@@ -354,7 +398,7 @@ class Transformation:
             raise TypeError('Transformation.apply_module can only be applied to Module object')
 
         # Apply the actual transformation for modules
-        if plan:
+        if plan_mode:
             self.plan_module(module, **kwargs)
         else:
             if module._incomplete:
@@ -365,7 +409,7 @@ class Transformation:
         # Recurse to procedures contained in this module
         if self.recurse_to_procedures:
             for routine in module.subroutines:
-                self.apply_subroutine(routine, plan=plan, **kwargs)
+                self.apply_subroutine(routine, plan_mode=plan_mode, **kwargs)
 
     def post_apply(self, source, rescope_symbols=False):
         """

--- a/loki/transformations/build_system/file_write.py
+++ b/loki/transformations/build_system/file_write.py
@@ -54,12 +54,7 @@ class FileWriteTransformation(Transformation):
             return (ProcedureItem, ModuleItem)
         return ProcedureItem
 
-    def transform_file(self, sourcefile, **kwargs):
-        item = kwargs.get('item', None)
-        if not item and 'items' in kwargs:
-            if kwargs['items']:
-                item = kwargs['items'][0]
-
+    def _get_file_path(self, item, build_args):
         if not item:
             raise ValueError('No Item provided; required to determine file write path')
 
@@ -69,7 +64,26 @@ class FileWriteTransformation(Transformation):
         path = Path(item.path)
         suffix = self.suffix if self.suffix else path.suffix
         sourcepath = Path(item.path).with_suffix(f'.{_mode}{suffix}')
-        build_args = kwargs.get('build_args', {})
         if build_args and (output_dir := build_args.get('output_dir', None)) is not None:
             sourcepath = Path(output_dir)/sourcepath.name
+        return sourcepath
+
+    def transform_file(self, sourcefile, **kwargs):
+        item = kwargs.get('item')
+        if not item and 'items' in kwargs:
+            if kwargs['items']:
+                item = kwargs['items'][0]
+
+        build_args = kwargs.get('build_args', {})
+        sourcepath = self._get_file_path(item, build_args)
         sourcefile.write(path=sourcepath, cuf=self.cuf)
+
+    def plan_file(self, sourcefile, **kwargs):  # pylint: disable=unused-argument
+        item = kwargs.get('item')
+        if not item and 'items' in kwargs:
+            if kwargs['items']:
+                item = kwargs['items'][0]
+
+        build_args = kwargs.get('build_args', {})
+        sourcepath = self._get_file_path(item, build_args)
+        item.trafo_data['FileWriteTransformation'] = {'path': sourcepath}

--- a/loki/transformations/build_system/plan.py
+++ b/loki/transformations/build_system/plan.py
@@ -1,0 +1,84 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Transformations to be used for exposing planned changes to
+the build system
+"""
+
+from pathlib import Path
+
+from loki.batch import Transformation
+from loki.logging import debug
+
+class CMakePlanTransformation(Transformation):
+    """
+    Generate the "plan file" for CMake
+
+    The plan file is a CMake file defining three lists:
+
+    * ``LOKI_SOURCES_TO_TRANSFORM``: The list of files that are
+        processed in the dependency graph
+    * ``LOKI_SOURCES_TO_APPEND``: The list of files that are created
+        and have to be added to the build target as part of the processing
+    * ``LOKI_SOURCES_TO_REMOVE``: The list of files that are no longer
+        required (because they have been replaced by transformed files) and
+        should be removed from the build target.
+
+    Parameters
+    ----------
+    rootpath : str (optional)
+
+    """
+
+    # This transformation is applied over the file graph
+    traverse_file_graph = True
+
+    item_filter = None
+
+    def __init__(self, rootpath=None):
+        self.rootpath = None if rootpath is None else Path(rootpath).resolve()
+        self.sources_to_append = []
+        self.sources_to_remove = []
+        self.sources_to_transform = []
+
+    def plan_file(self, sourcefile, **kwargs):
+        item = kwargs.get('item')
+        if not item:
+            raise ValueError('No Item provided; required to determine CMake plan')
+
+        if not 'FileWriteTransformation' in item.trafo_data:
+            return
+
+        sourcepath = item.path.resolve()
+        if self.rootpath is not None:
+            sourcepath = sourcepath.relative_to(self.rootpath)
+
+        newsource = item.trafo_data['FileWriteTransformation']['path']
+
+        debug(f'Planning:: {item.name} (role={item.role}, mode={item.mode})')
+
+        if newsource not in self.sources_to_append:
+            self.sources_to_transform += [sourcepath]
+            if item.replicate:
+                # Add new source file next to the old one
+                self.sources_to_append += [newsource]
+            else:
+                # Replace old source file to avoid ghosting
+                self.sources_to_append += [newsource]
+                self.sources_to_remove += [sourcepath]
+
+    def write_plan(self, filepath):
+        with Path(filepath).open('w') as f:
+            s_transform = '\n'.join(f'    {s}' for s in self.sources_to_transform)
+            f.write(f'set( LOKI_SOURCES_TO_TRANSFORM \n{s_transform}\n   )\n')
+
+            s_append = '\n'.join(f'    {s}' for s in self.sources_to_append)
+            f.write(f'set( LOKI_SOURCES_TO_APPEND \n{s_append}\n   )\n')
+
+            s_remove = '\n'.join(f'    {s}' for s in self.sources_to_remove)
+            f.write(f'set( LOKI_SOURCES_TO_REMOVE \n{s_remove}\n   )\n')

--- a/loki/transformations/build_system/plan.py
+++ b/loki/transformations/build_system/plan.py
@@ -12,7 +12,7 @@ the build system
 
 from pathlib import Path
 
-from loki.batch import Transformation
+from loki.batch.transformation import Transformation
 from loki.logging import debug
 
 class CMakePlanTransformation(Transformation):

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -15,7 +15,7 @@ from subprocess import CalledProcessError
 
 import pytest
 
-from loki.batch import Scheduler, SchedulerConfig
+from loki.batch import Scheduler, SchedulerConfig, ProcessingStrategy
 from loki.frontend import available_frontends, OMNI
 from loki.logging import log_levels
 from loki.transformations.build_system import FileWriteTransformation
@@ -162,7 +162,7 @@ end module d_mod
     # Generate the CMake plan
     plan_file = tmp_path/'plan.cmake'
     root_path = tmp_path if use_rootpath else None
-    scheduler.process(transformation, plan=True)
+    scheduler.process(transformation, proc_strategy=ProcessingStrategy.PLAN)
     scheduler.write_cmake_plan(filepath=plan_file, rootpath=root_path)
 
     # Validate the plan file content
@@ -294,7 +294,7 @@ end subroutine d
     transformation = FileWriteTransformation(include_module_var_imports=True)
 
     # Generate the CMake plan
-    scheduler.process(transformation, plan=True)
+    scheduler.process(transformation, proc_strategy=ProcessingStrategy.PLAN)
     plan_file = tmp_path/'plan.cmake'
 
     caplog.clear()

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -163,10 +163,7 @@ end module d_mod
     plan_file = tmp_path/'plan.cmake'
     root_path = tmp_path if use_rootpath else None
     scheduler.process(transformation, plan=True)
-    scheduler.write_cmake_plan(
-        filepath=plan_file, mode=config.default['mode'], buildpath=out_path,
-        rootpath=root_path
-    )
+    scheduler.write_cmake_plan(filepath=plan_file, rootpath=root_path)
 
     # Validate the plan file content
     plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
@@ -302,10 +299,7 @@ end subroutine d
 
     caplog.clear()
     with caplog.at_level(log_levels['WARNING']):
-        scheduler.write_cmake_plan(
-            filepath=plan_file, mode=config.default['mode'], buildpath=out_path,
-            rootpath=tmp_path
-        )
+        scheduler.write_cmake_plan(filepath=plan_file, rootpath=tmp_path)
         if have_non_replicate_conflict:
             assert len(caplog.records) == 1
             assert 'c.f90' in caplog.records[0].message

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -153,9 +153,16 @@ end module d_mod
     # Check the dependency graph
     assert expected_items == {item.name for item in scheduler.items}
 
+    # Set-up the file write
+    transformation = FileWriteTransformation(
+        suffix=suffix,
+        include_module_var_imports=enable_imports
+    )
+
     # Generate the CMake plan
     plan_file = tmp_path/'plan.cmake'
     root_path = tmp_path if use_rootpath else None
+    scheduler.process(transformation, plan=True)
     scheduler.write_cmake_plan(
         filepath=plan_file, mode=config.default['mode'], buildpath=out_path,
         rootpath=root_path
@@ -192,10 +199,6 @@ end module d_mod
     }
 
     # Write the outputs
-    transformation = FileWriteTransformation(
-        suffix=suffix,
-        include_module_var_imports=enable_imports
-    )
     scheduler.process(transformation)
 
     # Validate the list of written files
@@ -290,7 +293,11 @@ end subroutine d
     # Check the dependency graph
     assert expected_items == {item.name for item in scheduler.items}
 
+    # Set-up the file write
+    transformation = FileWriteTransformation(include_module_var_imports=True)
+
     # Generate the CMake plan
+    scheduler.process(transformation, plan=True)
     plan_file = tmp_path/'plan.cmake'
 
     caplog.clear()
@@ -319,7 +326,6 @@ end subroutine d
     assert plan_dict['LOKI_SOURCES_TO_APPEND'] == {'a.foobar', 'b.foobar', 'c.foobar', 'd.foobar'}
 
     # Write the outputs
-    transformation = FileWriteTransformation(include_module_var_imports=True)
     scheduler.process(transformation)
 
     # Validate the list of written files


### PR DESCRIPTION
This is an alternative implementation suggestion to #444 

The objective here would be to retain current functionality and implement support for transformations that change scheduler graph topology in subsequent PRs.

Please have a look and point out anything that looks odd to you. In particular, please consider the interface - e.g., is a `plan` argument acceptable and the naming ok?

With this, the `loki-transform.py plan` command is redirected to the `loki-transform.py convert` command, clearing the way for subsequent removal of the custom transformation entry point and further homogenisation in the CLI and CMake layer.

I will also add another commit to add some more documentation (and I expect the linter pass to fail due to the local import).