### PR TITLE
SCC: Make privatising derived-type variables configurable

### DIFF
--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -955,7 +955,8 @@ def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking, dims_type, tmp
     pragma_model.transform_subroutine(routine, role='driver', targets=['some_kernel',])
 
     scc_pipeline = SCCVectorPipeline(
-        horizontal=horizontal, block_dim=blocking, directive='openacc'
+        horizontal=horizontal, block_dim=blocking, directive='openacc',
+        privatise_derived_types=True
     )
 
     if dims_type in ['pointer', 'allocatable']:


### PR DESCRIPTION
This cause trouble in EC-physics, as we rely on them being treated as globals in various places. So, by default we leave this option off for now, until this is tested further.

As a bonus, this also replaces a use of `set` for unique variable lists with `dict.fromkeys()` to ensure reproducible string output in the list of private variable names.

This PR should bring EC-physics regression back to green.