### PR TITLE
FieldOffloadBlockedTransformation - Add transformation for blocked and asynchronous data offload using FIELD API

### DIFF
--- a/loki/transformations/data_offload/field_offload.py
+++ b/loki/transformations/data_offload/field_offload.py
@@ -121,14 +121,14 @@ class FieldOffloadBlockedTransformation(Transformation):
         calls (defaults to ``'IBL'``).
     """
 
-    def __init__(self, devptr_prefix=None, field_group_types=None,
+    def __init__(self, block_size, devptr_prefix=None, field_group_types=None,
                  offload_index=None, blocking_index=None):
+        self.block_size = block_size
         self.deviceptr_prefix = 'loki_devptr_' if devptr_prefix is None else devptr_prefix
         field_group_types = [''] if field_group_types is None else field_group_types
         self.field_group_types = tuple(typename.lower() for typename in field_group_types)
         self.offload_index = 'IBL' if offload_index is None else offload_index
         self.blocking_index = offload_index
-        self.block_size = sym.IntLiteral(100)   # TODO: Fix proper initialization
         self.asynchronous = False
         self.num_queues = 0
     def transform_subroutine(self, routine, **kwargs):

--- a/loki/transformations/data_offload/field_offload.py
+++ b/loki/transformations/data_offload/field_offload.py
@@ -296,7 +296,9 @@ def add_device_field_allocations(driver, block_loop, offload_map, block_size, nu
 def add_async_blocking_vars(routine, block_loop, num_queues, splitting_vars):
     queue = sym.Variable(name='loki_block_queue', type=SymbolAttributes(BasicType.INTEGER),
                          scope=routine)
-    nqueues = sym.Variable(name='loki_block_nqueues', type=SymbolAttributes(BasicType.INTEGER),
+    nqueues = sym.Variable(name='loki_block_nqueues', type=SymbolAttributes(BasicType.INTEGER,
+                                                                            parameter=True,
+                                                                            initial=sym.IntLiteral(num_queues)),
                            scope=routine)
     offset = sym.Variable(name='loki_block_offset', type=SymbolAttributes(BasicType.INTEGER),
                           scope=routine)
@@ -305,7 +307,6 @@ def add_async_blocking_vars(routine, block_loop, num_queues, splitting_vars):
 
     # set queue and offset in loop
     async_blocking_body = (
-        ir.Assignment(nqueues, sym.IntLiteral(num_queues)),   # TODO: Make a parameter
         ir.Assignment(queue,
                       sym.Sum(children=(sym.InlineCall(sym.DeferredTypeSymbol('MODULO', scope=routine),
                                                        parameters=(splitting_vars.block_idx,

--- a/loki/transformations/data_offload/field_offload.py
+++ b/loki/transformations/data_offload/field_offload.py
@@ -264,7 +264,6 @@ def add_device_field_allocations(driver, block_loop, offload_map, block_size, nu
         }
         Transformer(update_map, inplace=True).visit(driver.body)
 
-
 def replace_kernel_args(driver, offload_map, offload_index):
     change_map = {}
     offload_idx_expr = driver.variable_map[offload_index]
@@ -284,7 +283,6 @@ def replace_kernel_args(driver, offload_map, offload_index):
     driver.body = SubstituteExpressions(change_map, inplace=True).visit(driver.body)
 
 
-
 def block_driver_loops(driver, region, block_size):
     with pragmas_attached(driver, ir.Loop):
         driver_loops = find_driver_loops(driver.body, targets=None)
@@ -295,7 +293,8 @@ def block_driver_loops(driver, region, block_size):
         else:
             warning(f'[Loki] Data offload (field blocking): No driver loops found in {driver.name}')
             return
-        splitting_vars, inner_loop, outer_loop = split_loop(driver, loop, block_size)
+        splitting_vars, inner_loop, outer_loop = split_loop(driver, loop, block_size, data_region=region)
+        # move loop pragmas to inner loop
         if outer_loop.pragma is not None:
             inner_loop._update(pragma=outer_loop.pragma)
             outer_loop._update(pragma=None)

--- a/loki/transformations/data_offload/offload.py
+++ b/loki/transformations/data_offload/offload.py
@@ -9,7 +9,7 @@ from loki.batch import Transformation
 from loki.expression import Array
 from loki.ir import (
     FindNodes, PragmaRegion, CallStatement, Pragma, Transformer,
-    pragma_regions_attached,
+    pragma_regions_attached, get_pragma_parameters
 )
 from loki.logging import warning, error
 from loki.tools import as_tuple
@@ -173,6 +173,13 @@ class DataOffloadTransformation(Transformation):
                     copyout = f'out({", ".join(outargs)})' if outargs else ''
                     pragma = Pragma(keyword='loki', content=f'structured-data {copyin} {copy} {copyout}')
                     pragma_post = Pragma(keyword='loki', content='end structured-data')
+
+                # Add async if present
+                async_parameter = get_pragma_parameters(region.pragma).get('async', '')
+                if async_parameter:
+                    pragma = Pragma(keyword='loki', content=pragma.content+f' async({async_parameter})')
+
+                # Add pragmas to map
                 pragma_map[region.pragma] = pragma
                 pragma_map[region.pragma_post] = pragma_post
 

--- a/loki/transformations/data_offload/tests/test_field_offload.py
+++ b/loki/transformations/data_offload/tests/test_field_offload.py
@@ -164,8 +164,6 @@ def test_field_offload(frontend, state_module, tmp_path):
         assert len(devptr.shape) == 3
         assert devptr.name in (arg.name for arg in kernel_call.arguments)
     from loki import fgen
-    print("\nIR:")
-    print(fgen(driver_mod))
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -667,12 +665,6 @@ def test_field_offload_blocked(frontend, state_module, tmp_path):
                  role='driver',
                  targets=['kernel_routine'])
 
-    from loki import fgen, pprint
-    print('\n')
-    print(pprint(driver.ir))
-    print('\n')
-    print(fgen(driver.ir))
-
     calls = FindNodes(CallStatement).visit(driver.body)
     kernel_call = next(c for c in calls if c.name=='kernel_routine')
 
@@ -752,12 +744,6 @@ def test_field_offload_blocked_async(frontend, state_module, tmp_path):
                                                    num_queues=3),
                  role='driver',
                  targets=['kernel_routine'])
-
-    from loki import fgen, pprint
-    print('\n')
-    print(pprint(driver.ir))
-    print('\n')
-    print(fgen(driver.ir))
 
     calls = FindNodes(CallStatement).visit(driver.body)
     kernel_call = next(c for c in calls if c.name=='kernel_routine')

--- a/loki/transformations/data_offload/tests/test_field_offload.py
+++ b/loki/transformations/data_offload/tests/test_field_offload.py
@@ -662,7 +662,8 @@ def test_field_offload_blocked(frontend, state_module, tmp_path):
     deviceptr_prefix = 'loki_devptr_prefix_'
     driver.apply(FieldOffloadBlockedTransformation(devptr_prefix=deviceptr_prefix,
                                                    offload_index='i',
-                                                   field_group_types=['state_type']),
+                                                   field_group_types=['state_type'],
+                                                   block_size=100),
                  role='driver',
                  targets=['kernel_routine'])
 

--- a/loki/transformations/data_offload/tests/test_field_offload.py
+++ b/loki/transformations/data_offload/tests/test_field_offload.py
@@ -163,7 +163,9 @@ def test_field_offload(frontend, state_module, tmp_path):
         assert isinstance(devptr, sym.Array)
         assert len(devptr.shape) == 3
         assert devptr.name in (arg.name for arg in kernel_call.arguments)
-
+    from loki import fgen
+    print("\nIR:")
+    print(fgen(driver_mod))
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_field_offload_slices(frontend, parkind_mod, field_module, tmp_path):  # pylint: disable=unused-argument

--- a/loki/transformations/data_offload/tests/test_field_offload.py
+++ b/loki/transformations/data_offload/tests/test_field_offload.py
@@ -696,3 +696,92 @@ def test_field_offload_blocked(frontend, state_module, tmp_path):
         assert isinstance(devptr, sym.Array)
         assert len(devptr.shape) == 3
         assert devptr.name in (arg.name for arg in kernel_call.arguments)
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_field_offload_blocked_async(frontend, state_module, tmp_path):
+    fcode = """
+    module driver_mod
+      use state_mod, only: state_type
+      use parkind1, only: jprb
+      use field_module, only: field_2rb, field_3rb
+      implicit none
+
+    contains
+
+      subroutine kernel_routine(nlon, nlev, a, b, c)
+        integer, intent(in)             :: nlon, nlev
+        real(kind=jprb), intent(in)     :: a(nlon,nlev)
+        real(kind=jprb), intent(inout)  :: b(nlon,nlev)
+        real(kind=jprb), intent(out)    :: c(nlon,nlev)
+        integer :: i, j
+
+        do j=1, nlon
+          do i=1, nlev
+            b(i,j) = a(i,j) + 0.1
+            c(i,j) = 0.1
+          end do
+        end do
+      end subroutine kernel_routine
+
+      subroutine driver_routine(nlon, nlev, state)
+        integer, intent(in)             :: nlon, nlev
+        type(state_type), intent(inout) :: state
+        integer                         :: i
+
+        !$loki data
+        !$loki driver-loop
+        do i=1,nlev
+            call state%update_view(i)
+            call kernel_routine(nlon, nlev, state%a, state%b, state%c)
+        end do
+        !$loki end data
+
+      end subroutine driver_routine
+    end module driver_mod
+    """
+    driver_mod = Module.from_source(
+        fcode, frontend=frontend, definitions=state_module, xmods=[tmp_path]
+    )
+    driver = driver_mod['driver_routine']
+    deviceptr_prefix = 'loki_devptr_prefix_'
+    driver.apply(FieldOffloadBlockedTransformation(devptr_prefix=deviceptr_prefix,
+                                                   offload_index='i',
+                                                   field_group_types=['state_type'],
+                                                   block_size=100,
+                                                   asynchronous=True,
+                                                   num_queues=3),
+                 role='driver',
+                 targets=['kernel_routine'])
+
+    from loki import fgen, pprint
+    print('\n')
+    print(pprint(driver.ir))
+    print('\n')
+    print(fgen(driver.ir))
+
+    calls = FindNodes(CallStatement).visit(driver.body)
+    kernel_call = next(c for c in calls if c.name=='kernel_routine')
+
+    # verify that field offloads are generated properly
+    in_calls = [c for c in calls if 'get_device_data_force' in c.name.name.lower()]
+    assert len(in_calls) == 3
+    # verify that field sync host calls are generated properly
+    sync_calls = [c for c in calls if 'sync_host_force' in c.name.name.lower()]
+    assert len(sync_calls) == 2
+
+    # verify that data offload pragmas remain
+    pragmas = FindNodes(Pragma).visit(driver.body)
+    assert len(pragmas) == 3
+    assert all(p.keyword=='loki' and p.content==c for p, c in zip(pragmas,
+                                                                  ['data async(loki_block_queue)',
+                                                                   'driver-loop async(loki_block_queue)',
+                                                                   'end data']))
+
+    # verify that new pointer variables are created and used in driver calls
+    for var in ['state_a', 'state_b', 'state_c']:
+        name = deviceptr_prefix + var
+        assert name in driver.variable_map
+        devptr = driver.variable_map[name]
+        assert isinstance(devptr, sym.Array)
+        assert len(devptr.shape) == 3
+        assert devptr.name in (arg.name for arg in kernel_call.arguments)

--- a/loki/transformations/data_offload/tests/test_field_offload.py
+++ b/loki/transformations/data_offload/tests/test_field_offload.py
@@ -169,90 +169,6 @@ def test_field_offload(frontend, state_module, tmp_path):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_field_offload_blocked(frontend, state_module, tmp_path):
-    fcode = """
-    module driver_mod
-      use state_mod, only: state_type
-      use parkind1, only: jprb
-      use field_module, only: field_2rb, field_3rb
-      implicit none
-
-    contains
-
-      subroutine kernel_routine(nlon, nlev, a, b, c)
-        integer, intent(in)             :: nlon, nlev
-        real(kind=jprb), intent(in)     :: a(nlon,nlev)
-        real(kind=jprb), intent(inout)  :: b(nlon,nlev)
-        real(kind=jprb), intent(out)    :: c(nlon,nlev)
-        integer :: i, j
-
-        do j=1, nlon
-          do i=1, nlev
-            b(i,j) = a(i,j) + 0.1
-            c(i,j) = 0.1
-          end do
-        end do
-      end subroutine kernel_routine
-
-      subroutine driver_routine(nlon, nlev, state)
-        integer, intent(in)             :: nlon, nlev
-        type(state_type), intent(inout) :: state
-        integer                         :: i
-
-        !$loki data
-        !$loki driver-loop
-        do i=1,nlev
-            call state%update_view(i)
-            call kernel_routine(nlon, nlev, state%a, state%b, state%c)
-        end do
-        !$loki end data
-
-      end subroutine driver_routine
-    end module driver_mod
-    """
-    driver_mod = Module.from_source(
-        fcode, frontend=frontend, definitions=state_module, xmods=[tmp_path]
-    )
-    driver = driver_mod['driver_routine']
-    deviceptr_prefix = 'loki_devptr_prefix_'
-    driver.apply(FieldOffloadBlockedTransformation(devptr_prefix=deviceptr_prefix,
-                                            offload_index='i',
-                                            field_group_types=['state_type']),
-                 role='driver',
-                 targets=['kernel_routine'])
-
-    from loki import fgen, pprint
-    print('\n')
-    print(pprint(driver.ir))
-    print('\n')
-    print(fgen(driver.ir))
-
-    calls = FindNodes(CallStatement).visit(driver.body)
-    kernel_call = next(c for c in calls if c.name=='kernel_routine')
-
-    # verify that field offloads are generated properly
-    in_calls = [c for c in calls if 'get_device_data_force' in c.name.name.lower()]
-    assert len(in_calls) == 3
-    # verify that field sync host calls are generated properly
-    sync_calls = [c for c in calls if 'sync_host_force' in c.name.name.lower()]
-    assert len(sync_calls) == 2
-
-    # verify that data offload pragmas remain
-    pragmas = FindNodes(Pragma).visit(driver.body)
-    assert len(pragmas) == 3
-    assert all(p.keyword=='loki' and p.content==c for p, c in zip(pragmas, ['data', 'driver-loop', 'end data']))
-
-    # verify that new pointer variables are created and used in driver calls
-    for var in ['state_a', 'state_b', 'state_c']:
-        name = deviceptr_prefix + var
-        assert name in driver.variable_map
-        devptr = driver.variable_map[name]
-        assert isinstance(devptr, sym.Array)
-        assert len(devptr.shape) == 3
-        assert devptr.name in (arg.name for arg in kernel_call.arguments)
-
-
-@pytest.mark.parametrize('frontend', available_frontends())
 def test_field_offload_slices(frontend, parkind_mod, field_module, tmp_path):  # pylint: disable=unused-argument
     fcode = """
     module driver_mod
@@ -695,3 +611,87 @@ def test_field_offload_driver_compute(frontend, state_module, tmp_path):
     assert assigns[0].rhs == 'state_b(i,1,ibl) + 0.1'
     assert assigns[1].lhs == 'state_a(i,2,ibl)'
     assert assigns[1].rhs == 'state_a(i,1,ibl)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_field_offload_blocked(frontend, state_module, tmp_path):
+    fcode = """
+    module driver_mod
+      use state_mod, only: state_type
+      use parkind1, only: jprb
+      use field_module, only: field_2rb, field_3rb
+      implicit none
+
+    contains
+
+      subroutine kernel_routine(nlon, nlev, a, b, c)
+        integer, intent(in)             :: nlon, nlev
+        real(kind=jprb), intent(in)     :: a(nlon,nlev)
+        real(kind=jprb), intent(inout)  :: b(nlon,nlev)
+        real(kind=jprb), intent(out)    :: c(nlon,nlev)
+        integer :: i, j
+
+        do j=1, nlon
+          do i=1, nlev
+            b(i,j) = a(i,j) + 0.1
+            c(i,j) = 0.1
+          end do
+        end do
+      end subroutine kernel_routine
+
+      subroutine driver_routine(nlon, nlev, state)
+        integer, intent(in)             :: nlon, nlev
+        type(state_type), intent(inout) :: state
+        integer                         :: i
+
+        !$loki data
+        !$loki driver-loop
+        do i=1,nlev
+            call state%update_view(i)
+            call kernel_routine(nlon, nlev, state%a, state%b, state%c)
+        end do
+        !$loki end data
+
+      end subroutine driver_routine
+    end module driver_mod
+    """
+    driver_mod = Module.from_source(
+        fcode, frontend=frontend, definitions=state_module, xmods=[tmp_path]
+    )
+    driver = driver_mod['driver_routine']
+    deviceptr_prefix = 'loki_devptr_prefix_'
+    driver.apply(FieldOffloadBlockedTransformation(devptr_prefix=deviceptr_prefix,
+                                                   offload_index='i',
+                                                   field_group_types=['state_type']),
+                 role='driver',
+                 targets=['kernel_routine'])
+
+    from loki import fgen, pprint
+    print('\n')
+    print(pprint(driver.ir))
+    print('\n')
+    print(fgen(driver.ir))
+
+    calls = FindNodes(CallStatement).visit(driver.body)
+    kernel_call = next(c for c in calls if c.name=='kernel_routine')
+
+    # verify that field offloads are generated properly
+    in_calls = [c for c in calls if 'get_device_data_force' in c.name.name.lower()]
+    assert len(in_calls) == 3
+    # verify that field sync host calls are generated properly
+    sync_calls = [c for c in calls if 'sync_host_force' in c.name.name.lower()]
+    assert len(sync_calls) == 2
+
+    # verify that data offload pragmas remain
+    pragmas = FindNodes(Pragma).visit(driver.body)
+    assert len(pragmas) == 3
+    assert all(p.keyword=='loki' and p.content==c for p, c in zip(pragmas, ['data', 'driver-loop', 'end data']))
+
+    # verify that new pointer variables are created and used in driver calls
+    for var in ['state_a', 'state_b', 'state_c']:
+        name = deviceptr_prefix + var
+        assert name in driver.variable_map
+        devptr = driver.variable_map[name]
+        assert isinstance(devptr, sym.Array)
+        assert len(devptr.shape) == 3
+        assert devptr.name in (arg.name for arg in kernel_call.arguments)

--- a/loki/transformations/data_offload/tests/test_field_offload.py
+++ b/loki/transformations/data_offload/tests/test_field_offload.py
@@ -13,7 +13,7 @@ from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes, Pragma, CallStatement
 from loki.logging import log_levels
 
-from loki.transformations import FieldOffloadTransformation
+from loki.transformations import FieldOffloadTransformation, FieldOffloadBlockedTransformation
 
 
 @pytest.fixture(name="parkind_mod")
@@ -166,6 +166,91 @@ def test_field_offload(frontend, state_module, tmp_path):
     from loki import fgen
     print("\nIR:")
     print(fgen(driver_mod))
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_field_offload_blocked(frontend, state_module, tmp_path):
+    fcode = """
+    module driver_mod
+      use state_mod, only: state_type
+      use parkind1, only: jprb
+      use field_module, only: field_2rb, field_3rb
+      implicit none
+
+    contains
+
+      subroutine kernel_routine(nlon, nlev, a, b, c)
+        integer, intent(in)             :: nlon, nlev
+        real(kind=jprb), intent(in)     :: a(nlon,nlev)
+        real(kind=jprb), intent(inout)  :: b(nlon,nlev)
+        real(kind=jprb), intent(out)    :: c(nlon,nlev)
+        integer :: i, j
+
+        do j=1, nlon
+          do i=1, nlev
+            b(i,j) = a(i,j) + 0.1
+            c(i,j) = 0.1
+          end do
+        end do
+      end subroutine kernel_routine
+
+      subroutine driver_routine(nlon, nlev, state)
+        integer, intent(in)             :: nlon, nlev
+        type(state_type), intent(inout) :: state
+        integer                         :: i
+
+        !$loki data
+        !$loki driver-loop
+        do i=1,nlev
+            call state%update_view(i)
+            call kernel_routine(nlon, nlev, state%a, state%b, state%c)
+        end do
+        !$loki end data
+
+      end subroutine driver_routine
+    end module driver_mod
+    """
+    driver_mod = Module.from_source(
+        fcode, frontend=frontend, definitions=state_module, xmods=[tmp_path]
+    )
+    driver = driver_mod['driver_routine']
+    deviceptr_prefix = 'loki_devptr_prefix_'
+    driver.apply(FieldOffloadBlockedTransformation(devptr_prefix=deviceptr_prefix,
+                                            offload_index='i',
+                                            field_group_types=['state_type']),
+                 role='driver',
+                 targets=['kernel_routine'])
+
+    from loki import fgen, pprint
+    print('\n')
+    print(pprint(driver.ir))
+    print('\n')
+    print(fgen(driver.ir))
+
+    calls = FindNodes(CallStatement).visit(driver.body)
+    kernel_call = next(c for c in calls if c.name=='kernel_routine')
+
+    # verify that field offloads are generated properly
+    in_calls = [c for c in calls if 'get_device_data_force' in c.name.name.lower()]
+    assert len(in_calls) == 3
+    # verify that field sync host calls are generated properly
+    sync_calls = [c for c in calls if 'sync_host_force' in c.name.name.lower()]
+    assert len(sync_calls) == 2
+
+    # verify that data offload pragmas remain
+    pragmas = FindNodes(Pragma).visit(driver.body)
+    assert len(pragmas) == 3
+    assert all(p.keyword=='loki' and p.content==c for p, c in zip(pragmas, ['data', 'driver-loop', 'end data']))
+
+    # verify that new pointer variables are created and used in driver calls
+    for var in ['state_a', 'state_b', 'state_c']:
+        name = deviceptr_prefix + var
+        assert name in driver.variable_map
+        devptr = driver.variable_map[name]
+        assert isinstance(devptr, sym.Array)
+        assert len(devptr.shape) == 3
+        assert devptr.name in (arg.name for arg in kernel_call.arguments)
+
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_field_offload_slices(frontend, parkind_mod, field_module, tmp_path):  # pylint: disable=unused-argument
@@ -566,15 +651,16 @@ def test_field_offload_driver_compute(frontend, state_module, tmp_path):
         integer                         :: i, ibl
 
         !$loki data
+        !$loki loop
         do ibl=1,nlev
           call state%update_view(ibl)
-
           do i=1, nlon
             state%a(i, 1) = state%b(i, 1) + 0.1
             state%a(i, 2) = state%a(i, 1)
           end do
 
         end do
+        !$loki end loop
         !$loki end data
 
       end subroutine driver_routine

--- a/loki/transformations/field_api.py
+++ b/loki/transformations/field_api.py
@@ -376,3 +376,9 @@ def field_sync_host(field_ptr, transfer_type: FieldAPITransferType, scope: Scope
 def field_create_device_data(field_ptr, scope: Scope, blk_bounds=None):
     return ir.CallStatement(name=sym.ProcedureSymbol('CREATE_DEVICE_DATA', parent=field_ptr, scope=scope),
                             kwarguments=(('blk_bounds', blk_bounds),))
+
+
+def field_wait_for_async_queue(queue, scope: Scope):
+    return ir.CallStatement(name=sym.ProcedureSymbol('WAIT_FOR_ASYNC_QUEUE', scope=scope),
+                            arguments=(queue))
+

--- a/loki/transformations/field_api.py
+++ b/loki/transformations/field_api.py
@@ -352,21 +352,3 @@ def field_sync_host(field_ptr, transfer_type: FieldAPITransferType, scope: Scope
 
     return _field_sync(field_ptr, transfer_type, FieldAPITransferDirection.DEVICE_TO_HOST,
                        scope, queue, blk_bounds)
-
-
-def find_field_offload_calls(ir_section):
-    """
-    Utility function to find all :any:`CallStatement` nodes that are Field API data transfer calls.
-
-    Parameters
-    ----------
-    field_ptr: pointer to field object
-        Pointer to the field to call ``SYNC_HOST`` from.
-    scope: :any:`Scope`
-        Scope of the created :any:`CallStatement`
-    queue: integer
-       ``QUEUE`` optional  argument
-    blk_bounds: integer dimension(2) array
-        ``BLK_BOUNDS`` optional argument
-    """
-    pass

--- a/loki/transformations/field_api.py
+++ b/loki/transformations/field_api.py
@@ -20,7 +20,7 @@ from loki.scope import Scope
 
 __all__ = [
     'FieldAPITransferType', 'FieldPointerMap', 'get_field_type', 'field_get_device_data',
-    'field_get_host_data', 'field_sync_device', 'field_sync_host'
+    'field_get_host_data', 'field_sync_device', 'field_sync_host', 'field_create_device_data'
 ]
 
 
@@ -352,3 +352,7 @@ def field_sync_host(field_ptr, transfer_type: FieldAPITransferType, scope: Scope
 
     return _field_sync(field_ptr, transfer_type, FieldAPITransferDirection.DEVICE_TO_HOST,
                        scope, queue, blk_bounds)
+
+def field_create_device_data(field_ptr, scope: Scope, blk_bounds=None):
+    return ir.CallStatement(name=sym.ProcedureSymbol('CREATE_DEVICE_DATA', parent=field_ptr, scope=scope),
+                            kwarguments=(('blk_bounds', blk_bounds),))

--- a/loki/transformations/field_api.py
+++ b/loki/transformations/field_api.py
@@ -240,7 +240,7 @@ def field_get_device_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferTyp
         ``BLK_BOUNDS`` optional argument
     """
     return _field_get_data(field_ptr, dev_ptr, transfer_type, FieldAPITransferDirection.HOST_TO_DEVICE,
-                           scope, blk_bounds)
+                           scope, queue, blk_bounds)
 
 
 def field_get_host_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferType, scope: Scope,
@@ -265,7 +265,7 @@ def field_get_host_data(field_ptr, dev_ptr, transfer_type: FieldAPITransferType,
         ``BLK_BOUNDS`` optional argument
     """
     return _field_get_data(field_ptr, dev_ptr, transfer_type, FieldAPITransferDirection.DEVICE_TO_HOST,
-                           scope, blk_bounds)
+                           scope, queue, blk_bounds)
 
 
 

--- a/loki/transformations/field_api.py
+++ b/loki/transformations/field_api.py
@@ -125,6 +125,30 @@ class FieldPointerMap:
         )
         return tuple(dict.fromkeys(sync_host))
 
+    def host_to_device_force_calls(self, queue=None, blk_bounds=None):
+        """
+        Returns a tuple of :any:`CallStatement` for host-to-device force transfers on fields.
+        """
+        FORCE = FieldAPITransferType.FORCE
+        host_to_device = tuple(field_get_device_data(
+            self.field_ptr_from_view(arg), self.dataptr_from_array(arg), transfer_type=FORCE,
+            scope=self.scope, queue=queue, blk_bounds=blk_bounds)
+                               for arg in chain(self.inargs, self.inoutargs, self.outargs))
+        return tuple(dict.fromkeys(host_to_device))
+
+
+    def sync_host_force_calls(self, force=False, queue=None, blk_bounds=None):
+        """
+        Returns a tuple of :any:`CallStatement` for host-synchronization transfers on fields.
+        """
+        FORCE = FieldAPITransferType.FORCE
+
+        sync_host = tuple(field_sync_host(
+            self.field_ptr_from_view(arg), transfer_type=FORCE, scope=self.scope, queue=queue,
+            blk_bounds=blk_bounds)
+                          for arg in chain(self.inoutargs, self.outargs))
+        return tuple(dict.fromkeys(sync_host))
+
 
 def get_field_type(a: sym.Array) -> sym.DerivedType:
     """

--- a/loki/transformations/field_blocking.py
+++ b/loki/transformations/field_blocking.py
@@ -1,0 +1,3 @@
+
+from loop_blocking import LoopSplittingVariables, block_loop_arrays, split_loop
+

--- a/loki/transformations/loop_blocking.py
+++ b/loki/transformations/loop_blocking.py
@@ -113,7 +113,7 @@ def split_loop(routine: Subroutine, loop: ir.Loop, block_size: int, data_region=
                       sym.InlineCall(sym.DeferredTypeSymbol('MIN', scope=routine),
                                      parameters=(sym.Product(children=(
                                          splitting_vars.block_idx, splitting_vars.block_size)),
-                                                 loop.bounds.upper))
+                                                 loop.bounds.num_iterations))
                       ))
 
     # Outer loop blocking variable assignments

--- a/loki/transformations/loop_blocking.py
+++ b/loki/transformations/loop_blocking.py
@@ -151,7 +151,6 @@ def split_loop(routine: Subroutine, loop: ir.Loop, block_size: int, data_region=
         # Transformer to place block loop outside data region
         class BlockDataRegionTransformer(Transformer):
             def visit_PragmaRegion(self, pragma_region, **kwargs):
-                # if not is_loki_pragma(pragma_region.pragma, starts_with='data'):
                 if not pragma_region is data_region:
                     return pragma_region
                 change_map = {loop: (inner_loop,)}

--- a/loki/transformations/loop_blocking.py
+++ b/loki/transformations/loop_blocking.py
@@ -13,6 +13,7 @@ from loki.subroutine import Subroutine
 from loki.expression import (
     symbols as sym, parse_expr, ceil_division, iteration_index
 )
+from loki.logging import error
 
 __all__ = ['split_loop', 'block_loop_arrays']
 
@@ -26,10 +27,16 @@ class LoopSplittingVariables:
     def __init__(self, loop_var: sym.Variable, block_size):
         self._loop_var = loop_var
         # self._splitting_vars = splitting_vars
+        if isinstance(block_size, int):
+            blk_size = sym.IntLiteral(block_size)
+        elif isinstance(block_size, sym.Scalar):
+            blk_size = block_size
+        else:
+            error("Block size must a be a an integer constant or a scalar variable")
+
         self._splitting_vars = (loop_var.clone(name=loop_var.name + "_loop_block_size",
                                                type=loop_var.type.clone(parameter=True,
-                                                                        initial=sym.IntLiteral(
-                                                                            block_size))),
+                                                                        initial=blk_size)),
                                 loop_var.clone(name=loop_var.name + "_loop_num_blocks"),
                                 loop_var.clone(name=loop_var.name + "_loop_block_idx"),
                                 loop_var.clone(name=loop_var.name + "_loop_local"),

--- a/loki/transformations/loop_blocking.py
+++ b/loki/transformations/loop_blocking.py
@@ -141,8 +141,8 @@ def split_loop(routine: Subroutine, loop: ir.Loop, block_size: int, outer_loop=N
 
     #  Outer loop bounds + body
     if outer_loop is None:
-        outer_loop = ir.Loop(variable=splitting_vars.block_idx, body=blocking_body + (inner_loop,),
-                             bounds=sym.LoopRange((sym.IntLiteral(1), splitting_vars.num_blocks)))
+        outer_loop = loop.clone(variable=splitting_vars.block_idx, body=blocking_body + (inner_loop,),
+                                bounds=sym.LoopRange((sym.IntLiteral(1), splitting_vars.num_blocks)))
         change_map = {loop: block_loop_inits + (outer_loop,)}
         Transformer(change_map, inplace=True).visit(routine.body)
     else:

--- a/loki/transformations/loop_blocking.py
+++ b/loki/transformations/loop_blocking.py
@@ -151,11 +151,13 @@ def split_loop(routine: Subroutine, loop: ir.Loop, block_size: int, data_region=
         # Transformer to place block loop outside data region
         class BlockDataRegionTransformer(Transformer):
             def visit_PragmaRegion(self, pragma_region, **kwargs):
-                if not is_loki_pragma(pragma_region.pragma, starts_with='data'):
+                # if not is_loki_pragma(pragma_region.pragma, starts_with='data'):
+                if not pragma_region is data_region:
                     return pragma_region
                 change_map = {loop: (inner_loop,)}
-                Transformer(change_map, inplace=True).visit(data_region.body)
-                return outer_loop
+                Transformer(change_map, inplace=True).visit(data_region)
+                return block_loop_inits + (outer_loop,)
+
         BlockDataRegionTransformer(inplace=True).visit(routine.body)
 
     return splitting_vars, inner_loop, outer_loop

--- a/loki/transformations/pragma_model.py
+++ b/loki/transformations/pragma_model.py
@@ -125,6 +125,8 @@ class OpenACCPragmaMapper(GenericPragmaMapper):
             content += f' default({params_default})'
         if params_default := parameters.get('present'):
             content += f' present({params_default})'
+        if params_asynchronous := parameters.get('async'):
+            content += f' async({params_asynchronous})'
         if content:
             return Pragma(keyword='acc', content=f'data{content}')
         return self.default_retval()
@@ -158,7 +160,9 @@ class OpenACCPragmaMapper(GenericPragmaMapper):
             fprivate = f' firstprivate({fprivate_param})' if fprivate_param else ''
             vlength_param = parameters.get('vlength')
             vlength = f' vector_length({vlength_param})' if vlength_param else ''
-            content = f'parallel loop gang{private}{fprivate}{vlength}'
+            asynchronous_param = parameters.get('async')
+            asynchronous = f' async({asynchronous_param})' if asynchronous_param else ''
+            content = f'parallel loop gang{private}{fprivate}{vlength}{asynchronous}'
             return Pragma(keyword='acc', content=content)
         return self.default_retval()
 
@@ -168,16 +172,20 @@ class OpenACCPragmaMapper(GenericPragmaMapper):
         return self.default_retval()
 
     def pmap_device_present(self, pragma, parameters, **kwargs):
+        asynchronous_param = parameters.get('async')
+        asynchronous = f' async({asynchronous_param})' if asynchronous_param else ''
         if param_vars := parameters.get('vars'):
-            return Pragma(keyword='acc', content=f'data present({param_vars})')
+            return Pragma(keyword='acc', content=f'data present({param_vars})'+asynchronous)
         return self.default_retval()
 
     def pmap_end_device_present(self, pragma, parameters, **kwargs):
         return Pragma(keyword='acc', content='end data')
 
     def pmap_device_ptr(self, pragma, parameters, **kwargs):
+        asynchronous_param = parameters.get('async')
+        asynchronous = f' async({asynchronous_param})' if asynchronous_param else ''
         if param_vars := parameters.get('vars'):
-            return Pragma(keyword='acc', content=f'data deviceptr({param_vars})')
+            return Pragma(keyword='acc', content=f'data deviceptr({param_vars})'+asynchronous)
         return self.default_retval()
 
     def pmap_end_device_ptr(self, pragma, parameters, **kwargs):

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -308,10 +308,11 @@ class SCCAnnotateTransformation(Transformation):
                 # Replace `!$loki loop driver` pragma with OpenACC equivalent
                 params = get_pragma_parameters(loop.pragma, starts_with='loop driver')
                 vlength = params.get('vector_length')
-
+                asynchronous = params.get('async')
                 vlength_clause = f' vlength({vlength})' if vlength else ''
+                asynchronous_clause = f' async({asynchronous})' if asynchronous else ''
 
-                content = f'loop gang{private_clause}{vlength_clause}'
+                content = f'loop gang{private_clause}{vlength_clause}{asynchronous_clause}'
                 pragma_new = ir.Pragma(keyword='loki', content=content)
                 pragma_post = ir.Pragma(keyword='loki', content='end loop gang')
 

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -155,6 +155,7 @@ class SCCAnnotateTransformation(Transformation):
 
         role = kwargs['role']
         targets = as_tuple(kwargs.get('targets'))
+        nested_driver_loops = True
 
         if role == 'kernel':
             # Bail if this routine has been processed before
@@ -185,13 +186,15 @@ class SCCAnnotateTransformation(Transformation):
             with pragma_regions_attached(routine):
                 with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
                     # Find variables with existing OpenACC data declarations
-                    acc_vars = self.find_acc_vars(routine, targets)
+                    acc_vars = self.find_acc_vars(routine, targets,
+                                                  nested_driver_loops=nested_driver_loops)
 
-                    driver_loops = find_driver_loops(section=routine.body, targets=targets)
+                    driver_loops = find_driver_loops(section=routine.body, targets=targets,
+                                                     nested=nested_driver_loops)
                     for loop in driver_loops:
                         self.annotate_driver_loop(loop, acc_vars.get(loop, []))
 
-    def find_acc_vars(self, routine, targets):
+    def find_acc_vars(self, routine, targets, nested_driver_loops=False):
         """
         Find variables already specified in loki/acc data clauses.
 
@@ -215,7 +218,8 @@ class SCCAnnotateTransformation(Transformation):
                     parameters = get_pragma_parameters(region.pragma, starts_with='structured-data',
                             only_loki_pragmas=False)
                 if parameters is not None:
-                    driver_loops = find_driver_loops(section=region.body, targets=targets)
+                    driver_loops = find_driver_loops(section=region.body, targets=targets,
+                                                     nested=nested_driver_loops)
                     if not driver_loops:
                         continue
 

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -155,7 +155,6 @@ class SCCAnnotateTransformation(Transformation):
 
         role = kwargs['role']
         targets = as_tuple(kwargs.get('targets'))
-        nested_driver_loops = True
 
         if role == 'kernel':
             # Bail if this routine has been processed before
@@ -186,15 +185,13 @@ class SCCAnnotateTransformation(Transformation):
             with pragma_regions_attached(routine):
                 with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
                     # Find variables with existing OpenACC data declarations
-                    acc_vars = self.find_acc_vars(routine, targets,
-                                                  nested_driver_loops=nested_driver_loops)
+                    acc_vars = self.find_acc_vars(routine, targets)
 
-                    driver_loops = find_driver_loops(section=routine.body, targets=targets,
-                                                     nested=nested_driver_loops)
+                    driver_loops = find_driver_loops(section=routine.body, targets=targets)
                     for loop in driver_loops:
                         self.annotate_driver_loop(loop, acc_vars.get(loop, []))
 
-    def find_acc_vars(self, routine, targets, nested_driver_loops=False):
+    def find_acc_vars(self, routine, targets):
         """
         Find variables already specified in loki/acc data clauses.
 
@@ -218,8 +215,7 @@ class SCCAnnotateTransformation(Transformation):
                     parameters = get_pragma_parameters(region.pragma, starts_with='structured-data',
                             only_loki_pragmas=False)
                 if parameters is not None:
-                    driver_loops = find_driver_loops(section=region.body, targets=targets,
-                                                     nested=nested_driver_loops)
+                    driver_loops = find_driver_loops(section=region.body, targets=targets)
                     if not driver_loops:
                         continue
 

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -185,11 +185,19 @@ class BaseRevectorTransformation(Transformation):
         vector_length = f' vector_length({sizes[0]})' if sizes else ''
 
         # Replace existing `!$loki loop driver markers, but leave all others
-        pragma = ir.Pragma(keyword='loki', content=f'loop driver{vector_length}')
-        loop_pragmas = tuple(
-            p for p in as_tuple(loop.pragma) if not is_loki_pragma(p, starts_with='driver-loop')
-        )
-        loop._update(pragma=loop_pragmas + (pragma,))
+        loop_pragmas = []
+        driver_pragma = None
+        for p in as_tuple(loop.pragma):
+            if is_loki_pragma(p, starts_with='driver-loop'):
+                driver_pragma = p
+            else:
+                loop_pragmas.append(p)
+        loop_pragmas = tuple(loop_pragmas)
+        driver_content = f'loop driver{vector_length}'
+        if driver_pragma is not None:
+            driver_content = p.content.replace('driver-loop', driver_content)
+        driver_pragma = ir.Pragma(keyword='loki', content=driver_content)
+        loop._update(pragma=loop_pragmas + (driver_pragma,))
 
 
 class SCCVecRevectorTransformation(BaseRevectorTransformation):

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -224,6 +224,7 @@ class SCCVecRevectorTransformation(BaseRevectorTransformation):
         """
         role = kwargs['role']
         targets = kwargs.get('targets', ())
+        nested_driver_loops = True
 
         if role == 'kernel':
             # Skip if kernel is marked as `!$loki routine seq`
@@ -245,7 +246,8 @@ class SCCVecRevectorTransformation(BaseRevectorTransformation):
 
         if role == 'driver':
             with pragmas_attached(routine, ir.Loop):
-                driver_loops = find_driver_loops(section=routine.body, targets=targets)
+                driver_loops = find_driver_loops(section=routine.body, targets=targets,
+                                                 nested=nested_driver_loops)
 
                 for loop in driver_loops:
                     # Revector all marked sections within the driver loop body
@@ -343,6 +345,7 @@ class SCCSeqRevectorTransformation(BaseRevectorTransformation):
         # ignore = kwargs.get('ignore', ())
         item = kwargs.get('item', None)
         ignore = item.ignore if item else () + tuple(str(t).lower() for t in as_tuple(kwargs.get('ignore', None)))
+        nested_driver_loops = True
 
         if role == 'kernel':
             # Skip if kernel is marked as `!$loki routine seq`
@@ -401,7 +404,8 @@ class SCCSeqRevectorTransformation(BaseRevectorTransformation):
             routine.variables += (index,)
 
             with pragmas_attached(routine, ir.Loop):
-                driver_loops = find_driver_loops(section=routine.body, targets=targets)
+                driver_loops = find_driver_loops(section=routine.body, targets=targets,
+                                                 nested=nested_driver_loops)
 
                 for loop in driver_loops:
 

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -224,7 +224,6 @@ class SCCVecRevectorTransformation(BaseRevectorTransformation):
         """
         role = kwargs['role']
         targets = kwargs.get('targets', ())
-        nested_driver_loops = True
 
         if role == 'kernel':
             # Skip if kernel is marked as `!$loki routine seq`
@@ -246,8 +245,7 @@ class SCCVecRevectorTransformation(BaseRevectorTransformation):
 
         if role == 'driver':
             with pragmas_attached(routine, ir.Loop):
-                driver_loops = find_driver_loops(section=routine.body, targets=targets,
-                                                 nested=nested_driver_loops)
+                driver_loops = find_driver_loops(section=routine.body, targets=targets)
 
                 for loop in driver_loops:
                     # Revector all marked sections within the driver loop body
@@ -345,7 +343,6 @@ class SCCSeqRevectorTransformation(BaseRevectorTransformation):
         # ignore = kwargs.get('ignore', ())
         item = kwargs.get('item', None)
         ignore = item.ignore if item else () + tuple(str(t).lower() for t in as_tuple(kwargs.get('ignore', None)))
-        nested_driver_loops = True
 
         if role == 'kernel':
             # Skip if kernel is marked as `!$loki routine seq`
@@ -404,8 +401,7 @@ class SCCSeqRevectorTransformation(BaseRevectorTransformation):
             routine.variables += (index,)
 
             with pragmas_attached(routine, ir.Loop):
-                driver_loops = find_driver_loops(section=routine.body, targets=targets,
-                                                 nested=nested_driver_loops)
+                driver_loops = find_driver_loops(section=routine.body, targets=targets)
 
                 for loop in driver_loops:
 

--- a/loki/transformations/tests/test_field_blocking.py
+++ b/loki/transformations/tests/test_field_blocking.py
@@ -1,0 +1,69 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+from loki.frontend import available_frontends
+from loki import Module, pprint, fgen
+from loki.ir import FindNodes, nodes as ir
+from loki.transformations.loop_blocking import split_loop
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_field_blocking_simple_loop(tmp_path, frontend):
+    fsource = """
+    module driver_mod
+      ! use state_mod, only: state_type
+      ! use parkind1, only: jprb
+      ! use field_module, only: field_2rb, field_3rb
+
+      implicit none
+      contains
+
+      subroutine driver_routine (nlon, nlev, a, b, c)
+        integer, intent(in) :: nlon
+        integer, intent(in) :: nlev
+        type(field_2rb), intent(inout) :: a, b, c
+
+        real, pointer :: ptr_a(:,:), ptr_b(:,:), ptr_c(:,:)
+        integer :: i
+        integer :: j
+
+        call a%get_device_data_rdwr(ptr_a)
+        call b%get_device_data_rdwr(ptr_b)
+        call c%get_device_data_rdwr(ptr_c)
+
+        !$loki driver-loop
+        do j=1,nlon
+          do i=1,nlev
+            ptr_b(i, j) = ptr_a(i, j) + 0.1
+            ptr_c(i, j) = 0.1
+          end do
+        end do
+
+        call a%sync_host_rdwr()
+        call b%sync_host_rdwr()
+        call c%sync_host_rdwr()
+
+      end subroutine driver_routine
+
+    end module driver_mod
+    """
+    driver_mod = Module.from_source(
+        fsource, frontend=frontend, xmods=[tmp_path]
+    )
+    driver = driver_mod['driver_routine']
+    loops = FindNodes(ir.Loop).visit(driver.ir)
+    assert len(loops) == 2
+
+    block_size = 100
+    splitting_vars, inner_loop, outer_loop = split_loop(driver, loops[0], block_size)
+
+    print('\n')
+    print(pprint(driver.ir))
+    print('\n')
+    print(fgen(driver.ir))
+

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -594,15 +594,7 @@ def is_pragma_driver_loop(loop):
     return False
 
 
-def has_target_calls(loop, targets, recurse=True):
-    greedy = not recurse
-    for call in FindNodes(ir.CallStatement, greedy=greedy).visit(loop.body):
-        if call.name in targets:
-            return True
-    return False
-
-
-def is_driver_loop(loop, targets):
+def is_target_driver_loop(loop, targets):
     """
     Test/check whether a given loop is a *driver loop*.
 
@@ -614,10 +606,10 @@ def is_driver_loop(loop, targets):
         List of subroutines that are to be considered as part of
         the transformation call tree.
     """
-    if is_pragma_driver_loop(loop):
-        return True
-    return has_target_calls(loop, targets)
-
+    for call in FindNodes(ir.CallStatement).visit(loop.body):
+        if call.name in targets:
+            return True
+    return False
 
 def find_driver_loops(section, targets):
     """
@@ -634,22 +626,23 @@ def find_driver_loops(section, targets):
         List of subroutines that are to be considered as part of
         the transformation call tree.
     """
-    driver_loops = []
-    def add_driver_loop(loop, targets):
+    pragma_driver_loops = []
+    target_driver_loops = []
+    nested_driver_loops = []
+    for loop in FindNodes(ir.Loop).visit(section):
         if is_pragma_driver_loop(loop):
-            driver_loops.append(loop)
-            return False
-        if has_target_calls(loop, targets, recurse=False):
-            return True
-        for nested_loop in FindNodes(ir.Loop, greedy=True).visit(loop):
-            if add_driver_loop(nested_loop):
-                return True
-        return False
-
-    for loop in FindNodes(ir.Loop, greedy=True).visit(section):
-        if add_driver_loop(loop, targets):
-            driver_loops.append(loop)
-    return driver_loops
+            pragma_driver_loops.append(loop)
+        if loop in nested_driver_loops:
+            continue
+        if targets and not is_target_driver_loop(loop, targets):
+            continue
+        target_driver_loops.append(loop)
+        loops = FindNodes(ir.Loop).visit(loop.body)
+        nested_driver_loops.extend(loops)
+    
+    if pragma_driver_loops:
+        return pragma_driver_loops
+    return target_driver_loops
 
 
 def get_local_arrays(routine, section, unique=True):

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -585,6 +585,23 @@ def get_loop_bounds(routine, dimension):
     return bounds
 
 
+def is_pragma_driver_loop(loop):
+    if loop.pragma:
+        for pragma in loop.pragma:
+            if is_loki_pragma(pragma, starts_with='driver-loop') or \
+               is_loki_pragma(pragma, starts_with='loop driver'):
+                return True
+    return False
+
+
+def has_target_calls(loop, targets, recurse=True):
+    greedy = not recurse
+    for call in FindNodes(ir.CallStatement, greedy=greedy).visit(loop.body):
+        if call.name in targets:
+            return True
+    return False
+
+
 def is_driver_loop(loop, targets):
     """
     Test/check whether a given loop is a *driver loop*.
@@ -597,18 +614,12 @@ def is_driver_loop(loop, targets):
         List of subroutines that are to be considered as part of
         the transformation call tree.
     """
-    if loop.pragma:
-        for pragma in loop.pragma:
-            if is_loki_pragma(pragma, starts_with='driver-loop') or \
-               is_loki_pragma(pragma, starts_with='loop driver'):
-                return True
-    for call in FindNodes(ir.CallStatement).visit(loop.body):
-        if call.name in targets:
-            return True
-    return False
+    if is_pragma_driver_loop(loop):
+        return True
+    return has_target_calls(loop, targets)
 
 
-def find_driver_loops(section, targets, nested=False):
+def find_driver_loops(section, targets):
     """
     Find and return all driver loops in a given `section`.
 
@@ -623,21 +634,21 @@ def find_driver_loops(section, targets, nested=False):
         List of subroutines that are to be considered as part of
         the transformation call tree.
     """
-    print(f"\nnested = {nested}\n")
     driver_loops = []
-    nested_driver_loops = []
-    for loop in FindNodes(ir.Loop).visit(section):
-        if loop in nested_driver_loops:
-            continue
+    def add_driver_loop(loop, targets):
+        if is_pragma_driver_loop(loop):
+            driver_loops.append(loop)
+            return False
+        if has_target_calls(loop, targets, recurse=False):
+            return True
+        for nested_loop in FindNodes(ir.Loop, greedy=True).visit(loop):
+            if add_driver_loop(nested_loop):
+                return True
+        return False
 
-        if not is_driver_loop(loop, targets):
-            continue
-
-        driver_loops.append(loop)
-        loops = FindNodes(ir.Loop).visit(loop.body)
-        nested_driver_loops.extend(loops)
-    if nested:
-        return nested_driver_loops
+    for loop in FindNodes(ir.Loop, greedy=True).visit(section):
+        if add_driver_loop(loop, targets):
+            driver_loops.append(loop)
     return driver_loops
 
 

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -585,6 +585,29 @@ def get_loop_bounds(routine, dimension):
     return bounds
 
 
+def is_driver_loop(loop, targets):
+    """
+    Test/check whether a given loop is a *driver loop*.
+
+    Parameters
+    ----------
+    loop : :any: `Loop`
+        The loop to test if it is a *driver loop*.
+    targets : list or string
+        List of subroutines that are to be considered as part of
+        the transformation call tree.
+    """
+    if loop.pragma:
+        for pragma in loop.pragma:
+            if is_loki_pragma(pragma, starts_with='driver-loop') or \
+               is_loki_pragma(pragma, starts_with='loop driver'):
+                return True
+    for call in FindNodes(ir.CallStatement).visit(loop.body):
+        if call.name in targets:
+            return True
+    return False
+
+
 def is_pragma_driver_loop(loop):
     if loop.pragma:
         for pragma in loop.pragma:

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -608,7 +608,7 @@ def is_driver_loop(loop, targets):
     return False
 
 
-def find_driver_loops(section, targets):
+def find_driver_loops(section, targets, nested=False):
     """
     Find and return all driver loops in a given `section`.
 
@@ -623,7 +623,7 @@ def find_driver_loops(section, targets):
         List of subroutines that are to be considered as part of
         the transformation call tree.
     """
-
+    print(f"\nnested = {nested}\n")
     driver_loops = []
     nested_driver_loops = []
     for loop in FindNodes(ir.Loop).visit(section):
@@ -636,6 +636,8 @@ def find_driver_loops(section, targets):
         driver_loops.append(loop)
         loops = FindNodes(ir.Loop).visit(loop.body)
         nested_driver_loops.extend(loops)
+    if nested:
+        return nested_driver_loops
     return driver_loops
 
 


### PR DESCRIPTION
This PR adds a new transformation, FieldOffloadBlockedTransformation, that can block driver loops and perform blocked (optionally asynchronous) offload using Field API.

There is a corresponding dwarf-p-cloudsc PR:


