### PR TITLE
POC: allow multi-level/subgraph duplication of kernels

### DIFF
--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -545,6 +545,8 @@ class Scheduler:
             if transformation.renames_items or transformation.creates_items:
                 kwargs['item_factory'] = self.item_factory
                 kwargs['scheduler_config'] = self.config
+                kwargs['graph'] = graph
+                kwargs['item_filter'] = item_filter
 
             for _item in traversal:
                 if isinstance(_item, ExternalItem):

--- a/loki/transformations/tests/test_dependency.py
+++ b/loki/transformations/tests/test_dependency.py
@@ -22,6 +22,7 @@ from loki.tools import as_tuple
 from loki.transformations.dependency import (
         DuplicateKernel, RemoveKernel
 )
+from loki.backend import fgen
 from loki.transformations.build_system import FileWriteTransformation
 
 
@@ -476,3 +477,137 @@ def test_dependency_duplicate_remove_plan_no_module(tmp_path, frontend, duplicat
     assert plan_dict['LOKI_SOURCES_TO_TRANSFORM'] == transformed_items
     assert plan_dict['LOKI_SOURCES_TO_REMOVE'] == transformed_items
     assert plan_dict['LOKI_SOURCES_TO_APPEND'] == {f'{name[1:]}.idem' for name in expected_items}
+
+
+@pytest.fixture(name='fcode_as_module_extended')
+def fixture_fcode_as_module_extended(tmp_path):
+    fcode_driver = """
+subroutine driver(NLON, NB, FIELD1)
+    use kernel_mod, only: kernel
+    implicit none
+    INTEGER, INTENT(IN) :: NLON, NB
+    integer :: b
+    integer, intent(inout) :: field1(nlon, nb)
+    integer :: local_nlon
+    local_nlon = nlon
+    do b=1,nb
+        call kernel(local_nlon, field1(:,b))
+    end do
+end subroutine driver
+    """.strip()
+    fcode_kernel = """
+module kernel_mod
+    implicit none
+contains
+    subroutine kernel(klon, field1)
+        use kernel_nested_mod, only: kernel_nested_vector, kernel_nested_seq
+        use compute_2_mod, only: compute_2
+        implicit none
+        integer, intent(in) :: klon
+        integer, intent(inout) :: field1(klon)
+        integer :: tmp1(klon)
+        integer :: jl
+
+        call kernel_nested_vector(klon, field1)
+
+        do jl=1,klon
+            call kernel_nested_seq(field1(jl))
+            call compute_2(field1(jl))
+            tmp1(jl) = 0
+            field1(jl) = tmp1(jl)
+        end do
+
+    end subroutine kernel
+end module kernel_mod
+    """.strip()
+    fcode_kernel_nested = """
+module kernel_nested_mod
+    implicit none
+contains
+    subroutine kernel_nested_vector(klon, field1)
+        implicit none
+        integer, intent(in) :: klon
+        integer, intent(inout) :: field1(klon)
+        integer :: tmp1(klon)
+        integer :: jl
+
+        do jl=1,klon
+            tmp1(jl) = 0
+            field1(jl) = tmp1(jl)
+        end do
+
+    end subroutine kernel_nested_vector
+    subroutine kernel_nested_seq(val)
+        use compute_1_mod, only: compute_1
+        implicit none
+        integer, intent(inout) :: val
+
+        val = 0
+        call compute_1(val)
+
+    end subroutine kernel_nested_seq
+end module kernel_nested_mod
+    """.strip()
+    fcode_compute_1 = """
+module compute_1_mod
+    implicit none
+contains
+    subroutine compute_1(val)
+        implicit none
+        integer, intent(inout) :: val
+
+        val = 0
+
+    end subroutine compute_1
+end module compute_1_mod
+    """.strip()
+    fcode_compute_2 = """
+module compute_2_mod
+    implicit none
+contains
+    subroutine compute_2(val)
+        implicit none
+        integer, intent(inout) :: val
+
+        val = 0
+
+    end subroutine compute_2
+end module compute_2_mod
+    """.strip()
+    (tmp_path/'driver.F90').write_text(fcode_driver)
+    (tmp_path/'kernel_mod.F90').write_text(fcode_kernel)
+    (tmp_path/'nested_kernel_mod.F90').write_text(fcode_kernel_nested)
+    (tmp_path/'compute_1_mod.F90').write_text(fcode_compute_1)
+    (tmp_path/'compute_2_mod.F90').write_text(fcode_compute_2)
+
+@pytest.mark.usefixtures('fcode_as_module_extended')
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('suffix,module_suffix', (
+    ('_duplicated', None), # ('_dupl1', '_dupl2'), ('_d_test_1', '_d_test_2')
+))
+@pytest.mark.parametrize('full_parse', (True,)) #  False))
+@pytest.mark.parametrize('duplicate_subgraph', (True, False))
+def test_dependency_duplicate_plan_test(tmp_path, frontend, suffix, module_suffix, config, full_parse, duplicate_subgraph):
+
+    scheduler = Scheduler(
+        paths=[tmp_path], config=SchedulerConfig.from_dict(config),
+        frontend=frontend, xmods=[tmp_path], full_parse=full_parse
+    )
+
+    pipeline = Pipeline(classes=(DuplicateKernel, FileWriteTransformation),
+                        duplicate_kernels=('kernel',), duplicate_suffix=suffix,
+                        duplicate_module_suffix=module_suffix,
+                        duplicate_subgraph=duplicate_subgraph)
+
+    plan_file = tmp_path/'plan.cmake'
+    
+    # dry-run for planning
+    scheduler.process(pipeline, proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.write_cmake_plan(filepath=plan_file, rootpath=tmp_path)
+    
+    # generate callgraph
+    scheduler.callgraph(tmp_path/'callgraph', with_file_graph=True)
+    print(f"wrote callgraph to: {tmp_path/'callgraph.pdf'}")
+
+    # actual transformation(s)
+    scheduler.process(pipeline)


### PR DESCRIPTION
POC duplicating a kernel and optionally duplicating/separating the underlying subgraph.

E.g., starting with:

![callgraph_orig.pdf](https://github.com/user-attachments/files/18426060/callgraph_orig.pdf)

the result of the `DuplicateKernel` trafo with `duplicate_kernels=('kernel',)` is:

![callgraph.pdf](https://github.com/user-attachments/files/18426078/callgraph.pdf)

However, with this PR one can specify `duplicate_subgraph=True`, which yields for the example above:

![callgraph.pdf](https://github.com/user-attachments/files/18426090/callgraph.pdf)

Further, the actual transformation part works as well, producing e.g.,:

```fortran
MODULE kernel_mod_duplicated
  IMPLICIT NONE
  CONTAINS
  SUBROUTINE kernel_duplicated (klon, field1)
    USE kernel_nested_mod_duplicated, ONLY: kernel_nested_vector_duplicated, kernel_nested_seq_duplicated
    USE compute_2_mod_duplicated, ONLY: compute_2_duplicated
    IMPLICIT NONE
    INTEGER, INTENT(IN) :: klon
    INTEGER, INTENT(INOUT) :: field1(klon)
    INTEGER :: tmp1(klon)
    INTEGER :: jl
    
    CALL kernel_nested_vector_duplicated(klon, field1)
    
    DO jl=1,klon
      CALL kernel_nested_seq_duplicated(field1(jl))
      CALL compute_2_duplicated(field1(jl))
      tmp1(jl) = 0
      field1(jl) = tmp1(jl)
    END DO
    
  END SUBROUTINE kernel_duplicated
END MODULE kernel_mod_duplicated
```
