### PR TITLE
Expression: Remove logical literals in and/or operations during simplify

### DIFF
--- a/loki/expression/tests/test_symbolic.py
+++ b/loki/expression/tests/test_symbolic.py
@@ -197,6 +197,10 @@ def test_simplify_collect_coefficients(source, ref):
     ('.false. .or. .false.', 'False'),
     ('2 == 1 .and. 1 == 1', 'False'),
     ('2 == 1 .or. 1 == 1', 'True'),
+    ('.true. .or. a', 'True'),
+    ('.false. .or. a', 'a'),
+    ('.false. .and. a', 'False'),
+    ('.true. .and. a', 'a'),
 ])
 def test_simplify_logic_evaluation(source, ref):
     scope = Scope()


### PR DESCRIPTION
The current implementation would only resolve .and./.or. operations if all arguments are logical literals. Instead, we can evaluate `.true. and a` => `.true.` and `.false. and a` => `a`, and vice versa for `or` operations. This allows us to further trim code paths in dead code elimination where this is used to remove conditionals.  