### PR TITLE
Add offload utils

### DIFF
--- a/docs/source/loki_pragma_model.csv
+++ b/docs/source/loki_pragma_model.csv
@@ -1,8 +1,8 @@
 Loki,OpenACC,OMP-GPU
-``create device(...)``,``declare create(...)``,
+``create device(...)``,``declare create(...)``,``declare target(...)``
 ``update device(...) host(...)``,``update device(...) self(...)``,
-``unstructured-data in(...) create(...)``,``enter data copyin(...) create(...)``,``target enter data map(to: ...) map(alloc: ...)``
-``end unstructured-data out(...) delete(...)``,``exit data copyout(...) delete(...)``,``target exit data map(from: ...) map(delete: ...) map(release: ... ???)``
+``unstructured-data in(...) create(...) attach(...)``,``enter data copyin(...) create(...) attach(...)``,``target enter data map(to: ...) map(alloc: ...)``
+``end unstructured-data out(...) delete(...) detach(...)``,``exit data copyout(...) delete(...) detach(...)``,``target exit data map(from: ...) map(delete: ...) map(release: ... ???)``
 ``structured-data inout(...) in(...) out(...) create(...) present(...)``,``data copy(...) copyin(...) copyout(...) create(...) present(...)``,``target data map(tofrom: ...) map(to: ...) map(from: ...) map(to: ...)``
 ``end structured-data inout(...) in(...) out(...)``,``end data``,``end target data``
 ``loop gang private(...) vlength(...)``,``parallel loop gang private(...) vector_length(...)``,``target teams distribute thread_limit(...) ???``

--- a/loki/transformations/pragma_model.py
+++ b/loki/transformations/pragma_model.py
@@ -97,6 +97,8 @@ class OpenACCPragmaMapper(GenericPragmaMapper):
             content += f' copyin({param_in})'
         if param_create := parameters.get('create'):
             content += f' create({param_create})'
+        if param_attach := parameters.get('attach'):
+            content += f' attach({param_attach})'
         if content:
             return Pragma(keyword='acc', content=f'enter data{content}')
         return self.default_retval()
@@ -107,6 +109,8 @@ class OpenACCPragmaMapper(GenericPragmaMapper):
             content += f' copyout({params_out})'
         if params_delete := parameters.get('delete'):
             content += f' delete({params_delete})'
+        if param_detach := parameters.get('detach'):
+            content += f' detach({param_detach})'
         if content:
             final = ' finalize' if 'finalize' in parameters else ''
             return Pragma(keyword='acc', content=f'exit data{content}{final}')

--- a/loki/transformations/pragma_model.py
+++ b/loki/transformations/pragma_model.py
@@ -108,7 +108,8 @@ class OpenACCPragmaMapper(GenericPragmaMapper):
         if params_delete := parameters.get('delete'):
             content += f' delete({params_delete})'
         if content:
-            return Pragma(keyword='acc', content=f'exit data{content}')
+            final = ' finalize' if 'finalize' in parameters else ''
+            return Pragma(keyword='acc', content=f'exit data{content}{final}')
         return self.default_retval()
 
     def pmap_structured_data(self, pragma, parameters, **kwargs):

--- a/loki/transformations/tests/test_pragma_model.py
+++ b/loki/transformations/tests/test_pragma_model.py
@@ -43,8 +43,8 @@ subroutine some_func(ret)
 
   !$loki create device(tmp1, tmp2)
   !$loki update device(tmp1) host(tmp2)
-  !$loki unstructured-data in(tmp1, tmp2) create(tmp3, tmp4)
-  !$loki end unstructured-data out(tmp2, tmp3, tmp4) delete(tmp1)
+  !$loki unstructured-data in(tmp1, tmp2) create(tmp3, tmp4) attach(tmp1)
+  !$loki end unstructured-data out(tmp2, tmp3, tmp4) detach(tmp1) delete(tmp1) finalize
   !$loki structured-data in(tmp1) out(tmp2) inout(tmp3) create(tmp4)
   !$loki end structured-data in(tmp1) out(tmp2) inout(tmp3) create(tmp4)
   !$loki loop gang private(tmp1) vlength(128)
@@ -92,8 +92,8 @@ end subroutine some_func
     if directive == 'openacc':
         args = (('acc', 'declare create(tmp1, tmp2)'),
                 ('acc', ('update', 'device(tmp1)', 'self(tmp2)'), False),
-                ('acc', ('enter data', 'copyin(tmp1, tmp2)', 'create(tmp3, tmp4)'), False),
-                ('acc', ('exit data', 'copyout(tmp2, tmp3, tmp4)', 'delete(tmp1)'), False),
+                ('acc', ('enter data', 'copyin(tmp1, tmp2)', 'create(tmp3, tmp4)', 'attach(tmp1)'), False),
+                ('acc', ('exit data', 'copyout(tmp2, tmp3, tmp4)', 'detach(tmp1)', 'delete(tmp1)', 'finalize'), False),
                 ('acc', ('data', 'copyin(tmp1)', 'copy(tmp3)', 'copyout(tmp2)', 'create(tmp4)'), False),
                 ('acc', 'end data'),
                 ('acc', ('parallel loop gang', 'private(tmp1)', 'vector_length(128)'), False),
@@ -143,8 +143,9 @@ end subroutine some_func
     if directive is None:
         args = (('loki', 'create device(tmp1, tmp2)'),
                 ('loki', ('update', 'device(tmp1)', 'host(tmp2)'), False),
-                ('loki', ('unstructured-data', 'in(tmp1, tmp2)', 'create(tmp3, tmp4)'), False),
-                ('loki', ('end unstructured-data', 'out(tmp2, tmp3, tmp4)', 'delete(tmp1)'), False),
+                ('loki', ('unstructured-data', 'in(tmp1, tmp2)', 'create(tmp3, tmp4)', 'attach(tmp1)', ), False),
+                ('loki', ('end unstructured-data', 'out(tmp2, tmp3, tmp4)', 'detach(tmp1)', 'delete(tmp1)', 'finalize'),
+                          False),
                 ('loki', ('structured-data', 'in(tmp1)', 'out(tmp2)', 'inout(tmp3)', 'create(tmp4)'), False),
                 ('loki', ('end structured-data', 'in(tmp1)', 'out(tmp2)', 'inout(tmp3)', 'create(tmp4)'), False),
                 ('loki', ('loop gang', 'private(tmp1)', 'vlength(128)'), False),


### PR DESCRIPTION
This small PR contributes the following offload utilities:
- `attach/detach` clauses for OpenACC unstructured data pragmas
- Optional `finalize` clause for OpenACC unstructured data pragmas
- Addition of `GET_HOST_DATA_*` and `DELETE_DEVICE_DATA`