### PR TITLE
Enable inlining of a subroutine with an array subrange in an argument

### DIFF
--- a/loki/transformations/inline/procedures.py
+++ b/loki/transformations/inline/procedures.py
@@ -12,7 +12,7 @@ from loki.ir import (
     FindNodes, FindVariables, FindInlineCalls, SubstituteExpressions,
     pragmas_attached, is_loki_pragma, Interface, Pragma, AttachScopes
 )
-from loki.expression import symbols as sym
+from loki.expression import symbols as sym, simplify
 from loki.types import BasicType
 from loki.tools import as_tuple, CaseInsensitiveDict
 from loki.logging import error
@@ -87,12 +87,29 @@ def map_call_to_procedure_body(call, caller, callee=None):
         For example, mapping the passed array ``m(:,j)`` to the local
         expression ``a(i)`` yields ``m(i,j)``.
         """
+
+        def _offset_lbound(lbound, v):
+            return simplify(sym.Sum((sym.Sum((lbound, -1)), v)))
+
         new_dimensions = list(val.dimensions)
 
         indices = [index for index, dim in enumerate(val.dimensions) if isinstance(dim, sym.Range)]
 
         for index, dim in enumerate(var.dimensions):
-            new_dimensions[indices[index]] = dim
+            # if the argument contains an array range, we must map the bounds accordingly
+            if isinstance(val.dimensions[index], sym.Range) and (lower := val.dimensions[index].lower):
+                if isinstance(dim, sym.Range):
+                    _lower = dim.lower or sym.IntLiteral(1)
+                    _upper = dim.upper or val.dimensions[index].upper
+
+                    _lower = _offset_lbound(lower, _lower)
+                    _upper = _offset_lbound(lower, _upper)
+
+                    new_dimensions[indices[index]] = sym.Range((_lower, _upper))
+                else:
+                    new_dimensions[indices[index]] = _offset_lbound(lower, dim)
+            else:
+                new_dimensions[indices[index]] = dim
 
         return val.clone(dimensions=tuple(new_dimensions))
 

--- a/loki/transformations/inline/procedures.py
+++ b/loki/transformations/inline/procedures.py
@@ -88,8 +88,10 @@ def map_call_to_procedure_body(call, caller, callee=None):
         expression ``a(i)`` yields ``m(i,j)``.
         """
 
-        def _offset_lbound(lbound, v):
-            return simplify(sym.Sum((sym.Sum((lbound, -1)), v)))
+        def _offset_lbound(local_lbound, decl_lbound, v):
+            _sum = sym.Product((-1, decl_lbound))
+            _sum = sym.Sum((_sum, local_lbound, v))
+            return simplify(_sum)
 
         new_dimensions = list(val.dimensions)
 
@@ -110,16 +112,17 @@ def map_call_to_procedure_body(call, caller, callee=None):
             # if the argument contains an array range, we must map the bounds accordingly
             if isinstance(val.dimensions[index], sym.Range) and (lower := val.dimensions[index].lower):
                 lower = simplify(sym.Sum((lower, lbdiff)))
+                decl_lbound = decl_lbounds[index][0]
                 if isinstance(dim, sym.Range):
                     _lower = dim.lower or decl_lbounds[index][1]
                     _upper = dim.upper or var_ubounds[index]
 
-                    _lower = _offset_lbound(lower, _lower)
-                    _upper = _offset_lbound(lower, _upper)
+                    _lower = _offset_lbound(lower, decl_lbound, _lower)
+                    _upper = _offset_lbound(lower, decl_lbound, _upper)
 
                     new_dimensions[indices[index]] = sym.Range((_lower, _upper))
                 else:
-                    new_dimensions[indices[index]] = _offset_lbound(lower, dim)
+                    new_dimensions[indices[index]] = _offset_lbound(lower, decl_lbound, dim)
             else:
                 new_dimensions[indices[index]] = simplify(sym.Sum((dim, lbdiff)))
 

--- a/loki/transformations/inline/tests/test_inline_transformation.py
+++ b/loki/transformations/inline/tests/test_inline_transformation.py
@@ -324,7 +324,7 @@ subroutine test_inline_outer(a, b, f)
   use test_inline_another_mod, only: test_inline_another_inner
   implicit none
 
-  real(kind=8), intent(inout) :: a(n), b(n), f(n)
+  real(kind=8), intent(inout) :: a(n), b(n), f(0:n-1)
   real(kind=8) :: c(12)
 
   !$loki inline
@@ -343,7 +343,7 @@ subroutine test_inline_inner(a, b, c, d, e, f)
   use BNDS_module, only: n, m
   use another_module, only: x
 
-  real(kind=8), intent(inout) :: a(n), b(n), f(0:n-1)
+  real(kind=8), intent(inout) :: a(n), b(n), f(2:n+1)
   real(kind=8), intent(out) :: c(4), d(4), e(0:3)
   real(kind=8) :: tmp(m)
   integer :: i
@@ -361,7 +361,7 @@ subroutine test_inline_inner(a, b, c, d, e, f)
   d(1:4) = 1.
   e(0:3) = 1.
   e(:) = 2.
-  do i=0, n-1
+  do i=2, n+1
     f(i) = 2.
   end do
 end subroutine test_inline_inner
@@ -414,7 +414,7 @@ end module test_inline_another_mod
     assert assign[7].rhs == '1.'
     assert assign[8].lhs == 'c(9:12)'
     assert assign[8].rhs == '2.'
-    assert assign[9].lhs == 'f(1 + i)'
+    assert assign[9].lhs == 'f(-2 + i)'
     assert assign[9].rhs == '2.'
 
     # Now check that the right modules have been moved,

--- a/loki/transformations/inline/tests/test_inline_transformation.py
+++ b/loki/transformations/inline/tests/test_inline_transformation.py
@@ -318,19 +318,19 @@ end module another_module
     """
 
     fcode_outer = """
-subroutine test_inline_outer(a, b)
+subroutine test_inline_outer(a, b, f)
   use bnds_module, only: n
   use test_inline_mod, only: test_inline_inner
   use test_inline_another_mod, only: test_inline_another_inner
   implicit none
 
-  real(kind=8), intent(inout) :: a(n), b(n)
-  real(kind=8) :: c(8)
+  real(kind=8), intent(inout) :: a(n), b(n), f(n)
+  real(kind=8) :: c(12)
 
   !$loki inline
   call test_inline_another_inner()
   !$loki inline
-  call test_inline_inner(a, b, c(1:4), c(5:8))
+  call test_inline_inner(a, b, c(1:4), c(5:8), c(9:12), f)
 end subroutine test_inline_outer
     """
 
@@ -339,12 +339,12 @@ module test_inline_mod
   implicit none
   contains
 
-subroutine test_inline_inner(a, b, c, d)
+subroutine test_inline_inner(a, b, c, d, e, f)
   use BNDS_module, only: n, m
   use another_module, only: x
 
-  real(kind=8), intent(inout) :: a(n), b(n)
-  real(kind=8), intent(out) :: c(4), d(4)
+  real(kind=8), intent(inout) :: a(n), b(n), f(0:n-1)
+  real(kind=8), intent(out) :: c(4), d(4), e(0:3)
   real(kind=8) :: tmp(m)
   integer :: i
 
@@ -354,9 +354,16 @@ subroutine test_inline_inner(a, b, c, d)
   end do
   do i=1,4
     c(i) = 0.
+    d(i) = 0.
+    e(i-1) = 0.
   enddo
   c(:) = 1.
-  d(1:4) = 0.
+  d(1:4) = 1.
+  e(0:3) = 1.
+  e(:) = 2.
+  do i=0, n-1
+    f(i) = 2.
+  end do
 end subroutine test_inline_inner
 end module test_inline_mod
     """
@@ -388,17 +395,27 @@ end module test_inline_another_mod
 
     # Check that the inlining has happened
     assign = FindNodes(ir.Assignment).visit(outer.body)
-    assert len(assign) == 5
+    assert len(assign) == 10
     assert assign[0].lhs == 'tmp(1:m)'
     assert assign[0].rhs == 'x'
     assert assign[1].lhs == 'a(i)'
     assert assign[1].rhs == 'b(i) + sum(tmp)'
     assert assign[2].lhs == 'c(i)'
     assert assign[2].rhs == '0.'
-    assert assign[3].lhs == 'c(1:4)'
-    assert assign[3].rhs == '1.'
-    assert assign[4].lhs == 'c(5:8)'
+    assert assign[3].lhs == 'c(4 + i)'
+    assert assign[3].rhs == '0.'
+    assert assign[4].lhs == 'c(8 + i)'
     assert assign[4].rhs == '0.'
+    assert assign[5].lhs == 'c(1:4)'
+    assert assign[5].rhs == '1.'
+    assert assign[6].lhs == 'c(5:8)'
+    assert assign[6].rhs == '1.'
+    assert assign[7].lhs == 'c(9:12)'
+    assert assign[7].rhs == '1.'
+    assert assign[8].lhs == 'c(9:12)'
+    assert assign[8].rhs == '2.'
+    assert assign[9].lhs == 'f(1 + i)'
+    assert assign[9].rhs == '2.'
 
     # Now check that the right modules have been moved,
     # and the import of the call has been removed


### PR DESCRIPTION
A small fix to the inlining trafo that enables inlining of calls where we pass a subrange of an array argument, i.e.:
```
real :: a(8)

!$loki inline
call kernel(a(5:8)

....

subroutine kernel
real, intent(in) :: a(4)

```