### PR TITLE
CMakePlan: ensure file list matches what the build system provided to the Scheduler

### DIFF
--- a/loki/transformations/build_system/__init__.py
+++ b/loki/transformations/build_system/__init__.py
@@ -8,3 +8,4 @@
 from loki.transformations.build_system.dependency import * # noqa
 from loki.transformations.build_system.file_write import * # noqa
 from loki.transformations.build_system.module_wrap import * # noqa
+from loki.transformations.build_system.plan import * # noqa

--- a/loki/transformations/build_system/plan.py
+++ b/loki/transformations/build_system/plan.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from loki.batch.transformation import Transformation
 from loki.logging import debug
 
+__all__ = ['CMakePlanTransformation']
+
 class CMakePlanTransformation(Transformation):
     """
     Gather the planning information from all :any:`Item.trafo_data` to which
@@ -79,7 +81,7 @@ class CMakePlanTransformation(Transformation):
         if not 'FileWriteTransformation' in item.trafo_data:
             return
 
-        sourcepath = item.path.resolve()
+        sourcepath = item.path
 
         # This makes sure the sourcepath does in fact exist. Combined with
         # item duplication or other transformations we might end up adding
@@ -88,7 +90,7 @@ class CMakePlanTransformation(Transformation):
         source_exists = sourcepath.exists()
 
         if self.rootpath is not None:
-            sourcepath = sourcepath.relative_to(self.rootpath)
+            sourcepath = sourcepath.resolve().relative_to(self.rootpath)
 
         newsource = item.trafo_data['FileWriteTransformation']['path']
 
@@ -104,7 +106,12 @@ class CMakePlanTransformation(Transformation):
                 # Replace old source file to avoid ghosting
                 self.sources_to_append += [newsource]
                 if source_exists:
-                    self.sources_to_remove += [sourcepath]
+                    # NB: we use the item path directly here instead of resolving it,
+                    #     to stay compatible with what has been provided on the CLI.
+                    #     This is because the build system will likely use this path
+                    #     internally to identify the original file, and if the paths
+                    #     don't match the removal of source files from the target fails.
+                    self.sources_to_remove += [item.path]
 
     def write_plan(self, filepath):
         """

--- a/loki/transformations/build_system/tests/test_plan.py
+++ b/loki/transformations/build_system/tests/test_plan.py
@@ -1,0 +1,134 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from pathlib import Path
+import re
+
+import pytest
+
+from loki.batch import Scheduler, SchedulerConfig, ProcessingStrategy
+from loki.transformations.build_system import CMakePlanTransformation, FileWriteTransformation
+
+
+@pytest.mark.parametrize('rootpath', [None, 'tmp_path'])
+def test_plan_relative_paths(tmp_path, monkeypatch, rootpath):
+    """
+    A test that emulates the use of overlay file systems that may cause issues
+    if paths are resolved prematurely.
+
+    This can generate file names in the lists produced by the CMakePlanTransformation
+    that don't match the internal lists of files in the CMake target, thus breaking
+    the source list update process.
+
+    This test creates a file system hierarchy like this:
+
+    - real_path/
+        - module/
+            - mymod.F90
+        - src/
+            - mysub.F90
+    - overlay_path -> real_path
+    - build/
+
+    and initiates the Scheduler on the overlay path
+
+    """
+    (tmp_path/'real_path').mkdir()
+    (tmp_path/'real_path/src').mkdir()
+    (tmp_path/'real_path/module').mkdir()
+    (tmp_path/'overlay_path').symlink_to('real_path')
+    (tmp_path/'build').mkdir()
+
+    if rootpath == 'tmp_path':
+        rootpath = tmp_path
+
+    fcode_mymod = """
+module mymod
+    implicit none
+    contains
+        subroutine mod_sub
+        end subroutine mod_sub
+end module mymod
+    """
+    fcode_mysub = """
+subroutine mysub
+    use mymod, only: mod_sub
+    implicit none
+    call mod_sub
+end subroutine mysub
+    """
+
+    (tmp_path/'real_path/src/mysub.F90').write_text(fcode_mysub)
+    (tmp_path/'real_path/module/mymod.F90').write_text(fcode_mymod)
+
+    assert (tmp_path/'overlay_path/src/mysub.F90').exists()
+
+    # Run the test in tmp_path to be able to specify relative paths to the scheduler
+    monkeypatch.chdir(tmp_path)
+
+    # Initialize the Scheduler
+    config = SchedulerConfig.from_dict({
+        'default': {
+            'role': 'kernel',
+            'expand': True,
+            'strict': True,
+            'mode': 'test',
+        },
+        'routines': {
+            'mysub': {'role': 'driver'}
+        }
+    })
+    scheduler = Scheduler(
+        paths=['overlay_path'],
+        config=config,
+        full_parse=False,
+        output_dir=tmp_path/'build'
+    )
+    assert scheduler.items == ('#mysub', 'mymod#mod_sub')
+
+    # Scheduler items are all relative paths
+    assert scheduler['#mysub'].source.path == Path('overlay_path/src/mysub.F90')
+    assert scheduler['mymod#mod_sub'].source.path == Path('overlay_path/module/mymod.F90')
+
+    # Run the planning transformation pipeline
+    scheduler.process(
+        transformation=FileWriteTransformation(),
+        proc_strategy=ProcessingStrategy.PLAN
+    )
+    plan_trafo = CMakePlanTransformation(rootpath=rootpath)
+    scheduler.process(
+        transformation=plan_trafo,
+        proc_strategy=ProcessingStrategy.PLAN
+    )
+    planfile = tmp_path/'build/plan.cmake'
+    plan_trafo.write_plan(planfile)
+
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+    plan_dict = {k: v.split() for k, v in plan_pattern.findall(planfile.read_text())}
+    plan_dict = {k: [Path(p) for p in v] for k, v in plan_dict.items()}
+
+     # The newly generated files will always have fully qualified paths
+    to_append = [tmp_path/'build/mysub.test.F90', tmp_path/'build/mymod.test.F90']
+
+    # The list of files to transform (this property is currently not used by the CMake macros)
+    # will provide the original relative paths - unless we resolve them relative to a provided
+    # root directory, which will also resolve symlinks
+    if rootpath:
+        to_transform = [Path('real_path/src/mysub.F90'), Path('real_path/module/mymod.F90')]
+    else:
+        to_transform = [Path('overlay_path/src/mysub.F90'), Path('overlay_path/module/mymod.F90')]
+
+    # The list of files to remove matches the relative paths given to the original Scheduler
+    # invocation to ensure we match exactly what the build system gave us
+    to_remove = [Path('overlay_path/src/mysub.F90'), Path('overlay_path/module/mymod.F90')]
+
+    assert plan_trafo.sources_to_append == to_append
+    assert plan_dict['LOKI_SOURCES_TO_APPEND'] == to_append
+    assert plan_trafo.sources_to_transform == to_transform
+    assert plan_dict['LOKI_SOURCES_TO_TRANSFORM'] == to_transform
+    assert plan_trafo.sources_to_remove == to_remove
+    assert plan_dict['LOKI_SOURCES_TO_REMOVE'] == to_remove

--- a/scripts/loki_transform.py
+++ b/scripts/loki_transform.py
@@ -120,8 +120,8 @@ def convert(
         definitions = definitions + list(sfile.definitions)
 
     # Create a scheduler to bulk-apply source transformations
-    paths = [Path(p).resolve() for p in as_tuple(source)]
-    paths += [Path(h).resolve().parent for h in as_tuple(header)]
+    paths = [Path(p) for p in as_tuple(source)]
+    paths += [Path(h).parent for h in as_tuple(header)]
     # Skip full source parse for planning mode
     full_parse = processing_strategy == ProcessingStrategy.DEFAULT
     scheduler = Scheduler(


### PR DESCRIPTION
When using a system where overlay file systems are in place, or if symlinks are used in a repository, the premature resolution of file paths to absolute paths can cause aliasing problems in the CMake macros. There, we rely on the implicit assumption that the relative paths of the source files in a CMake target match the lists we write into the CMake plan.

This adds a test for this behaviour using an artificial symlink setup and fixes the CMake transformation accordingly.