### PR TITLE
Backend: New generalised "string-conservative" FGen backend

### DIFF
--- a/loki/backend/__init__.py
+++ b/loki/backend/__init__.py
@@ -14,6 +14,7 @@ from loki.backend.cudagen import * # noqa
 from loki.backend.cufgen import * # noqa
 from loki.backend.dacegen import * # noqa
 from loki.backend.fgen import * # noqa
+from loki.backend.fgencon import * # noqa
 from loki.backend.pygen import * # noqa
 from loki.backend.pprint import * # noqa
 from loki.backend.style import * # noqa

--- a/loki/backend/cufgen.py
+++ b/loki/backend/cufgen.py
@@ -60,7 +60,7 @@ class CudaFortranCodegen(FortranCodegen):
         return self.join_items([attr_str] + attributes)
 
 
-def cufgen(ir, style=None, depth=0, conservative=False):
+def cufgen(ir, style=None, depth=0):
     """
     Generate CUDA Fortran code from one or many IR objects/trees.
 
@@ -80,4 +80,4 @@ def cufgen(ir, style=None, depth=0, conservative=False):
     .. _CUDA_FORTRAN_PROGRAMMING_GUIDE: https://docs.nvidia.com/hpc-sdk/compilers/cuda-fortran-prog-guide/index.html
     """
     style = style if style else FortranStyle()
-    return CudaFortranCodegen(style=style, depth=depth, conservative=conservative).visit(ir)
+    return CudaFortranCodegen(style=style, depth=depth).visit(ir)

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -1053,11 +1053,12 @@ def fgen(ir, style=None, depth=0, conservative=False):
     """
     Generate standardized Fortran code from one or many IR objects/trees.
     """
-    from loki.backend.fgencon import FortranCodegenConservative  # pylint: disable=import-outside-toplevel,cyclic-import
-
     style = style if style else FortranStyle()
 
     if conservative:
+        # pylint: disable=import-outside-toplevel,cyclic-import
+        from loki.backend.fgencon import FortranCodegenConservative
+
         return FortranCodegenConservative(style=style, depth=depth).visit(ir) or ''
 
     return FortranCodegen(style=style, depth=depth).visit(ir) or ''

--- a/loki/backend/fgen.py
+++ b/loki/backend/fgen.py
@@ -143,6 +143,12 @@ class FortranCodegen(Stringifier):
         """
         return self.visit(o.ir, **kwargs)
 
+    def _construct_module_header(self, o, **kwargs):
+        return self.format_line('MODULE ', o.name)
+
+    def _construct_module_footer(self, o, **kwargs):
+        return self.format_line('END MODULE ', o.name if self.style.module_end_named else '')
+
     def visit_Module(self, o, **kwargs):
         """
         Format as
@@ -152,8 +158,8 @@ class FortranCodegen(Stringifier):
             ...routines...
           END MODULE
         """
-        header = self.format_line('MODULE ', o.name)
-        footer = self.format_line('END MODULE ', o.name if self.style.module_end_named else '')
+        header = self._construct_module_header(o, **kwargs)
+        footer = self._construct_module_footer(o, **kwargs)
 
         self.depth += self.style.module_spec_indent
 
@@ -245,7 +251,6 @@ class FortranCodegen(Stringifier):
         return self.join_lines(header, docstring, spec, body, footer)
 
     def _construct_subroutine_header(self, o, **kwargs):
-        ftype = 'FUNCTION' if o.is_function else 'SUBROUTINE'
         prefix = self.join_items(o.prefix, sep=' ')
         if o.prefix:
             prefix += ' '
@@ -257,7 +262,7 @@ class FortranCodegen(Stringifier):
         else:
             bind_c = ''
 
-        return self.format_line(prefix, ftype, ' ', o.name, ' (', arguments, ')', bind_c)
+        return self.format_line(prefix, 'SUBROUTINE ', o.name, ' (', arguments, ')', bind_c)
 
     def visit_Subroutine(self, o, **kwargs):
         """

--- a/loki/backend/fgencon.py
+++ b/loki/backend/fgencon.py
@@ -19,11 +19,57 @@ class FortranCodegenConservative(FortranCodegen):
     the frontends where possible.
     """
 
-    def visit(self, o, *args, **kwargs):
-        """
-        Overwrite standard visit routine to inject original source in conservative mode.
-        """
-        if hasattr(o, 'source') and o.source and o.source.status == SourceStatus.VALID:
-            # Re-use original source associated with node
+    def visit_Node(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
             return o.source.string
-        return super().visit(o, *args, **kwargs)
+        return super().visit_Node(o, *args, **kwargs)
+
+    def visit_Assignment(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_Assignment(o, *args, **kwargs)
+
+    def visit_CallStatement(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_CallStatement(o, *args, **kwargs)
+
+    def visit_Comment(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_Comment(o, *args, **kwargs)
+
+    def visit_Conditional(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_Conditional(o, *args, **kwargs)
+
+    def visit_VariableDeclaration(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_VariableDeclaration(o, *args, **kwargs)
+
+    def visit_Import(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_Import(o, *args, **kwargs)
+
+    def visit_Loop(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_Loop(o, *args, **kwargs)
+
+    def visit_Section(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_Section(o, *args, **kwargs)
+
+    def visit_Subroutine(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_Subroutine(o, *args, **kwargs)
+
+    def visit_Module(self, o, *args, **kwargs):
+        if o.source and o.source.status == SourceStatus.VALID:
+            return o.source.string
+        return super().visit_Module(o, *args, **kwargs)

--- a/loki/backend/fgencon.py
+++ b/loki/backend/fgencon.py
@@ -7,6 +7,7 @@
 
 from loki.backend.fgen import FortranCodegen
 from loki.frontend.source import SourceStatus
+from loki.tools.util import as_tuple
 
 
 __all__ = ['FortranCodegenConservative']
@@ -35,7 +36,7 @@ class FortranCodegenConservative(FortranCodegen):
 
             # If LHS hasn't changed, prefer source
             lhs = self.visit(o.lhs, **kwargs) + ' '
-            if slist[0].strip() == lhs.strip():
+            if slist[0] == o.lhs:
                 lhs = slist[0]
             else:
                 # At least prescribe previous indent...
@@ -44,7 +45,7 @@ class FortranCodegenConservative(FortranCodegen):
 
             # If RHS hasn't changed, prefer source
             rhs = ' ' + self.visit(o.rhs, **kwargs)
-            if slist[1].strip() == rhs.strip():
+            if slist[1] == o.rhs:
                 rhs = slist[1]
 
             comment = str(self.visit(o.comment, **kwargs)) if o.comment else ''
@@ -119,13 +120,14 @@ class FortranCodegenConservative(FortranCodegen):
 
             # If type attributes haven't changed, prefer source (and don't indent)
             attributes = str(self.join_items(self._construct_type_attributes(o, **kwargs))) + ' '
-            if slist[0].strip() == attributes.strip():
+            # TODO: Type attributes don't string compare cleanly yet; needs fixing!
+            if slist[0].strip().lower() == attributes.strip().lower():
                 attributes = slist[0]
                 no_indent = True
 
             # If declared variables haven't changed, prefer source
             variables = ' ' + str(self.join_items(self._construct_decl_variables(o, **kwargs)))
-            if slist[1].strip() == variables.strip():
+            if o.symbols == as_tuple(slist[1].split(',')):
                 variables = slist[1]
 
             comment = str(self.visit(o.comment, **kwargs)) if o.comment else ''

--- a/loki/backend/fgencon.py
+++ b/loki/backend/fgencon.py
@@ -83,6 +83,19 @@ class FortranCodegenConservative(FortranCodegen):
     def visit_Loop(self, o, *args, **kwargs):
         if o.source and o.source.status == SourceStatus.VALID:
             return o.source.string
+
+        if o.source and o.source.status == SourceStatus.INVALID_CHILDREN:
+            # Recapture header and footer from source
+            header = o.source.string.splitlines()[0]
+            footer = o.source.string.splitlines()[o.source.lines[1]-o.source.lines[0]]
+
+            pragma = self.visit(o.pragma, **kwargs)
+            pragma_post = self.visit(o.pragma_post, **kwargs)
+            self.depth += self.style.loop_indent
+            body = self.visit(o.body, **kwargs)
+            self.depth -= self.style.loop_indent
+            return self.join_lines(pragma, header, body, footer, pragma_post)
+
         return super().visit_Loop(o, *args, **kwargs)
 
     def visit_Section(self, o, *args, **kwargs):

--- a/loki/backend/fgencon.py
+++ b/loki/backend/fgencon.py
@@ -1,0 +1,29 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki.backend.fgen import FortranCodegen
+from loki.frontend.source import SourceStatus
+
+
+__all__ = ['FortranCodegenConservative']
+
+
+class FortranCodegenConservative(FortranCodegen):
+    """
+    Strictly conservative version of :any:`FortranCodegen` visitor
+    that will attempt to use existing :any:`Source` information from
+    the frontends where possible.
+    """
+
+    def visit(self, o, *args, **kwargs):
+        """
+        Overwrite standard visit routine to inject original source in conservative mode.
+        """
+        if hasattr(o, 'source') and o.source and o.source.status == SourceStatus.VALID:
+            # Re-use original source associated with node
+            return o.source.string
+        return super().visit(o, *args, **kwargs)

--- a/loki/backend/fgencon.py
+++ b/loki/backend/fgencon.py
@@ -67,6 +67,43 @@ class FortranCodegenConservative(FortranCodegen):
     def visit_Subroutine(self, o, *args, **kwargs):
         if o.source and o.source.status == SourceStatus.VALID:
             return o.source.string
+
+        if o.source and o.source.status == SourceStatus.INVALID_CHILDREN:
+            # Re-construct header and footer from source if possible
+            h_end = o.body.source.lines[0] if o.body.source else o.source.lines[1]
+            h_end = min(h_end, o.spec.source.lines[0]) if o.spec.source else h_end
+            if o.docstring:
+                h_end = min(h_end, o.docstring[0].source.lines[0])
+
+            if h_end < o.source.lines[1]:
+                header = '\n'.join(o.source.string.splitlines()[:h_end-o.source.lines[0]])
+            else:
+                header = self._construct_subroutine_header(o, **kwargs)
+
+            # For one-line footers reconstruct from source
+            foot = o.source.string.splitlines()[o.source.lines[1]-o.source.lines[0]]
+            if 'END ' in foot.upper():
+                footer = foot
+            else:
+                footer = self._construct_procedure_footer(o, **kwargs)
+
+            self.depth += self.style.procedure_spec_indent
+            docstring = self.visit(o.docstring, **kwargs)
+            spec = self.visit(o.spec, **kwargs)
+            self.depth -= self.style.procedure_spec_indent
+
+            self.depth += self.style.procedure_body_indent
+            body = self.visit(o.body, **kwargs)
+            self.depth -= self.style.procedure_body_indent
+
+            self.depth += self.style.procedure_contains_indent
+            contains = self.visit(o.contains, **kwargs)
+            self.depth -= self.style.procedure_contains_indent
+            if contains:
+                return self.join_lines(header, docstring, spec, body, contains, footer)
+
+            return self.join_lines(header, docstring, spec, body, footer)
+
         return super().visit_Subroutine(o, *args, **kwargs)
 
     def visit_Module(self, o, *args, **kwargs):

--- a/loki/backend/fgencon.py
+++ b/loki/backend/fgencon.py
@@ -111,14 +111,17 @@ class FortranCodegenConservative(FortranCodegen):
             return o.source.string
 
         if o.source and o.source.status == SourceStatus.INVALID_NODE:
+            no_indent = False
+
             # Attempt to recreate some structure by locating `::`
             slist = o.source.string.split('::', maxsplit=1)
             assert len(slist) == 2
 
-            # If type attributes haven't changed, prefer source
+            # If type attributes haven't changed, prefer source (and don't indent)
             attributes = str(self.join_items(self._construct_type_attributes(o, **kwargs))) + ' '
             if slist[0].strip() == attributes.strip():
                 attributes = slist[0]
+                no_indent = True
 
             # If declared variables haven't changed, prefer source
             variables = ' ' + str(self.join_items(self._construct_decl_variables(o, **kwargs)))
@@ -127,7 +130,7 @@ class FortranCodegenConservative(FortranCodegen):
 
             comment = str(self.visit(o.comment, **kwargs)) if o.comment else ''
 
-            return f'{attributes}::{variables}{comment}'
+            return self.format_line(attributes, '::', variables, comment, no_indent=no_indent)
 
         return super().visit_VariableDeclaration(o, *args, **kwargs)
 

--- a/loki/backend/fgencon.py
+++ b/loki/backend/fgencon.py
@@ -218,14 +218,14 @@ class FortranCodegenConservative(FortranCodegen):
             if h_end < o.source.lines[1]:
                 header = '\n'.join(o.source.string.splitlines()[:h_end-o.source.lines[0]])
             else:
-                header = self._construct_subroutine_header(o, **kwargs)
+                header = self._construct_module_header(o, **kwargs)
 
             # For one-line footers reconstruct from source
             foot = o.source.string.splitlines()[o.source.lines[1]-o.source.lines[0]]
             if 'END ' in foot.upper():
                 footer = foot
             else:
-                footer = self._construct_procedure_footer(o, **kwargs)
+                footer = self._construct_module_footer(o, **kwargs)
 
             self.depth += self.style.module_spec_indent
             spec = self.visit(o.spec, **kwargs)

--- a/loki/backend/tests/test_conservative.py
+++ b/loki/backend/tests/test_conservative.py
@@ -1,0 +1,85 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki import Subroutine, config_override
+from loki.backend import fgen
+from loki.ir import nodes as ir, FindNodes, SubstituteExpressions
+from loki.frontend import FP, SourceStatus
+
+
+def test_fgen_conservative_routine():
+    fcode = """
+SUBROUTINE MY_TEST_ROUTINE( N,DAVE)
+  USE MY_MOD, ONLY : AKIND, RTYPE
+  IMPLICIT NONE
+  INTEGER,          INTENT(IN) :: N
+  TYPE(RTYPE)                 :: RICK ! CAN'T MAKE ARGUMENT YET!
+  REAL(KIND=AKIND), INTENT(INOUT) :: DAVE(N)
+  REAL(KIND=AKIND) :: TMP
+  INTEGER :: I
+
+  DO I=1, N
+    IF (  DAVE(I)    > 0.5) THEN
+      ! Who is DAVE = ...
+      TMP = RICK%A
+      DAVE(I)   =   DAVE( I   )+TMP
+
+         ! BUT ALSO...
+         RICK%B = 42.0
+       ELSE
+          ! ... AND ...
+            DAVE(I) = 66.6
+    END IF
+
+      ! BECAUSE DAVE WILL ...
+      CALL  NEVER_GONNA ( DAVE%YOU_UP   )
+  END DO
+END SUBROUTINE   MY_TEST_ROUTINE
+"""
+    with config_override({'frontend-store-source': True}):
+        routine = Subroutine.from_source(fcode, frontend=FP)
+
+    # Check the untouched output of a few noes
+    s_routine = fgen(routine, conservative=True)
+    assert fcode.strip() == s_routine.strip()
+
+    str_spec = fgen(routine.spec, conservative=True)
+    exp_spec = '\n'.join(fcode.splitlines()[2:9])
+    assert exp_spec.strip() == str_spec.strip()
+
+    str_body = fgen(routine.body, conservative=True)
+    exp_body = '\n'.join(fcode.splitlines()[9:26])
+    assert exp_body.strip() == str_body.strip()
+
+    str_loop = fgen(FindNodes(ir.Loop).visit(routine.body), conservative=True)
+    exp_loop = '\n'.join(fcode.splitlines()[10:26])
+    assert exp_loop == str_loop
+
+    # Use `SubstituteExpressions` to replace RICk with BOB, including in spec!
+    decls = FindNodes(ir.VariableDeclaration).visit(routine.spec)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    rick = routine.variable_map['RICK']
+    bob = routine.Variable(name='BOB', type=rick.type)  # This replicates type info!
+    sub_rick = SubstituteExpressions({rick: bob}, invalidate_source=True)
+
+    routine.spec = sub_rick.visit(routine.spec)
+    routine.body = sub_rick.visit(routine.body)
+
+    routine.source.status = SourceStatus.INVALID_CHILDREN
+    assert routine.spec.source.status == SourceStatus.INVALID_CHILDREN
+    assert routine.body.source.status == SourceStatus.INVALID_CHILDREN
+
+    decls = FindNodes(ir.VariableDeclaration).visit(routine.spec)
+    assert 'bob' in decls[1].symbols and not decls[1].source.status == SourceStatus.VALID
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    assert 'bob%a' == assigns[0].rhs and not assigns[0].source.status == SourceStatus.VALID
+    assert 'bob%b' == assigns[2].lhs and not assigns[2].source.status == SourceStatus.VALID
+
+    # And now check the actual output formatting...
+    expected = fcode.replace('RICK', 'BOB').strip()
+    generated = fgen(routine, conservative=True).strip()
+    assert generated == expected

--- a/loki/backend/tests/test_conservative.py
+++ b/loki/backend/tests/test_conservative.py
@@ -19,7 +19,7 @@ SUBROUTINE MY_TEST_ROUTINE( N,DAVE)
   USE MY_MOD, ONLY : AKIND, RTYPE
   IMPLICIT NONE
   INTEGER,          INTENT(IN) :: N
-  TYPE(RTYPE)                 :: RICK ! CAN'T MAKE ARGUMENT YET!
+  tyPe(RTYPE)                 :: RICK ! CAN'T MAKE ARGUMENT YET!
   REAL(KIND=AKIND), INTENT(INOUT) :: DAVE(N)
   REAL(KIND=AKIND) :: TMP
   INTEGER :: I
@@ -28,13 +28,13 @@ SUBROUTINE MY_TEST_ROUTINE( N,DAVE)
     IF (  DAVE(I)    > 0.5) THEN
       ! Who is DAVE = ...
       TMP = RICK%A
-      DAVE(I)   =   DAVE( I   )+TMP
+      DAvE( I)   = RICK%A
 
          ! BUT ALSO...
-         RICK%B = 42.0
+         RICK%B = DaVe(  i)
        ELSE
           ! ... AND ...
-            DAVE(I) = 66.6
+            DaVE( I ) = 66.6
     END IF
 
       ! BECAUSE DAVE WILL ...
@@ -102,7 +102,7 @@ MODULE MY_TEST_MOD
   USE MY_MOD, ONLY: AKIND, RTYPE
   IMPLICIT NONE
 
-  REAL(KIND=AKIND) ::    DAVE(5)
+  REAL(KIND=AKIND) ::    DaVE(  5 )
 
   CONTAINS
 
@@ -110,7 +110,7 @@ MODULE MY_TEST_MOD
     INTEGER,          INTENT(IN) :: N
     REAL(KIND=AKIND), INTENT(INOUT) :: DAVE(N)
 
-    DAVE(:) = DAVE(:) + 2.0
+    DaVE(:) = DaVE(:) + 2.0
   END SUBROUTINE   A_SHORT_ROUTINE
 END MODULE MY_TEST_MOD
 """

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1855,11 +1855,19 @@ class FParser2IR(GenericVisitor):
                 spec_lines = (spec.body[0].source.lines[0], spec.body[-1].source.lines[1])
                 spec_string = ''.join(self.raw_source[spec_lines[0]-1:spec_lines[1]]).strip('\n')
                 spec._update(source=Source(lines=spec_lines, string=spec_string))
+            else:
+                # Empty spec source object
+                line = source.lines[0] + 1
+                spec._update(source=Source(lines=(line, line), string=''))
 
             if body.body:
                 body_lines = (body.body[0].source.lines[0], body.body[-1].source.lines[1])
                 body_string = ''.join(self.raw_source[body_lines[0]-1:body_lines[1]]).strip('\n')
                 body._update(source=Source(lines=body_lines, string=body_string))
+            else:
+                # Empty body source object
+                line = spec.source.lines[1] + 1
+                body._update(source=Source(lines=(line, line), string=''))
 
         # Finally, call the subroutine constructor on the object again to register all
         # bits and pieces in place and rescope all symbols

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1862,7 +1862,7 @@ class FParser2IR(GenericVisitor):
 
             if body.body:
                 body_lines = (body.body[0].source.lines[0], body.body[-1].source.lines[1])
-                body_string = ''.join(self.raw_source[body_lines[0]-1:body_lines[1]]).strip('\n')
+                body_string = ''.join(self.raw_source[body_lines[0]-1:body_lines[1]]).rstrip('\n')
                 body._update(source=Source(lines=body_lines, string=body_string))
             else:
                 # Empty body source object

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -374,6 +374,9 @@ def parse_regex_source(source, parser_classes=None, scope=None):
     timeout_message = f'REGEX frontend timeout of {config["regex-frontend-timeout"]} s exceeded'
     with timeout(config['regex-frontend-timeout'], message=timeout_message):
         ir_ = Pattern.match_block_candidates(reader, candidates, parser_classes=parser_classes, scope=scope)
+
+    lines = (1, source.count('\n') + 1)
+    source = Source(lines, string=source)
     return ir.Section(body=as_tuple(ir_), source=source)
 
 

--- a/loki/frontend/source.py
+++ b/loki/frontend/source.py
@@ -157,11 +157,21 @@ class Source:
             for idx, line in enumerate(self.string.splitlines())
         ]
 
-    def invalidate(self):
+    def invalidate(self, children=False):
         """
-        Return an invalid copy of this source with ``status=SourceStatus=INVALID_NODE``.
+        Set the status of this source to ``SourceStatus.INVALID_NODE``
+        or ``SourceStatus.INVALID_CHILDREN``.
+
+        Calling ``source.invalidate()`` marks the entire source object as invalid,
+        while ``source.invalidate(children=True)`` denotes that interior properties the
+        associated node have not been changed, but its children have been invalidated.
         """
-        return self.clone(status=SourceStatus.INVALID_NODE)
+        self.status = SourceStatus.INVALID_CHILDREN if children else SourceStatus.INVALID_NODE
+        return self
+
+    def is_valid(self):
+        """ Returns ``True`` if the :any:`Source` object is still valid. """
+        return self.status == SourceStatus.VALID
 
 
 class FortranReader:

--- a/loki/frontend/tests/test_fparser_source.py
+++ b/loki/frontend/tests/test_fparser_source.py
@@ -168,9 +168,13 @@ end module test_source_mod
         routine = module['my_test_routine']
 
     if store_source:
+        assert module.spec.source and module.spec.source.lines == (3, 10)
+        assert module.contains.source and module.contains.source.lines == (11, 27)
         assert routine.spec.source and routine.spec.source.lines == (14, 16)
         assert routine.body.source and routine.body.source.lines == (17, 26)
     else:
+        assert not module.spec.source
+        assert not module.contains.source
         assert not routine.spec.source
         assert not routine.body.source
 

--- a/loki/ir/expr_visitors.py
+++ b/loki/ir/expr_visitors.py
@@ -11,7 +11,6 @@ Visitor classes for traversing and transforming all expression trees in
 """
 from pymbolic.primitives import Expression
 
-from loki.frontend.source import SourceStatus
 from loki.ir.nodes import Node
 from loki.ir.visitor import Visitor
 from loki.ir.transformer import Transformer
@@ -257,7 +256,7 @@ class ExpressionTransformer(Transformer):
             new = self.expr_mapper(o)
         # Invalidate `Source` object if we've changed the expression
         if kwargs.get('source') and o != new:
-            kwargs['source'].status = SourceStatus.INVALID_NODE
+            kwargs['source'].invalidate()
         return new
 
 

--- a/loki/ir/expr_visitors.py
+++ b/loki/ir/expr_visitors.py
@@ -299,15 +299,38 @@ class SubstituteExpressions(ExpressionTransformer):
 
     def visit_Import(self, o, **kwargs):
         """
-        For :any:`Import` (as well as :any:`VariableDeclaration` and :any:`ProcedureDeclaration`)
-        we set ``recurse_to_declaration_attributes=True`` to make sure properties in the symbol
-        table are updated during dispatch to the expression mapper
+        For :any:`Import` we set ``recurse_to_declaration_attributes=True``
+        to make sure properties in the symbol table are updated during
+        dispatch to the expression mapper.
         """
         kwargs['recurse_to_declaration_attributes'] = True
         return super().visit_Node(o, **kwargs)
 
-    visit_VariableDeclaration = visit_Import
-    visit_ProcedureDeclaration = visit_Import
+    def visit_VariableDeclaration(self, o, **kwargs):
+        """
+        For :any:`VariableDeclaration`  or :any:`ProcedureDeclaration`
+        we set ``recurse_to_declaration_attributes=True`` to make sure
+        properties in the symbol table are updated during dispatch to
+        the expression mapper.
+
+        If source invalidation is being requested, we also check the
+        associated type (on first symbol) to track changes there.
+        """
+        kwargs['recurse_to_declaration_attributes'] = True
+
+        # Store a copy of the old type, as it will be in-place updated
+        old_type = o.symbols[0].type.clone() if self.invalidate_source else None
+        new = super().visit_Node(o, **kwargs)
+
+        # Check the type if we're tracking source invalidation
+        if self.invalidate_source and o.source:
+            if old_type != o.symbols[0].type:
+                new.source.invalidate()
+
+        return new
+
+    # visit_VariableDeclaration = visit_Import
+    visit_ProcedureDeclaration = visit_VariableDeclaration
 
 
 class SubstituteStringExpressions(SubstituteExpressions):

--- a/loki/ir/tests/test_transformer.py
+++ b/loki/ir/tests/test_transformer.py
@@ -55,7 +55,7 @@ end subroutine routine_simple
     new_expr = sym.Sum((*stmt.rhs.children[:-1], sym.FloatLiteral(2.)))
 
     # Check source invalidation via status flags
-    mapper = {stmt: stmt.clone(rhs=new_expr, source=stmt.source.invalidate())}
+    mapper = {stmt: stmt.clone(rhs=new_expr, source=stmt.source.clone().invalidate())}
     body_invalid_source = Transformer(mapper, invalidate_source=True).visit(routine.body)
 
     # Check that original source has not been modified
@@ -131,7 +131,7 @@ end subroutine routine_simple
 
     cond = get_conditional(routine.ir)
     new_stmt = ir.Assignment(lhs=routine.arguments[0], rhs=routine.arguments[1])
-    mapper = {cond: (new_stmt, cond.clone(source=cond.source.invalidate()))}
+    mapper = {cond: (new_stmt, cond.clone(source=cond.source.clone().invalidate()))}
 
     body_invalid_source = Transformer(mapper, invalidate_source=True).visit(routine.body)
 

--- a/loki/ir/transformer.py
+++ b/loki/ir/transformer.py
@@ -8,7 +8,7 @@
 """
 Visitor classes for transforming the IR
 """
-from loki.frontend.source import Source, SourceStatus
+from loki.frontend.source import Source
 from loki.ir.nodes import Node, Conditional, ScopedNode
 from loki.ir.visitor import Visitor
 from loki.tools import flatten, is_iterable, as_tuple, replace_windowed
@@ -23,7 +23,7 @@ __all__ = [
 def is_source_valid(source):
     """ Determine the validty status of a given :any:`Node` """
     if source and isinstance(source, Source):
-        return source.status == SourceStatus.VALID
+        return source.is_valid()
     return False
 
 
@@ -101,9 +101,8 @@ class Transformer(Visitor):
             # If any child node has been invalidated, mark this node as invalid too
             if is_source_valid(args_frozen.get('source')):
                 if any(isinstance(c, Node) and not is_source_valid(c) for c in flatten(children)):
-                    args_frozen['source'] = args_frozen['source'].clone(
-                        status=SourceStatus.INVALID_CHILDREN
-                    )
+                    args_frozen['source'] = args_frozen['source'].clone()
+                    args_frozen['source'].invalidate(children=True)
 
         if self.inplace:
             # Updated nodes in place, if requested

--- a/loki/lint/tests/test_linter.py
+++ b/loki/lint/tests/test_linter.py
@@ -531,15 +531,15 @@ def test_linter_lint_files_fix(tmp_path, config, backup_suffix):
         @classmethod
         def fix_sourcefile(cls, sourcefile, rule_report, config):
             if rule_report.problem_reports:
-                subroutine.source.status = SourceStatus.INVALID_CHILDREN
-                subroutine.ir.status = SourceStatus.INVALID_CHILDREN
+                subroutine.source.invalidate(children=True)
+                subroutine.ir.source.invalidate(children=True)
 
         @classmethod
         def fix_subroutine(cls, subroutine, rule_report, config):
             assert len(rule_report.problem_reports) == 1
             if rule_report.problem_reports[0].location is subroutine:
                 subroutine.name = subroutine.name.upper()
-                subroutine.source.status = SourceStatus.INVALID_NODE
+                subroutine.source.invalidate()
                 return {None: None}
             return {}
 

--- a/loki/lint/tests/test_linter.py
+++ b/loki/lint/tests/test_linter.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree as ET
 import pytest
 from fparser.two.utils import FortranSyntaxError
 
-from loki import Sourcefile, Assignment, FindNodes, FindVariables
+from loki import Sourcefile, Assignment, FindNodes, FindVariables, SourceStatus
 from loki.lint import (
     GenericHandler, Reporter, Linter, GenericRule,
     LinterTransformation, lint_files, LazyTextfile
@@ -531,13 +531,15 @@ def test_linter_lint_files_fix(tmp_path, config, backup_suffix):
         @classmethod
         def fix_sourcefile(cls, sourcefile, rule_report, config):
             if rule_report.problem_reports:
-                sourcefile._source = None
+                subroutine.source.status = SourceStatus.INVALID_CHILDREN
+                subroutine.ir.status = SourceStatus.INVALID_CHILDREN
 
         @classmethod
         def fix_subroutine(cls, subroutine, rule_report, config):
             assert len(rule_report.problem_reports) == 1
             if rule_report.problem_reports[0].location is subroutine:
                 subroutine.name = subroutine.name.upper()
+                subroutine.source.status = SourceStatus.INVALID_NODE
                 return {None: None}
             return {}
 

--- a/loki/lint/utils.py
+++ b/loki/lint/utils.py
@@ -8,7 +8,6 @@
 from hashlib import md5
 import re
 
-from loki import SourceStatus
 from loki.ir import Comment, CommentBlock, LeafNode, FindNodes, Transformer
 from loki.module import Module
 from loki.sourcefile import Sourcefile
@@ -30,7 +29,7 @@ class Fixer:
         """
         # TODO: implement this!
         if reports:
-            module.source.status = SourceStatus.INVALID_NODE
+            module.source.invalidate()
         return module
 
     @classmethod
@@ -47,10 +46,10 @@ class Fixer:
             # Apply the changes and invalidate source objects
             subroutine.spec = Transformer(mapper).visit(subroutine.spec)
             subroutine.body = Transformer(mapper).visit(subroutine.body)
-            subroutine.source.status = SourceStatus.INVALID_NODE
+            subroutine.source.invalidate()
             parent = subroutine.parent
             while parent is not None:
-                parent.source.status = SourceStatus.INVALID_NODE
+                parent.source.invalidate(children=True)
                 parent = getattr(parent, 'parent', None)
 
         return subroutine
@@ -62,8 +61,8 @@ class Fixer:
         """
         # TODO: implement this!
         if reports:
-            sourcefile.source.status = SourceStatus.INVALID_CHILDREN
-            sourcefile.ir.source.status = SourceStatus.INVALID_NODE
+            sourcefile.source.invalidate(children=True)
+            sourcefile.ir.source.invalidate(children=True)
         return sourcefile
 
     @classmethod

--- a/loki/lint/utils.py
+++ b/loki/lint/utils.py
@@ -8,6 +8,7 @@
 from hashlib import md5
 import re
 
+from loki import SourceStatus
 from loki.ir import Comment, CommentBlock, LeafNode, FindNodes, Transformer
 from loki.module import Module
 from loki.sourcefile import Sourcefile
@@ -29,7 +30,7 @@ class Fixer:
         """
         # TODO: implement this!
         if reports:
-            module._source = None
+            module.source.status = SourceStatus.INVALID_NODE
         return module
 
     @classmethod
@@ -46,10 +47,10 @@ class Fixer:
             # Apply the changes and invalidate source objects
             subroutine.spec = Transformer(mapper).visit(subroutine.spec)
             subroutine.body = Transformer(mapper).visit(subroutine.body)
-            subroutine._source = None
+            subroutine.source.status = SourceStatus.INVALID_NODE
             parent = subroutine.parent
             while parent is not None:
-                parent._source = None
+                parent.source.status = SourceStatus.INVALID_NODE
                 parent = getattr(parent, 'parent', None)
 
         return subroutine
@@ -61,7 +62,8 @@ class Fixer:
         """
         # TODO: implement this!
         if reports:
-            sourcefile._source = None
+            sourcefile.source.status = SourceStatus.INVALID_CHILDREN
+            sourcefile.ir.source.status = SourceStatus.INVALID_NODE
         return sourcefile
 
     @classmethod

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -792,7 +792,7 @@ class ProgramUnit(Scope):
         """
         if cuf:
             from loki.backend.cufgen import cufgen # pylint: disable=import-outside-toplevel
-            return cufgen(self, conservative=conservative)
+            return cufgen(self)
         from loki.backend.fgen import fgen  # pylint: disable=import-outside-toplevel
         return fgen(self, conservative=conservative)
 

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -263,6 +263,7 @@ class Sourcefile:
 
         lines = (1, raw_source.count('\n') + 1)
         source = Source(lines, string=raw_source, file=path)
+        ir._update(source=source)
         return cls(path=path, ir=ir, ast=ast, source=source)
 
     @classmethod

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -426,7 +426,7 @@ class Sourcefile:
 
     def to_fortran(self, conservative=False, cuf=False, style=None):
         if cuf:
-            return cufgen(self, conservative=conservative, style=style)
+            return cufgen(self, style=style)
         return fgen(self, conservative=conservative, style=style)
 
     @property


### PR DESCRIPTION
~_Integration note: This is based on top of PR #524 and needs to be reviewed/merged after._~

This PR brings in a rudimentary rethink of the "conservative" `fgen` option that is based on a dedicated backend visitor that aims to re-create as much of the original source string as possible. The purpose of this is to then create string output that only captures the changes to the IR/expression tree in comparison to the originally parsed source, which would allow us to generate reasonably a diff/patch when comparing to the original file. **Please note that this is not yet far enough for diff-generation(!) in all cases**, but provides a first set of changes that can recapture a significant amount the original source (eg. non-conformant indentation).

In particular, up to now, we hard-invalidated the source as soon as a node, or any of its children was touched. Following PR #524 we now retain the source object and track its status, allowing us to even recover partial matches when a node or its children have changed. For example, for an `Assignment` or `VariableDeclaration` we let `fgen` create the respective string to the left and right of the delimiter (`=` and `::` respectively), and compare the expression to the original source - allowing us to prefer if we detect no change in, eg. the LHS expression. Similarly, if only the children of a `Loop` or `Conditional` have changed, we use the original source to re-capture the loop or condition or conditional expression. And finally we attempt to re-capture the header/footer of subroutines if possible to capture non-standard indentation and whitespaces.

Final remark: I'm sure there's a lot more that can be done to break this, but I had to start somewhere. 😉 

Edit: Post-rebase I also slightly changed the behaviour of the source invalidation API, so that we can now tell each node to `node.source.invalidate(children=True/False)`, and then query it with `node.source.is_valid()`. This avoids having to import the enum type that we use to track the status.