### PR TITLE
Small bug fixes in the `DataflowAnalysis`

### DIFF
--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -149,7 +149,10 @@ class DataflowAnalysisAttacher(Transformer):
     def visit_Loop(self, o, **kwargs):
         # A loop defines the induction variable for its body before entering it
         live = kwargs.pop('live_symbols', set())
+        mem_calls = as_tuple(i for i in FindInlineCalls().visit(o.bounds) if i.function in self._mem_property_queries)
+        query_args = as_tuple(flatten(FindVariables().visit(i.parameters) for i in mem_calls))
         uses = self._symbols_from_expr(o.bounds)
+        uses = {v for v in uses if not v in query_args}
         body, defines, uses = self._visit_body(o.body, live=live|{o.variable.clone()}, uses=uses, **kwargs)
         o._update(body=body)
         # Make sure the induction variable is not considered outside the loop

--- a/loki/analyse/tests/test_analyse_dataflow.py
+++ b/loki/analyse/tests/test_analyse_dataflow.py
@@ -436,10 +436,14 @@ implicit none
 
   real,intent(out) :: a(:,:)
   real             :: b(10)
-  integer                     :: bsize
+  integer          :: bsize, i
 
   if(size(a) > 0) a(:,:) = 0.
   bsize = size(b)
+
+  do i=1,size(b)
+    print *, i
+  enddo
 
 end subroutine test
     """.strip()

--- a/loki/transformations/data_offload/tests/test_global_var.py
+++ b/loki/transformations/data_offload/tests/test_global_var.py
@@ -208,8 +208,8 @@ def test_global_variable_analysis(frontend, key, config, global_variable_analysi
         'global_var_analysis_kernel_mod#kernel_b': {
             'defines_symbols': {('rdata(:, :, :)', 'global_var_analysis_data_mod')},
             'uses_symbols': nfld_data | {
-                ('rdata(:, :, :)', 'global_var_analysis_data_mod'), ('tt', 'global_var_analysis_data_mod'),
-                ('tt%vals', 'global_var_analysis_data_mod'), (f'iarr({nfld_dim})', 'global_var_analysis_header_mod')
+                ('rdata(:, :, :)', 'global_var_analysis_data_mod'), ('tt%vals', 'global_var_analysis_data_mod'),
+                (f'iarr({nfld_dim})', 'global_var_analysis_header_mod')
             }
         },
         '#driver': {
@@ -272,7 +272,7 @@ def test_global_variable_offload(frontend, key, config, global_variable_analysis
         },
         'global_var_analysis_data_mod': {
             'declares': {'rdata(:, :, :)', 'tt'},
-            'offload': {'rdata(:, :, :)', 'tt', 'tt%vals'}
+            'offload': {'rdata(:, :, :)', 'tt%vals'}
         },
     }
 


### PR DESCRIPTION
This PR fixes the following bugs in the dataflow analysis:
- Stripping dimensions of nested derived-type accesses
- Extending the exclusion of memory status checking calls to loop bounds

The PR also includes a behaviour change. Previously, all parents of a derived-type expression were marked as used if a single type member was used. Now, only the full derived-type expression is included in the used symbols set. For example, the `used_symbols` for the assignment `D = A%B%C` will be limited to `A%B%C`, whereas previously it would have also included `A%B, A`. 