### PR TITLE
Add ``LoopTree`` data structure for simplifying loop structure analyses and update ``find_driver_loops`` to handle nested pragma marked driver loops correctly.

### DIFF
--- a/loki/analyse/__init__.py
+++ b/loki/analyse/__init__.py
@@ -9,3 +9,4 @@ Advanced analysis utilities, such as dataflow analysis functionalities.
 """
 
 from loki.analyse.analyse_dataflow import *  # noqa
+from loki.analyse.loop_analysis import *  # noqa

--- a/loki/analyse/loop_analysis.py
+++ b/loki/analyse/loop_analysis.py
@@ -1,0 +1,132 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+LoopTree data structure for analysing loop structure and utility methods for
+loop analysis.
+"""
+
+from collections import deque
+from loki.ir import nodes as ir, Visitor
+
+
+__all__ = [
+    'LoopTree', 'get_loop_tree'
+]
+
+
+class LoopTree:
+    """
+    A data structure that stores nested loops in a forest of trees.
+
+    Parameters
+    ----------
+    roots : list of :any:`LoopTree.TreeNode`
+        top level loops in the ir section of the LoopTree
+    loop_map : dict of (:any:`ir.Loop`, :any:`TreeNode`)
+        dictionary with key-value pairs of :any:`ir.Loop` nodes in the tree
+        and corresponding :any:`TreeNode` nodes
+    """
+
+    class TreeNode:
+        """
+        Internal node class for nodes in the LoopTree
+
+        Parameters
+        ----------
+        loop : :any:`ir.Loop`
+            :any:`ir.Loop` of the tree node
+        parent : :any:`LoopTree.Treenode` or None
+            parent node in the LoopTree
+        parent : list of :any:`LoopTree.Treenode`
+            child nodes in the LoopTree
+        depth : int
+            nesting depth of the node (0 if root)
+        """
+
+        def __init__(self, loop: ir.Loop, parent=None):
+            self.loop = loop
+            self.parent = parent
+            self.children = []
+            self.depth = 0 if parent is None else parent.depth+1
+
+            if parent:
+                parent.children.append(self)
+
+    def __init__(self):
+        self.roots = []
+        self.loop_map = {}
+
+    def add_node(self, loop: ir.Loop, parent: TreeNode = None):
+        """
+        Helper function to add a loop to the LoopTree
+        """
+        tree_node = self.TreeNode(loop, parent)
+        if parent is None:
+            self.roots.append(tree_node)
+        self.loop_map[loop] = tree_node
+        return tree_node
+
+    def get_tree_node(self, loop: ir.Loop):
+        """
+        Get LoopTree node corresponding to Loki IR Loop node.
+        """
+        return self.loop_map.get(loop)
+
+    def walk_depth_first(self, pre_order=True):
+        """
+        Generator for depth first traversal of the loop tree.
+
+        Parameters
+        ----------
+        pre_order : `bool`
+            Order of depth first traversal, if `True` parent nodes are visited before children.
+            default: True
+        """
+        def visit(tree_node):
+            if pre_order:
+                yield tree_node
+
+            for child in tree_node.children:
+                yield from visit(child)
+
+            if not pre_order:
+                yield tree_node
+
+        for root in self.roots:
+            yield from visit(root)
+
+    def walk_breadth_first(self):
+        """
+        Generator for breadth first traversal of the loop tree.
+        """
+        queue = deque(self.roots)
+        while queue:
+            tree_node = queue.popleft()
+            yield tree_node
+            queue.extend(tree_node.children)
+
+
+def get_loop_tree(region: ir.Node):
+    """
+    Function that construct a loop tree with all loops in an IR region
+    """
+    class LoopTreeBuilder(Visitor):
+        def __init__(self):
+            super().__init__()
+            self.loop_tree = LoopTree()
+
+        def visit_Loop(self, loop, **kwargs):
+            parent = kwargs.pop('parent', None)
+            tree_node = self.loop_tree.add_node(loop, parent)
+
+            for o in loop.children:
+                self.visit(o, parent=tree_node, **kwargs)
+
+    tree_builder = LoopTreeBuilder()
+    tree_builder.visit(region)
+    return tree_builder.loop_tree

--- a/loki/analyse/tests/test_loop_analysis.py
+++ b/loki/analyse/tests/test_loop_analysis.py
@@ -1,0 +1,86 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from loki import Subroutine
+from loki.frontend import available_frontends
+from loki.analyse import get_loop_tree
+from loki.ir import nodes as ir, FindNodes
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_loop_tree(frontend):
+    fcode = """
+subroutine driver(a, b, c, m, n, p)
+  real, intent(inout) :: a(:,:,:), b(:,:,:), c(:,:,:)
+  integer, intent(in) :: m, n, p
+  integer             :: i,j,k
+
+  do i=1,m
+
+    do j=1,n
+      do k=1,p
+        b(k,j,i) = k
+      end do
+    end do
+
+    do j=2,n
+      a(:,j,i) = j
+    end do
+  end do
+
+  do i=2,m
+    c(:,:,i) = i
+  end do
+
+  do i=3,m
+    do j=3,m
+      do k=2,p
+        c(k,j,i) = i+j+k
+      end do
+    end do
+  end do
+end subroutine driver
+"""
+    driver = Subroutine.from_source(fcode, frontend=frontend)
+
+    loops = FindNodes(ir.Loop).visit(driver.ir)
+    assert len(loops) == 8
+
+    loop_tree = get_loop_tree(driver.ir)
+    assert len(loop_tree.roots) == 3
+
+    # verify that pre-order dfs walk order is corect
+    for tree_node, loop in zip(loop_tree.walk_depth_first(), loops):
+        assert tree_node.loop == loop, "pre order dfs walk should be the same sequence as FindNodes"
+
+    # verify that loop map works correctly
+    for tree_node, loop in zip(loop_tree.walk_depth_first(), loops):
+        assert tree_node == loop_tree.get_tree_node(loop), "wrong loop_map entry for curent loop"
+
+    # verify that depths of loop tree nodes are correct
+    depths = [0, 1, 2, 1, 0, 0, 1, 2]
+    for tree_node, depth in zip(loop_tree.walk_depth_first(), depths):
+        assert tree_node.depth == depth
+
+    # verify that post-order dfs walk order is correct
+    post_order_indices = [2, 1, 3, 0, 4, 7, 6, 5]
+    post_order_loops = [loops[i] for i in post_order_indices]
+    for tree_node, loop in zip(loop_tree.walk_depth_first(pre_order=False), post_order_loops):
+        assert tree_node.loop == loop
+
+    # verify that bfs walk order is correct
+    bfs_indices = [0, 4, 5, 1, 3, 6, 2, 7]
+    bfs_loops = [loops[i] for i in bfs_indices]
+    for tree_node, loop in zip(loop_tree.walk_breadth_first(), bfs_loops):
+        assert tree_node.loop == loop
+
+    # verify that depths are correct with dfs walk
+    bfs_depths = [0, 0, 0, 1, 1, 1, 2, 2]
+    for tree_node, depth in zip(loop_tree.walk_breadth_first(), bfs_depths):
+        assert tree_node.depth == depth

--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -21,7 +21,8 @@ from loki.transformations.utilities import (
     convert_to_lower_case, replace_intrinsics, rename_variables,
     get_integer_variable, get_loop_bounds, is_driver_loop,
     find_driver_loops, get_local_arrays, check_routine_sequential,
-    substitute_variables_for_definitions, get_loop_tree, LoopTree
+    substitute_variables_for_definitions, get_loop_tree,
+    is_pragma_driver_loop, is_target_driver_loop
 )
 
 
@@ -467,6 +468,95 @@ end subroutine test_find_driver_loops
         assert isinstance(driver_loops[0].body[0], ir.Assignment)
         assert driver_loops[1].variable == 'i'
         assert isinstance(driver_loops[1].body[0], ir.CallStatement)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_utilities_find_driver_loops_multiple_nested(frontend):
+    """ Test :any:`find_driver_loops` utility. """
+
+    fcode = """
+subroutine test_find_driver_loops(n, start, end, arr)
+  integer, intent(in) :: n, start, end
+  real, intent(inout) :: arr(1000)
+  integer :: i, j, k, l
+
+  !$loki driver-loop
+  do i=start,end       ! driver loop 0 (loop 0)
+    arr(i) = 2. * arr(i)
+  end do
+
+  do j=start,end
+    arr(j) = 2. * arr(j)
+  end do
+
+  do i=start, end
+    !$loki driver-loop
+    do j=start,end     ! driver loop 1 (loop 3)
+      arr(j) = 2. * arr(j)
+    end do
+
+    do j=start,end     ! driver loop 2 (loop 4)
+        call target_kernel(arr(j))
+    end do
+  end do
+
+  do i=start,end
+    do j=start,end     ! driver loop 3 (loop 6)
+        do l=start,end
+            call target_kernel(arr(i+j+l))
+        end do
+    end do
+
+    !$loki driver-loop
+    do j=start,end     ! driver loop 4 (loop 8)
+        arr(j+l) = 2. * arr(j+l)
+    end do
+  end do
+
+
+  do i=start,end        ! driver loop 5 (loop 9)
+
+    call target_kernel(arr(i))
+
+    do j=start,end
+      arr(j) = 2. * arr(j)
+    end do
+
+    call target_kernel(arr(i))
+
+  end do
+
+  !$loki driver-loop
+  do i=start,end       ! driver loop 6 (loop 11)
+    arr(i) = 2. * arr(i)
+  end do
+
+end subroutine test_find_driver_loops
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    with pragmas_attached(routine, node_type=ir.Loop):
+        # Test is_driver_loop utility
+        loops = FindNodes(ir.Loop).visit(routine.body)
+        assert len(loops) == 12
+
+        assert is_pragma_driver_loop(loops[0])
+        assert is_driver_loop(loops[0], targets=())
+        assert not is_pragma_driver_loop(loops[1])
+
+        assert not is_driver_loop(loops[1], targets=())
+        assert not is_driver_loop(loops[2], targets=())
+
+        assert is_driver_loop(loops[3], targets=())
+        assert not is_driver_loop(loops[4], targets=())
+        assert is_driver_loop(loops[4], targets=('target_kernel', ))
+        assert is_target_driver_loop(loops[4], targets=('target_kernel', ))
+
+        # Test find_driver_loops utility
+        driver_loops = find_driver_loops(routine.body, targets=('target_kernel',))
+        assert len(driver_loops) == 7
+        for i in [0, 3, 4, 6, 8, 9, 11]:
+            assert loops[i] in driver_loops
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -707,6 +707,13 @@ def is_target_driver_loop(loop, targets):
     return False
 
 
+def has_target_call(loop, targets):
+    for o in loop.body:
+        if isinstance(o, ir.CallStatement) and o.name in targets:
+            return True
+    return False
+
+
 def is_driver_loop(loop, targets):
     """
     Test/check whether a given loop is a *driver loop*.
@@ -745,8 +752,8 @@ def find_driver_loops(section, targets):
             for root in loop_tree.roots:
                 target_driver_loops = []
                 has_pragma_driver = self.__visit(root, targets, target_driver_loops)
-            if not has_pragma_driver:
-                self.driver_loops.extend(target_driver_loops)
+                if not has_pragma_driver:
+                    self.driver_loops.extend(target_driver_loops)
 
             return [node.loop for node in self.driver_loops]
 
@@ -755,13 +762,13 @@ def find_driver_loops(section, targets):
             if is_pragma_driver_loop(node.loop):
                 self.driver_loops.append(node)
                 return True
-            is_target_driver = is_target_driver_loop(node.loop, targets)
+            is_target_driver = has_target_call(node.loop, targets)
 
 
             nested_pragma_driver = False
             nested_target_driver_loops = []
             for child in node.children:
-                nested_pragma_driver |= self.__visit(node, targets, nested_target_driver_loops)
+                nested_pragma_driver |= self.__visit(child, targets, nested_target_driver_loops)
 
             if is_target_driver:
                 if nested_pragma_driver:


### PR DESCRIPTION
This PR introduces a new data structure, ``LoopTree``, for doing analyses of nested loops in Loki and an updated version of the ``find_driver_loops`` utility function.

The data structure is a tree (actually a forest of trees) of loop IR nodes with some additional information about the loop nesting, e.g. children and parent references. Similar data structures are common in many compilers (see for instance LLVMs LoopInfo class) and make it easier to perform analyses that require information about loop nesting.

The motivation for introducing the LoopTree came as I was updating the ``find_driver_loops`` utility function. Previously, if multiple loops were nested,  this utility function would always return the outermost loop, even if an inner loop was explicitly marked as a driver-loop with a ``!$loki driver-loop``-pragma. . A modification/update to the ``find_driver_loops`` utility is required for the ``FieldOffloadBlockedTransformation`` that introduces an outer block loop around the driver loop to perform blocked data offload (see PR: [FieldOffloadBlockedTransformation - Add transformation for blocked and asynchronous data offload using FIELD API #560](https://github.com/ecmwf-ifs/loki/pull/560)).

The update to make ``find_driver_loops`` in this PR will make it honour Loki-pragma marked driver loops, even if there is a nested loop within that has a target call. In the case of nested loops with target calls, the new implementation will make the outermost loop that does not contain a nested ``!$loki driver-loop`` the driver loop. This means that the behaviour is the same as before, unless there is a  ``!$loki driver-loop``, in which case the pragma-marked loop takes precedence.

There is an open issue [SCC: Loop over blocks not annotated correctly when nested within another loop in driver #246](https://github.com/ecmwf-ifs/loki/issues/246) where a similar issue is discussed. With this update to ``find_driver_loops`` it will be possible to explicitly select which loops that should be considered driver loops by introducing a new ``Transformation`` that marks the selected loops with ``!$loki driver-loop`` pragmas (as pragma-marked loops now always will be marked driver loops). I think this is a sensible solution as it gives users the freedom to override the default behaviour but still behaves more or less as before and does not break any existing tests.

