### PR TITLE
Inline: Avoid Import duplication from multiple callees

### DIFF
--- a/loki/transformations/inline/procedures.py
+++ b/loki/transformations/inline/procedures.py
@@ -331,6 +331,10 @@ def inline_marked_subroutines(routine, allowed_aliases=None, adjust_imports=True
                     routine, calls, callee, allowed_aliases=allowed_aliases
                 )
 
+            if adjust_imports:
+                # Move imports that the callee uses up to the caller
+                propagate_callee_imports(routine, callee)
+
     # Remove imported symbols that have become obsolete
     if adjust_imports:
         callees = tuple(callee.procedure_symbol for callee in call_sets.keys())
@@ -361,23 +365,6 @@ def inline_marked_subroutines(routine, allowed_aliases=None, adjust_imports=True
                 else:
                     import_map[intf] = None
 
-        # Now move any callee imports we might need over to the caller
-        new_imports = set()
-        imported_module_map = CaseInsensitiveDict((im.module, im) for im in routine.imports)
-        for callee in call_sets.keys():
-            for impt in callee.imports:
-
-                # Add any callee module we do not yet know
-                if impt.module not in imported_module_map:
-                    new_imports.add(impt)
-
-                # If we're importing the same module, check for missing symbols
-                if m := imported_module_map.get(impt.module):
-                    _m = import_map.get(m, m)
-                    if not all(s in _m.symbols for s in impt.symbols):
-                        new_symbols = tuple(s.rescope(routine) for s in impt.symbols)
-                        import_map[m] = m.clone(symbols=tuple(set(_m.symbols + new_symbols)))
-
         # Finally, apply the import remapping
         routine.spec = Transformer(import_map).visit(routine.spec)
 
@@ -393,8 +380,38 @@ def inline_marked_subroutines(routine, allowed_aliases=None, adjust_imports=True
         if new_intfs:
             routine.spec.append(Interface(body=as_tuple(new_intfs)))
 
-        # Add Fortran imports to the top, and C-style interface headers at the bottom
-        c_imports = tuple(im for im in new_imports if im.c_import)
-        f_imports = tuple(im for im in new_imports if not im.c_import)
-        routine.spec.prepend(f_imports)
-        routine.spec.append(c_imports)
+
+def propagate_callee_imports(routine, callee):
+    """
+    Move any :any:`Import` nodes from the :data:`callee` routine to
+    the caller, trimming symbols where needed.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine to which to propagate imports.
+    callee : :any:`Subroutine`
+        The subroutine from which to get the relevant imports.
+    """
+
+    # Now move any callee imports we might need over to the caller
+    new_imports = tuple()
+    imported_module_map = CaseInsensitiveDict((im.module, im) for im in routine.imports)
+
+    for impt in callee.imports:
+        # Add any callee module we do not yet know
+        if impt.module not in imported_module_map:
+            new_imports += (impt,)
+
+        # If we're importing the same module, check for missing symbols
+        if m := imported_module_map.get(impt.module):
+            if not all(s in m.symbols for s in impt.symbols):
+                # Add new, rescoped symbols in-place
+                new_symbols = tuple(s.rescope(routine) for s in impt.symbols)
+                m._update(symbols=tuple(dict.fromkeys(m.symbols + new_symbols)))
+
+    # Add Fortran imports to the top, and C-style interface headers at the bottom
+    c_imports = tuple(im for im in new_imports if im.c_import)
+    f_imports = tuple(im for im in new_imports if not im.c_import)
+    routine.spec.prepend(f_imports)
+    routine.spec.append(c_imports)


### PR DESCRIPTION
The previous logic does not account for the same import modules being used by multiple callees, as it attempts to propagate imported symbols in one go. Instead, we now call a utility method for each callee, so that the previous redundancy mechanics avoid duplication across multiple callees, not just between caller and callee.