### PR TITLE
FieldOffload: Allow and skip non-enriched calls in offload region

### DIFF
--- a/loki/transformations/data_offload/field_offload.py
+++ b/loki/transformations/data_offload/field_offload.py
@@ -12,7 +12,7 @@ from loki.ir import (
     nodes as ir, FindNodes, FindVariables, Transformer,
     SubstituteExpressions, pragma_regions_attached, is_loki_pragma
 )
-from loki.logging import warning, error
+from loki.logging import warning
 from loki.types import BasicType
 
 from loki.transformations.field_api import FieldPointerMap
@@ -126,9 +126,9 @@ def find_offload_variables(driver, region, field_group_types):
     # Do some sanity checking and warning for enclosed calls
     for call in FindNodes(ir.CallStatement).visit(region):
         if call.routine is BasicType.DEFERRED:
-            error(f'[Loki] Data offload: Routine {driver.name} has not been enriched ' +
+            warning(f'[Loki] Data offload: Routine {driver.name} has not been enriched ' +
                     f'in {str(call.name).lower()}')
-            raise RuntimeError
+            continue
         for param, arg in call.arg_iter():
             if not isinstance(param, Array):
                 continue

--- a/loki/transformations/data_offload/tests/test_field_offload.py
+++ b/loki/transformations/data_offload/tests/test_field_offload.py
@@ -367,9 +367,8 @@ def test_field_offload_unknown_kernel(caplog, frontend, state_module, tmp_path):
                                                          offload_index='i',
                                                          field_group_types=['state_type'])
     caplog.clear()
-    with caplog.at_level(log_levels['ERROR']):
-        with pytest.raises(RuntimeError):
-            driver.apply(field_offload_trafo, role='driver', targets=['another_kernel'])
+    with caplog.at_level(log_levels['WARNING']):
+        driver.apply(field_offload_trafo, role='driver', targets=['another_kernel'])
         assert len(caplog.records) == 1
         assert ('[Loki] Data offload: Routine driver_routine has not been enriched '+
                 'in another_kernel') in caplog.records[0].message


### PR DESCRIPTION
Turns out in our CLOUDSC regression test we were not yet testing the new FIELD-API generation transformation, and it was broken. 🙀 The issue was that there are several calls to timer routines that are harmless, but break the rigorous sanity checks. So, instead of breaking we now warn ans kip, and enable the test in the regression suite. 