### PR TITLE
Exclude calls to contained member procedures from dependencies

### DIFF
--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -709,6 +709,8 @@ class ProcedureItem(Item):
         calls to functions) nodes that constitute dependencies of this item.
         """
         calls = tuple({call.name.name: call for call in FindNodes(CallStatement).visit(self.ir.ir)}.values())
+        if internal_procedures := [routine.name.lower() for routine in self.ir.routines]:
+            calls = tuple(call for call in calls if call.name.name.lower() not in internal_procedures)
         inline_calls = tuple({
             call.function.name: call.function
             for call in FindInlineCalls().visit(self.ir.ir)


### PR DESCRIPTION
We had this situation as an x-failing test previously, leaving open the question how to handle calls to internal member procedures when building the Scheduler's SGraph. But as discussed offline, since internal member procedures are fully contained within their enclosing parent routine, it does not make much sense to add them explicitly to the scheduler's dependency graph. For the SCC adaptation recipes, we typically inline those anyway.

The implication is of course that the Scheduler's processing of transformation pipelines will by default not include internal member routines, which is also the current behaviour. However, if we were to introduce transformations that were to specifically require processing of internal member procedures in the future, this should likely be achieved via the `recurse_to_internal_procedures` property of the `Transformation` class instead.