### PR TITLE
Fix JIT tests with derived types

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,23 +12,7 @@ See the pytest documentation for more details:
 https://docs.pytest.org/en/stable/how-to/writing_plugins.html#local-conftest-plugins
 """
 
-import os
-
 from loki.config import config as loki_config
-
-
-XFAIL_DERIVED_TYPE_JIT_TESTS = os.environ.get('XFAIL_DERIVED_TYPE_JIT_TESTS', '1') == '1'
-"""
-Flag to mark tests that use JIT compilation for derived type argument procedures
-as expected to fail with :any:`pytest.mark.xfail`
-
-The derived type wrapping support provided by f90wrap has stopped working in the
-Loki JIT backend that is used for tests. Because this is not a crucial feature, we
-are temporarily allowing these tests to fail to fix this separately in the future.
-
-By setting the environment variable ``XFAIL_DERIVED_TYPE_JIT_TESTS`` to ``0``, tests
-will no longer be marked as xfail.
-"""
 
 
 def pytest_addoption(parser, pluginmanager):  # pylint: disable=unused-argument

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -21,8 +21,6 @@ from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI, FP, HAVE_FP
 from loki.ir import nodes as ir, FindNodes, FindVariables
 
-from conftest import XFAIL_DERIVED_TYPE_JIT_TESTS
-
 
 @pytest.fixture(name='reset_frontend_mode')
 def fixture_reset_frontend_mode():
@@ -31,10 +29,6 @@ def fixture_reset_frontend_mode():
     config['frontend-strict-mode'] = original_frontend_mode
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_check_alloc_opts(tmp_path, frontend):
     """
@@ -128,10 +122,6 @@ end module alloc_mod
     mod.free_deferred(item2)
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_associates(tmp_path, frontend):
     """Test the use of associate to access and modify other items"""

--- a/loki/tests/test_derived_types.py
+++ b/loki/tests/test_derived_types.py
@@ -23,8 +23,6 @@ from loki import (
 from loki.jit_build import jit_compile, jit_compile_lib, Obj
 from loki.frontend import available_frontends, OMNI
 
-from conftest import XFAIL_DERIVED_TYPE_JIT_TESTS
-
 
 @pytest.fixture(name='builder')
 def fixture_builder(tmp_path):
@@ -32,10 +30,6 @@ def fixture_builder(tmp_path):
     Obj.clear_cache()
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_simple_loops(tmp_path, frontend):
     """
@@ -93,10 +87,6 @@ end module
     assert (item.vector == 7.).all() and (item.matrix == 6.).all()
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_array_indexing_explicit(tmp_path, frontend):
     """
@@ -135,10 +125,6 @@ end module
     assert (item.matrix == np.array([[1., 2., 3.], [1., 2., 3.], [1., 2., 3.]])).all()
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_array_indexing_deferred(tmp_path, frontend):
     """
@@ -193,10 +179,6 @@ end module
     mod.free_deferred(item)
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_array_indexing_nested(tmp_path, frontend):
     """
@@ -245,10 +227,6 @@ end module
                                                   [1., 2., 3.]])).all()
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_deferred_array(tmp_path, frontend):
     """
@@ -324,10 +302,6 @@ end module
     mod.free_deferred(item)
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_derived_type_caller(tmp_path, frontend):
     """
@@ -384,10 +358,6 @@ end module
     assert (item.vector == 7.).all() and (item.matrix == 6.).all() and item.red_herring == 42.
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_case_sensitivity(tmp_path, frontend):
     """
@@ -1169,10 +1139,6 @@ end module {module_name}
     yield fcode
 
 
-@pytest.mark.xfail(
-    XFAIL_DERIVED_TYPE_JIT_TESTS,
-    reason='Support for user-defined derived type arguments is broken in JIT compile'
-)
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_derived_type_rescope_symbols_shadowed(tmp_path, shadowed_typedef_symbols_fcode, frontend):
     """


### PR DESCRIPTION
As described in issue #494 the f90wrap step of our built-in JIT compiler does has started having problems with the recent switch to meson. This PR fixes this by adding a dedicated compilation step of the pure Fortran sources into a small, static utility lib that then gets linked into the dynamic lib alongside the wrappers by `f2py-f90wrap`. This follows the internal examples of 90wrap.