### PR TITLE
Inline Trafo CMake planing when inlining marked routines

### DIFF
--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -706,7 +706,7 @@ class ProcedureItem(Item):
     _parser_class = RegexParserClass.ProgramUnitClass
     _depends_class = (
         RegexParserClass.ImportClass | RegexParserClass.InterfaceClass | RegexParserClass.TypeDefClass |
-        RegexParserClass.DeclarationClass | RegexParserClass.CallClass
+        RegexParserClass.DeclarationClass | RegexParserClass.CallClass | RegexParserClass.PragmaClass
     )
 
     @property

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -607,7 +607,12 @@ class ItemFactory:
         :any:`MetaSymbol` or :any:`TypedSymbol` :
             The symbol in the defining scope
         """
-        imprt_symbol = imprt.symbols[imprt.symbols.index(symbol_name)]
+        if imprt.symbols:
+            imprt_symbol = imprt.symbols[imprt.symbols.index(symbol_name)]
+        else:
+            rename_dic = CaseInsensitiveDict({local.name: use for (use, local) in imprt.rename_list})
+            symbol_name = rename_dic[symbol_name]
+            imprt_symbol = None
         if imprt_symbol and imprt_symbol.type.use_name:
             symbol_name = imprt_symbol.type.use_name
         return symbol_name

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -315,7 +315,7 @@ class ProgramUnit(Scope):
                 # Import all symbols
                 rename_list = CaseInsensitiveDict((k, v) for k, v in as_tuple(imprt.rename_list))
                 symbols = [
-                    Variable(name=rename_list.get(symbol.name, symbol.name), scope=self)
+                    Variable(name=str(rename_list.get(symbol.name, symbol.name)), scope=self)
                     for symbol in module.symbols
                 ]
 

--- a/loki/transformations/inline/tests/test_inline_transformation.py
+++ b/loki/transformations/inline/tests/test_inline_transformation.py
@@ -515,14 +515,14 @@ module outermost_mod
 implicit none
 contains
 subroutine outermost()
-use intermediate_1_mod, only: intermediate_1
-use intermediate_2_mod, only: intermediate_2
+use intermediate_1_mod, only: intermediate1 => intermediate_1
+use intermediate_2_mod, intermediate2 => intermediate_2
 
 !$loki inline
-call intermediate_1()
+call intermediate1()
 
 !$loki inline
-call intermediate_2()
+call intermediate2()
 
 end subroutine outermost
 end module outermost_mod

--- a/loki/transformations/inline/tests/test_inline_transformation.py
+++ b/loki/transformations/inline/tests/test_inline_transformation.py
@@ -5,14 +5,17 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import re
+from pathlib import Path
 import pytest
 
-from loki import Module, Subroutine
+from loki import Module, Subroutine, ProcessingStrategy
 from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
-from loki.batch import Scheduler, SchedulerConfig, TransformationError
+from loki.batch import Scheduler, SchedulerConfig, TransformationError, Pipeline
 
 from loki.transformations.inline import InlineTransformation
+from loki.transformations.build_system import FileWriteTransformation
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -503,3 +506,193 @@ end module innermost_mod
     assert len(scheduler.items) == 2
     assert len(_get_successors('outermost_mod#outermost')) == 1
     assert scheduler['innermost_mod#innermost'] in _get_successors('outermost_mod#outermost')
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('full_parse', (True, False))
+def test_inline_transformation_plan(tmp_path, frontend, full_parse):
+    fcode_outermost = """
+module outermost_mod
+implicit none
+contains
+subroutine outermost()
+use intermediate_1_mod, only: intermediate_1
+use intermediate_2_mod, only: intermediate_2
+
+!$loki inline
+call intermediate_1()
+
+!$loki inline
+call intermediate_2()
+
+end subroutine outermost
+end module outermost_mod
+"""
+
+    fcode_intermediate_1 = """
+module intermediate_1_mod
+implicit none
+contains
+subroutine intermediate_1()
+use innermost_1_mod, only: innermost_1
+use innermost_2_mod, only: innermost_2
+use innermost_3_mod, only: innermost_3
+
+!$loki inline
+call innermost_1()
+
+call innermost_2()
+
+!$loki inline
+call innermost_3()
+
+end subroutine intermediate_1
+end module intermediate_1_mod
+"""
+
+    fcode_intermediate_2 = """
+module intermediate_2_mod
+implicit none
+contains
+subroutine intermediate_2()
+use innermost_1_mod, only: innermost_1
+
+!$loki inline
+call innermost_1()
+
+call innermost_1()
+
+end subroutine intermediate_2
+end module intermediate_2_mod
+"""
+
+    fcode_innermost_1 = """
+module innermost_1_mod
+implicit none
+contains
+subroutine innermost_1()
+use innerinnermost_1_mod, only: innerinnermost_1
+
+!$loki inline
+call innerinnermost_1()
+
+end subroutine innermost_1
+end module innermost_1_mod
+"""
+
+    fcode_innermost_2 = """
+module innermost_2_mod
+implicit none
+contains
+subroutine innermost_2()
+
+end subroutine innermost_2
+end module innermost_2_mod
+"""
+
+    fcode_innermost_3 = """
+module innermost_3_mod
+implicit none
+contains
+subroutine innermost_3()
+
+end subroutine innermost_3
+end module innermost_3_mod
+"""
+
+    fcode_innerinnermost_1 = """
+module innerinnermost_1_mod
+implicit none
+contains
+subroutine innerinnermost_1()
+use innerinnerinnermost_1_mod, only: innerinnerinnermost_1
+
+call innerinnerinnermost_1()
+
+end subroutine innerinnermost_1
+end module innerinnermost_1_mod
+"""
+
+    fcode_innerinnerinnermost_1 = """
+module innerinnerinnermost_1_mod
+implicit none
+contains
+subroutine innerinnerinnermost_1()
+
+end subroutine innerinnerinnermost_1
+end module innerinnerinnermost_1_mod
+"""
+
+    (tmp_path/'outermost_mod.F90').write_text(fcode_outermost)
+    (tmp_path/'intermediate_1_mod.F90').write_text(fcode_intermediate_1)
+    (tmp_path/'intermediate_2_mod.F90').write_text(fcode_intermediate_2)
+    (tmp_path/'innermost_1_mod.F90').write_text(fcode_innermost_1)
+    (tmp_path/'innermost_2_mod.F90').write_text(fcode_innermost_2)
+    (tmp_path/'innermost_3_mod.F90').write_text(fcode_innermost_3)
+    (tmp_path/'innerinnermost_1_mod.F90').write_text(fcode_innerinnermost_1)
+    (tmp_path/'innerinnerinnermost_1_mod.F90').write_text(fcode_innerinnerinnermost_1)
+
+    config = {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True,
+            'replicate': True,
+        },
+        'routines': {
+            'outermost': {'role': 'driver', 'replicate': False}
+        }
+    }
+
+    scheduler = Scheduler(
+        paths=[tmp_path], config=SchedulerConfig.from_dict(config),
+        frontend=frontend, xmods=[tmp_path], full_parse=full_parse
+    )
+
+    pipeline = Pipeline(classes=(InlineTransformation, FileWriteTransformation))
+
+    plan_file = tmp_path/'plan.cmake'
+    scheduler.process(pipeline, proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.write_cmake_plan(filepath=plan_file, rootpath=tmp_path)
+
+    outermost_item = scheduler["outermost_mod#outermost"]
+    intermediate_1_item = scheduler["intermediate_1_mod#intermediate_1"]
+    intermediate_2_item = scheduler["intermediate_2_mod#intermediate_2"]
+    innermost_1_item = scheduler["innermost_1_mod#innermost_1"]
+    innermost_2_item = scheduler["innermost_2_mod#innermost_2"]
+    innermost_3_item = scheduler["innermost_3_mod#innermost_3"]
+    innerinnermost_1_item = scheduler["innerinnermost_1_mod#innerinnermost_1"]
+    innerinnerinnermost_1_item = scheduler["innerinnerinnermost_1_mod#innerinnerinnermost_1"]
+
+    assert hasattr(outermost_item, 'plan_data')
+    assert set(outermost_item.plan_data['additional_dependencies']) == \
+            {'innerinnerinnermost_1_mod#innerinnerinnermost_1', 'innermost_2_mod#innermost_2',
+                    'innermost_1_mod#innermost_1'}
+    assert set(outermost_item.plan_data['removed_dependencies']) == \
+            {'intermediate_2_mod#intermediate_2', 'intermediate_1_mod#intermediate_1'}
+    assert not hasattr(intermediate_1_item, 'plan_data')
+    assert not hasattr(intermediate_2_item, 'plan_data')
+    assert hasattr(innermost_1_item, 'plan_data')
+    assert set(innermost_1_item.plan_data['additional_dependencies']) == \
+            {'innerinnerinnermost_1_mod#innerinnerinnermost_1'}
+    assert set(innermost_1_item.plan_data['removed_dependencies']) == \
+            {'innerinnermost_1_mod#innerinnermost_1'}
+    assert hasattr(innermost_2_item, 'plan_data')
+    assert not hasattr(innermost_3_item, 'plan_data')
+    assert not hasattr(innerinnermost_1_item, 'plan_data')
+    assert hasattr(innerinnerinnermost_1_item, 'plan_data')
+
+    # Validate the plan file content
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+    loki_plan = plan_file.read_text()
+    plan_dict = {k: v.split() for k, v in plan_pattern.findall(loki_plan)}
+    plan_dict = {k: {Path(s).stem for s in v} for k, v in plan_dict.items()}
+
+    expected_items_to_transform = {'innermost_2_mod', 'outermost_mod', 'innermost_1_mod', 'innerinnerinnermost_1_mod'}
+    expected_items_to_append = {'innerinnerinnermost_1_mod.idem', 'outermost_mod.idem', 'innermost_2_mod.idem',
+            'innermost_1_mod.idem'}
+    expected_items_to_remove = {'outermost_mod'}
+
+    assert plan_dict['LOKI_SOURCES_TO_TRANSFORM'] == expected_items_to_transform
+    assert plan_dict['LOKI_SOURCES_TO_APPEND'] == expected_items_to_append
+    assert plan_dict['LOKI_SOURCES_TO_REMOVE'] == expected_items_to_remove

--- a/loki/transformations/inline/transformation.py
+++ b/loki/transformations/inline/transformation.py
@@ -158,7 +158,10 @@ class InlineTransformation(Transformation):
                 for imprt in reversed(getattr(routine, 'imports', ()))
                 for s in imprt.symbols or [r[1] for r in imprt.rename_list or ()]
                 )
-        inline_items = [successor_map[rename_map.get(call, call)] for call in removed_calls]
+        inline_items = [successor_map[rename_map.get(call, call)] for call in removed_calls
+                # this shouldn't be necessary, however, if for example a call is marked as to be inlined
+                # within a loki remove pragma region this could otherwise end up throwing an error
+                if rename_map.get(call, call) in successor_map]
         # Add fully inlined dependencies to the 'removed_dependencies' list in the plan data to indicate that
         # they will no longer be dependents. At the same time add any dependencies of inlined successors
         # to the current item's dependencies as these will be inherited as dependents (unless they are also

--- a/loki/transformations/inline/transformation.py
+++ b/loki/transformations/inline/transformation.py
@@ -152,7 +152,12 @@ class InlineTransformation(Transformation):
                     not_inline_calls.add(str(call.name).lower())
         # removed/inlined calls, making sure all calls to the same routine are inlined
         removed_calls = inline_calls - not_inline_calls
-        inline_items = [successor_map[call] for call in removed_calls]
+        rename_map = CaseInsensitiveDict(
+                (s.name, s.type.use_name if s.type.use_name else s.name)
+                for imprt in reversed(getattr(routine, 'imports', ()))
+                for s in imprt.symbols or [r[1] for r in imprt.rename_list or ()]
+                )
+        inline_items = [successor_map[rename_map.get(call, call)] for call in removed_calls]
         # adapt 'removed_dependencies' and 'additional_dependencies' accordingly
         if inline_items:
             item.plan_data.setdefault('removed_dependencies', ())


### PR DESCRIPTION
Inline Trafo CMake planing when inlining marked routines.

In the planning step:

* look for calls with and without `!$loki inline` pragmas
* adapt `removed_dependencies` and `additional_dependencies` according to which calls are inlined