### PR TITLE
Hotfix for GH Actions: Replace package distribution version of JDK with setup-java action

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -30,7 +30,7 @@ jobs:
             os: ubuntu-24.04
             install-options: --with-omni --with-tests --without-dace
             env: JAVA_HOME=${JAVA_HOME_11_X64}
-            pkg-dependencies: graphviz gfortran byacc flex openjdk-11-jdk ant cmake meson ninja-build libhdf5-dev libopenmpi-dev
+            pkg-dependencies: graphviz gfortran byacc flex cmake meson ninja-build libhdf5-dev libopenmpi-dev
             pip-dependencies: pyyaml fypp
 
     runs-on: ${{ matrix.os }}
@@ -66,6 +66,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
               # Enable --with-dace as soon as DaCe supports 3.13 and Numpy>2.0
             install-options: --with-omni --with-examples --with-tests --without-dace
             env: JAVA_HOME=${JAVA_HOME_11_X64}
-            pkg-dependencies: graphviz gfortran byacc flex openjdk-11-jdk ant cmake meson ninja-build
+            pkg-dependencies: graphviz gfortran byacc flex cmake meson ninja-build
 
           # - name: macos
           #   os: macos-14
@@ -54,6 +54,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The download of OpenJDK in the dependency installation for OMNI failed spuriously but increasingly often in the last two days. This replaces the installation of the JDK by the official setup-java action, which is hopefully more robust and independent from the runner image.