### PR TITLE
optionally duplicating/separating the underlying subgraph when duplicating item/call 

### DIFF
--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -29,18 +29,135 @@ class DuplicateKernel(Transformation):
     duplicate_module_suffix : str, optional
         Suffix to be used to append the original module name(s),
         if defined, otherwise `duplicate_suffix`
+    duplicate_subgraph : bool, optional
+        Whether or not duplicate the subgraph beneath the kernel(s)
+        that are duplicated.
     """
 
     creates_items = True
     reverse_traversal = True
 
     def __init__(self, duplicate_kernels=None, duplicate_suffix='duplicated',
-                 duplicate_module_suffix=None):
+                 duplicate_module_suffix=None, duplicate_subgraph=False):
         self.suffix = duplicate_suffix
         self.module_suffix = duplicate_module_suffix or duplicate_suffix
         self.duplicate_kernels = tuple(kernel.lower() for kernel in as_tuple(duplicate_kernels))
+        self.duplicate_subgraph = duplicate_subgraph
 
-    def _create_duplicate_items(self, successors, item_factory, config):
+    def _get_new_item_name(self, item):
+        """
+        Get new/duplicated item name, more specifically ``local_name``,
+        ``scope_name`` and ``new_item_name``.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            The item used to derive ``local_name``,
+            ``scope_name`` and ``new_item_name``.
+        """
+        # Determine new item name
+        scope_name = item.scope_name
+        local_name = f'{item.local_name}{self.suffix}'
+        if scope_name:
+            scope_name = f'{scope_name}{self.module_suffix}'
+        # Try to get existing item from cache
+        new_item_name = f'{scope_name or ""}#{local_name}'
+        return scope_name, local_name, new_item_name
+
+    def _get_or_create_or_rename_item(self, item, item_factory, scope_name, new_item_name, local_name, config):
+        """
+        Get, create or rename item including the scope item if there is a
+        scope.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            Item to duplicate/to use to derive new item.
+        item_factory : :any:`ItemFactory`
+            The :any:`ItemFactory` to use when creating the items.
+        scope_name : str
+            New item scope name.
+        new_item_name : str
+            New item name.
+        local_name : str
+            New item local name.
+        config : :any:`SchedulerConfig`
+            The scheduler config to use when instantiating new items.
+        Returns
+        -------
+        :any:`Item`
+            Newly created item.
+        """
+        new_item = item_factory.item_cache.get(new_item_name)
+        # Try to get an item for the scope or create that first
+        if new_item is None and scope_name:
+            scope_item = item_factory.item_cache.get(scope_name)
+            if scope_item:
+                scope = scope_item.ir
+                if local_name not in scope and item.local_name in scope:
+                    # Rename the existing item to the new name
+                    scope[item.local_name].name = local_name
+
+                if local_name in scope:
+                    new_item = item_factory.create_from_ir(
+                        scope[local_name], scope, config=config
+                    )
+        # Create new item
+        if new_item is None:
+            new_item = item_factory.get_or_create_item_from_item(new_item_name, item, config=config)
+        return new_item
+
+    def _modify_sgraph(self, sgraph, item, new_items):
+        """
+        Add new items to graph.
+
+        Parameters
+        ----------
+        sgraph : :any:`SGraph`
+            Directed graph or rather copy of it to
+            be modified.
+        item : :any:`Item`
+            Node to which add the new items.
+        new_items : tuple
+            Tuple of :any:`Item` to add to graph.
+        """
+        sgraph.add_nodes(new_items)
+        sgraph.add_edges((item, _item) for _item in new_items)
+
+    def _rename_calls(self, new_item, new_dependencies):
+        """
+        Rename calls and imports according to the newly created
+        duplicated items.
+
+        Parameters
+        ----------
+        new_item : :any:`Item`
+            The newly created item for which calls and imports
+            to be renamed.
+        new_dependencies : dict
+            Dictionary used to get information about how
+            to rename calls and imports.
+        """
+        call_map = {}
+        for call in FindNodes(ir.CallStatement).visit(new_item.ir.body):
+            call_name = str(call.name).lower()
+            new_call_name = f'{call_name}{self.suffix}'.lower()
+            call_new_item = new_dependencies[new_call_name]
+            proc_symbol = call_new_item.ir.procedure_symbol.rescope(scope=new_item.ir)
+            call_map[call] = call.clone(name=proc_symbol)
+        # TODO: imports at module level ...
+        imp_map = {}
+        for imp in FindNodes(ir.Import).visit(new_item.ir.spec):
+            new_symbols = [symbol.clone(name=f'{symbol.name}{self.suffix}') for symbol in imp.symbols]
+            imp_map[imp] = imp.clone(module=f'{imp.module.lower()}{self.module_suffix}',
+                                     symbols=as_tuple(new_symbols))
+        if call_map:
+            new_item.ir.body = Transformer(call_map).visit(new_item.ir.body)
+        if imp_map:
+            new_item.ir.spec = Transformer(imp_map).visit(new_item.ir.spec)
+
+    def _create_duplicate_items(self, successors, item_factory, config, item, sub_sgraph,
+            rename_calls=False, force_duplicate=False):
         """
         Create new/duplicated items.
 
@@ -53,6 +170,18 @@ class DuplicateKernel(Transformation):
             The :any:`ItemFactory` to use when creating the items.
         config : :any:`SchedulerConfig`
             The scheduler config to use when instantiating new items.
+        item : :any:`Item`
+            Starting point/source item from which the successors
+            originate from
+        sub_sgraph : :any:`SGraph`
+            Sgraph (copy) representing the subgraph of the directed
+            overall graph.
+        rename_calls : bool, optional
+            Rename calls/imports in accordance to the duplicated
+            kernels.
+        force_duplicate : bool, optional
+            Check whether successor is within ``duplicate_kernels``
+            or duplicate either way.
         Returns
         -------
         tuple
@@ -60,36 +189,36 @@ class DuplicateKernel(Transformation):
         """
 
         new_items = ()
-        for item in successors:
-            if item.local_name in self.duplicate_kernels:
-                # Determine new item name
-                scope_name = item.scope_name
-                local_name = f'{item.local_name}{self.suffix}'
-                if scope_name:
-                    scope_name = f'{scope_name}{self.module_suffix}'
-
-                # Try to get existing item from cache
-                new_item_name = f'{scope_name or ""}#{local_name}'
-                new_item = item_factory.item_cache.get(new_item_name)
-
-                # Try to get an item for the scope or create that first
-                if new_item is None and scope_name:
-                    scope_item = item_factory.item_cache.get(scope_name)
-                    if scope_item:
-                        scope = scope_item.ir
-                        if local_name not in scope and item.local_name in scope:
-                            # Rename the existing item to the new name
-                            scope[item.local_name].name = local_name
-
-                        if local_name in scope:
-                            new_item = item_factory.create_from_ir(
-                                scope[local_name], scope, config=config
-                            )
-
-                # Create new item
-                if new_item is None:
-                    new_item = item_factory.get_or_create_item_from_item(new_item_name, item, config=config)
+        for child in successors:
+            if child.local_name in self.duplicate_kernels or force_duplicate:
+                # get scope, local and new item name
+                scope_name, local_name, new_item_name = self._get_new_item_name(child)
+                # get/create/rename item
+                new_item = self._get_or_create_or_rename_item(child, item_factory, scope_name,
+                        new_item_name, local_name, config)
                 new_items += as_tuple(new_item)
+                # duplicate subgraph?
+                if self.duplicate_subgraph:
+                    new_item = as_tuple(new_item)[0]
+                    # add new_items to sgraph (copy)
+                    self._modify_sgraph(sub_sgraph, item, new_items)
+                    # get the successors
+                    child_successors = as_tuple(sub_sgraph.successors(child))
+                    if child_successors:
+                        # create new/duplicated successors
+                        new_dependencies = self._create_duplicate_items(child_successors, item_factory, config,
+                                sub_sgraph=sub_sgraph, item=new_item, rename_calls=rename_calls, force_duplicate=True)
+                        new_dependencies_dic = CaseInsensitiveDict((new_item.local_name, new_item)
+                                for new_item in new_dependencies)
+                        # add dependencies to new/duplicated successors and remove the "old" ones
+                        new_item.plan_data.setdefault('additional_dependencies', ())
+                        new_item.plan_data.setdefault('removed_dependencies', ())
+                        new_item.plan_data['additional_dependencies'] += as_tuple(new_dependencies)
+                        new_item.plan_data['removed_dependencies'] += as_tuple(child_successors)
+                        sub_sgraph._add_children(new_item, item_factory, config, dependencies=new_dependencies)
+                        # rename calls and imports
+                        if rename_calls:
+                            self._rename_calls(new_item, new_dependencies_dic)
         return tuple(new_items)
 
     def transform_subroutine(self, routine, **kwargs):
@@ -100,7 +229,10 @@ class DuplicateKernel(Transformation):
         new_dependencies = self._create_duplicate_items(
             successors=successors,
             item_factory=kwargs.get('item_factory'),
-            config=kwargs.get('scheduler_config')
+            config=kwargs.get('scheduler_config'),
+            item=kwargs.get('item'),
+            sub_sgraph=sub_sgraph,
+            rename_calls=True
         )
         new_dependencies = CaseInsensitiveDict((new_item.local_name, new_item) for new_item in new_dependencies)
 
@@ -133,7 +265,9 @@ class DuplicateKernel(Transformation):
         item.plan_data['additional_dependencies'] += self._create_duplicate_items(
             successors=successors,
             item_factory=kwargs.get('item_factory'),
-            config=kwargs.get('scheduler_config')
+            config=kwargs.get('scheduler_config'),
+            item=item,
+            sub_sgraph=sub_sgraph
         )
 
 


### PR DESCRIPTION
Duplicating a kernel and optionally duplicating/separating the underlying subgraph.

E.g., starting with:

![callgraph_0.pdf](https://github.com/user-attachments/files/18989691/callgraph_0.pdf)

the result of the DuplicateKernel trafo with duplicate_kernels=('kernel',) is:

![callgraph_1.pdf](https://github.com/user-attachments/files/18989693/callgraph_1.pdf)

However, with this PR one can specify duplicate_subgraph=True, which yields for the example above:

![callgraph_2.pdf](https://github.com/user-attachments/files/18989694/callgraph_2.pdf)
