### PR TITLE
SCC re-vector ad driver level and OpenMP offload

### DIFF
--- a/loki/transformations/pool_allocator.py
+++ b/loki/transformations/pool_allocator.py
@@ -451,6 +451,14 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                 body_prepend += [pragma_data_start]
                 pragma_data_end = Pragma(keyword='acc', content='end data')
                 body_append += [pragma_data_end]
+            elif self.directive == 'omp-gpu':
+                pragma_data_start = Pragma(
+                    keyword='omp',
+                    content=f'target enter data map(alloc: {stack_storage.name})' # pylint: disable=no-member
+                )
+                body_prepend += [pragma_data_start]
+                pragma_data_end = Pragma(keyword='omp', content=f'target exit data map(delete: {stack_storage.name})') # pylint: disable=no-member
+                body_append += [pragma_data_end]
             body_append += [stack_dealloc]
 
         # Inject new variables and body nodes

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -41,7 +41,7 @@ class SCCBaseTransformation(Transformation):
     def __init__(self, horizontal, directive=None):
         self.horizontal = horizontal
 
-        assert directive in [None, 'openacc']
+        assert directive in [None, 'openacc', 'omp-gpu']
         self.directive = directive
 
     # TODO: correct "definition" of a pure/elemental routine (take e.g. loki serial into account ...)


### PR DESCRIPTION
extend SCC family pipelines to allow revectorisation at driver level and OpenMP offload

* you can test this via e.g., CLOUDSC branch [`nams-loki-scc-omp`](https://github.com/ecmwf-ifs/dwarf-p-cloudsc/tree/nams-loki-scc-omp)
    * new config file `src/cloudsc_loki/cloudsc_loki_omp.config` (which is currently set in `src/cloudsc_loki/CMakeLists.txt` to build `SCC`, `SCC-HOIST` (some minor problem do debug) and `SCC-STACK`