### PR TITLE
SCC: privatise derived-type scalars

### DIFF
--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -277,6 +277,9 @@ class SCCAnnotateTransformation(Transformation):
         arrays = [v for v in arrays if not v.type.pointer]
         arrays = [v for v in arrays if not v.name_parts[0].lower() in acc_vars]
 
+        # Derived-types are classified as "aggregate variables" in the OpenACC and OpenMP offload
+        # standards and have the same implicit data attributes as arrays. Therefore, local derived-type
+        # scalars must also be privatised.
         structs = [v for v in loop_vars if isinstance(v.type.dtype, sym.DerivedType)]
         structs = [v for v in structs if not v.name_parts[0].lower() in acc_vars]
         structs = [v for v in structs if not v.type.intent]

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -13,7 +13,7 @@ from loki.ir import (
     pragmas_attached, is_loki_pragma, get_pragma_parameters,
     pragma_regions_attached
 )
-from loki.logging import info
+from loki.logging import info, warning
 from loki.tools import as_tuple, flatten
 from loki.types import DerivedType
 
@@ -271,16 +271,26 @@ class SCCAnnotateTransformation(Transformation):
         """
 
         # Mark driver loop as "gang parallel".
-        arrays = FindVariables(unique=True).visit(loop)
-        arrays = [v for v in arrays if isinstance(v, sym.Array)]
+        loop_vars = FindVariables(unique=True).visit(loop)
+        arrays = [v for v in loop_vars if isinstance(v, sym.Array)]
         arrays = [v for v in arrays if not v.type.intent]
         arrays = [v for v in arrays if not v.type.pointer]
+        arrays = [v for v in arrays if not v.name_parts[0].lower() in acc_vars]
+
+        structs = [v for v in loop_vars if isinstance(v.type.dtype, sym.DerivedType)]
+        structs = [v for v in structs if not v.name_parts[0].lower() in acc_vars]
+        structs = [v for v in structs if not v.type.intent]
+        structs = [v for v in structs if not v in arrays]
+        if (dynamic_structs := [v.name for v in structs if (v.type.pointer or v.type.allocatable)]):
+            warning(f'[Loki-SCC::Annotate] dynamically allocated structs are being privatised: {dynamic_structs}')
+
 
         # Filter out arrays that are explicitly allocated with block dimension
         sizes = self.block_dim.size_expressions
-        arrays = [v for v in arrays if not any(d in sizes for d in as_tuple(v.shape))]
-        private_arrays = ', '.join(set(v.name for v in arrays if not v.name_parts[0].lower() in acc_vars))
-        private_clause = '' if not private_arrays else f' private({private_arrays})'
+        aggregate_vars = [v for v in arrays + structs
+                          if not any(d in sizes for d in as_tuple(getattr(v, 'shape', [])))]
+        private_vars = ', '.join(set(v.name for v in aggregate_vars))
+        private_clause = '' if not private_vars else f' private({private_vars})'
 
         for pragma in as_tuple(loop.pragma):
             if is_loki_pragma(pragma, starts_with='loop driver'):

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -169,6 +169,13 @@ class BaseRevectorTransformation(Transformation):
         This method assumes that pragmas have been attached via
         :any:`pragmas_attached`.
         """
+
+        # Skip loops with existing parallel annotations
+        if loop.pragma:
+            if any(pragma.keyword.lower() in ['omp', 'acc'] and 'parallel' in pragma.content.lower()
+                   for pragma in loop.pragma):
+                return
+
         # Find a horizontal size variable to mark vector_length
         symbol_map = routine.symbol_map
         sizes = tuple(

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -172,8 +172,8 @@ class BaseRevectorTransformation(Transformation):
         # Find a horizontal size variable to mark vector_length
         symbol_map = routine.symbol_map
         sizes = tuple(
-            symbol_map.get(size) for size in self.horizontal.size_expressions
-            if size in symbol_map
+            routine.resolve_typebound_var(size, symbol_map) for size in self.horizontal.size_expressions
+            if size.split('%')[0] in symbol_map
         )
         vector_length = f' vector_length({sizes[0]})' if sizes else ''
 

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -16,7 +16,7 @@ from loki.ir import (
     Pragma, PragmaRegion, pragmas_attached, is_loki_pragma,
     pragma_regions_attached, FindInlineCalls
 )
-
+from loki.logging import WARNING
 from loki.transformations import (
     DataOffloadTransformation, SanitiseTransformation,
     InlineTransformation, get_loop_bounds, PragmaModelTransformation
@@ -33,7 +33,8 @@ from loki.transformations.single_column import (
 def fixture_horizontal():
     return Dimension(
         name='horizontal', size=['dims%klon', 'nlon'], index='jl',
-        bounds=('start', 'end'), aliases=('nproma',)
+        aliases=('nproma',), lower=('start', 'dims%ist'),
+        upper=('end', 'dims%iend')
     )
 
 @pytest.fixture(scope='module', name='horizontal_bounds_aliases')
@@ -873,17 +874,21 @@ def test_scc_multicond(frontend, horizontal, blocking):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking):
+@pytest.mark.parametrize('dims_type', ['pointer', 'allocatable', 'static'])
+def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking, dims_type, tmp_path, caplog):
     """
     Test that both '!$acc data' and '!$acc parallel loop gang' pragmas are created at the
     driver layer.
     """
 
-    fcode = """
+    fcode = f"""
     module test_mod
 
     type dims_type
       integer :: klon
+      integer :: ist
+      integer :: iend
+      integer :: kbl
     end type
 
     contains
@@ -894,33 +899,43 @@ def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking):
       integer, intent(in) :: nb
       type(dims_type), intent(in) :: dims
       real, dimension(nlon, nb), intent(inout) :: work
+      {'type(dims_type), pointer :: local_dims' if dims_type == 'pointer' else ''}
+      {'type(dims_type), allocatable :: local_dims' if dims_type == 'allocatable' else ''}
+      {'type(dims_type) :: local_dims' if dims_type == 'static' else ''}
       integer :: b
 
+      local_dims = dims
+      !$acc data present(dims)
       !$loki data
       !$omp parallel do private(b) shared(work, nproma)
         do b=1, nb
-           call some_kernel(1, dims%klon, dims%klon, work(:,b))
+           local_dims%ist = 1
+           local_dims%iend = dims%klon
+           local_dims%kbl = b
+           call some_kernel(local_dims, local_dims%klon, work(:,b))
         enddo
       !$omp end parallel do
       !$loki end data
+      !$acc end data
 
     end subroutine test
 
-    subroutine some_kernel(start, end, nlon, work)
+    subroutine some_kernel(dims, nlon, work)
     implicit none
 
-      integer, intent(in) :: start, end, nlon
+      type(dims_type), intent(in) :: dims
+      integer, intent(in) :: nlon
       real, dimension(nlon), target, intent(inout) :: work
       real, pointer :: tmp(:) => null()
       integer :: jl
 
-      do jl=start,end
+      do jl=dims%ist,dims%iend
          work(jl) = work(jl) + 1.
       enddo
 
       tmp => work
 
-      do jl=start,end
+      do jl=dims%ist,dims%iend
          tmp(jl) = tmp(jl) + 1.
       enddo
 
@@ -928,7 +943,7 @@ def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking):
     end module test_mod
     """
 
-    source = Sourcefile.from_source(fcode, frontend=frontend)
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     routine = source['test']
     routine.enrich(source.all_subroutines)
 
@@ -940,22 +955,33 @@ def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking):
     scc_pipeline = SCCVectorPipeline(
         horizontal=horizontal, block_dim=blocking, directive='openacc'
     )
-    scc_pipeline.apply(routine, role='driver', targets=['some_kernel',])
 
-    # Check that both acc pragmas are created
+    if dims_type in ['pointer', 'allocatable']:
+        with caplog.at_level(WARNING):
+            scc_pipeline.apply(routine, role='driver', targets=['some_kernel',])
+        if frontend == OMNI:
+            assert len(caplog.records) == 2
+            message = caplog.records[1].message
+        else:
+            assert len(caplog.records) == 1
+            message = caplog.records[0].message
+        assert "[Loki-SCC::Annotate] dynamically allocated structs are being privatised: ['local_dims']" in message
+    else:
+        scc_pipeline.apply(routine, role='driver', targets=['some_kernel',])
+
     pragmas = FindNodes(Pragma).visit(routine.ir)
-    assert len(pragmas) == 4
-    assert pragmas[0].keyword == 'acc'
-    assert pragmas[1].keyword == 'acc'
-    assert pragmas[2].keyword == 'acc'
-    assert pragmas[3].keyword == 'acc'
+    assert len(pragmas) == 6
 
-    assert 'data' in pragmas[0].content
-    assert 'copy' in pragmas[0].content
-    assert '(work)' in pragmas[0].content
-    assert pragmas[1].content == 'parallel loop gang vector_length(dims%klon)'
-    assert pragmas[2].content == 'end parallel loop'
-    assert pragmas[3].content == 'end data'
+    assert all(p.keyword.lower() == 'acc' for p in pragmas)
+    assert pragmas[0].content == 'data present(dims)'
+    assert pragmas[2].content == 'parallel loop gang private(local_dims) vector_length(dims%klon)'
+    assert pragmas[3].content == 'end parallel loop'
+    assert pragmas[4].content == 'end data'
+    assert pragmas[5].content == 'end data'
+
+    assert 'data' in pragmas[1].content
+    assert 'copy' in pragmas[1].content
+    assert '(work)' in pragmas[1].content
 
     # check that pointer association was correctly identified as a separator node
     routine = source['some_kernel']


### PR DESCRIPTION
Derived-types are classified as "aggregate variables" in the OpenACC and OpenMP offload standards and have the same implicit data attributes as arrays. This PR therefore extends `SCCAnnotate` to also privatise derived-type scalars (derived-type arrays would have already been privatised according to the existing implementation).

Other changes included are:
- Skip driver loop labeling for loops with existing parallel pragmas
- The ability to use a derived-type component to set the vector_length in a gang loop