### PR TITLE
Basic exception handling with some origin information for Transformation.apply

### DIFF
--- a/loki/batch/tests/test_transformation.py
+++ b/loki/batch/tests/test_transformation.py
@@ -61,13 +61,13 @@ end subroutine myroutine
     assert source._incomplete is lazy
     if method == 'source':
         if lazy:
-            with pytest.raises(RuntimeError):
+            with pytest.raises(TransformationError):
                 source.apply(rename_transform)
             source.make_complete(frontend=frontend, xmods=[tmp_path])
         source.apply(rename_transform)
     elif method == 'transformation':
         if lazy:
-            with pytest.raises(RuntimeError):
+            with pytest.raises(TransformationError):
                 rename_transform.apply(source)
             source.make_complete(frontend=frontend, xmods=[tmp_path])
         rename_transform.apply(source)
@@ -135,7 +135,7 @@ end subroutine myroutine
     assert source[target]._incomplete is lazy
 
     if lazy:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(TransformationError):
             apply_method(rename_transform, source[target])
         source[target].make_complete(frontend=frontend, xmods=[tmp_path])
     apply_method(rename_transform, source[target])
@@ -198,7 +198,7 @@ end subroutine myroutine
     assert source['myroutine']._incomplete is lazy
 
     if lazy:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(TransformationError):
             apply_method(rename_transform, source['mymodule'])
         source['mymodule'].make_complete(frontend=frontend, xmods=[tmp_path])
     apply_method(rename_transform, source['mymodule'])
@@ -443,7 +443,7 @@ end subroutine rick
     ricks_path.unlink()
 
     # Check error behaviour if no item provided
-    with pytest.raises(ValueError):
+    with pytest.raises(TransformationError):
         FileWriteTransformation().apply(source=source)
 
 

--- a/loki/batch/tests/test_transformation.py
+++ b/loki/batch/tests/test_transformation.py
@@ -3,9 +3,9 @@ from pathlib import Path
 import pytest
 
 from loki import (
-    Sourcefile, Subroutine, FindInlineCalls, fgen, IntLiteral, Module
+    Sourcefile, Subroutine, FindInlineCalls, fgen, IntLiteral, Module, Function
 )
-from loki.batch import Transformation, Pipeline, ProcedureItem
+from loki.batch import Transformation, Pipeline, ProcedureItem, TransformationError
 from loki.jit_build import jit_compile, clean_test
 from loki.frontend import available_frontends, OMNI, REGEX
 from loki.ir import nodes as ir, FindNodes
@@ -634,3 +634,80 @@ end subroutine test_pipeline_compose
     assert '<MaybeNotTrafo  [loki.batch.tests.test_transformation]' in str(pipe)
     assert '<YesTrafo  [loki.batch.tests.test_transformation]' in str(pipe)
     assert '<NoTrafo  [loki.batch.tests.test_transformation]' in str(pipe)
+
+
+@pytest.mark.parametrize('plan_mode', [True, False])
+def test_transformation_exception_handling(plan_mode):
+    fcode = """
+module some_mod
+    implicit none
+    integer :: mod_var
+contains
+    subroutine some_routine(arg)
+        integer, intent(inout) :: arg
+    end subroutine some_routine
+
+    real function func()
+        func = 0.0
+    end function func
+end module some_mod
+
+subroutine free_routine(val)
+    implicit none
+    integer, intent(in) :: val
+end subroutine free_routine
+    """.strip()
+
+    class RuntimeErrorTransformation(Transformation):
+
+        recurse_to_modules = True
+        recurse_to_procedures = True
+
+        def __init__(self, fail_cls, fail_name):
+            self.fail_cls = fail_cls
+            self.fail_name = fail_name
+
+        def transform_file(self, sourcefile, **kwargs):
+            if self.fail_cls == Sourcefile:
+                raise RuntimeError
+
+        plan_file = transform_file
+
+        def transform_module(self, module, **kwargs):
+            if self.fail_cls == Module and self.fail_name == module.name.lower():
+                raise RuntimeError
+
+        plan_module = transform_module
+
+        def transform_subroutine(self, routine, **kwargs):
+            if self.fail_cls in (Subroutine, Function) and self.fail_name == routine.name.lower():
+                raise RuntimeError
+
+        plan_subroutine = transform_subroutine
+
+    # Dummy run without triggering
+    source = Sourcefile.from_source(fcode)
+    RuntimeErrorTransformation(fail_cls=None, fail_name=None).apply(source, plan_mode=plan_mode)
+
+    for fail_cls, fail_name in (
+            (Sourcefile, ''),
+            (Subroutine, 'some_routine'),
+            (Function, 'func'),
+            (Subroutine, 'free_routine'),
+            (Module, 'some_mod')
+    ):
+        message_pattern = f'RuntimeErrorTransformation.*?{fail_cls.__name__}.*?{fail_name.lower()}'
+
+        with pytest.raises(TransformationError, match=message_pattern):
+            RuntimeErrorTransformation(fail_cls=fail_cls, fail_name=fail_name).apply(source, plan_mode=plan_mode)
+
+        # Validate direct call with ir node
+        if fail_name:
+            with pytest.raises(TransformationError, match=message_pattern):
+                RuntimeErrorTransformation(
+                    fail_cls=fail_cls,
+                    fail_name=fail_name
+                ).apply(
+                    source[fail_name],
+                    plan_mode=plan_mode
+                )

--- a/loki/batch/transformation.py
+++ b/loki/batch/transformation.py
@@ -306,7 +306,7 @@ class Transformation:
                 self.transform_file(sourcefile, item=item, role=role, targets=targets, items=items, **kwargs)
         except Exception as e:
             raise TransformationError(
-                message=f'Error in Sourcefile {sourcefile.path!s}',
+                message=f'Error in Sourcefile {sourcefile.path!s} -- {e!s}',
                 transformation=type(self), source=sourcefile
             ) from e
 
@@ -341,7 +341,7 @@ class Transformation:
                                 )
                         except Exception as e:
                             raise TransformationError(
-                                message=f'Error in Module {item.ir.name}',
+                                message=f'Error in Module {item.ir.name} -- {e!s}',
                                 transformation=type(self), source=item.ir
                             ) from e
             else:
@@ -353,7 +353,7 @@ class Transformation:
                             self.transform_module(module, item=item, role=role, targets=targets, items=items, **kwargs)
                     except Exception as e:
                         raise TransformationError(
-                            message=f'Error in Module {module.name}',
+                            message=f'Error in Module {module.name} -- {e!s}',
                             transformation=type(self), source=module
                         ) from e
 
@@ -374,7 +374,7 @@ class Transformation:
                                 )
                         except Exception as e:
                             raise TransformationError(
-                                message=f'Error in Procedure {item.ir.name}',
+                                message=f'Error in Procedure {item.ir.name} -- {e!s}',
                                 transformation=type(self), source=item.ir
                             ) from e
             else:
@@ -386,7 +386,7 @@ class Transformation:
                             self.transform_subroutine(routine, item=item, role=role, targets=targets, **kwargs)
                     except Exception as e:
                         raise TransformationError(
-                            message=f'Error in Procedure {routine.name}',
+                            message=f'Error in Procedure {routine.name} -- {e!s}',
                             transformation=type(self), source=routine
                         ) from e
 
@@ -425,7 +425,7 @@ class Transformation:
                 self.transform_subroutine(subroutine, **kwargs)
         except Exception as e:
             raise TransformationError(
-                message=f'Error in Procedure {subroutine.name}',
+                message=f'Error in Procedure {subroutine.name} -- {e!s}',
                 transformation=type(self), source=subroutine
             ) from e
 
@@ -468,7 +468,7 @@ class Transformation:
                 self.transform_module(module, **kwargs)
         except Exception as e:
             raise TransformationError(
-                message=f'Error in Module {module.name}',
+                message=f'Error in Module {module.name} -- {e!s}',
                 transformation=type(self), source=module
             ) from e
 

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -672,7 +672,7 @@ class OMNI2IR(GenericVisitor):
             body += [ir.Intrinsic('SEQUENCE')]
 
         # Build the list of derived type members and individual body for each
-        if struct_type.find('symbols'):
+        if struct_type.find('symbols') is not None:
             variables = self.visit(struct_type.find('symbols'), **kwargs)
             for v in variables:
                 if isinstance(v.type.dtype, ProcedureType):
@@ -685,7 +685,7 @@ class OMNI2IR(GenericVisitor):
                 else:
                     body += [ir.VariableDeclaration(symbols=(v,))]
 
-        if struct_type.find('typeBoundProcedures'):
+        if struct_type.find('typeBoundProcedures') is not None:
             # See if components are marked private
             body += [ir.Intrinsic('CONTAINS')]
             if struct_type.attrib.get('is_internal_private') == 'true':
@@ -747,7 +747,7 @@ class OMNI2IR(GenericVisitor):
         if o.get('is_public') == 'true':
             _type = _type.clone(public=True)
 
-        if o.find('binding'):
+        if o.find('binding') is not None:
             bind_name = self.visit(o.find('binding/name'), **kwargs)
             bind_name_scope = scope.get_symbol_scope(bind_name.name)
 
@@ -1094,7 +1094,7 @@ class OMNI2IR(GenericVisitor):
     def visit_FifStatement(self, o, **kwargs):
         condition = self.visit(o.find('condition'), **kwargs)
         body = self.visit(o.find('then/body'), **kwargs)
-        if o.find('else'):
+        if o.find('else') is not None:
             else_body = self.visit(o.find('else/body'), **kwargs)
         else:
             else_body = ()

--- a/loki/transformations/inline/tests/test_inline_transformation.py
+++ b/loki/transformations/inline/tests/test_inline_transformation.py
@@ -10,7 +10,7 @@ import pytest
 from loki import Module, Subroutine
 from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
-from loki.batch import Scheduler, SchedulerConfig
+from loki.batch import Scheduler, SchedulerConfig, TransformationError
 
 from loki.transformations.inline import InlineTransformation
 
@@ -194,7 +194,7 @@ end module somemod
         inline_marked=True, inline_internals=True, resolve_sequence_association=False
     )
     outer = module["outer"]
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TransformationError):
         trafo.apply(outer)
     callnames = [call.name for call in FindNodes(ir.CallStatement).visit(outer.body)]
 
@@ -258,7 +258,7 @@ end module somemod
         inline_marked=True, inline_internals=False, resolve_sequence_association=False
     )
     outer = module["outer"]
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TransformationError):
         trafo.apply(outer)
 
     # Test case that crash is avoided by activating sequence association.
@@ -297,7 +297,7 @@ end module somemod
         inline_marked=True, inline_internals=False, resolve_sequence_association=True
     )
     outer = module["outer"]
-    with pytest.raises(ValueError):
+    with pytest.raises(TransformationError):
         trafo.apply(outer)
 
 

--- a/loki/transformations/tests/test_block_index_inject.py
+++ b/loki/transformations/tests/test_block_index_inject.py
@@ -12,6 +12,7 @@ from loki import (
     Dimension, gettempdir, Scheduler, OMNI, FindNodes, Assignment, FindVariables, CallStatement, Subroutine,
     Item, available_frontends, Module, ir, get_pragma_parameters
 )
+from loki.batch import TransformationError
 from loki.transformations import (
         BlockViewToFieldViewTransformation, InjectBlockIndexTransformation,
         LowerBlockIndexTransformation, LowerBlockLoopTransformation
@@ -411,11 +412,11 @@ end subroutine kernel
     kernel = Subroutine.from_source(fcode, frontend=frontend)
     item = Item(name='#kernel', source=kernel)
     item.trafo_data['BlockViewToFieldViewTransformation'] = {'definitions': []}
-    with pytest.raises(KeyError):
+    with pytest.raises(TransformationError):
         BlockViewToFieldViewTransformation(horizontal).apply(kernel, item=item, role='kernel',
                                            targets=('compute',))
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TransformationError):
         BlockViewToFieldViewTransformation(horizontal).apply(kernel, role='kernel',
                                            targets=('compute',))
 


### PR DESCRIPTION
This should give a slightly more informative message when hitting an exception in a transformation, giving an indication on what program unit node the problem occurs.