### PR TITLE
change behaviour for 'device-present' pragmas

### DIFF
--- a/docs/source/loki_pragma_model.csv
+++ b/docs/source/loki_pragma_model.csv
@@ -3,7 +3,7 @@ Loki,OpenACC,OMP-GPU
 ``update device(...) host(...)``,``update device(...) self(...)``,
 ``unstructured-data in(...) create(...)``,``enter data copyin(...) create(...)``,``target enter data map(to: ...) map(alloc: ...)``
 ``end unstructured-data out(...) delete(...)``,``exit data copyout(...) delete(...)``,``target exit data map(from: ...) map(delete: ...) map(release: ... ???)``
-``structured-data inout(...) in(...) out(...) create(...)``,``data copy(...) copyin(...) copyout(...) create(...)``,``target data map(tofrom: ...) map(to: ...) map(from: ...)``
+``structured-data inout(...) in(...) out(...) create(...) present(...)``,``data copy(...) copyin(...) copyout(...) create(...) present(...)``,``target data map(tofrom: ...) map(to: ...) map(from: ...) map(to: ...)``
 ``end structured-data inout(...) in(...) out(...)``,``end data``,``end target data``
 ``loop gang private(...) vlength(...)``,``parallel loop gang private(...) vector_length(...)``,``target teams distribute thread_limit(...) ???``
 ``end loop gang``,``end parallel loop``,``end target teams distribute``

--- a/loki/transformations/data_offload/offload.py
+++ b/loki/transformations/data_offload/offload.py
@@ -161,11 +161,12 @@ class DataOffloadTransformation(Transformation):
                     else:
                         offload_args = inargs + outargs + inoutargs
                         if offload_args:
-                            present = f' vars({", ".join(offload_args)})'
+                            present = f' present({", ".join(offload_args)})'
                         else:
                             present = ''
-                        pragma = Pragma(keyword='loki', content=f'device-present{present}')
-                        pragma_post = Pragma(keyword='loki', content='end device-present')
+                        pragma = Pragma(keyword='loki', content=f'structured-data {present}')
+                        pragma_post = Pragma(keyword='loki', content='end structured-data')
+
                 else:
                     copyin = f'in({", ".join(inargs)})' if inargs else ''
                     copy = f'inout({", ".join(inoutargs)})' if inoutargs else ''

--- a/loki/transformations/pragma_model.py
+++ b/loki/transformations/pragma_model.py
@@ -123,6 +123,8 @@ class OpenACCPragmaMapper(GenericPragmaMapper):
             content += f' create({params_create})'
         if params_default := parameters.get('default'):
             content += f' default({params_default})'
+        if params_default := parameters.get('present'):
+            content += f' present({params_default})'
         if content:
             return Pragma(keyword='acc', content=f'data{content}')
         return self.default_retval()
@@ -226,8 +228,16 @@ class OpenMPOffloadPragmaMapper(GenericPragmaMapper):
 
     def pmap_structured_data(self, pragma, parameters, **kwargs):
         content = ''
-        if params_in := parameters.get('in'):
-            content += f' map(to: {params_in})'
+        params_in = parameters.get('in', None)
+        params_present = parameters.get('present', None)
+        # both 'in'/'copyin' and 'present' map to 'map(to: ...)'
+        if params_in is not None and params_present is not None:
+            content += f' map(to: {params_in}, {params_present})'
+        else:
+            if params_in is not None:
+                content += f' map(to: {params_in})'
+            if params_present is not None:
+                content += f' map(to: {params_present})'
         if params_inout := parameters.get('inout'):
             content += f' map(tofrom: {params_inout})'
         if params_out := parameters.get('out'):

--- a/loki/transformations/tests/test_pragma_model.py
+++ b/loki/transformations/tests/test_pragma_model.py
@@ -62,6 +62,10 @@ subroutine some_func(ret)
   !$loki unmapped-directive whatever(tmp1) foo(tmp2)
   ! misspelled by purpose
   !$loki create drvice(tmp1)
+  !$loki structured-data present(tmp3, tmp4)
+  !$loki end structured-data
+  !$loki structured-data in(tmp1) present(tmp3, tmp4)
+  !$loki end structured-data
 
 end subroutine some_func
     """.strip()
@@ -105,7 +109,11 @@ end subroutine some_func
                 ('acc', 'data deviceptr(tmp1, tmp2)'),
                 ('acc', 'end data'),
                 ('loki', 'unmapped-directive whatever(tmp1) foo(tmp2)'),
-                ('loki', 'create drvice(tmp1)'))
+                ('loki', 'create drvice(tmp1)'),
+                ('acc', 'data present(tmp3, tmp4)'),
+                ('acc', 'end data'),
+                ('acc', ('data', 'copyin(tmp1)', 'present(tmp3, tmp4)'), False),
+                ('acc', 'end data'))
     if directive == 'omp-gpu':
         args = (('omp', 'declare target(tmp1, tmp2)'),
                 ('omp', ('target update', 'to(tmp1)', 'from(tmp2)'), False),
@@ -127,7 +135,11 @@ end subroutine some_func
                 ('loki', ('device-ptr', 'vars(tmp1, tmp2)'), False),
                 ('loki', ('end device-ptr', 'vars(tmp1, tmp2)'), False),
                 ('loki', 'unmapped-directive whatever(tmp1) foo(tmp2)'),
-                ('loki', 'create drvice(tmp1)'))
+                ('loki', 'create drvice(tmp1)'),
+                ('omp', 'target data map(to: tmp3, tmp4)'),
+                ('omp', 'end target data'),
+                ('omp', ('target data', 'map(to: tmp1, tmp3, tmp4)'), False),
+                ('omp', 'end target data'))
     if directive is None:
         args = (('loki', 'create device(tmp1, tmp2)'),
                 ('loki', ('update', 'device(tmp1)', 'host(tmp2)'), False),
@@ -148,7 +160,11 @@ end subroutine some_func
                 ('loki', ('device-ptr', 'vars(tmp1, tmp2)'), False),
                 ('loki', ('end device-ptr', 'vars(tmp1, tmp2)'), False),
                 ('loki', 'unmapped-directive whatever(tmp1) foo(tmp2)'),
-                ('loki', 'create drvice(tmp1)'))
+                ('loki', 'create drvice(tmp1)'),
+                ('loki', 'structured-data present(tmp3, tmp4)'),
+                ('loki', 'end structured-data'),
+                ('loki', ('structured-data', 'in(tmp1)', 'present(tmp3, tmp4)'), False),
+                ('loki', 'end structured-data'))
 
     if not keep_loki_pragmas:
         args = tuple(arg for arg in args if arg[0] != 'loki')


### PR DESCRIPTION
'loki device-present' only for execution on device which is not mapped for OpenMP, 'loki structured-data present(...)' on host mapped for both OpenACC and OpenMP