### PR TITLE
Scheduler: Allow explicit file paths to be added as sources

### DIFF
--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -216,7 +216,10 @@ class Scheduler:
         }
 
         # Create a list of initial files to scan with the fast REGEX frontend
-        path_list = [path.glob(f'**/*{ext}') for path in self.paths for ext in self.source_suffixes]
+        path_list = [
+            path.glob(f'**/*{ext}') if path.is_dir() else path
+            for path in self.paths for ext in self.source_suffixes
+        ]
         path_list = list(set(flatten(path_list)))  # Filter duplicates and flatten
 
         # Instantiate FileItem instances for all files in the search path

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -297,10 +297,13 @@ def test_scheduler_graph_simple(
                            |
                            | --> another_l1 -> another_l2
     """
+
+    # Combine directory globbing and explicit file paths for lookup
     projA = testdir/'sources/projA'
+    paths = [projA/'module', projA/'source/another_l1.F90', projA/'source/another_l2.F90']
 
     scheduler = Scheduler(
-        paths=projA, includes=projA/'include', config=config,
+        paths=paths, includes=projA/'include', config=config,
         seed_routines=seed, frontend=frontend, xmods=[tmp_path]
     )
 


### PR DESCRIPTION
This change allows individual source file locations to be added without resorting to directory globs. This is particularly useful for auto-inlining individual external utility routines, without having to search their entire parent location during discover.

This extends one of the existing tests instead of adding a new one.