### PR TITLE
Reusable cmake macro to update target sources

### DIFF
--- a/loki/frontend/preprocessing.py
+++ b/loki/frontend/preprocessing.py
@@ -215,7 +215,7 @@ class PPRule:
 sanitize_registry = {
     REGEX: {
         # Strip line annotations from Fypp preprocessor
-        'FYPP ANNOTATIONS': PPRule(match=re.compile(r'(# [1-9].*\".*\.fypp\"\n)'), replace=''),
+        'FYPP ANNOTATIONS': PPRule(match=re.compile(r'(# [1-9].*\".*\.(?:fypp|hypp)\"(?:\s+\d+)?\n)'), replace=''),
     },
     OMNI: {},
     FP: {
@@ -251,7 +251,7 @@ sanitize_registry = {
             postprocess=reinsert_open_newunit),
 
         # Strip line annotations from Fypp preprocessor
-        'FYPP ANNOTATIONS': PPRule(match=re.compile(r'(# [1-9].*\".*\.fypp\"\n)'), replace=''),
+        'FYPP ANNOTATIONS': PPRule(match=re.compile(r'(# [1-9].*\".*\.(?:fypp|hypp)\"(?:\s+\d+)?\n)'), replace=''),
     }
 }
 """

--- a/loki/frontend/tests/test_fparser_source.py
+++ b/loki/frontend/tests/test_fparser_source.py
@@ -202,3 +202,31 @@ end module test_source_mod
         assert not tdefs[0].source
         assert not tdecls[0].source
         assert not tdecls[1].source
+
+
+def test_fparser_sanitize_fypp_line_annotations():
+    """
+    Test that fypp line number annotations are sanitized correctly.
+    """
+
+    fcode = """
+module some_templated_mod
+
+# 1 "/path-to-hypp-macro/macro.hypp" 1
+# 2 "/path-to-hypp-macro/macro.hypp"
+# 3 "/path-to-hypp-macro/macro.hypp"
+# 5 "/path-to-fypp-template/template.fypp" 2
+
+integer :: a0
+integer :: a1
+integer :: a2
+integer :: a3
+integer :: a4
+
+end module some_templated_mod
+"""
+
+    module = Module.from_source(fcode, frontend=FP)
+    decls = FindNodes(ir.VariableDeclaration).visit(module.spec)
+
+    assert len(decls) == 5

--- a/loki/frontend/tests/test_regex_frontend.py
+++ b/loki/frontend/tests/test_regex_frontend.py
@@ -1322,3 +1322,31 @@ end subroutine
     assert routine.variable_map['str'].type.length == 10
     assert routine.variable_map['var'].type.dtype == BasicType.REAL
     assert routine.variable_map['var'].type.kind == 'jprb'
+
+
+def test_regex_sanitize_fypp_line_annotations():
+    """
+    Test that fypp line number annotations are sanitized correctly.
+    """
+
+    fcode = """
+module some_templated_mod
+
+# 1 "/path-to-hypp-macro/macro.hypp" 1
+# 2 "/path-to-hypp-macro/macro.hypp"
+# 3 "/path-to-hypp-macro/macro.hypp"
+# 5 "/path-to-fypp-template/template.fypp" 2
+
+integer :: a0
+integer :: a1
+integer :: a2
+integer :: a3
+integer :: a4
+
+end module some_templated_mod
+"""
+
+    module = Module.from_source(fcode, frontend=REGEX)
+    decls = FindNodes(ir.VariableDeclaration).visit(module.spec)
+
+    assert len(decls) == 5


### PR DESCRIPTION
A small PR that turns the functionality of updating a target's sources into a reusable macro that Loki exports. I've also piggybacked a small fix to the fypp line number annotation sanitization.