### PR TITLE
Subroutine: Remove automatic derivation of shape from ALLOCATE

### DIFF
--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -1445,7 +1445,9 @@ end module some_mod
     module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     routine = module['some_routine']
     assert 'levels%data' in routine.symbol_attrs
-    shape = routine.symbol_attrs['levels%data'].shape
+    alloc = FindNodes(ir.Allocation).visit(routine.body)[0]
+    assert len(alloc.variables) == 1
+    shape = alloc.variables[0].dimensions
     assert len(shape) == 2
     for i, dim in enumerate(shape):
         assert isinstance(dim, sym.InlineCall)

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1861,10 +1861,6 @@ class FParser2IR(GenericVisitor):
                 decl._update(symbols=tuple(s.clone() if routine.symbol_attrs[s.name].is_stmt_func else s
                                            for s in decl.symbols))
 
-        # For deferred array dimensions on allocatables, we infer the conceptual
-        # dimension by finding any `allocate(var(<dims>))` statements.
-        routine._infer_allocatable_shapes()
-
         # Update array shapes with Loki dimension pragmas
         with pragmas_attached(routine, ir.VariableDeclaration):
             routine.spec = process_dimension_pragmas(routine.spec, scope=routine)
@@ -2514,8 +2510,7 @@ class FParser2IR(GenericVisitor):
         """
         name = self.visit(o.children[0], **kwargs)
         shape = self.visit(o.children[1], **kwargs)
-        name = name.clone(dimensions=shape, type=name.type.clone(shape=shape))
-        return name
+        return name.clone(dimensions=shape)
 
     visit_Allocate_Shape_Spec = visit_Explicit_Shape_Spec
     visit_Allocate_Shape_Spec_List = visit_List

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -430,10 +430,6 @@ class OMNI2IR(GenericVisitor):
             source=routine.source, incomplete=False
         )
 
-        # For deferred array dimensions on allocatables, we infer the conceptual
-        # dimension by finding any `allocate(var(<dims>))` statements.
-        routine._infer_allocatable_shapes()
-
         # Update array shapes with Loki dimension pragmas
         with pragmas_attached(routine, ir.VariableDeclaration):
             routine.spec = process_dimension_pragmas(routine.spec, scope=routine)

--- a/loki/subroutine.py
+++ b/loki/subroutine.py
@@ -137,22 +137,6 @@ class Subroutine(ProgramUnit):
         # Ensure that we are attaching all symbols to the newly create ``self``.
         self.rescope_symbols()
 
-
-    def _infer_allocatable_shapes(self):
-        """
-        Infer variable symbol shapes from allocations of ``allocatable`` arrays.
-        """
-        for alloc in FindNodes(ir.Allocation).visit(self.body):
-            for v in alloc.variables:
-                if isinstance(v, sym.Array):
-                    if alloc.data_source:
-                        new_shape = alloc.data_source.type.shape
-                    else:
-                        new_shape = v.dimensions
-
-                    # Update the type to inject shape info into symbol table
-                    v.type = v.type.clone(shape=new_shape)
-
     @classmethod
     def from_omni(cls, ast, raw_source, definitions=None, parent=None, type_map=None):
         """

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -453,13 +453,12 @@ subroutine routine_dim_shapes(v1, v2, v3, v4, v5)
 
 end subroutine routine_dim_shapes
 """
-    # TODO: Need a named subroutine lookup
     routine = Subroutine.from_source(fcode, frontend=frontend)
     assert routine.arguments == ('v1', 'v2', 'v3(:)', 'v4(v1, v2)', 'v5(0:v1, v2 - 1)')
 
     # Make sure variable/argument shapes on the routine work
     shapes = [fexprgen(v.shape) for v in routine.arguments if isinstance(v, sym.Array)]
-    assert shapes == ['(v1,)', '(v1, v2)', '(0:v1, v2 - 1)']
+    assert shapes == ['(:,)', '(v1, v2)', '(0:v1, v2 - 1)']
 
     # Ensure that all spec variables (including dimension symbols) are scoped correctly
     spec_vars = [v for v in FindVariables(unique=False).visit(routine.spec) if v.name.lower() != 'selected_real_kind']
@@ -469,7 +468,7 @@ end subroutine routine_dim_shapes
     # Ensure shapes of body variables are ok
     b_shapes = [fexprgen(v.shape) for v in FindVariables(unique=False).visit(routine.body)
                 if isinstance(v, sym.Array)]
-    assert b_shapes == ['(v1,)', '(v1,)', '(v1, v2)', '(0:v1, v2 - 1)']
+    assert b_shapes == ['(:,)', '(:,)', '(v1, v2)', '(0:v1, v2 - 1)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/sanitise/tests/test_associates.py
+++ b/loki/transformations/sanitise/tests/test_associates.py
@@ -132,7 +132,9 @@ end subroutine transform_associates_simple
     call = FindNodes(ir.CallStatement).visit(routine.body)[0]
     assert call.kwarguments[0][1] == 'some_array(i)%n'
     assert call.kwarguments[0][1].type.dtype == BasicType.DEFERRED
-    assert routine.variable_map['local_arr'].type.shape == ('a%n',)
+    assert routine.variable_map['local_arr'].type.shape == (':',)
+    allocs = FindNodes(ir.Allocation).visit(routine.body)
+    assert allocs[0].variables[0].dimensions == ('a%n',)
 
     # Now apply the association resolver
     do_resolve_associates(routine)
@@ -144,8 +146,10 @@ end subroutine transform_associates_simple
     assert call.kwarguments[0][1].scope == routine
     assert call.kwarguments[0][1].type.dtype == BasicType.DEFERRED
 
-    # Test the special case of shapes derived from allocations
-    assert routine.variable_map['local_arr'].type.shape == ('some_obj%a%n',)
+    # Test that symbols in the allocation have been resolved
+    assert routine.variable_map['local_arr'].type.shape == (':',)
+    allocs = FindNodes(ir.Allocation).visit(routine.body)
+    assert allocs[0].variables[0].dimensions == ('some_obj%a%n',)
 
 
 @pytest.mark.parametrize('frontend', available_frontends(


### PR DESCRIPTION
~_Note: Sits on top of #543 out of sheer laziness, but should address #195._~

Another housekeeping PR that removes a remnant from the past. This little hack lived in the constructor of subroutines and is no longer needed, I think. I've run this with ecphys regression, and everything is fine, so I would like to remove it instead of re-implementing, as suggested in #195.