### PR TITLE
Fix: Invalid parsing of empty PRINT statements with fparser

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2990,7 +2990,9 @@ class FParser2IR(GenericVisitor):
                             label=kwargs.get('label'))
 
     def visit_Print_Stmt(self, o, **kwargs):
-        return ir.Intrinsic(text=f'PRINT {", ".join(str(i) for i in o.items)}',
+        # NOTE: fparser returns None for an empty print (`PRINT *`) instead of
+        #       the usual `Output_Item_List` entity.
+        return ir.Intrinsic(text=f'PRINT {", ".join(str(i) for i in o.items if i is not None)}',
                             source=kwargs.get('source'), label=kwargs.get('label'))
 
     # TODO: Deal with line-continuation pragmas!

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -1303,8 +1303,9 @@ class OMNI2IR(GenericVisitor):
     def visit_FprintStatement(self, o, **kwargs):
         values = [self.visit(v, **kwargs) for v in o.find('valueList')]
         args = ', '.join(f'{v}' for v in values)
+        args = f", {args}" if values else ""
         fmt = o.attrib['format']
-        return ir.Intrinsic(text=f'print {fmt}, {args}', source=kwargs['source'])
+        return ir.Intrinsic(text=f'print {fmt}{args}', source=kwargs['source'])
 
     def visit_FformatDecl(self, o, **kwargs):
         fmt = f'FORMAT{o.attrib["format"]}'


### PR DESCRIPTION
This simple PR tries to resolve the bug mentioned in #504.

Tell me if some unit tests for this case are necessary in your opinion.