### PR TITLE
Remove unused arguments in a call-tree

### DIFF
--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -10,12 +10,12 @@ Collection of utilities to automatically remove code elements or
 section and to perform Dead Code Elimination.
 """
 
+from loki.analyse import dataflow_analysis_attached
 from loki.batch import Transformation
 from loki.expression import simplify, symbols as sym
-from loki.tools import flatten, as_tuple
 from loki.ir import Conditional, Transformer, Comment, CallStatement, FindNodes, FindVariables
 from loki.ir.pragma_utils import is_loki_pragma, pragma_regions_attached
-from loki.analyse import dataflow_analysis_attached
+from loki.tools import flatten, as_tuple
 from loki.types import BasicType
 
 

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -535,8 +535,7 @@ def test_remove_code_unused_args(frontend, source_with_args, kernel_override, tm
     config = {
         'default': {
             'role': 'kernel', 'expand': True, 'strict': False,
-            'disable': ['dr_hook', 'abor1'], 'enable_imports': True,
-            'block': ['an_unused_kernel']
+            'enable_imports': True, 'block': ['an_unused_kernel']
         },
         'routines': {
             'driver': {'role': 'driver'},

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -131,7 +131,7 @@ end module types_mod
 """
 
     fcode_driver = """
-subroutine driver(dims, struct)
+subroutine driver(dims, StrUct)
     use types_mod, only : dims_type, some_unused_type
     implicit none
     type(dims_type), intent(in) :: dims
@@ -139,18 +139,18 @@ subroutine driver(dims, struct)
     real, dimension(dims%klon) :: a, b, c, d
 
 
-    call kernel(dims%kst, dims%kend, dims, struct, a, b, c, d)
+    call kernel(dims%kst, dims%kend, dIms, sTRucT, a, b, c, d)
 
 end subroutine driver
 """
 
     fcode_kernel = """
-subroutine kernel(kst, kend, dims, struct, a, b, c, d)
+subroutine kernel(kst, kend, diMs, stRUCt, a, b, c, d)
     use types_mod, only : dims_type, some_unused_type
     implicit none
     integer, intent(in) :: kst, kend
-    type(dims_type), intent(in) :: dims
-    type(some_unused_type), intent(in) :: struct
+    type(dims_type), intent(in) :: dIms
+    type(some_unused_type), intent(in) :: StrucT
     real, intent(out), dimension(dims%klon) :: a, b, c, d
     integer :: jrof
 
@@ -160,16 +160,16 @@ subroutine kernel(kst, kend, dims, struct, a, b, c, d)
     enddo
 
     !$loki remove
-    call an_unused_kernel(struct)
+    call an_unused_kernel(stRuCt)
     !$loki end remove
 
-    call another_kernel(kst, kend, d=c, e=d)
+    call another_kernel(kst, kend, d=C, e=D)
 
 end subroutine kernel
 """
 
     fcode_another_kernel = """
-subroutine another_kernel(kst, kend, d, e)
+subroutine another_kernel(kst, kend, D, E)
     implicit none
     integer, intent(in) :: kst, kend
     real, intent(out) :: d(:), e(:)


### PR DESCRIPTION
This PR adds the ability to optionally remove unused arguments from a call-tree. A single reverse pass is used, which means the `Subroutine` signature is updated before the `CallStatement`. That's why `call.arg_map` isn't used but rather the order of the arguments is relied upon to map unused dummy arguments to arguments.