### PR TITLE
Various fixes to SCC separator nodes 

### DIFF
--- a/loki/dimension.py
+++ b/loki/dimension.py
@@ -188,4 +188,5 @@ class Dimension:
         exprs += (f'1:{self.size}', )
         if self.bounds:
             exprs += (f'{self.bounds[1]} - {self.bounds[0]} + 1', )
+            exprs += (f'{self.bounds[0]}:{self.bounds[1]}', )
         return exprs

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -7,6 +7,7 @@
 
 from loki.batch import Transformation
 from loki.expression import symbols as sym
+from loki.frontend import HAVE_FP
 from loki.ir import (
     nodes as ir, FindNodes, Transformer, FindExpressions,
     SubstituteExpressions
@@ -17,6 +18,8 @@ from loki.transformations.sanitise import do_resolve_associates
 from loki.transformations.utilities import (
     get_integer_variable, get_loop_bounds, check_routine_sequential
 )
+if HAVE_FP:
+    from fparser.two import Fortran2003
 
 
 __all__ = ['SCCBaseTransformation']
@@ -113,8 +116,10 @@ class SCCBaseTransformation(Transformation):
         mapper = {}
         for stmt in FindNodes(ir.Assignment).visit(routine.body):
             # We want to preserve vector notation for an array reduction intrinsic
-            if isinstance(stmt.rhs, sym.InlineCall) and isinstance(stmt.lhs, sym.Scalar):
-                continue
+            if HAVE_FP:
+                if any(redux_op in FindExpressions().visit(stmt.rhs)
+                       for redux_op in Fortran2003.Intrinsic_Name.array_reduction_names):
+                    continue
 
             ranges = [e for e in FindExpressions().visit(stmt)
                       if isinstance(e, sym.RangeIndex) and e == bounds_str]

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -112,6 +112,10 @@ class SCCBaseTransformation(Transformation):
 
         mapper = {}
         for stmt in FindNodes(ir.Assignment).visit(routine.body):
+            # We want to preserve vector notation for an array reduction intrinsic
+            if isinstance(stmt.rhs, sym.InlineCall) and isinstance(stmt.lhs, sym.Scalar):
+                continue
+
             ranges = [e for e in FindExpressions().visit(stmt)
                       if isinstance(e, sym.RangeIndex) and e == bounds_str]
             if ranges:

--- a/loki/transformations/single_column/devector.py
+++ b/loki/transformations/single_column/devector.py
@@ -66,9 +66,30 @@ class SCCDevectorTransformation(Transformation):
         nodes that are not assignments involving vector parallel arrays.
     """
 
+    _scope_node_types = (ir.Loop, ir.Conditional, ir.MultiConditional)
+
     def __init__(self, horizontal, trim_vector_sections=False):
         self.horizontal = horizontal
         self.trim_vector_sections = trim_vector_sections
+
+    @classmethod
+    def _add_separator(cls, node, section, separator_nodes):
+        """
+        Add either the current node or its highest ancestor scope to the list of separator nodes.
+        """
+
+        if node in section:
+            # If the node is at the current section's level, it's a separator
+            separator_nodes.append(node)
+
+        else:
+            # If the node is deeper in the IR tree, it's highest ancestor is used
+            ancestors = flatten(FindScopes(node).visit(section))
+            ancestor_scopes = [a for a in ancestors if isinstance(a, cls._scope_node_types)]
+            if len(ancestor_scopes) > 0 and ancestor_scopes[0] not in separator_nodes:
+                separator_nodes.append(ancestor_scopes[0])
+
+        return separator_nodes
 
     @classmethod
     def extract_vector_sections(cls, section, horizontal):
@@ -85,8 +106,6 @@ class SCCDevectorTransformation(Transformation):
             The dimension specifying the horizontal vector dimension
         """
 
-        _scope_node_types = (ir.Loop, ir.Conditional, ir.MultiConditional)
-
         # Identify outer "scopes" (loops/conditionals) constrained by recursive routine calls
         calls = FindNodes(ir.CallStatement).visit(section)
         pragmas = [pragma for pragma in FindNodes(ir.Pragma).visit(section) if pragma.keyword.lower() == "loki" and
@@ -101,22 +120,14 @@ class SCCDevectorTransformation(Transformation):
                 if check_routine_sequential(routine=call.routine):
                     continue
 
-            if call in section:
-                # If the call is at the current section's level, it's a separator
-                separator_nodes.append(call)
-
-            else:
-                # If the call is deeper in the IR tree, it's highest ancestor is used
-                ancestors = flatten(FindScopes(call).visit(section))
-                ancestor_scopes = [a for a in ancestors if isinstance(a, _scope_node_types)]
-                if len(ancestor_scopes) > 0 and ancestor_scopes[0] not in separator_nodes:
-                    separator_nodes.append(ancestor_scopes[0])
+            separator_nodes = cls._add_separator(call, section, separator_nodes)
 
         for pragma in FindNodes(ir.Pragma).visit(section):
             # Reductions over thread-parallel regions should be marked as a separator node
             if (is_loki_pragma(pragma, starts_with='vector-reduction') or
                 is_loki_pragma(pragma, starts_with='end vector-reduction')):
-                separator_nodes.append(pragma)
+
+                separator_nodes = cls._add_separator(pragma, section, separator_nodes)
 
         # Extract contiguous node sections between separator nodes
         assert all(n in section for n in separator_nodes)

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -109,6 +109,8 @@ class BaseRevectorTransformation(Transformation):
         to define the horizontal data dimension and iteration space.
     """
 
+    _reduction_match_pattern = r'reduction\([\+\w:0-9 \t]+\)'
+
     def __init__(self, horizontal):
         self.horizontal = horizontal
 
@@ -127,7 +129,7 @@ class BaseRevectorTransformation(Transformation):
         with pragma_regions_attached(routine):
             for region in FindNodes(ir.PragmaRegion).visit(section):
                 if is_loki_pragma(region.pragma, starts_with='vector-reduction'):
-                    if (reduction_clause := re.search(r'reduction\([\w:0-9 \t]+\)', region.pragma.content)):
+                    if (reduction_clause := re.search(self._reduction_match_pattern, region.pragma.content)):
 
                         loops = FindNodes(ir.Loop).visit(region)
                         assert len(loops) == 1
@@ -303,7 +305,7 @@ class SCCSeqRevectorTransformation(BaseRevectorTransformation):
         with pragma_regions_attached(routine):
             for region in FindNodes(ir.PragmaRegion).visit(section):
                 if is_loki_pragma(region.pragma, starts_with='vector-reduction'):
-                    if (reduction_clause := re.search(r'reduction\([\w:0-9 \t]+\)', region.pragma.content)):
+                    if (reduction_clause := re.search(self._reduction_match_pattern, region.pragma.content)):
 
                         loops = FindNodes(ir.Loop).visit(region)
                         if loops:

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -109,7 +109,7 @@ class BaseRevectorTransformation(Transformation):
         to define the horizontal data dimension and iteration space.
     """
 
-    _reduction_match_pattern = r'reduction\([\+\w:0-9 \t]+\)'
+    _reduction_match_pattern = r'reduction\([\+\*\.\w \t]+:[\w\, \t]+\)'
 
     def __init__(self, horizontal):
         self.horizontal = horizontal

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -293,26 +293,15 @@ class SCCSeqRevectorTransformation(BaseRevectorTransformation):
 
     def mark_vector_reductions(self, routine, section):
         """
-        Mark vector-reduction loops in marked vector-reduction
-        regions.
-        If a region explicitly marked with
-        ``!$loki vector-reduction(<reduction clause>)``/
-        ``!$loki end vector-reduction`` is encountered, we replace
-        existing ``!$loki loop vector`` loop pragmas and add the
-        reduction keyword and clause. These will be turned into
-        OpenACC equivalents by :any:`SCCAnnotate`.
+        Vector reductions are not applicable to sequential routines
+        so we raise an axception here.
         """
+
         with pragma_regions_attached(routine):
             for region in FindNodes(ir.PragmaRegion).visit(section):
                 if is_loki_pragma(region.pragma, starts_with='vector-reduction'):
-                    if (reduction_clause := re.search(self._reduction_match_pattern, region.pragma.content)):
-
-                        loops = FindNodes(ir.Loop).visit(region)
-                        if loops:
-                            pragma = ir.Pragma(keyword='loki', content=f'loop vector {reduction_clause[0]}')
-                            # Update loop and region in place to remove marker pragmas
-                            loops[0]._update(pragma=(pragma,))
-                            region._update(pragma=None, pragma_post=None)
+                    if re.search(self._reduction_match_pattern, region.pragma.content):
+                        raise RuntimeError(f'[Loki::SCCSeq] Vector reduction invalid in seq routine {routine.name}')
 
     @staticmethod
     def _get_loop_bound(bound, call_arg_map):

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -1049,7 +1049,7 @@ def test_scc_vector_reduction(frontend, pipeline, horizontal, blocking):
        integer, dimension(nlon), intent(in) :: mij
        logical, intent(in) :: lcond
 
-       integer :: jl, maxij, sumij
+       integer :: jl, maxij, sumij, sum0
 
        maxij = -1
        !$loki vector-reduction( mAx:maXij )
@@ -1064,11 +1064,11 @@ def test_scc_vector_reduction(frontend, pipeline, horizontal, blocking):
 
        if (lcond) then
           sumij = 0
-          !$loki vector-reduction( +:sumij )
+          !$loki vector-reduction( +: sUmij, sUm0 )
           do jl=start,end
              sumij = sumij + mij(jl)
           enddo
-          !$loki end vector-reduction( +:sumij )
+          !$loki end vector-reduction( +: sUmij, sUm0 )
        endif
 
        do jl=start,end
@@ -1107,13 +1107,13 @@ def test_scc_vector_reduction(frontend, pipeline, horizontal, blocking):
             loops = FindNodes(Loop).visit(routine.body)
             assert len(loops) == 4
             assert loops[0].pragma[0].content == 'loop vector reduction( mAx:maXij )'
-            assert loops[2].pragma[0].content == 'loop vector reduction( +:sumij )'
+            assert loops[2].pragma[0].content == 'loop vector reduction( +: sUmij, sUm0 )'
 
             conds = FindNodes(Conditional).visit(routine.body)
             assert len(conds) == 1
             loops = FindNodes(Loop).visit(conds[0].body)
             assert len(loops) == 1
-            assert loops[0].pragma[0].content == 'loop vector reduction( +:sumij )'
+            assert loops[0].pragma[0].content == 'loop vector reduction( +: sUmij, sUm0 )'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -1089,7 +1089,11 @@ def test_scc_vector_reduction(frontend, pipeline, horizontal, blocking):
             assert is_loki_pragma(region.pragma, starts_with = 'vector-reduction')
 
 
-    scc_pipeline.apply(routine, role='kernel', targets=['some_kernel',])
+    if pipeline == SCCSVectorPipeline:
+        with pytest.raises(RuntimeError):
+            scc_pipeline.apply(routine, role='kernel', targets=['some_kernel',])
+    else:
+        scc_pipeline.apply(routine, role='kernel', targets=['some_kernel',])
 
     pragmas = FindNodes(Pragma).visit(routine.body)
     if pipeline == SCCVVectorPipeline:
@@ -1108,15 +1112,6 @@ def test_scc_vector_reduction(frontend, pipeline, horizontal, blocking):
             loops = FindNodes(Loop).visit(conds[0].body)
             assert len(loops) == 1
             assert loops[0].pragma[0].content == 'loop vector reduction( +:sumij )'
-
-    if pipeline == SCCSVectorPipeline:
-        assert len(pragmas) == 4
-        assert pragmas[0].keyword == 'acc'
-        assert pragmas[1].keyword == 'loki'
-        assert 'vector-reduction' in pragmas[1].content
-        assert pragmas[2].keyword == 'loki'
-        assert 'vector-reduction' in pragmas[2].content
-        assert pragmas[3].keyword == 'acc'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -10,7 +10,7 @@ import pytest
 from loki import Subroutine, Sourcefile, Dimension, fgen
 from loki.batch import ProcedureItem
 from loki.expression import Scalar, Array, IntLiteral
-from loki.frontend import available_frontends, OMNI
+from loki.frontend import available_frontends, OMNI, HAVE_FP
 from loki.ir import (
     FindNodes, Assignment, CallStatement, Conditional, Loop,
     Pragma, PragmaRegion, pragmas_attached, is_loki_pragma,
@@ -236,6 +236,7 @@ def test_scc_demote_transformation(frontend, horizontal):
     assert fgen(assigns[10]).lower() == 'q(jl, nz) = q(jl, nz)*c + b(3)'
 
 
+@pytest.mark.xfail(not HAVE_FP, reason="Identification of array reduction intrinsics requires fparser.")
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('acc_data', ['default', 'copyin', None])
 def test_scc_annotate_openacc(frontend, horizontal, blocking, acc_data):
@@ -358,6 +359,7 @@ def test_scc_annotate_openacc(frontend, horizontal, blocking, acc_data):
                 'parallel loop gang private(other_var, more_var) vector_length(nlon)',
                 'parallel loop gang private(more_var, other_var) vector_length(nlon)'
             )
+
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('directive', [None, 'openacc', 'omp-gpu'])
@@ -1318,3 +1320,39 @@ def test_scc_inline_and_sequence_association(
 
         assign = FindNodes(Assignment).visit(loop.body)[0]
         assert fgen(assign).lower() == 'work(jl) = 1.'
+
+
+@pytest.mark.xfail(not HAVE_FP, reason="Identification of array reduction intrinsics requires fparser.")
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_scc_resolve_vector_dimension(frontend, horizontal):
+    """
+    Test SCC vector resolution utility.
+    """
+
+    fcode = """
+subroutine kernel(start, end, nlon, work)
+   integer, intent(in) :: start, end, nlon
+   real, intent(out) :: work(nlon)
+   integer :: jl
+   real :: work_maxval
+
+   work(start:end) = 0.
+   work_maxval = maxval(work(start:end))
+
+end subroutine kernel
+"""
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    SCCBaseTransformation.resolve_vector_dimension(routine, routine.variable_map[horizontal.index],
+                                                   horizontal.bounds)
+
+    loops = FindNodes(Loop).visit(routine.body)
+    assigns = FindNodes(Assignment).visit(routine.body)
+    assert len(assigns) == 2
+
+    assert len(loops) == 1
+    assert assigns[0] in loops[0].body
+    assert not assigns[1] in loops[0].body
+
+    assert 'maxval' == assigns[1].rhs.name.lower()
+    assert 'start:end' in assigns[1].rhs.parameters[0].dimensions

--- a/loki/transformations/single_column/tests/test_scc_hoist.py
+++ b/loki/transformations/single_column/tests/test_scc_hoist.py
@@ -176,11 +176,12 @@ def test_scc_hoist_multiple_kernels_loops(tmp_path, frontend, trim_vector_sectio
     """
 
     fcode_driver = """
-  SUBROUTINE driver(nlon, nz, q, nb)
+  SUBROUTINE driver(nlon, nz, q, nb, lflag)
     use kernel_mod, only: kernel
     implicit none
     INTEGER, INTENT(IN)   :: nlon, nz, nb  ! Size of the horizontal and vertical
     REAL, INTENT(INOUT)   :: q(nlon,nz,nb)
+    LOGICAL, INTENT(IN)   :: lflag
     REAL                  :: c, tmp(nlon,nz,nb)
     INTEGER :: b, jk, jl, start, end
 
@@ -219,13 +220,15 @@ def test_scc_hoist_multiple_kernels_loops(tmp_path, frontend, trim_vector_sectio
 
     !$loki driver-loop
     do b=3, nb
-      end = nlon - nb
-      !$loki separator
-      do jk = 2, nz
-        do jl = start, end
-          q(jl, jk, b) = 2.0 * jk * jl
+      if (lflag) then
+        end = nlon - nb
+        !$loki separator
+        do jk = 2, nz
+          do jl = start, end
+            q(jl, jk, b) = 2.0 * jk * jl
+          end do
         end do
-      end do
+      endif
     end do
   END SUBROUTINE driver
 """.strip()


### PR DESCRIPTION
This PR includes the following fixes/updates to the identification of SCC separator nodes:
- Vector inline calls, typically an array reduction intrinsic like `SUM`, are now marked as separator nodes
- Pointer association to a horizontal array target is also marked as a separator node
- Explicit `!$loki separator` pragmas can now be placed at an arbitrary nesting depth inside a subroutine body
- Explicit `!$loki vector-reduction` pragmas can now be placed at an arbitrary nesting depth inside a subroutine body
- An exception is now raised when an explicit `!$loki vector-reduction` pragma is discovered during an SCCSeq transformation