### PR TITLE
Function: Add test and fix for implicit return type with result name

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -1950,7 +1950,7 @@ class FParser2IR(GenericVisitor):
 
         # If the return type is given, inject it into the symbol table
         if return_type:
-            routine.symbol_attrs[routine.name] = return_type
+            routine.symbol_attrs[routine.result_name] = return_type
 
         # Now all declarations are well-defined and we can parse the member routines
         contains = self.visit(get_child(o, Fortran2003.Internal_Subprogram_Part), **kwargs)

--- a/loki/tests/test_function.py
+++ b/loki/tests/test_function.py
@@ -42,6 +42,12 @@ contains
 
     fun = a
   end function funcky
+
+  real function square(a) result(b)
+    implicit none
+    real, intent(in) :: a
+    b = a * a
+  end function square
 end module my_funcs
     """
     module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
@@ -83,6 +89,13 @@ end module my_funcs
     assert module['funcky'].return_type.kind == 8
     assert len(FindNodes(ir.VariableDeclaration).visit(module['funcky'].spec)) == 2
     assert len(FindNodes(ir.ProcedureDeclaration).visit(module['funcky'].spec)) == 0
+
+    # Implicit return type and renamed result name
+    assert isinstance(module['square'], Function)
+    assert module['square'].result_name == 'b'
+    assert module['square'].return_type.dtype == BasicType.REAL
+    assert len(FindNodes(ir.VariableDeclaration).visit(module['square'].spec)) == 2 if frontend == OMNI else 1
+    assert len(FindNodes(ir.ProcedureDeclaration).visit(module['square'].spec)) == 0
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
This covers the corner case in which the function return type is declared implicitly as a function prefix, but the result variable is defined without explicit declaration via `result(var)`.

This corner case seems to have been missed in PR #552 and should now address issue #513. Many thanks to @remi-kazeroni for providing the test case that was added in this PR.