### PR TITLE
Missing PROTECTED access specifier in the fgen backend

### DIFF
--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -861,6 +861,8 @@ class FortranCodegen(Stringifier):
             attributes += ['PRIVATE']
         if o.public:
             attributes += ['PUBLIC']
+        if o.protected:
+            attributes += ['PROTECTED']
 
         # Binding attributes
         if o.pass_attr is True:


### PR DESCRIPTION
Fixes missing PROTECTED attribute in the fgen backend #506 
