### PR TITLE
Sanitise: Resolve free range indices when resolving associates

### DIFF
--- a/loki/transformations/sanitise/associates.py
+++ b/loki/transformations/sanitise/associates.py
@@ -175,7 +175,7 @@ class ResolveAssociateMapper(LokiIdentityMapper):
         new = self.map_scalar(expr, *args, **kwargs)
 
         # Recurse over array dimensions
-        if isinstance(new, sym.Array):
+        if isinstance(new, sym.Array) and new.dimensions:
             # Resolve unbound range symbols form existing indices
             new_dims = self.rec(new.dimensions, *args, **kwargs)
             new_dims = self._match_range_indices(new_dims, expr_dims)

--- a/loki/transformations/sanitise/associates.py
+++ b/loki/transformations/sanitise/associates.py
@@ -121,9 +121,17 @@ class ResolveAssociateMapper(LokiIdentityMapper):
         free_symbols = tuple(e for e in expressions if isinstance(e, sym.RangeIndex))
         if any(s.lower not in (None, 1) for s in free_symbols):
             warning('WARNING: Bounds shifts through association is currently not supported')
-        symbol_map = dict(zip(free_symbols, indices))
 
-        return tuple(symbol_map.get(e, e) for e in expressions)
+        if len(free_symbols) == len(indices):
+            # If the provided indices are enough to bind free symbols,
+            # we match them in sequence.
+            it = iter(indices)
+            return tuple(
+                next(it) if isinstance(e, sym.RangeIndex) else e
+                for e in expressions
+            )
+
+        return expressions
 
     def map_scalar(self, expr, *args, **kwargs):
         # Skip unscoped expressions

--- a/loki/transformations/sanitise/tests/test_associates.py
+++ b/loki/transformations/sanitise/tests/test_associates.py
@@ -33,7 +33,7 @@ subroutine transform_associates_simple
   real :: local_var
 
   associate (a => some_obj%a)
-    local_var = a
+    local_var = a(:)
   end associate
 end subroutine transform_associates_simple
 """
@@ -42,7 +42,7 @@ end subroutine transform_associates_simple
     assert len(FindNodes(ir.Associate).visit(routine.body)) == 1
     assert len(FindNodes(ir.Assignment).visit(routine.body)) == 1
     assign = FindNodes(ir.Assignment).visit(routine.body)[0]
-    assert assign.rhs == 'a' and 'some_obj' not in assign.rhs
+    assert assign.rhs == 'a(:)' and 'some_obj' not in assign.rhs
     assert assign.rhs.type.dtype == BasicType.DEFERRED
 
     # Now apply the association resolver
@@ -51,7 +51,7 @@ end subroutine transform_associates_simple
     assert len(FindNodes(ir.Associate).visit(routine.body)) == 0
     assert len(FindNodes(ir.Assignment).visit(routine.body)) == 1
     assign = FindNodes(ir.Assignment).visit(routine.body)[0]
-    assert assign.rhs == 'some_obj%a'
+    assert assign.rhs == 'some_obj%a(:)'
     assert assign.rhs.parent == 'some_obj'
     assert assign.rhs.type.dtype == BasicType.DEFERRED
     assert assign.rhs.scope == routine


### PR DESCRIPTION
The current `Associate` resolution does not account for array index ranges if they are specific in the associate clauses (index remapping). This PR adds a partial resolution step to `ResolveAssociates`, which resolves free index ranges (`:`) in association clause against explicit indices from the original expression, should should both exist. The respective changes in the expression mapper require some care with respect to early termination and recursion into `.dimension` and `.type` properties of the given array expression.

Note: It does not resolve index shifts, where offsets are introduced by using bounded ranges (eg. `3:8`). Instead it warns about such (ab)use. 