### PR TITLE
Sanitise: Fix rescoping of symbols for nested associates

### DIFF
--- a/loki/transformations/sanitise/associates.py
+++ b/loki/transformations/sanitise/associates.py
@@ -161,8 +161,11 @@ class ResolveAssociateMapper(LokiIdentityMapper):
             expr = scope.inverse_map[expr.basename]
             return self.rec(expr, *args, **kwargs)
 
-        # Update the scope, as this one will be removed
-        return expr.clone(scope=scope.parent)
+        # Update the scope, as any inner associates will be removed.
+        # For this we count backwards the nested scopes, the tail of
+        # which will the (innermost) associates.
+        new_scope = scope.parents[::-1][depth-self.start_depth-1]
+        return expr.clone(scope=new_scope)
 
     def map_array(self, expr, *args, **kwargs):
         """ Partially resolve dimension indices and handle shape """


### PR DESCRIPTION
When nested associates are about to be removed, we need to account for that when updating the symbol-scope (a priori). This new logic does this by counting out the nested associates and picking the appropriate one, according to the septh of the symbol in the nest.

I've extended the stat-func test, where this most often triggers.

Note, this looks like a recurrence of the problem in #439 and hopefully should address issue #459 (@ecossevin to confirm).