### PR TITLE
Various `SCCHoist` fixes

### DIFF
--- a/docs/source/loki_pragma_model.csv
+++ b/docs/source/loki_pragma_model.csv
@@ -2,7 +2,7 @@ Loki,OpenACC,OMP-GPU
 ``create device(...)``,``declare create(...)``,``declare target(...)``
 ``update device(...) host(...)``,``update device(...) self(...)``,
 ``unstructured-data in(...) create(...) attach(...)``,``enter data copyin(...) create(...) attach(...)``,``target enter data map(to: ...) map(alloc: ...)``
-``end unstructured-data out(...) delete(...) detach(...)``,``exit data copyout(...) delete(...) detach(...)``,``target exit data map(from: ...) map(delete: ...) map(release: ... ???)``
+``end unstructured-data out(...) delete(...) detach(...) [finalize]``,``exit data copyout(...) delete(...) detach(...) [finalize]``,``target exit data map(from: ...) map(delete: ...) map(release: ... ???)``
 ``structured-data inout(...) in(...) out(...) create(...) present(...)``,``data copy(...) copyin(...) copyout(...) create(...) present(...)``,``target data map(tofrom: ...) map(to: ...) map(from: ...) map(to: ...)``
 ``end structured-data inout(...) in(...) out(...)``,``end data``,``end target data``
 ``loop gang private(...) vlength(...)``,``parallel loop gang private(...) vector_length(...)``,``target teams distribute thread_limit(...) ???``

--- a/loki/tests/sources/projHoist/module/driver_mod.f90
+++ b/loki/tests/sources/projHoist/module/driver_mod.f90
@@ -1,5 +1,5 @@
 module transformation_module_hoist
-    USE subroutines_mod, only: kernel1, kernel2, device1, device2
+    USE subroutines_mod, only: kernel1, kernel2, device1, device2, kernel3
     implicit none
     integer, parameter :: len = 3
 contains
@@ -21,6 +21,12 @@ contains
         real :: x, y
         call kernel1(a, b, c)
     end subroutine another_driver
+
+    subroutine yet_another_driver(a, a1)
+        integer, intent(in) :: a, a1
+
+        call kernel3(a, a1)
+    end subroutine yet_another_driver
 
 end module transformation_module_hoist
 

--- a/loki/tests/sources/projHoist/module/subroutines_mod.f90
+++ b/loki/tests/sources/projHoist/module/subroutines_mod.f90
@@ -45,5 +45,19 @@ contains
         b = z
     end subroutine device2
 
+    subroutine kernel3(a, a1)
+        integer, intent(in) :: a, a1
+
+        call device3(a)
+        call device3(a1)
+    end subroutine kernel3
+
+    subroutine device3(n)
+        integer, intent(in) :: n
+        integer :: x(n)
+
+        x = 1
+    end subroutine device3
+
 end module subroutines_mod
 

--- a/loki/transformations/pragma_model.py
+++ b/loki/transformations/pragma_model.py
@@ -112,6 +112,10 @@ class OpenACCPragmaMapper(GenericPragmaMapper):
         if param_detach := parameters.get('detach'):
             content += f' detach({param_detach})'
         if content:
+            # Rather than simply decrementing the dynamic reference counter,
+            # finalize forces it to zero. This isn't needed for OpenMP, where
+            # target exit data map(delete:<>) statement already sets the
+            # dynamic reference counter to 0
             final = ' finalize' if 'finalize' in parameters else ''
             return Pragma(keyword='acc', content=f'exit data{content}{final}')
         return self.default_retval()

--- a/loki/transformations/single_column/hoist.py
+++ b/loki/transformations/single_column/hoist.py
@@ -68,7 +68,7 @@ class SCCHoistTemporaryArraysTransformation(HoistVariablesTransformation):
         vnames = ', '.join(v.name for v in variables)
         if vnames:
             pragma = ir.Pragma(keyword='loki', content=f'unstructured-data create({vnames})')
-            pragma_post = ir.Pragma(keyword='loki', content=f'end unstructured-data delete({vnames})')
+            pragma_post = ir.Pragma(keyword='loki', content=f'end unstructured-data delete({vnames}) finalize')
 
             # Add comments around standalone pragmas to avoid false attachment
             routine.body.prepend((ir.Comment(''), pragma, ir.Comment('')))

--- a/loki/transformations/single_column/hoist.py
+++ b/loki/transformations/single_column/hoist.py
@@ -68,6 +68,9 @@ class SCCHoistTemporaryArraysTransformation(HoistVariablesTransformation):
         vnames = ', '.join(v.name for v in variables)
         if vnames:
             pragma = ir.Pragma(keyword='loki', content=f'unstructured-data create({vnames})')
+            # Rather than simply decrementing the dynamic reference counter,
+            # finalize sets it to zero. This shouldn't be needed, and likely points to an
+            # OpenACC runtime bug.
             pragma_post = ir.Pragma(keyword='loki', content=f'end unstructured-data delete({vnames}) finalize')
 
             # Add comments around standalone pragmas to avoid false attachment

--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -319,7 +319,7 @@ class SCCSeqRevectorTransformation(BaseRevectorTransformation):
                 if '%' in alias:
                     elem = alias_arg.split('%')[1]
                     alias_arg = alias_arg.split('%')[0]
-                if alias_arg in call_arg_map:
+                if alias_arg.lower() in call_arg_map:
                     return (call_arg_map[alias_arg.lower()], elem)
         return (call_arg_map[bound.lower()], None)
 

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -33,7 +33,7 @@ from loki.transformations.single_column import (
 def fixture_horizontal():
     return Dimension(
         name='horizontal', size=['dims%klon', 'nlon'], index='jl',
-        aliases=('nproma',), lower=('start', 'dims%ist'),
+        aliases=('nproma',), lower=('START', 'dims%ist'),
         upper=('end', 'dims%iend')
     )
 

--- a/loki/transformations/single_column/tests/test_scc_hoist.py
+++ b/loki/transformations/single_column/tests/test_scc_hoist.py
@@ -393,7 +393,7 @@ END MODULE kernel_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_scc_hoist_openacc(frontend, horizontal, vertical, blocking, tmp_path):
+def test_scc_hoist_openacc(frontend, horizontal, blocking, tmp_path):
     """
     Test the correct addition of OpenACC pragmas to SCC format code
     when hoisting array temporaries to driver.
@@ -430,13 +430,16 @@ END SUBROUTINE column_driver
 SUBROUTINE compute_column(start, end, nlon, nz, q)
     INTEGER, INTENT(IN) :: start, end  ! Iteration indices
     INTEGER, INTENT(IN) :: nlon, nz    ! Size of the horizontal and vertical
-    REAL, INTENT(INOUT) :: q(nlon,nz)
+    REAL, TARGET, INTENT(INOUT) :: q(nlon,nz)
     REAL :: t(nlon,nz)
     REAL :: a(nlon)
     REAL :: b(nlon,psize)
+    REAL, POINTER :: b_ptr(:,:)
     INTEGER, PARAMETER :: psize = 3
     INTEGER :: jl, jk
     REAL :: c
+
+    b_ptr => q
 
     c = 5.345
     DO jk = 2, nz
@@ -483,7 +486,7 @@ end module my_scaling_value_mod
 
     scc_hoist = SCCHoistPipeline(
         horizontal=horizontal, block_dim=blocking,
-        directive='openacc', dim_vars=vertical.sizes
+        directive='openacc'
     )
 
     graph_dic = {driver_item: [kernel_item]}

--- a/loki/transformations/single_column/tests/test_scc_hoist.py
+++ b/loki/transformations/single_column/tests/test_scc_hoist.py
@@ -530,7 +530,7 @@ end module my_scaling_value_mod
         assert driver_pragmas[0].keyword == 'acc'
         assert driver_pragmas[0].content == 'enter data create(compute_column_t)'
         assert driver_pragmas[1].keyword == 'acc'
-        assert driver_pragmas[1].content == 'exit data delete(compute_column_t)'
+        assert driver_pragmas[1].content == 'exit data delete(compute_column_t) finalize'
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('as_kwarguments', [False, True])

--- a/loki/transformations/temporaries/hoist_variables.py
+++ b/loki/transformations/temporaries/hoist_variables.py
@@ -141,13 +141,17 @@ class HoistVariablesAnalysis(Transformation):
             variables = self.find_variables(routine)
             item.trafo_data[self._key]["to_hoist"] = variables
             dims = flatten([getattr(v, 'shape', []) for v in variables])
+            kinds = [v.type.kind for v in variables if v.type.kind]
             import_map = routine.import_map
-            item.trafo_data[self._key]["imported_sizes"] = [(d.type.module, d) for d in dims
+            item.trafo_data[self._key]["imported_sizes"] = [(d.type.module.name, d) for d in dims
                                                             if str(d) in import_map]
+            item.trafo_data[self._key]["imported_kinds"] = [(import_map[k].module, k) for k in kinds
+                                                             if k.name in import_map]
             item.trafo_data[self._key]["hoist_variables"] = [var.clone(name=f'{routine.name}_{var.name}')
                                                              for var in variables]
         else:
             item.trafo_data[self._key]["imported_sizes"] = []
+            item.trafo_data[self._key]["imported_kinds"] = []
             item.trafo_data[self._key]["to_hoist"] = []
             item.trafo_data[self._key]["hoist_variables"] = []
 
@@ -173,6 +177,7 @@ class HoistVariablesAnalysis(Transformation):
             item.trafo_data[self._key]["hoist_variables"] = list(dict.fromkeys(
                 item.trafo_data[self._key]["hoist_variables"]))
             item.trafo_data[self._key]["imported_sizes"] += child.trafo_data[self._key]["imported_sizes"]
+            item.trafo_data[self._key]["imported_kinds"] += child.trafo_data[self._key]["imported_kinds"]
 
     def find_variables(self, routine):
         """
@@ -298,17 +303,20 @@ class HoistVariablesTransformation(Transformation):
         for module, var in item.trafo_data[self._key]["imported_sizes"]:
             if not var.name in import_map:
                 missing_imports_map[module] |= {var}
+        for module, var in item.trafo_data[self._key]["imported_kinds"]:
+            if not var.name in import_map:
+                missing_imports_map[module] |= {var}
 
         if missing_imports_map:
             routine.spec.prepend(Comment(text=(
                 '![Loki::HoistVariablesTransformation] ---------------------------------------'
             )))
             for module, variables in missing_imports_map.items():
-                routine.spec.prepend(Import(module=module.name, symbols=variables))
+                routine.spec.prepend(Import(module=module, symbols=variables))
 
             routine.spec.prepend(Comment(text=(
                 '![Loki::HoistVariablesTransformation] '
-                '-------- Added hoisted temporary size imports -------------------------------'
+                '-------- Added hoisted temporary size and kind imports -------------------------------'
             )))
 
         routine.body = Transformer(call_map).visit(routine.body)

--- a/loki/transformations/temporaries/hoist_variables.py
+++ b/loki/transformations/temporaries/hoist_variables.py
@@ -500,6 +500,7 @@ class HoistTemporaryArraysAnalysis(HoistVariablesAnalysis):
                 if var not in routine.arguments    # local variable
                 and not all(is_dimension_constant(d) for d in var.shape)
                 and not var.name.lower() == result_name.lower()
+                and not var.type.pointer and not var.type.allocatable
                 and (self.dim_vars is None         # if dim_vars not empty check if at least one dim is within dim_vars
                      or any(dim_var in self.dim_vars for dim_var in FindVariables().visit(var.dimensions)))]
 

--- a/loki/transformations/temporaries/tests/test_hoist_variables.py
+++ b/loki/transformations/temporaries/tests/test_hoist_variables.py
@@ -668,10 +668,12 @@ end subroutine another_kernel
     imports = FindNodes(ir.Import).visit(scheduler['kernel_mod#kernel'].ir.spec)
     assert len(imports) == 2
     assert 'n' in scheduler['kernel_mod#kernel'].ir.imported_symbols
+    assert imports[0].module.lower() == 'size_mod'
 
     imports = FindNodes(ir.Import).visit(scheduler['#driver'].ir.spec)
     assert len(imports) == 2
     assert 'n' in scheduler['#driver'].ir.imported_symbols
+    assert imports[0].module.lower() == 'size_mod'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -550,7 +550,11 @@ def get_integer_variable(routine, name):
     name : string
         Name of the variable to find the in the routine.
     """
-    if not (v_index := routine.symbol_map.get(name, None)):
+
+    symbol_map = routine.symbol_map
+    if name.split('%', maxsplit=1)[0] in symbol_map:
+        v_index = routine.resolve_typebound_var(name, symbol_map)
+    else:
         dtype = SymbolAttributes(BasicType.INTEGER)
         v_index = sym.Variable(name=name, type=dtype, scope=routine)
     return v_index


### PR DESCRIPTION
A bugfix PR that contributes the following fixes:
- Variable kind specifiers are hoisted as necessary with temporaries
- `get_integer_variable` can now also return a type-bound integer
- Pointers/allocatable temporaries are no longer hoisted
- Already hoisted temporaries are now filtered by name, to avoid repetitions when bounds aliases are used
- The finalize clause is added to the device deletion of hoisted temporaries. This shouldn't be necessary, and likely points to an nvhpc openacc runtime bug.
- SCCRevector can now also used dimension configs with bounds declared in upper-case 