### PR TITLE
Check access-spec lists when importing symbols from modules

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,6 +4,7 @@
 - J. Ericsson (ECMWF)
 - R. Heilemann Myhre (Met Norway)
 - S. Karppinen (FMI)
+- R. Kazeroni (CNRS/IPSL)
 - P. Kiepas (École polytechnique/IPSL)
 - M. Lange (ECMWF)
 - J. Legaux (CERFACS)

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -479,8 +479,15 @@ class FParser2IR(GenericVisitor):
                 # Import symbol attributes from module, if available
                 for k, v in module.symbol_attrs.items():
                     # Don't import private module symbols
-                    if v.private or (module.default_access_spec == "private" and not v.public):
+                    if v.private:
                         continue
+                    else:
+                        if module.default_access_spec == "private":
+                            if k not in module.public_access_spec and not v.public:
+                                continue
+                        else:
+                            if k in module.private_access_spec:
+                                continue
                     if k in rename_list:
                         local_name = rename_list[k].name
                         scope.symbol_attrs[local_name] = v.clone(imported=True, module=module, use_name=k)

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -481,13 +481,12 @@ class FParser2IR(GenericVisitor):
                     # Don't import private module symbols
                     if v.private:
                         continue
+                    if module.default_access_spec == "private":
+                        if k not in module.public_access_spec and not v.public:
+                            continue
                     else:
-                        if module.default_access_spec == "private":
-                            if k not in module.public_access_spec and not v.public:
-                                continue
-                        else:
-                            if k in module.private_access_spec:
-                                continue
+                        if k in module.private_access_spec:
+                            continue
                     if k in rename_list:
                         local_name = rename_list[k].name
                         scope.symbol_attrs[local_name] = v.clone(imported=True, module=module, use_name=k)


### PR DESCRIPTION
As mentioned in #510 , symbols listed in `private_access_spec` and `public_access_spec` of modules are not analyzed when importing symbols from other modules. This PR proposes a fix for the issue. I can add a specific unit test if needed