### PR TITLE
hack for OpenMP updating global variables on device

### DIFF
--- a/docs/source/loki_pragma_model.csv
+++ b/docs/source/loki_pragma_model.csv
@@ -18,3 +18,4 @@ Loki,OpenACC,OMP-GPU
 ``end device-present vars(...)``,``end data``,
 ``device-ptr vars (...)``,``data deviceptr(...)``,
 ``end device-ptr vars(...)``,``end data``,
+``omp-update-global-vars in(...)``,,``target enter data map(to: ...)``

--- a/loki/transformations/data_offload/global_var.py
+++ b/loki/transformations/data_offload/global_var.py
@@ -384,6 +384,9 @@ class GlobalVarOffloadTransformation(Transformation):
             if update_variables:
                 update_device += (
                     Pragma(keyword='loki', content=f'update device({", ".join(v.name for v in update_variables)})'),
+                    # this shouldn't be necessary but is currently necessary because of a bug in OpenMP
+                    Pragma(keyword='loki',
+                        content=f'omp-update-global-vars in({", ".join(v.name for v in update_variables)})'),
                 )
             if copyin_variables:
                 content = f'unstructured-data in({", ".join(v.name for v in copyin_variables)})'

--- a/loki/transformations/pragma_model.py
+++ b/loki/transformations/pragma_model.py
@@ -276,6 +276,13 @@ class OpenMPOffloadPragmaMapper(GenericPragmaMapper):
             return Pragma(keyword='omp', content='end target teams distribute')
         return self.default_retval()
 
+    def pmap_omp_update_global_vars(self, pragma, parameters, **kwargs):
+        # this shouldn't be necessary but is currently necessary because of a bug in OpenMP
+        if params_in := parameters.get('in'):
+            return Pragma(keyword='omp', content=f'target enter data map(to: {params_in})')
+        return self.default_retval()
+
+
 
 class OpenMPThreadingPragmaMapper(GenericPragmaMapper):
     """


### PR DESCRIPTION
Having:

```fortran
module some_mod
  integer, allocatable :: foo(:, :)
!$omp declare target(foo)
end module some_mod
```

Unfortunately, this doesn't work:

```fortran
use some_mod, only: foo

!$omp target update to(foo)
```

However, the following works (as workaround):

```fortran
use some_mod, only: foo

!$omp target update to(foo)
!$omp target enter data map(to: foo)
```
