### PR TITLE
Transformations: Fix downcasing of nested `InlineCall` symbols

### DIFF
--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -133,11 +133,20 @@ subroutine my_NOT_ALL_lowercase_ROUTINE(VAR1, another_VAR, lower_case, MiXeD_Cas
     do K=1,ANOTHER_VAR
         LOWER_CASE(MIXEd_cASE(1, K)) = K - 1
     end do
+
+    miXed_CasE(1, 1) = Max(mIn(sQrT(9.0), 2.0), 1.0)
 end subroutine my_NOT_ALL_lowercase_ROUTINE
     """.strip()
     routine = Subroutine.from_source(fcode, frontend=frontend)
     convert_to_lower_case(routine)
-    assert all(var.name.islower() and str(var).islower() for var in FindVariables(unique=False).visit(routine.ir))
+    assert all(
+        var.name.islower() and str(var).islower()
+        for var in FindVariables(unique=True).visit(routine.ir)
+    )
+    assert all(
+        f.name.islower() and str(f).islower()
+        for f in FindInlineCalls().visit(routine.ir)
+    )
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -113,6 +113,7 @@ def convert_to_lower_case(routine):
         (stmt.variable, stmt.variable.clone(name=stmt.variable.name.lower()))
         for stmt in FindNodes(StatementFunction).visit(routine.spec)
     )
+    mapper = recursive_expression_map_update(mapper, case_sensitive=True)
     routine.spec = SubstituteExpressions(mapper).visit(routine.spec)
     routine.body = SubstituteExpressions(mapper).visit(routine.body)
 


### PR DESCRIPTION
Nested calls to functions is not captured in `convert_to_lower_case`, which can break the Fortran-to-Python converter. This simple fix remedies this.