### PR TITLE
`DataOffloadDeepcopyTransformation`

### DIFF
--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -216,7 +216,7 @@ class BlockViewToFieldViewTransformation(Transformation):
         return var.clone(name=var.name.upper().replace('GFL_PTR', 'GFL_PTR_G'),
                          parent=parent, type=_type)
 
-    def process_body(self, body, definitions, successors, targets, exclude_arrays):
+    def process_body(self, body, item, successors, targets, exclude_arrays):
 
         # build list of type-bound array access using the horizontal index
         _vars = [var for var in FindVariables(unique=False).visit(body)
@@ -244,7 +244,9 @@ class BlockViewToFieldViewTransformation(Transformation):
         vmap = {k: v for k, v in vmap.items() if not any(e in k for e in exclude_arrays)}
 
         # propagate dummy field_api wrapper definitions to children
-        self.propagate_defs_to_children(self._key, definitions, successors)
+        if item.trafo_data.get(self._key, None):
+            definitions = item.trafo_data[self._key]['definitions']
+            self.propagate_defs_to_children(self._key, definitions, successors)
 
         # finally we perform the substitution
         return SubstituteExpressions(vmap).visit(body)
@@ -265,8 +267,7 @@ class BlockViewToFieldViewTransformation(Transformation):
         SCCBaseTransformation.resolve_vector_dimension(routine, loop_variable=v_index, bounds=bounds)
 
         # for kernels we process the entire body
-        routine.body = self.process_body(routine.body, item.trafo_data[self._key]['definitions'],
-                                         successors, targets, exclude_arrays)
+        routine.body = self.process_body(routine.body, item, successors, targets, exclude_arrays)
 
 
 class InjectBlockIndexTransformation(Transformation):

--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -153,6 +153,10 @@ class BlockViewToFieldViewTransformation(Transformation):
 
             typedefs += (ir.TypeDef(name=_type, body=decls, parent=field_array_module),) # pylint: disable=unexpected-keyword-arg
 
+        # attach a scope to the symbols in the newly created typedefs
+        for typedef in typedefs:
+            typedef.rescope_symbols()
+
         return typedefs
 
     def _create_dummy_field_api_defs(self, field_array_mod_imports):

--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -360,7 +360,51 @@ class DataOffloadDeepcopyAnalysis(Transformation):
 
 class DataOffloadDeepcopyTransformation(Transformation):
     """
-    A transformation to generate deepcopies of derived-types.
+    A transformation that generates a deepcopy of all the arguments to a
+    GPU kernel. It relies on the analysis gathered by the 
+    :any:`DataOffloadDeepcopyAnalysis` transformation, which must therefore
+    be run before this. Please note that the analysis and deepcopy are per
+    driver-loop, which must be wrapped in a `!$loki data` :any:`PragmaRegion`.
+
+    An underlying assumption of the transformation is that expressions used as 
+    lvalues and rvalues are of type :any:`BasicType`, i.e. the data
+    encompassed by a derived-type variable `a` with components `b` and `c` is
+    only ever accessed or modified via fully qualified derived-type expressions
+    `a%b` or `a%c`. The only accepted exception to this are memory status checks
+    such as `ubound`, `lbound`, `size` etc.
+
+    The encompassing `!$loki data` :any:`PragmaRegion` can be used to 
+    to pass hints to the transformation. Consider the following example:
+
+    .. code-block:: fortran
+       !$loki data present(a) write(b)
+       do ibl=1,nblks
+          call kernel(a, b, ...)
+       enddo
+       !$loki end data
+
+    Marking `a` as `present` instructs the transformation to skip the deepcopy
+    generation for it and simply place it in a `!$loki structured-data present`
+    clause. Marking `b` as `write` means the contents of the analysis are 
+    overriden and the generated deepcopy for `b` assumes write-only access. Other
+    hints that can be passed to the deepcopy generation are:
+     - read: Assume read-only access for the specified variables.
+     - readwrite: Assume read-write access for the specified variables.
+     - device_resident: Don't copy the specificied variables back to host and
+                        leave the device allocation intact.
+     - temporary: Wipe the device allocation of the specified variables but
+                  don't copy them  back to host.
+
+    The transformation supports two modes:
+     - offload: Generate device-host deepcopy for the arguments passed to the 
+                encompassed call-tree.
+     - set_pointers: Generate the FIELD_API boiler-plate to set host pointers
+                     for any argument representing a field.
+
+    Parameters
+    ----------
+    mode : str
+       Transformation mode, must be either "offload" or "set_pointers".
     """
 
     _key = 'DataOffloadDeepcopyAnalysis'

--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -424,9 +424,9 @@ class DataOffloadDeepcopyTransformation(Transformation):
 
         if mode == 'offload':
             # wrap in acc data present pragma
-            content = f"data present({', '.join(present_vars)})"
-            acc_data_pragma = ir.Pragma(keyword='acc', content=content)
-            acc_data_pragma_post = ir.Pragma(keyword='acc', content="end data")
+            content = f"structured-data present({', '.join(present_vars)})"
+            acc_data_pragma = ir.Pragma(keyword='loki', content=content)
+            acc_data_pragma_post = ir.Pragma(keyword='loki', content='end structured-data')
 
             pragma_map = {region.pragma: (copy, acc_data_pragma)}
             pragma_map.update({region.pragma_post: (acc_data_pragma_post, host, wipe)})
@@ -561,7 +561,7 @@ class DataOffloadDeepcopyTransformation(Transformation):
     @staticmethod
     def enter_data_copyin(var):
         """Generate unstructured data copyin instruction."""
-        return as_tuple(ir.Pragma(keyword='acc', content=f'enter data copyin({var})'))
+        return as_tuple(ir.Pragma(keyword='loki', content=f'unstructured-data in({var})'))
 
     @staticmethod
     def enter_data_create(var):
@@ -571,22 +571,22 @@ class DataOffloadDeepcopyTransformation(Transformation):
     @staticmethod
     def enter_data_attach(var):
         """Generate unstructured data attach instruction."""
-        return as_tuple(ir.Pragma(keyword='acc', content=f'enter data attach({var})'))
+        return as_tuple(ir.Pragma(keyword='loki', content=f'unstructured-data attach({var})'))
 
     @staticmethod
     def exit_data_detach(var):
         """Generate unstructured data detach instruction."""
-        return as_tuple(ir.Pragma(keyword='acc', content=f'exit data detach({var}) finalize'))
+        return as_tuple(ir.Pragma(keyword='loki', content=f'end unstructured-data detach({var}) finalize'))
 
     @staticmethod
     def exit_data_delete(var):
         """Generate unstructured data delete instruction."""
-        return as_tuple(ir.Pragma(keyword='acc', content=f'exit data delete({var}) finalize'))
+        return as_tuple(ir.Pragma(keyword='loki', content=f'end unstructured-data delete({var}) finalize'))
 
     @staticmethod
     def update_self(var):
         """Pull back data to host."""
-        return as_tuple(ir.Pragma(keyword='acc', content=f'update self({var})'))
+        return as_tuple(ir.Pragma(keyword='loki', content=f'update host({var})'))
 
     @staticmethod
     def create_aliased_ptr_assignment(ptr, alias):

--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -8,16 +8,26 @@
 from collections import defaultdict
 from pathlib import Path
 
+import re
 import yaml
 
 from loki.batch import Transformation, TypeDefItem, ProcedureItem
-from loki.ir import nodes as ir, FindNodes, SubstituteExpressions
+from loki.ir import (
+        nodes as ir, FindNodes, SubstituteExpressions, Transformer,
+        pragma_regions_attached, get_pragma_parameters, SubstitutePragmaStrings,
+        is_loki_pragma
+)
 from loki.expression import symbols as sym
 from loki.analyse.analyse_dataflow import DataflowAnalysisAttacher, DataflowAnalysisDetacher
 from loki.transformations.utilities import find_driver_loops
 from loki.logging import warning
+from loki.tools import as_tuple
+from loki.types import BasicType, DerivedType, SymbolAttributes
+from loki.transformations.field_api import (
+        FieldAPITransferType, field_get_device_data, field_get_host_data, field_delete_device_data
+)
 
-__all__ = ['DataOffloadDeepcopyAnalysis']
+__all__ = ['DataOffloadDeepcopyAnalysis', 'DataOffloadDeepcopyTransformation']
 
 
 def strip_nested_dimensions(expr):
@@ -346,3 +356,393 @@ class DataOffloadDeepcopyAnalysis(Transformation):
 
         item.trafo_data[self._key]['typedef_configs'][item.ir.name.lower()] = item.config
         self.gather_typedef_configs(successors, item.trafo_data[self._key]['typedef_configs'])
+
+
+class DataOffloadDeepcopyTransformation(Transformation):
+    """
+    A transformation to generate deepcopies of derived-types.
+    """
+
+    _key = 'DataOffloadDeepcopyAnalysis'
+    field_array_match_pattern = re.compile('^field_[0-9][a-z][a-z]_array')
+
+    def transform_subroutine(self, routine, **kwargs):
+
+        if not (item := kwargs.get('item', None)):
+            msg = '[Loki::DataOffloadDeepcopyTransformation] can only be applied by the Scheduler.'
+            raise RuntimeError(msg)
+
+        if not item.trafo_data[self._key]:
+            raise RuntimeError(f'[Loki::DataOffloadDeepcopyTransformation] item missing analysis: {item.name}.')
+
+        role = kwargs['role']
+        targets = kwargs['targets']
+
+        if role == 'driver':
+            self.process_driver(routine, item.trafo_data[self._key]['analysis'],
+                                item.trafo_data[self._key]['typedef_configs'], targets)
+
+    @staticmethod
+    def _is_active_loki_data_region(region):
+        """Determine if we are in an active loki data region and if so return the deepcopy mode."""
+
+        if is_loki_pragma(region.pragma, starts_with='data offload'):
+            return 'offload'
+        if is_loki_pragma(region.pragma, starts_with='data set_pointers'):
+            return 'set_pointers'
+
+        return False
+
+    @staticmethod
+    def update_with_manual_overrides(parameters, analysis, variable_map):
+        """Update analysis with manual overrides specified in !loki data pragma."""
+
+        override_map = {}
+        for key in ['write', 'read', 'readwrite']:
+            _vars = parameters.get(key, None)
+            if _vars:
+                _vars = [v.strip() for v in _vars.split(',')]
+                override_map.update({var: key for var in _vars})
+
+        for v, override in override_map.items():
+            name_parts = v.split('%', maxsplit=1)
+            var = variable_map[name_parts[0]]
+            if len(name_parts) > 1:
+                var = var.get_derived_type_member(name_parts[1])
+            temp_dict = create_nested_dict(var, override, variable_map)
+            analysis = merge_nested_dict(analysis, temp_dict, force=True)
+
+        return analysis
+
+    @staticmethod
+    def get_pragma_vars(parameters, category):
+        return [v.strip() for v in parameters.get(category, '').split(',')]
+
+    def insert_deepcopy_instructions(self, region, mode, copy, host, wipe, present_vars):
+        """Insert the generated deepcopy instructions and wrap the driver loop in 
+           a `data present` pragma region if applicable."""
+
+        if mode == 'offload':
+            # wrap in acc data present pragma
+            content = f"data present({', '.join(present_vars)})"
+            acc_data_pragma = ir.Pragma(keyword='acc', content=content)
+            acc_data_pragma_post = ir.Pragma(keyword='acc', content="end data")
+
+            pragma_map = {region.pragma: (copy, acc_data_pragma)}
+            pragma_map.update({region.pragma_post: (acc_data_pragma_post, host, wipe)})
+        else:
+            # We remove all offload instructions first and non F-API related boiler plate
+            vmap = {}
+
+            conds = FindNodes((ir.Conditional, ir.Loop), greedy=True).visit(host)
+            for cond in conds:
+                calls = FindNodes(ir.CallStatement).visit(cond.body)
+                get_host_call = any('get_host_data_rdwr' in v.name.name.lower() for v in calls)
+
+                if not get_host_call:
+                    vmap[cond] = None
+
+            host_pragmas = FindNodes(ir.Pragma).visit(host)
+            vmap.update({p: None for p in host_pragmas})
+            host = Transformer(vmap).visit(host)
+
+            # Now we insert the updated "host" body in the driver layer
+            pragma_map = {region.pragma: host, region.pragma_post: None}
+
+        return pragma_map
+
+    def process_driver(self, routine, analyses, typedef_configs, targets):
+
+        pragma_map = {}
+        with pragma_regions_attached(routine):
+            for region in FindNodes(ir.PragmaRegion).visit(routine.body):
+
+                # Only work on active `!$loki data` regions
+                if not is_loki_pragma(region.pragma, starts_with='data'):
+                    continue
+
+                parameters = get_pragma_parameters(region.pragma, starts_with='data')
+                driver_loops = find_driver_loops(region.body, targets)
+
+                # skip the deepcopy for variables previously marked as present/private
+                present = self.get_pragma_vars(parameters, 'present')
+                private = self.get_pragma_vars(parameters, 'private')
+
+                # temporary variables are not copied back to host and are wiped from device memory
+                temporary = self.get_pragma_vars(parameters, 'temporary')
+
+                # device_resident variables are left on device (i.e. neither copied back to host nor deleted)
+                device_resident = self.get_pragma_vars(parameters, 'device_resident')
+
+                copy, host, wipe = (), (), ()
+                present_vars = ()
+                for loop in driver_loops:
+
+                    analysis = analyses[loop]
+
+                    # update analysis with manual overrides
+                    analysis = self.update_with_manual_overrides(parameters, analysis, routine.symbol_map)
+
+                    # recursively traverse analysis and generate deepcopy
+                    _copy, _host, _wipe = self.generate_deepcopy(routine, analysis=analysis, present=present,
+                                                                 private=private, temporary=temporary,
+                                                                 device_resident=device_resident,
+                                                                 typedef_configs=typedef_configs)
+
+                    copy += _copy
+                    host += _host
+                    wipe += _wipe
+
+                    present_vars += as_tuple(v.name for v in analysis if not v in private)
+
+                # replace the `!$loki data` PragmaRegion with the generated deepcopy instructions
+                pragma_map.update(self.insert_deepcopy_instructions(region, mode, copy, host, wipe, present_vars))
+
+        routine.body = Transformer(pragma_map).visit(routine.body)
+
+    def wrap_in_loopnest(self, var, body, routine):
+        """Wrap body in loop nest corresponding to the shape of var."""
+
+        # Don't wrap an empty body
+        if not body:
+            return ()
+
+        loopbody = ()
+        loop_vars = []
+        variable_map = routine.variable_map
+
+        for dim in range(len(var.type.shape)):
+            if f'j{dim+1}' in variable_map:
+                loop_vars += [variable_map[f'j{dim+1}']]
+            else:
+                loop_vars += [sym.Variable(name=f'J{dim+1}', type=SymbolAttributes(dtype=BasicType.INTEGER),
+                                           scope=routine)]
+                routine.variables += as_tuple(loop_vars[-1])
+
+            # Create loop bounds
+            lstart = sym.InlineCall(function=sym.ProcedureSymbol('LBOUND', scope=routine),
+                                    parameters=(var, sym.IntLiteral(dim+1)))
+            lend = sym.InlineCall(function=sym.ProcedureSymbol('UBOUND', scope=routine),
+                                    parameters=(var, sym.IntLiteral(dim+1)))
+            bounds = sym.LoopRange((lstart, lend))
+
+            if not loopbody:
+                # Create first layer of loop nest
+                vmap = {var: var.clone(dimensions=as_tuple(loop_vars[-1]))}
+                str_map = {str(k): str(v) for k, v in vmap.items()}
+
+                SubstitutePragmaStrings(str_map).visit(body)
+                loopbody = as_tuple(SubstituteExpressions(vmap).visit(body))
+            else:
+                # Add subsequent layers
+                vmap = {loop_vars[-2]: (loop_vars[-2], loop_vars[-1])}
+                str_map = {str(k): str(v) for k, v in vmap.items()}
+
+                SubstitutePragmaStrings(str_map).visit(loopbody)
+                loopbody = as_tuple(SubstituteExpressions(vmap).visit(loopbody))
+
+            loop = ir.Loop(variable=loop_vars[-1], bounds=bounds, body=loopbody)
+            loopbody = loop
+
+        return as_tuple(loop)
+
+    @staticmethod
+    def create_memory_status_test(check, var, body, scope):
+        """Wrap a given body in a memory status check."""
+
+        # Don't wrap an empty body
+        if not body:
+            return ()
+
+        condition = sym.InlineCall(function=sym.ProcedureSymbol(check, scope=scope),
+                                   parameters=as_tuple(var))
+        return as_tuple(ir.Conditional(condition=condition, body=body))
+
+    @staticmethod
+    def enter_data_copyin(var):
+        """Generate unstructured data copyin instruction."""
+        return as_tuple(ir.Pragma(keyword='acc', content=f'enter data copyin({var})'))
+
+    @staticmethod
+    def enter_data_create(var):
+        """Generate unstructured data create instruction."""
+        return as_tuple(ir.Pragma(keyword='loki', content=f'unstructured-data create({var})'))
+
+    @staticmethod
+    def enter_data_attach(var):
+        """Generate unstructured data attach instruction."""
+        return as_tuple(ir.Pragma(keyword='acc', content=f'enter data attach({var})'))
+
+    @staticmethod
+    def exit_data_detach(var):
+        """Generate unstructured data detach instruction."""
+        return as_tuple(ir.Pragma(keyword='acc', content=f'exit data detach({var}) finalize'))
+
+    @staticmethod
+    def exit_data_delete(var):
+        """Generate unstructured data delete instruction."""
+        return as_tuple(ir.Pragma(keyword='acc', content=f'exit data delete({var}) finalize'))
+
+    @staticmethod
+    def update_self(var):
+        """Pull back data to host."""
+        return as_tuple(ir.Pragma(keyword='acc', content=f'update self({var})'))
+
+    @staticmethod
+    def create_aliased_ptr_assignment(ptr, alias):
+        """Associate an aliased pointer to its target."""
+
+        dims = [sym.InlineCall(function=sym.ProcedureSymbol('LBOUND', scope=ptr.scope),
+                               parameters=(ptr, sym.IntLiteral(r+1))) for r in range(len(ptr.shape))]
+
+        alias_ptr = ptr.parent.type.dtype.typedef.variable_map[alias]
+        lhs = alias_ptr.clone(parent=ptr.parent,
+                              dimensions=as_tuple([sym.RangeIndex(children=(d, None)) for d in dims]))
+
+        return ir.Assignment(lhs=lhs, rhs=ptr, ptr=True)
+
+    def create_field_api_offload(self, var, analysis, typedef_config, parent, scope):
+
+        #TODO: currently this assumes FIELD objects and their associated pointers are
+        # components of the same derived-type. This should be generalised for the case
+        # where the two are declared separately.
+
+        # Strip view pointer prefix
+        var_name = var.name.lower()
+
+        # Get FIELD object name
+        if not (field_object_name := typedef_config['field_ptr_map'].get(var_name, None)):
+            field_object_name = typedef_config['field_prefix'] + var_name.replace('_field', '')
+
+        # Create FIELD object
+        variable_map = parent.type.dtype.typedef.variable_map
+        field_object = variable_map[field_object_name].clone(parent=parent)
+        field_ptr = var.clone(dimensions=None, parent=parent)
+
+        if analysis == 'read':
+            access_mode = FieldAPITransferType.READ_ONLY
+        elif analysis == 'readwrite':
+            access_mode = FieldAPITransferType.READ_WRITE
+        else:
+            access_mode = FieldAPITransferType.WRITE_ONLY
+
+        device = as_tuple(field_get_device_data(field_object, field_ptr, access_mode, scope))
+        device += self.enter_data_attach(field_ptr)
+        host = as_tuple(field_get_host_data(field_object, field_ptr, FieldAPITransferType.READ_WRITE, scope))
+        wipe = self.exit_data_detach(field_ptr)
+        wipe += as_tuple(field_delete_device_data(field_object, scope))
+
+        device = self.create_memory_status_test('ASSOCIATED', field_object, device, scope)
+        host = self.create_memory_status_test('ASSOCIATED', field_object, host, scope)
+        wipe = self.create_memory_status_test('ASSOCIATED', field_object, wipe, scope)
+
+        return device, host, wipe
+
+    def create_dummy_field_array_typedef_config(self, parent):
+        """The scheduler will never traverse the FIELD_RANKSUFF_ARRAY type definitions,
+           so we create a dummy typedef config here."""
+
+        if self.field_array_match_pattern.match(parent.type.dtype.typedef.name.lower()):
+            typedef_config = {
+                'field_prefix': 'F_',
+                'field_ptr_suffix': '_FIELD',
+                'field_ptr_map': {}
+            }
+            return typedef_config
+        return None
+
+    def generate_deepcopy(self, routine, **kwargs):
+        """Recursively traverse the deepcopy analysis to generate the deepcopy instructions."""
+
+        # initialise tuples used to store the deepcopy instructions
+        copy, host, wipe = (), (), ()
+
+        analysis = kwargs.pop('analysis')
+        parent = kwargs.pop('parent', None)
+
+        for var in analysis:
+
+            _copy, _host, _wipe = (), (), ()
+
+            # Don't generate a deepcopy for variables marked as present or private
+            if var in kwargs['present'] or var in kwargs['private']:
+                continue
+
+            # determine if var should be kept on device
+            delete = not var in kwargs['device_resident']
+            # determine if this is a temporary variable
+            temporary = var in kwargs['temporary']
+
+            check = 'ASSOCIATED' if var.type.pointer else None
+            check = 'ALLOCATED' if var.type.allocatable else None
+
+            if isinstance(var.type.dtype, DerivedType):
+
+                var_with_parent = var.clone(parent=parent)
+                _copy, _host, _wipe = self.generate_deepcopy(routine, analysis=analysis[var], parent=var_with_parent,
+                                                             **kwargs)
+
+                #wrap in loop
+                if var.type.shape:
+                    _copy = self.wrap_in_loopnest(var_with_parent, _copy, routine)
+                    _host = self.wrap_in_loopnest(var_with_parent, _host, routine)
+                    _wipe = self.wrap_in_loopnest(var_with_parent, _wipe, routine)
+
+                # var must be allocated/deallocated on device
+                if not parent or check:
+                    _copy = self.enter_data_copyin(var_with_parent) + _copy
+                    _wipe += self.exit_data_delete(var_with_parent)
+
+                # wrap in memory status check
+                if check:
+                    _copy = self.create_memory_status_test(check, var_with_parent, _copy, routine)
+                    _host = self.create_memory_status_test(check, var_with_parent, _host, routine)
+                    _wipe = self.create_memory_status_test(check, var_with_parent, _wipe, routine)
+
+            else:
+
+                # First determine whether we have a field pointer or a regular array/scalar
+                typedef_config = None
+                if parent:
+                    typedef_config = kwargs['typedef_configs'].get(parent.type.dtype.typedef.name.lower(), None)
+
+                # Create a dummy typedef config for FIELD_RANKSUFF_ARRAY types
+                if parent and not typedef_config:
+                    typedef_config = self.create_dummy_field_array_typedef_config(parent)
+
+                field = False
+                if typedef_config:
+                    # Is our pointer in the given list of field ptrs or has the right suffix?
+                    suffix = typedef_config['field_ptr_suffix']
+                    field = var in typedef_config.get('field_ptrs', [])
+                    field = field or re.search(f'{suffix}$', var.name, re.IGNORECASE)
+
+                if field:
+                    _copy, _host, _wipe = self.create_field_api_offload(var, analysis[var], typedef_config,
+                                                                        parent, routine)
+                else:
+                    # We have a regular array/scalar
+                    if not parent or check:
+                        if analysis[var] == 'write':
+                            _copy = self.enter_data_create(var.clone(parent=parent))
+                        else:
+                            _copy = self.enter_data_copyin(var.clone(parent=parent))
+                        _wipe = self.exit_data_delete(var.clone(parent=parent))
+
+                    # Copy back to host if necessary
+                    if analysis[var] != 'read':
+                        _host = self.update_self(var.clone(parent=parent))
+
+                    # wrap in memory status check
+                    if check:
+                        _copy = self.create_memory_status_test(check, var.clone(parent=parent), _copy, routine)
+                        _host = self.create_memory_status_test(check, var.clone(parent=parent), _host, routine)
+                        _wipe = self.create_memory_status_test(check, var.clone(parent=parent), _wipe, routine)
+
+            copy += as_tuple(_copy)
+            if delete and not temporary:
+                host += as_tuple(_host)
+            if delete:
+                wipe += as_tuple(_wipe)
+
+        return copy, host, wipe

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -9,10 +9,13 @@ from shutil import rmtree
 import pytest
 import yaml
 
-from loki import (
-        gettempdir, available_frontends, Scheduler, DataOffloadDeepcopyAnalysis,
-        find_driver_loops, log_levels
-)
+from loki.backend import fgen
+from loki.batch import Scheduler
+from loki.ir import nodes as ir, FindNodes, is_loki_pragma, pragma_regions_attached, get_pragma_parameters
+from loki.frontend import available_frontends
+from loki.logging import log_levels
+from loki.tools import gettempdir, flatten
+from loki.transformations import DataOffloadDeepcopyAnalysis, DataOffloadDeepcopyTransformation, find_driver_loops
 
 
 @pytest.fixture(scope='module', name='deepcopy_code')
@@ -38,6 +41,11 @@ module type_def_mod
       real, pointer, contiguous :: p(:,:,:) => null()
    end type
 
+   type :: other_variable_type
+      class(field_3d), pointer :: f_t0 => null()
+      real, pointer, contiguous :: vt0_field(:,:,:) => null()
+   end type
+
    type :: superfluous_type
       type(variable_type) :: var
    end type
@@ -61,6 +69,15 @@ module type_def_mod
       integer :: kend
       integer :: kbl
       integer :: ngpblks
+   end type
+
+   type :: geom_dims
+      integer :: nproma
+   end type
+
+   type :: geom_type
+      type(geom_dims) :: dim
+      integer, allocatable :: metadata(:)
    end type
 end module type_def_mod
             """.strip()
@@ -118,21 +135,25 @@ end module other_kernel_mod
             """
 module kernel_mod
 contains
-subroutine kernel(bnds, struct)
+subroutine kernel(geometry, bnds, struct, variable)
    use nested_kernel_write_mod, only: nested_kernel_write
    use nested_kernel_read_mod, only: nested_kernel_read
    use other_kernel_mod, only : other_kernel
-   use type_def_mod, only: struct_type, dims_type
+   use type_def_mod, only: struct_type, dims_type, geom_type, other_variable_type
    implicit none
 
+   type(geom_type), intent(in) :: geometry
    type(dims_type), intent(in) :: bnds
    type(struct_type), intent(inout) :: struct
+   type(other_variable_type), intent(inout) :: variable
 
-   integer :: jrof, jfld
+   integer :: jrof, jfld, j
    real, pointer :: tmp(:,:,:) => null()
+   integer :: a(geometry%dim%nproma)
 
    call nested_kernel_write(struct%a%p(:,:,bnds%kbl))
    call nested_kernel_read(struct%b%p(:,:,bnds%kbl))
+   call nested_kernel_read(variable%vt0_field(:,:,bnds%kbl))
 
    tmp => struct%c%p !... yes this completely breaks the dataflow analysis
    tmp = 0.
@@ -147,7 +168,9 @@ subroutine kernel(bnds, struct)
 
    do jrof = bnds%kst, bnds%kend
      struct%d%p(jrof,:,bnds%kbl) = struct%e%p(jrof,:,bnds%kbl)
-   enddo 
+   enddo
+
+   j = geometry%metadata(1)
 
 end subroutine kernel
 end module kernel_mod
@@ -157,25 +180,43 @@ end module kernel_mod
         #----- driver -----
         'driver' : (
             """
-subroutine driver(dims, struct)
+subroutine driver(dims, struct, array_arg, geometry, variable)
    use kernel_mod, only : kernel
    use nested_kernel_write_mod, only: nested_kernel_write
-   use type_def_mod, only: struct_type, dims_type
+   use type_def_mod, only: struct_type, dims_type, geom_type, other_variable_type
    implicit none
 
    type(dims_type), intent(in) :: dims
    type(struct_type), intent(inout) :: struct
+   integer, intent(out) :: array_arg(:,:,:)
+   type(geom_type), intent(in) :: geometry
+   type(other_variable_type), intent(inout) :: variable
    type(dims_type) :: local_dims
    integer :: ibl
 
    local_dims = dims
 
+#ifdef geometry_present
+!$loki data private(local_dims) present(geometry) write(struct%c%p)
    do ibl=1,local_dims%ngpblks
      local_dims%kbl = ibl
 
-     call kernel(local_dims, struct)
+     call kernel(geometry, local_dims, struct, variable)
      call nested_kernel_write(struct%e%p(:,:,local_dims%kbl))
+     call nested_kernel_write(array_arg)
    enddo
+!$loki end data
+#else
+!$loki data private(local_dims) write(struct%c%p)
+   do ibl=1,local_dims%ngpblks
+     local_dims%kbl = ibl
+
+     call kernel(geometry, local_dims, struct, variable)
+     call nested_kernel_write(struct%e%p(:,:,local_dims%kbl))
+     call nested_kernel_write(array_arg)
+   enddo
+!$loki end data
+#endif
 
 end subroutine driver
             """.strip()
@@ -201,6 +242,16 @@ def fixture_expected_analysis():
             'kbl': 'read',
             'kend': 'read',
             'kst': 'read'
+        },
+        'geometry': {
+            'dim': {
+                'nproma': 'read'
+            },
+            'metadata' : 'read'
+        },
+        'array_arg': 'write',
+        'variable' : {
+            'vt0_field' : 'read'
         },
         'struct': {
             'a': {
@@ -239,6 +290,8 @@ def fixture_config():
             'expand': True,
             'strict': True,
             'enable_imports': True,
+            'field_ptr_suffix': '_field',
+            'field_ptr_map': {}
         },
     }
 
@@ -268,7 +321,7 @@ def test_offload_deepcopy_analysis(frontend, config, deepcopy_code, expected_ana
 
     scheduler = Scheduler(
         paths=deepcopy_code, config=config, frontend=frontend, xmods=[tmp_path],
-        output_dir=tmp_path
+        output_dir=tmp_path, preprocess=True
     )
 
     with caplog.at_level(log_levels['WARNING']):
@@ -296,3 +349,317 @@ def test_offload_deepcopy_analysis(frontend, config, deepcopy_code, expected_ana
         with open(tmp_path/'driver_kernel_dataoffload_analysis.yaml', 'r') as file:
             _dict = yaml.safe_load(file)
         assert _nested_sort(_dict) == sorted_expected_analysis
+
+
+def check_array_arg(mode, pragmas):
+    """Check the correct generation of deepcopy for `array_arg`."""
+
+    if mode == 'offload':
+        copy_pragma = [(p, loc) for loc, p in enumerate(pragmas)
+                       if 'unstructured-data create' in p.content and '(array_arg)' in p.content for p in pragmas]
+        host_pragma = [(p, loc) for loc, p in enumerate(pragmas)
+                       if 'update host' in p.content and '(array_arg)' in p.content for p in pragmas]
+        assert copy_pragma
+        assert host_pragma
+        assert host_pragma[0][1] > copy_pragma[0][1]
+    else:
+        assert not any('array_arg' in p.content for p in pragmas)
+
+
+def check_variable_type_host(var, conds):
+    """Check generated host pull-back for `type(variable_type)` variables."""
+
+    conds = [c for c in conds
+             if c.condition.name.lower() == 'associated' and f'{var}%fp' in c.condition.parameters]
+    calls = FindNodes(ir.CallStatement).visit(conds)
+    assert any(call.name.name.lower() == f'{var}%fp%get_host_data_rdwr' and f'{var}%p' in call.arguments
+               for call in calls)
+
+def check_variable_type_device(var, conds, access):
+    """Check generated copy to device for `type(variable_type)` variables."""
+
+    conds = [c for c in conds
+             if c.condition.name.lower() == 'associated' and f'{var}%fp' in c.condition.parameters]
+
+    _pass = 0
+    for cond in conds:
+        calls = FindNodes(ir.CallStatement).visit(cond.body)
+        pragmas = FindNodes(ir.Pragma).visit(cond.body)
+
+        calls = [call for call in calls
+                 if call.name.name.lower() == f'{var}%fp%get_device_data_{access}' and f'{var}%p' in call.arguments]
+        pragmas = [pragma for pragma in pragmas
+                   if 'unstructured-data attach' in pragma.content and f'{var}%p' in pragma.content]
+        if calls and pragmas:
+            assert cond.body.index(calls[0]) < cond.body.index(pragmas[0])
+            _pass += 1
+
+    assert _pass == 1
+
+
+def check_variable_type_wipe(var, conds):
+    """Check generated wipe for `type(variable_type)` variables."""
+
+    conds = [c for c in conds
+             if c.condition.name.lower() == 'associated' and f'{var}%fp' in c.condition.parameters]
+    _pass = 0
+    for cond in conds:
+        calls = FindNodes(ir.CallStatement).visit(cond.body)
+        pragmas = FindNodes(ir.Pragma).visit(cond.body)
+
+        calls = [call for call in calls
+                 if call.name.name.lower() == f'{var}%fp%delete_device_data']
+        pragmas = [pragma for pragma in pragmas
+                   if 'end unstructured-data detach' in pragma.content and f'{var}%p' in pragma.content
+                   and 'finalize' in pragma.content]
+        if calls and pragmas:
+            assert cond.body.index(calls[0]) > cond.body.index(pragmas[0])
+            _pass += 1
+
+    assert _pass == 1
+
+
+def check_other_variable_type(mode, conds, pragmas, routine):
+    """Check the generated deepcopy for `type(other_variable_type) :: variable`."""
+
+    # Check pullback to host
+    conds = [c for c in conds
+             if c.condition.name.lower() == 'associated' and 'variable%f_t0' in c.condition.parameters]
+    calls = FindNodes(ir.CallStatement).visit(conds)
+
+    assert any(call.name.name.lower() == 'variable%f_t0%get_host_data_rdwr' and 'variable%vt0_field' in call.arguments
+               for call in calls)
+
+    if mode == 'offload':
+        # Check copy to device of struct
+        pragma = [p for p in pragmas if
+                  'unstructured-data in' in p.content and '(variable)' in p.content][0]
+        assert routine.body.body.index(pragma) < routine.body.body.index(conds[0])
+
+        # Check deletion of struct from device
+        pragma = [p for p in pragmas if
+                  'end unstructured-data delete' in p.content and '(variable)' in p.content][0]
+        assert routine.body.body.index(pragma) > routine.body.body.index(conds[-1])
+
+        # Check FIELD_API boilerplate for copying to device and wiping device
+        _pass = 0
+        for cond in conds:
+            calls = FindNodes(ir.CallStatement).visit(cond.body)
+            pragmas = FindNodes(ir.Pragma).visit(cond.body)
+
+            calls = [call for call in calls
+                     if call.name.name.lower() == 'variable%f_t0%delete_device_data']
+            pragmas = [pragma for pragma in pragmas
+                       if 'end unstructured-data detach' in pragma.content and 'variable%vt0_field' in pragma.content
+                       and 'finalize' in pragma.content]
+            if calls and pragmas:
+                assert cond.body.index(calls[0]) > cond.body.index(pragmas[0])
+                _pass += 1
+
+        for cond in conds:
+            calls = FindNodes(ir.CallStatement).visit(cond.body)
+            pragmas = FindNodes(ir.Pragma).visit(cond.body)
+
+            calls = [call for call in calls
+                     if call.name.name.lower() == 'variable%f_t0%get_device_data_rdonly'
+                     and 'variable%vt0_field' in call.arguments]
+            pragmas = [pragma for pragma in pragmas
+                       if 'unstructured-data attach' in pragma.content and 'variable%vt0_field' in pragma.content]
+            if calls and pragmas:
+                assert cond.body.index(calls[0]) < cond.body.index(pragmas[0])
+                _pass += 1
+
+        assert _pass == 2
+
+
+def check_geometry(conds, pragmas, routine):
+    """Check the generated deepcopy for `type(geom_type) :: geometry`."""
+
+    conds = [c for c in conds
+             if 'geometry%metadata' in c.condition.parameters]
+
+    # geometry should only have copy and wipe related instructions
+    assert len(conds) == 2
+
+    # Check copy to device of struct
+    pragma = [p for p in pragmas if
+              'unstructured-data in' in p.content and '(geometry)' in p.content][0]
+    assert routine.body.body.index(pragma) < routine.body.body.index(conds[0])
+
+    # Check copy to device of member
+    assert 'unstructured-data in' in conds[0].body[0].content
+    assert '(geometry%metadata)' in conds[0].body[0].content
+
+    # Check deletion of struct from device
+    pragma = [p for p in pragmas if 'end unstructured-data delete' in p.content
+              and '(geometry)' in p.content and 'finalize' in p.content][0]
+    assert routine.body.body.index(pragma) > routine.body.body.index(conds[-1])
+
+    # Check deletion of member from device
+    assert 'end unstructured-data delete' in conds[-1].body[0].content
+    assert '(geometry%metadata)' in conds[-1].body[0].content
+    assert 'finalize' in conds[-1].body[0].content
+
+
+def check_struct(mode, conds, pragmas, routine):
+    """Check the generated deepcopy for `type(struct_type)`."""
+
+    # Filter out conditions on type(struct_type) :: struct
+    struct_conds = []
+    for cond in conds:
+        parameters = flatten([p.name.lower() for p in cond.condition.parameters])
+        if any('struct' in p for p in parameters):
+            struct_conds.append(cond)
+
+    # Check var_ptr member
+    check_struct_var_ptr(mode, struct_conds)
+
+    # Check host pull-back
+    check_variable_type_host('struct%a', struct_conds)
+    check_variable_type_host('struct%b', struct_conds)
+    check_variable_type_host('struct%c', struct_conds)
+    check_variable_type_host('struct%d', struct_conds)
+    check_variable_type_host('struct%e', struct_conds)
+
+    if mode == 'offload':
+        # Check copy to device of struct
+        pragma = [p for p in pragmas if
+                  'unstructured-data in' in p.content and '(struct)' in p.content][0]
+        assert routine.body.body.index(pragma) < routine.body.body.index(struct_conds[0])
+
+        # Check deletion of struct from device
+        pragma = [p for p in pragmas if
+                  'end unstructured-data delete' in p.content and '(struct)' in p.content][0]
+        assert routine.body.body.index(pragma) > routine.body.body.index(struct_conds[-1])
+
+        check_variable_type_device('struct%a', struct_conds, 'wronly')
+        check_variable_type_device('struct%b', struct_conds, 'rdwr')
+        check_variable_type_device('struct%c', struct_conds, 'wronly')
+        check_variable_type_device('struct%d', struct_conds, 'wronly')
+        check_variable_type_device('struct%e', struct_conds, 'rdwr')
+
+        check_variable_type_wipe('struct%a', struct_conds)
+        check_variable_type_wipe('struct%b', struct_conds)
+        check_variable_type_wipe('struct%c', struct_conds)
+        check_variable_type_wipe('struct%d', struct_conds)
+        check_variable_type_wipe('struct%e', struct_conds)
+
+
+def check_struct_var_ptr(mode, conds):
+    """Check the `var_ptr` member of `type(struct_type) :: struct`."""
+
+    # First check host pull-back FIELD_API calls
+    conds = [c for c in conds
+             if c.condition.name.lower() == 'allocated' and 'struct%var_ptr' in c.condition.parameters]
+    loops = FindNodes(ir.Loop).visit(conds)
+    calls = FindNodes(ir.CallStatement).visit(loops)
+
+    assert any(fgen(call.name).lower() == 'struct%var_ptr(j1)%var%fp%get_host_data_rdwr'
+               and 'struct%var_ptr(J1)%var%p' in call.arguments for call in calls)
+
+    if mode == 'offload':
+        _pass = 0
+        for cond in conds:
+            calls = FindNodes(ir.CallStatement).visit(cond.body)
+
+            if any('get_device_data' in call.name.name.lower() for call in calls):
+                # first entry in conditional body should be copyin pragma
+                assert 'unstructured-data in' in cond.body[0].content
+                assert '(struct%var_ptr)' in cond.body[0].content
+
+                # then we have a loop and an association check for a field object
+                loop = FindNodes(ir.Loop).visit(cond.body)[0]
+                _cond = FindNodes(ir.Conditional).visit(loop.body)[0]
+                assert _cond.condition.name.lower() == 'associated'
+                assert fgen(_cond.condition.parameters[0]).lower() == 'struct%var_ptr(j1)%var%fp'
+
+                # finally inside the conditional body we have a FIELD_API GET_DEVICE_DATA call
+                # and an attach statement
+                assert fgen(_cond.body[0].name).lower() == 'struct%var_ptr(j1)%var%fp%get_device_data_rdwr'
+                assert _cond.body[0].arguments[0] == 'struct%var_ptr(j1)%var%p'
+                assert 'unstructured-data attach' in _cond.body[1].content
+                assert 'struct%var_ptr(J1)%var%p' in _cond.body[1].content
+                _pass += 1
+
+            elif any('delete_device_data' in call.name.name.lower() for call in calls):
+                # last entry in conditional body should be delete pragma
+                assert 'end unstructured-data delete' in cond.body[-1].content
+                assert 'finalize' in cond.body[-1].content
+                assert '(struct%var_ptr)' in cond.body[-1].content
+
+                # then we have a loop and an association check for a field object
+                loop = FindNodes(ir.Loop).visit(cond.body)[0]
+                _cond = FindNodes(ir.Conditional).visit(loop.body)[0]
+                assert _cond.condition.name.lower() == 'associated'
+                assert fgen(_cond.condition.parameters[0]).lower() == 'struct%var_ptr(j1)%var%fp'
+
+                # finally inside the conditional body we have a FIELD_API DELETE_DEVICE_DATA call
+                # preceded by an detach statement
+                assert 'end unstructured-data detach' in _cond.body[0].content
+                assert 'finalize' in _cond.body[0].content
+                assert 'struct%var_ptr(J1)%var%p' in _cond.body[0].content
+                assert fgen(_cond.body[1].name).lower() == 'struct%var_ptr(j1)%var%fp%delete_device_data'
+                _pass += 1
+
+        assert _pass == 2
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('present', [True, False])
+@pytest.mark.parametrize('mode', ['offload', 'set_pointers'])
+def test_offload_deepcopy_transformation(frontend, config, deepcopy_code, present, mode, tmp_path):
+    """
+    Test the generation of host-device deepcopy.
+    """
+
+    config['routines'] = {
+        'driver': {'role': 'driver'},
+        'variable_type': {
+            'field_prefix': 'f',
+            'field_ptrs': ['p'],
+        },
+        'other_variable_type': {
+            'field_prefix': 'f_',
+            'view_prefix': 'v',
+            'field_ptr_map': {
+                'vt0_field': 'f_t0'
+            }
+        }
+    }
+
+    defines = ['geometry_present'] if present else []
+    scheduler = Scheduler(
+        paths=deepcopy_code, config=config, frontend=frontend, xmods=[tmp_path],
+        output_dir=tmp_path, preprocess=True, defines=defines
+    )
+
+    scheduler.process(transformation=DataOffloadDeepcopyAnalysis())
+    transformation = DataOffloadDeepcopyTransformation(mode=mode)
+    scheduler.process(transformation=transformation)
+
+    driver = scheduler['#driver'].ir
+    pragmas = FindNodes(ir.Pragma).visit(driver.body)
+    conds = FindNodes(ir.Conditional, greedy=True).visit(driver.body)
+
+    # check array_arg
+    check_array_arg(mode, pragmas)
+
+    # check other_variable_type
+    check_other_variable_type(mode, conds, pragmas, driver)
+
+    # check struct
+    check_struct(mode, conds, pragmas, driver)
+
+    if not present and mode == 'offload':
+        check_geometry(conds, pragmas, driver)
+
+    if mode == 'offload':
+        # check data present region
+        with pragma_regions_attached(driver):
+
+            region = FindNodes(ir.PragmaRegion).visit(driver.body)[-1]
+            assert is_loki_pragma(region.pragma, starts_with='structured-data')
+
+            parameters = get_pragma_parameters(region.pragma)
+            present_vars = [v.strip().lower() for v in parameters['present'].split(',')]
+            assert all(v in present_vars for v in ['geometry', 'struct', 'variable'])

--- a/loki/transformations/tests/test_block_index_inject.py
+++ b/loki/transformations/tests/test_block_index_inject.py
@@ -212,6 +212,15 @@ subroutine another_kernel(nproma, nlev, data, other)
    real, intent(in) :: other(nproma, nlev)
 end subroutine another_kernel
 """
+        ).strip(),
+        #-------
+        'empty_kernel': (
+        #-------
+"""
+subroutine empty_kernel()
+   implicit none
+end subroutine empty_kernel
+"""
         ).strip()
     }
 
@@ -234,7 +243,8 @@ def test_blockview_to_fieldview_pipeline(horizontal, blocking, config, frontend,
                                          force_inject_arrays, tmp_path):
 
     config['routines'] = {
-        'driver': {'role': 'driver'}
+        'driver': {'role': 'driver'},
+        'empty_kernel': {'role': 'kernel'}
     }
     if force_inject_arrays:
         config['routines'].update({'kernel': {'role': 'kernel', 'force_inject_arrays': ['yda_other%p_field']}})


### PR DESCRIPTION
This PR contributes the matching transformation to generate the deep-copy using the analysis. An assumption the deep-copy is based around is that data access is always via basic types, which rules out overloaded operators and copy on assignment for derived-types. The exception are memory status queries e.g. `ubound, lbound, size`. These are supported by the current implementation.

Another limitation is that access pointers to fields are assumed to be members of the same derived-type as the field pointer itself, i.e. `A%P_FIELD` is the access pointer associated with field `A%F_P`.  This is not an underlying assumption of the implementation however, and the transformation can easily be made more flexible in this regard.