### PR TITLE
Inline: Skip explicit intrinsics when inlining stmt functions

### DIFF
--- a/loki/transformations/inline/mapper.py
+++ b/loki/transformations/inline/mapper.py
@@ -58,7 +58,8 @@ class InlineSubstitutionMapper(LokiIdentityMapper):
         return expr.clone(parent=parent)
 
     def map_inline_call(self, expr, *args, **kwargs):
-        if expr.procedure_type is None or expr.procedure_type is BasicType.DEFERRED:
+        if expr.procedure_type is None or expr.procedure_type is BasicType.DEFERRED \
+           or expr.procedure_type.is_intrinsic:
             # Unkonw inline call, potentially an intrinsic
             # We still need to recurse and ensure re-scoping
             return super().map_inline_call(expr, *args, **kwargs)

--- a/loki/transformations/inline/mapper.py
+++ b/loki/transformations/inline/mapper.py
@@ -58,8 +58,7 @@ class InlineSubstitutionMapper(LokiIdentityMapper):
         return expr.clone(parent=parent)
 
     def map_inline_call(self, expr, *args, **kwargs):
-        if expr.procedure_type is None or expr.procedure_type is BasicType.DEFERRED \
-           or expr.procedure_type.is_intrinsic:
+        if expr.procedure_type in (None, BasicType.DEFERRED) or expr.procedure_type.is_intrinsic:
             # Unkonw inline call, potentially an intrinsic
             # We still need to recurse and ensure re-scoping
             return super().map_inline_call(expr, *args, **kwargs)

--- a/loki/transformations/inline/tests/test_functions.py
+++ b/loki/transformations/inline/tests/test_functions.py
@@ -253,7 +253,7 @@ def test_inline_statement_functions(frontend, stmt_decls):
     real :: FOEDELTA
     FOEDELTA ( PTARE ) = PTARE + 1.0
     real :: FOEEW
-    FOEEW ( PTARE ) = PTARE + FOEDELTA(PTARE)
+    FOEEW ( PTARE ) = PTARE + FOEDELTA(PTARE) + EXP(PTARE)
     """.strip()
 
     fcode = f"""
@@ -280,10 +280,10 @@ end subroutine stmt_func
 
     assert not FindNodes(ir.StatementFunction).visit(routine.spec)
     if stmt_decls:
-        assert not FindInlineCalls().visit(routine.body)
+        assert len(FindInlineCalls().visit(routine.body)) == 1
         assignments = FindNodes(ir.Assignment).visit(routine.body)
         assert assignments[0].lhs  == 'ret'
-        assert assignments[0].rhs  ==  "arr + arr + 1.0"
+        assert assignments[0].rhs  ==  "arr + arr + 1.0 + exp(arr)"
         assert assignments[1].lhs  == 'ret2'
         assert assignments[1].rhs  ==  "3.0 + 1.0"
     else:


### PR DESCRIPTION
The stmt function inliner does not actually test the case where the stmt function contains calls to intrinsics. This PR remedies this and fixes the corner case by including explicitly marked intrinsic calls in the skip condition.

This caused issue when the following lines attempt to touch the non-existent procedure definition.