### PR TITLE
Fix dependency on header files in loki_transform_target

### DIFF
--- a/cmake/loki_transform.cmake
+++ b/cmake/loki_transform.cmake
@@ -323,7 +323,7 @@ function( loki_transform_target )
             HEADERS     ${_PAR_T_HEADERS}
             DEFINITIONS ${_PAR_T_DEFINITIONS}
             INCLUDES    ${_PAR_T_INCLUDES}
-            DEPENDS     ${LOKI_SOURCES_TO_TRANSFORM} ${_PAR_T_HEADER} ${_PAR_T_CONFIG}
+            DEPENDS     ${LOKI_SOURCES_TO_TRANSFORM} ${_PAR_T_HEADERS} ${_PAR_T_CONFIG}
             ${_TRANSFORM_OPTIONS}
         )
     endif()


### PR DESCRIPTION
There was a typo in the variable name, possibly causing race conditions in parallel build when a header module is also generated.