### PR TITLE
Transformation: `False` to switch off pragma conversion in SCC trafo

### DIFF
--- a/loki/transformations/pragma_model.py
+++ b/loki/transformations/pragma_model.py
@@ -319,17 +319,18 @@ class PragmaModelTransformation(Transformation):
 
     Parameters
     ----------
-    directive : None, str
+    directive : False, str
         The directive(s) to be used, used to determine which
-        child class of :any:`GenericPragmaMapper` is used.
+        child class of :any:`GenericPragmaMapper` is used.  Use
+        ``False`` to suppress the directive translation entirely.
     keep_loki_pragmas: bool
         Keep or remove generic Loki pragmas that are not
         mapped.
     """
     item_filter = (ProcedureItem, ModuleItem)
 
-    def __init__(self, directive=None, keep_loki_pragmas=True):
-        assert directive in [None, 'openacc', 'omp-gpu', 'openmp']
+    def __init__(self, directive=False, keep_loki_pragmas=True):
+        assert directive in [False, 'openacc', 'omp-gpu', 'openmp']
         self.directive = directive
         self.keep_loki_pragmas = keep_loki_pragmas
         pmapper_cls_map = {

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -363,7 +363,7 @@ def test_scc_annotate_openacc(frontend, horizontal, blocking, acc_data):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-@pytest.mark.parametrize('directive', [None, 'openacc', 'omp-gpu'])
+@pytest.mark.parametrize('directive', [False, 'openacc', 'omp-gpu'])
 def test_scc_annotate_directive(frontend, horizontal, blocking, directive):
     """
     Test the correct addition of OpenACC pragmas to SCC format code (no hoisting).

--- a/loki/transformations/temporaries/tests/test_pool_allocator.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator.py
@@ -460,7 +460,7 @@ end module kernel_mod
     assert 'tmp5' not in pointers
 
 @pytest.mark.parametrize('frontend', available_frontends())
-@pytest.mark.parametrize('directive', [None, 'openmp', 'openacc', 'openmp-manual'])
+@pytest.mark.parametrize('directive', [False, 'openmp', 'openacc', 'openmp-manual'])
 @pytest.mark.parametrize('stack_insert_pragma', [False, True])
 @pytest.mark.parametrize('cray_ptr_loc_rhs', [False, True])
 def test_pool_allocator_temporaries_kernel_sequence(tmp_path, frontend, block_dim, directive,
@@ -795,7 +795,7 @@ end module kernel_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-@pytest.mark.parametrize('directive', [None, 'openmp', 'openacc'])
+@pytest.mark.parametrize('directive', [False, 'openmp', 'openacc'])
 @pytest.mark.parametrize('cray_ptr_loc_rhs', [False, True])
 def test_pool_allocator_temporaries_kernel_nested(tmp_path, frontend, block_dim, directive, cray_ptr_loc_rhs):
     driver_pragma = f'!$loki loop gang{" private(b)" if directive == "openmp" else ""}'

--- a/loki/transformations/tests/test_pragma_model.py
+++ b/loki/transformations/tests/test_pragma_model.py
@@ -22,7 +22,7 @@ def check_pragma(pragma, keyword, content, check_for_equality=True):
             assert _content in pragma.content
 
 @pytest.mark.parametrize('frontend', available_frontends())
-@pytest.mark.parametrize('directive', [None, 'openacc', 'omp-gpu'])
+@pytest.mark.parametrize('directive', [False, 'openacc', 'omp-gpu'])
 @pytest.mark.parametrize('keep_loki_pragmas', [True, False])
 def test_transform_pragma_model(tmp_path, frontend, directive, keep_loki_pragmas):
     """
@@ -84,7 +84,7 @@ end subroutine some_func
         check_pragma(pragmas[0], 'acc', 'declare create(a, b)')
     if directive == 'omp-gpu':
         check_pragma(pragmas[0], 'omp', 'declare target(a, b)')
-    if directive is None and keep_loki_pragmas:
+    if directive is False and keep_loki_pragmas:
         check_pragma(pragmas[0], 'loki', 'create device(a, b)')
 
     # CHECK ROUTINE
@@ -140,7 +140,7 @@ end subroutine some_func
                 ('omp', 'end target data'),
                 ('omp', ('target data', 'map(to: tmp1, tmp3, tmp4)'), False),
                 ('omp', 'end target data'))
-    if directive is None:
+    if directive is False:
         args = (('loki', 'create device(tmp1, tmp2)'),
                 ('loki', ('update', 'device(tmp1)', 'host(tmp2)'), False),
                 ('loki', ('unstructured-data', 'in(tmp1, tmp2)', 'create(tmp3, tmp4)', 'attach(tmp1)', ), False),


### PR DESCRIPTION
As `None` cannot be represented in TOML config files, we need to use something else to suppress explicit directive generation in `PragmaModelTransformation`. `False` seemed as good as any.