### PR TITLE
Introduce '__bool__' method for LogicLiterals

### DIFF
--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1143,6 +1143,9 @@ class LogicLiteral(StrCompareMixin, _Literal):
     def __getinitargs__(self):
         return (self.value, )
 
+    def __bool__(self):
+        return self.value
+
     mapper_method = intern('map_logic_literal')
 
 

--- a/loki/expression/tests/test_parser.py
+++ b/loki/expression/tests/test_parser.py
@@ -406,7 +406,7 @@ def test_expression_parser_evaluate(case):
     context = {'VAR1': True, 'VAR2': False}
     test_str = 'VAR1 .AND. VAR2 .AND. .TRUE.'
     parsed = parse_expr(convert_to_case(f'{test_str}', mode=case), evaluate=True, context=context)
-    assert parsed
+    assert not parsed
 
     test_str = '(2*3)**2 - 16'
     parsed = parse_expr(convert_to_case(f'{test_str}', mode=case), evaluate=True)


### PR DESCRIPTION
```py
>>> from loki import parse_expr
>>> expr = parse_expr('.FALSE.')
>>> expr
LogicLiteral(False)
>>> assert expr
>>> print(bool(expr))
True
```

since the normal behaviour is to return True whenever a Node/expression exists.

With this PR:

```py
>>> from loki import parse_expr
>>> expr = parse_expr('.FALSE.')
>>> expr
LogicLiteral(False)
>>> assert expr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
>>> print(bool(expr))
False
```

