### PR TITLE
`DataOffloadDeepcopyAnalysis`

### DIFF
--- a/loki/transformations/data_offload/__init__.py
+++ b/loki/transformations/data_offload/__init__.py
@@ -11,3 +11,4 @@ Sub-package providing data offload transformations.
 from loki.transformations.data_offload.field_offload import * # noqa
 from loki.transformations.data_offload.global_var import * # noqa
 from loki.transformations.data_offload.offload import * # noqa
+from loki.transformations.data_offload.offload_deepcopy import * # noqa

--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -1,0 +1,338 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+from loki.batch import Transformation, TypeDefItem, ProcedureItem
+from loki.ir import nodes as ir, FindNodes, SubstituteExpressions
+from loki.expression import symbols as sym
+from loki.analyse.analyse_dataflow import DataflowAnalysisAttacher, DataflowAnalysisDetacher
+from loki.transformations.utilities import find_driver_loops
+from loki.logging import warning
+
+__all__ = ['DataOffloadDeepcopyAnalysis']
+
+
+def strip_nested_dimensions(expr):
+    """
+    Strip dimensions from array expressions of arbitrary derived-type
+    nesting depth.
+    """
+
+    parent = expr.parent
+    if parent:
+        parent = strip_nested_dimensions(parent)
+    return expr.clone(dimensions=None, parent=parent)
+
+
+def get_sanitised_arg_map(arg_map):
+    """
+    Return sanitised mapping of dummy argument names to arguments.
+    """
+
+    _arg_map = {}
+    for dummy, arg in arg_map.items():
+        if isinstance(arg, sym._Literal):
+            continue
+        if isinstance(arg, sym.LogicalNot):
+            arg = arg.child
+
+        _arg_map[dummy.clone(dimensions=None)] = strip_nested_dimensions(arg)
+
+    return _arg_map
+
+
+def map_derived_type_arguments(arg_map, analysis):
+    """
+    Map the root variable of derived-type dummy argument components
+    to the corresponding argument.
+    """
+
+    _analysis = {}
+    for k, v in analysis.items():
+
+        dummy_root = k.parents[0] if k.parents else k
+        if not (arg := arg_map.get(dummy_root, None)):
+            continue
+
+        expr_map = {dummy_root: arg}
+        var = SubstituteExpressions(expr_map).visit(k)
+
+        _analysis[var] = v
+
+    return _analysis
+
+
+def create_nested_dict(k, v, variable_map):
+    """Create nested dict from derived-type expression."""
+
+    name_parts = k.name.split('%', maxsplit=1)
+    parent = variable_map[name_parts[0]].clone(dimensions=None)
+    if len(name_parts) > 1:
+        child_name_parts = name_parts[1].split('%', maxsplit=1)
+        child = parent.type.dtype.typedef.variable_map[child_name_parts[0]]
+        if len(child_name_parts) > 1:
+            child = child.get_derived_type_member(child_name_parts[1])
+        v = create_nested_dict(child, v, parent.type.dtype.typedef.variable_map)
+
+    return {parent: v}
+
+
+def merge_nested_dict(ref_dict, temp_dict, force=False):
+    """Merge nested dicts."""
+
+    for key in temp_dict:
+        if key in ref_dict:
+            if isinstance(temp_dict[key], dict) and isinstance(ref_dict[key], dict):
+                ref_dict[key] = merge_nested_dict(ref_dict[key], temp_dict[key], force=force)
+            elif force:
+                ref_dict[key] = temp_dict[key]
+        else:
+            ref_dict.update({key: temp_dict[key]})
+
+    return ref_dict
+
+
+class DeepcopyDataflowAnalysisAttacher(DataflowAnalysisAttacher):
+    """
+    Dummy argument intents in Fortran also have implications on memory status, and `INTENT(OUT)`
+    is therefore fundamentally unsafe for allocatables and pointers. Therefore in order to discern
+    write-only accesses to arguments, we have to bypass the intent. This is achieved here by importing
+    the dataflow analysis of the child :any:`Subroutine` and ignoring the intents altogether.
+    """
+
+    def visit_CallStatement(self, o, **kwargs):
+
+        successor_map = kwargs['successor_map']
+
+        if not o.routine:
+            msg = f'[Loki::DataOffloadDeepcopyAnalysis] Cannot apply transformation without enriching calls: {o}.'
+            raise RuntimeError(msg)
+
+        child = successor_map.get(o, None)
+        if not child:
+            return self.visit_Node(o, **kwargs)
+
+        # remap root variable names to current scope
+        arg_map = get_sanitised_arg_map(o.arg_map)
+        child_analysis = child.trafo_data['DataOffloadDeepcopyAnalysis']['analysis']
+        child_analysis = map_derived_type_arguments(arg_map, child_analysis)
+
+        defines, uses = set(), set()
+        for k, v in child_analysis.items():
+
+            if 'read' in v:
+                uses |= {k}
+            if 'write' in v:
+                defines |= {k}
+
+        return self.visit_Node(o, defines_symbols=defines, uses_symbols=uses, **kwargs)
+
+class DataOffloadDeepcopyAnalysis(Transformation):
+    """
+    A transformation pass to analyse the usage of subroutine arguments in a call-tree. The resulting analysis is a
+    nested dict, of nesting depth equal to the longest derived-type expression, containing the access
+    mode of all the arguments used in a call-tree. For example, the following assignments:
+
+    .. code-block:: fortran
+       a%b%c = a%b%c + 1
+       d = e
+
+
+    would yield the following analysis:
+
+    .. code-block:: python
+       {
+          a: {
+            b: {
+               c: 'readwrite'
+            }
+          },
+          d: 'write',
+          e: 'read' 
+       }
+
+    The analysis is stored in the :any:`Item.trafo_data` of the :any:`Item` corresponding to the driver layer
+    :any:`Subroutine`. It should be noted that the analysis is stored per driver-layer loop.
+
+    Parameters
+    ----------
+    output_analysis : bool
+       If enabled, the analysis is written to disk as yaml files. For kernels, the files are named
+       routine.name_dataoffload_analysis.yaml. For drivers, the files are named 
+       driver_target-name_offload_analysis.yaml, where "target-name" is the name of the first target
+       routine in a given driver loop.
+    """
+
+    _key = 'DataOffloadDeepcopyAnalysis'
+
+    reverse_traversal = True
+    """Traversal from the leaves upwards"""
+
+    item_filter = (ProcedureItem, TypeDefItem)
+    # Modules (correctly) placed in the ignore list contain type definitions and must
+    # therefore be processed.
+    process_ignored_items = True
+
+    def __init__(self, output_analysis=False):
+        self.output_analysis = output_analysis
+
+    def transform_subroutine(self, routine, **kwargs):
+
+        if not (item := kwargs.pop('item', None)):
+            msg = f'[Loki::DataOffloadDeepcopyAnalysis] Cannot apply transformation without item: {routine}.'
+            raise RuntimeError(msg)
+
+        role = kwargs.pop('role')
+        targets = kwargs.pop('targets')
+        successors = kwargs.pop('sub_sgraph').successors(item=item)
+
+
+        if role == 'driver':
+            self.process_driver(routine, item, successors, targets, **kwargs)
+        if role == 'kernel':
+            self.process_kernel(routine, item, successors, **kwargs)
+
+    def stringify_dict(self, _dict):
+        """
+        Stringify expression keys of a nested dict.
+        """
+
+        stringified_dict = {}
+        for k, v in _dict.items():
+            if isinstance(v, dict):
+                stringified_dict[k.name.lower()] = self.stringify_dict(v)
+            else:
+                stringified_dict[k.name.lower()] = v
+
+        return stringified_dict
+
+    def process_driver(self, routine, item, successors, targets, **kwargs):
+
+        item.trafo_data[self._key] = defaultdict(dict)
+
+        for loop in find_driver_loops(routine.body, targets):
+
+            # We can't simply map successor.ir: successor here because we may call a routine twice with different
+            # arguments
+            successor_map = {}
+            calls = FindNodes(ir.CallStatement).visit(loop.body)
+            for call in calls:
+                if (successor := [s for s in successors if call.routine == s.ir]):
+                    successor_map[call] = successor[0]
+
+            #gather analysis from children
+            analysis = self.gather_analysis_from_children(successor_map)
+            self.gather_typedefs_from_children(successors, item.trafo_data[self._key]['typedef_configs'])
+
+            layered_dict = {}
+            for k, v in analysis.items():
+                _temp_dict = create_nested_dict(k, v, routine.symbol_map)
+                layered_dict = merge_nested_dict(layered_dict, _temp_dict)
+
+            item.trafo_data[self._key]['analysis'][loop] = layered_dict
+
+            if self.output_analysis:
+                str_layered_dict = self.stringify_dict(layered_dict)
+                base_dir = Path(kwargs['build_args']['output_dir'])
+                with open(base_dir/f'driver_{list(successor_map.keys())[0].name}_dataoffload_analysis.yaml', 'w') as f:
+                    yaml.dump(str_layered_dict, f)
+
+    def process_kernel(self, routine, item, successors, **kwargs):
+
+        #gather analysis from children
+        item.trafo_data[self._key] = defaultdict(dict)
+        self.gather_typedefs_from_children(successors, item.trafo_data[self._key]['typedef_configs'])
+
+        pointers = any(a.ptr for a in FindNodes(ir.Assignment).visit(routine.body))
+        if pointers:
+            warning(f'[Loki::DataOffloadDeepcopyAnalysis] Pointer associations found in {routine.name}')
+
+        # We can't simply map successor.ir: successor here because we may call a routine twice with different
+        # arguments
+        successor_map = {}
+        for call in FindNodes(ir.CallStatement).visit(routine.body):
+            if (successor := [s for s in successors if call.routine == s.ir]):
+                successor_map[call] = successor[0]
+
+        # We make do here (lazily) without a context manager, as this override of the
+        # DataflowAnalysisAttacher is not meant for use outside of the current module.
+        DeepcopyDataflowAnalysisAttacher().visit(routine.spec, successor_map=successor_map)
+        DeepcopyDataflowAnalysisAttacher().visit(routine.body, successor_map=successor_map)
+
+        #gather used symbols in specification
+        for v in routine.spec.uses_symbols:
+            if v.name_parts[0].lower() in routine._dummies:
+                item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'read'
+
+        #gather used and defined symbols in body
+        for v in routine.body.uses_symbols:
+            if v.name_parts[0].lower() in routine._dummies:
+                item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'read'
+
+        for v in routine.body.defines_symbols:
+            if v.name_parts[0].lower() in routine._dummies:
+                if v in (routine.spec.uses_symbols | routine.body.uses_symbols):
+                    item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'readwrite'
+                else:
+                    item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'write'
+
+        DataflowAnalysisDetacher().visit(routine.spec)
+        DataflowAnalysisDetacher().visit(routine.body)
+
+        if self.output_analysis:
+            layered_dict = {}
+            for k, v in item.trafo_data[self._key]['analysis'].items():
+                _temp_dict = create_nested_dict(k, v, routine.symbol_map)
+                layered_dict = merge_nested_dict(layered_dict, _temp_dict)
+
+            base_dir = Path(kwargs['build_args']['output_dir'])
+            with open(base_dir/f'{routine.name.lower()}_dataoffload_analysis.yaml', 'w') as file:
+                str_layered_dict = self.stringify_dict(layered_dict)
+                yaml.dump(str_layered_dict, file)
+
+    def gather_analysis_from_children(self, successor_map):
+        """Gather analysis from callees."""
+
+        analysis = {}
+        for call, child in successor_map.items():
+
+            arg_map = get_sanitised_arg_map(call.arg_map)
+            child_analysis = child.trafo_data[self._key]['analysis']
+            child_analysis = map_derived_type_arguments(arg_map, child_analysis)
+
+            for k, v in child_analysis.items():
+                _v = analysis.get(k, v)
+                if _v != v:
+                    if _v == 'write':
+                        continue
+                    analysis[k] = 'readwrite'
+                else:
+                    analysis[k] = _v
+
+        return analysis
+
+    def gather_typedefs_from_children(self, successors, typedef_configs):
+        """Gather type definitions imported in children."""
+
+        for child in successors:
+            if isinstance(child, TypeDefItem) and child.trafo_data.get(self._key, None):
+                for k, v in child.trafo_data[self._key]['typedef_configs'].items():
+                    typedef_configs[k] = v
+
+    def transform_typedef(self, typedef, **kwargs):
+        """Cache the current type definition for later reuse."""
+
+        item = kwargs['item']
+        successors = kwargs['sub_sgraph'].successors(item=item)
+
+        item.trafo_data[self._key] = defaultdict(dict)
+        item.trafo_data[self._key]['typedef_configs'][typedef.name.lower()] = item.config
+        self.gather_typedefs_from_children(successors, item.trafo_data[self._key]['typedef_configs'])

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -210,7 +210,7 @@ def fixture_expected_analysis():
                 'p': 'readwrite'
             },
             'c': {
-                'p': 'readwrite'
+                'p': 'read'
             },
             'd': {
                 'p': 'write'
@@ -257,7 +257,7 @@ def test_offload_deepcopy_analysis(frontend, config, deepcopy_code, expected_ana
             if isinstance(v, dict):
                 sorted_dict[k] = _nested_sort(v)
             else:
-                sorted_dict[k] = k
+                sorted_dict[k] = v
 
         return dict(sorted(sorted_dict.items()))
 

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -1,0 +1,298 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from shutil import rmtree
+import pytest
+import yaml
+
+from loki import (
+        gettempdir, available_frontends, Scheduler, DataOffloadDeepcopyAnalysis,
+        find_driver_loops, log_levels
+)
+
+
+@pytest.fixture(scope='module', name='deepcopy_code')
+def fixture_deepcopy_code():
+    fcode = {
+        #----- field_module -----
+        'field_module' : (
+            """
+module field_module
+type :: field_3d
+end type
+end module field_module
+            """.strip()
+        ),
+
+        #----- type_mod -----
+        'type_def_mod' : (
+            """
+module type_def_mod
+   use field_module, only : field_3d
+   type :: variable_type
+      class(field_3d), pointer :: fp => null()
+      real, pointer, contiguous :: p(:,:,:) => null()
+   end type
+
+   type :: superfluous_type
+      type(variable_type) :: var
+   end type
+
+   type :: struct_type
+      type(variable_type) :: a
+      type(variable_type) :: b
+      type(variable_type) :: c
+      type(variable_type) :: d
+      type(variable_type) :: e
+      type(superfluous_type), allocatable :: var_ptr(:)
+   end type
+
+   type :: opts_type
+      logical :: one_flag
+      logical :: another_flag
+   end type
+
+   type :: dims_type
+      integer :: kst
+      integer :: kend
+      integer :: kbl
+      integer :: ngpblks
+   end type
+end module type_def_mod
+            """.strip()
+        ),
+
+        #----- nested_kernel_write -----
+        'nested_kernel_write' : (
+            """
+module nested_kernel_write_mod
+contains
+subroutine nested_kernel_write(p)
+    !... intent(out) can be dangerous with pointers, so we make this intent(inout)
+    real, intent(inout) :: p(:,:,:)
+
+    p = 0.
+end subroutine nested_kernel_write
+end module nested_kernel_write_mod
+            """.strip()
+        ),
+
+        #----- nested_kernel_read -----
+        'nested_kernel_read' : (
+            """
+module nested_kernel_read_mod
+contains
+subroutine nested_kernel_read(p)
+    real, intent(in) :: p(:,:,:)
+    real, allocatable :: b(:,:,:)
+
+    allocate(b, mold=p)
+    b = p
+    deallocate(b)
+end subroutine nested_kernel_read
+end module nested_kernel_read_mod
+            """.strip()
+        ),
+
+        #----- other_kernel -----
+        'other_kernel' : (
+            """
+module other_kernel_mod
+contains
+subroutine other_kernel(struct)
+   use type_def_mod, only : variable_type
+   type(variable_type), intent(inout) :: struct
+
+   struct%p = struct%p + 1.
+end subroutine other_kernel
+end module other_kernel_mod
+            """.strip()
+        ),
+
+        #----- kernel -----
+        'kernel' : (
+            """
+module kernel_mod
+contains
+subroutine kernel(bnds, struct)
+   use nested_kernel_write_mod, only: nested_kernel_write
+   use nested_kernel_read_mod, only: nested_kernel_read
+   use other_kernel_mod, only : other_kernel
+   use type_def_mod, only: struct_type, dims_type
+   implicit none
+
+   type(dims_type), intent(in) :: bnds
+   type(struct_type), intent(inout) :: struct
+
+   integer :: jrof, jfld
+   real, pointer :: tmp(:,:,:) => null()
+
+   call nested_kernel_write(struct%a%p(:,:,bnds%kbl))
+   call nested_kernel_read(struct%b%p(:,:,bnds%kbl))
+
+   tmp => struct%c%p !... yes this completely breaks the dataflow analysis
+   tmp = 0.
+
+   do jrof = bnds%kst, bnds%kend
+     struct%b%p(jrof,:,bnds%kbl) = struct%a%p(jrof,:,bnds%kbl)
+   enddo 
+
+   do jfld = 1, size(struct%var_ptr)
+     call other_kernel(struct%var_ptr(jfld)%var)
+   enddo
+
+   do jrof = bnds%kst, bnds%kend
+     struct%d%p(jrof,:,bnds%kbl) = struct%e%p(jrof,:,bnds%kbl)
+   enddo 
+
+end subroutine kernel
+end module kernel_mod
+            """.strip()
+        ),
+
+        #----- driver -----
+        'driver' : (
+            """
+subroutine driver(dims, struct)
+   use kernel_mod, only : kernel
+   use nested_kernel_write_mod, only: nested_kernel_write
+   use type_def_mod, only: struct_type, dims_type
+   implicit none
+
+   type(dims_type), intent(in) :: dims
+   type(struct_type), intent(inout) :: struct
+   type(dims_type) :: local_dims
+   integer :: ibl
+
+   local_dims = dims
+
+   do ibl=1,local_dims%ngpblks
+     local_dims%kbl = ibl
+
+     call kernel(local_dims, struct)
+     call nested_kernel_write(struct%e%p(:,:,local_dims%kbl))
+   enddo
+
+end subroutine driver
+            """.strip()
+        )
+    }
+
+    workdir = gettempdir()/'test_offload_deepcopy'
+    if workdir.exists():
+        rmtree(workdir)
+    workdir.mkdir()
+    for name, code in fcode.items():
+        (workdir/f'{name}.F90').write_text(code)
+
+    yield workdir
+
+    rmtree(workdir)
+
+
+@pytest.fixture(scope='module', name='expected_analysis')
+def fixture_expected_analysis():
+    return {
+        'local_dims': {
+            'kbl': 'read',
+            'kend': 'read',
+            'kst': 'read'
+        },
+        'struct': {
+            'a': {
+                'p': 'write'
+            },
+            'b': {
+                'p': 'readwrite'
+            },
+            'c': {
+                'p': 'readwrite'
+            },
+            'd': {
+                'p': 'write'
+            },
+            'e': {
+                'p': 'readwrite'
+            },
+            'var_ptr': {
+                'var': {
+                    'p': 'readwrite'
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture(scope='function', name='config')
+def fixture_config():
+    """
+    Default configuration dict with basic options.
+    """
+    return {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': True,
+            'enable_imports': True,
+        },
+    }
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('output_analysis', [True, False])
+def test_offload_deepcopy_analysis(frontend, config, deepcopy_code, expected_analysis,
+                                   output_analysis, tmp_path, caplog):
+    """
+    Test the analysis for the data offload deepcopy generation.
+    """
+
+    def _nested_sort(_dict):
+        sorted_dict = {}
+        for k, v in _dict.items():
+            if isinstance(v, dict):
+                sorted_dict[k] = _nested_sort(v)
+            else:
+                sorted_dict[k] = k
+
+        return dict(sorted(sorted_dict.items()))
+
+    config['routines'] = {
+        'driver': {'role': 'driver'},
+        'variable_type': {'field_prefix': 'f'}
+    }
+
+    scheduler = Scheduler(
+        paths=deepcopy_code, config=config, frontend=frontend, xmods=[tmp_path],
+        output_dir=tmp_path
+    )
+
+    with caplog.at_level(log_levels['WARNING']):
+        transformation = DataOffloadDeepcopyAnalysis(output_analysis=output_analysis)
+        scheduler.process(transformation=transformation)
+
+        # check that the warning for pointer associations is produced
+        messages = [log.message for log in caplog.records]
+        assert '[Loki::DataOffloadDeepcopyAnalysis] Pointer associations found in kernel' in messages
+
+    # The analysis is tied to driver loops
+    trafo_data_key = transformation._key
+    driver_item = scheduler['#driver']
+    driver_loop = find_driver_loops(driver_item.ir.body, targets=['kernel', 'nested_kernel_write'])[0]
+
+    #stringify dict for comparison
+    stringified_dict = transformation.stringify_dict(driver_item.trafo_data[trafo_data_key]['analysis'][driver_loop])
+    sorted_expected_analysis = _nested_sort(expected_analysis)
+    assert _nested_sort(stringified_dict) == sorted_expected_analysis
+
+    # check that the typedef config was also collected
+    assert driver_item.trafo_data[trafo_data_key]['typedef_configs']['variable_type']['field_prefix'] == 'f'
+
+    if output_analysis:
+        with open(tmp_path/'driver_kernel_dataoffload_analysis.yaml', 'r') as file:
+            _dict = yaml.safe_load(file)
+        assert _nested_sort(_dict) == sorted_expected_analysis

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -82,7 +82,6 @@ class SCCAnnotateTransformation(Transformation):
                             for v in pragma_params.get('private', []) + private_arrays
                         )
                         pragma_content = [f'{kw}({val})' if val else kw for kw, val in pragma_params.items()]
-                        print(f"pragma_content: {pragma_content}")
                         pragma._update(content=f'loop vector {" ".join(pragma_content)}'.strip())
 
     def warn_vec_within_seq_loops(self, routine):


### PR DESCRIPTION
This PR contributes an analysis pass to determine the nested usage of arguments to a call-tree. The result is a nested dict per driver-loop containing the access mode of arguments to all the target routines in that driver loop. Three access modes are possible: `read, write, readwrite`. The companion to this analysis is a transformation to generate deepcopy data offload instructions based on the analysis.

The analysis relies on a reversed traversal of the scheduler tree, but the accompanying transformation does not traverse the scheduler tree, and instead just operates at the driver layer using the collected analysis. Clearly, some level of configurability is necessary in the deepcopy generation, for example for inconsistent naming conventions in type definitions. The best way I could think of doing this was to place entries in the scheduler config corresponding to typedefs, and to then collect these typedef config entries during the analysis to pass to the transformation. That's why this PR also contributes a `transform_typedef` entry point in the `Transformation` class. I am open to suggestions for more elegant ways of achieving this.