### PR TITLE
Fix indentation in fgen after Associate blocks and add TypeConditional node

### DIFF
--- a/docs/source/internal_representation.rst
+++ b/docs/source/internal_representation.rst
@@ -203,6 +203,7 @@ Leaf node classes
    loki.ir.StatementFunction
    loki.ir.TypeDef
    loki.ir.MultiConditional
+   loki.ir.TypeConditional
    loki.ir.MaskedStatement
    loki.ir.Intrinsic
    loki.ir.Enumeration

--- a/lint_rules/lint_rules/ifs_coding_standards_2011.py
+++ b/lint_rules/lint_rules/ifs_coding_standards_2011.py
@@ -72,6 +72,8 @@ class CodeBodyRule(GenericRule):  # Coding standards 1.3
             too_deep += self.visit(o.else_body, level=level + 1, **kwargs)
             return too_deep
 
+        visit_TypeConditional = visit_MultiConditional
+
     @classmethod
     def check_subroutine(cls, subroutine, rule_report, config, **kwargs):
         '''Check the code body: Nesting of conditional blocks.'''

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -188,6 +188,8 @@ class DataflowAnalysisAttacher(Transformer):
         defines = defines | else_defines
         return self.visit_Node(o, live_symbols=live, defines_symbols=defines, uses_symbols=uses, **kwargs)
 
+    visit_TypeConditional = visit_MultiConditional
+
     def visit_MaskedStatement(self, o, **kwargs):
         live = kwargs.pop('live_symbols', set())
         conditions = self._symbols_from_expr(o.conditions)

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -810,7 +810,7 @@ class FortranCodegen(Stringifier):
         footer = self.format_line('END ASSOCIATE')
         self.depth += self.style.associate_indent
         body = self.visit(o.body, **kwargs)
-        self.depth += self.style.associate_indent
+        self.depth -= self.style.associate_indent
         return self.join_lines(header, body, footer)
 
     def visit_CallStatement(self, o, **kwargs):

--- a/loki/backend/pprint.py
+++ b/loki/backend/pprint.py
@@ -321,6 +321,35 @@ class Stringifier(Visitor):
         body = [item for branch in zip(values, bodies) for item in branch]
         return self.join_lines(header, *body)
 
+    def visit_TypeConditional(self, o, **kwargs):
+        """
+        Format :any:`TypeConditional` as
+
+        .. code-block:: none
+
+           <repr(TypeConditional)>
+             <Class [value(s)]>
+               ...
+             <Type [value(s)]>
+               ...
+             <Default>
+               ...
+        """
+        header = self.format_node(repr(o))
+        self.depth += self.style.indent_default
+        values = []
+        for expr in o.values:
+            value = self.visit(expr[0], **kwargs)
+            values += [self.format_node('Class' if expr[1] else 'Type', value)]
+        if o.else_body:
+            values += [self.format_node('Default')]
+        self.depth += self.style.indent_default
+        bodies = self.visit_all(*o.bodies, o.else_body, **kwargs)
+        self.depth -= self.style.indent_default
+        self.depth -= self.style.indent_default
+        body = [item for branch in zip(values, bodies) for item in branch]
+        return self.join_lines(header, *body)
+
 
 def pprint(ir, stream=None):
     """

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -2468,24 +2468,6 @@ class FParser2IR(GenericVisitor):
 
         return self.visit(o.children[1], **kwargs), is_polymorphic
 
-        # # The banter before the construct...
-        # banter = []
-        # for ch in o.content:
-        #     if isinstance(ch, Fortran2003.Select_Type_Stmt):
-        #         select_stmt = ch
-        #         break
-        #     banter += [self.visit(ch, **kwargs)]
-        # else:
-        #     select_stmt = get_child(o, Fortran2003.Select_Type_Stmt)
-        # # Extract source by looking at everything between SELECT and END SELECT
-        # end_select_stmt = rget_child(o, Fortran2003.End_Select_Type_Stmt)
-        # lines = (select_stmt.item.span[0], end_select_stmt.item.span[1])
-        # string = ''.join(self.raw_source[lines[0]-1:lines[1]]).strip('\n')
-        # source = Source(lines=lines, string=string)
-        # label = self.get_label(select_stmt)
-        # # TODO: Treat this with a dedicated IR node (LOKI-33)
-        # return (*banter, ir.Intrinsic(text=string, label=label, source=source))
-
     #
     # Allocation statements
     #

--- a/loki/frontend/tests/test_frontends.py
+++ b/loki/frontend/tests/test_frontends.py
@@ -1001,3 +1001,68 @@ END SUBROUTINE test_routine
     # NOTE: OMNI always uses single quotes ('') to represent string data in PRINT statements
     #       while fparser will mimic the quotes used in the parsed source code
     assert print_stmts[1].text.lower() == "print *, 'test_text'"
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI fails to read without full module')]))
+def test_select_type(frontend, tmp_path):
+    fcode = """
+module select_type_mod
+    use imported_type_mod, only: imported_type
+    implicit none
+    type, abstract :: base
+    end type base
+    type, extends(base) :: derived1
+        real :: val
+    end type derived1
+    type, extends(base) :: derived2
+        integer :: val
+    end type derived2
+contains
+    subroutine select_type_routine(arg, arg2)
+        class(base), intent(inout) :: arg
+        class(imported_type), intent(inout) :: arg2
+        select type( arg )
+            class is(derived1)
+                arg%val = 1.0
+            class is(derived2)
+                arg%val = 1
+            class default
+                print *, 'error'
+        end select
+        ! Some comment before the second select
+        select type( arg )
+            type is(base)
+                write(*,*) 'default'
+        end select
+        select type( arg2 )
+            ! inline comment
+            type is(imported_type)
+                print *, 'imported type'
+        end select
+    end subroutine select_type_routine
+end module select_type_mod
+    """.strip()
+
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    tconds = FindNodes(ir.TypeConditional).visit(module['select_type_routine'].body)
+    assert len(tconds) == 3
+
+    assert tconds[0].expr == 'arg'
+    assert tconds[0].values == (
+        ('derived1', True), ('derived2', True)
+    )
+    assert len(tconds[0].bodies) == 2
+    assert len(tconds[0].else_body) == 1
+
+    assert tconds[1].expr == 'arg'
+    assert tconds[1].values == (('base', False),)
+    assert not tconds[1].else_body
+
+    assert tconds[2].expr == 'arg2'
+    assert tconds[2].values == (('imported_type', False),)
+    assert not tconds[2].else_body
+
+    comments = FindNodes(ir.Comment).visit(module['select_type_routine'].body)
+    assert len(comments) == 2
+    assert 'Some comment' in comments[0].text
+    assert 'inline comment' in comments[1].text

--- a/loki/ir/transformer.py
+++ b/loki/ir/transformer.py
@@ -596,3 +596,5 @@ class NestedMaskedTransformer(MaskedTransformer):
         # rebuild conditional with remaining branches
         values, bodies = zip(*branches)
         return self._rebuild(o, tuple((expr,) + (values,) + (bodies,) + (else_body,)))
+
+    visit_TypeConditional = visit_MultiConditional

--- a/loki/tools/strings.py
+++ b/loki/tools/strings.py
@@ -66,8 +66,10 @@ class JoinableStringList:
             if len(cont) == 1:
                 cont += ['']
         assert is_iterable(cont) and len(cont) == 2
-        # Reset indentation if we exceed the line length
-        cont = [c.strip() if len(c) >= width else c for c in cont]
+        # Reset indentation if we exceed the line length by just having
+        # both continuation parts on the same line
+        if len(cont[0] + cont[1]) >= width:
+            cont = [c.strip(' ') for c in cont]
         assert all(width > len(c) for c in cont)
 
         self.items = [item for item in items if item is not None]

--- a/loki/tools/strings.py
+++ b/loki/tools/strings.py
@@ -66,6 +66,8 @@ class JoinableStringList:
             if len(cont) == 1:
                 cont += ['']
         assert is_iterable(cont) and len(cont) == 2
+        # Reset indentation if we exceed the line length
+        cont = [c.strip() if len(c) >= width else c for c in cont]
         assert all(width > len(c) for c in cont)
 
         self.items = [item for item in items if item is not None]

--- a/loki/tools/tests/test_tools.py
+++ b/loki/tools/tests/test_tools.py
@@ -174,6 +174,16 @@ def test_joinable_string_list_long():
     assert str(obj) == ref
 
 
+def test_joinable_string_list_exceeding_indentation():
+    items = ['a', 'b', 'c']
+    for depth in range(100):
+        # This should not throw an assertion
+        obj = JoinableStringList(
+            items, sep=' ', width=132,
+            cont=f' &\n{"  " * depth}&')
+        assert all(len(line) <= 132 for line in str(obj).splitlines())
+
+
 @pytest.mark.parametrize('string, length, continuation, ref', [
     ('short string', 16, '...', 'short string'),
     ('short string', 12, '...', 'short string'),

--- a/loki/tools/tests/test_tools.py
+++ b/loki/tools/tests/test_tools.py
@@ -176,10 +176,10 @@ def test_joinable_string_list_long():
 
 def test_joinable_string_list_exceeding_indentation():
     items = ['a', 'b', 'c']
-    for depth in range(100):
+    for depth in range(50, 100):
         # This should not throw an assertion
         obj = JoinableStringList(
-            items, sep=' ', width=132,
+            items, sep='  ' * depth, width=132,
             cont=f' &\n{"  " * depth}&')
         assert all(len(line) <= 132 for line in str(obj).splitlines())
 

--- a/loki/transformations/single_column/vector.py
+++ b/loki/transformations/single_column/vector.py
@@ -145,7 +145,7 @@ class SCCDevectorTransformation(Transformation):
                 for ebody in separator.else_bodies:
                     subsections += cls.extract_vector_sections(ebody, horizontal)
 
-            if isinstance(separator, ir.MultiConditional):
+            if isinstance(separator, (ir.MultiConditional, ir.TypeConditional)):
                 for body in separator.bodies:
                     subsec_body = cls.extract_vector_sections(body, horizontal)
                     if subsec_body:
@@ -276,7 +276,7 @@ def wrap_vector_section_from_dimension(section, routine, horizontal, insert_prag
 def wrap_vector_section(section, routine, bounds, index, insert_pragma=True):
     """
     Wrap a section of nodes in a vector-level loop across the horizontal.
-    
+
     Parameters
     ----------
     section : tuple of :any:`Node`


### PR DESCRIPTION
This is a bugfix PR for a line continuation problem I was facing. In the end it turned out to be the 1-character fix in 0ff12f700de0f5a08a85bf9d00cf4dc45c10387c that was missing, but to get to that realization I implemented a TypeConditional node and a safeguarding against excessive indentation in JoinableStringList. So, we have those now, too.