### PR TITLE
improve, extend and move `LokiEvaluationMapper`

### DIFF
--- a/loki/expression/__init__.py
+++ b/loki/expression/__init__.py
@@ -14,3 +14,4 @@ from loki.expression.operations import *  # noqa
 from loki.expression.mappers import *  # noqa
 from loki.expression.symbolic import *  # noqa
 from loki.expression.parser import *  # noqa
+from loki.expression.evaluation import *  # noqa

--- a/loki/expression/evaluation.py
+++ b/loki/expression/evaluation.py
@@ -1,0 +1,176 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import math
+import numpy as np
+from pymbolic.mapper.evaluator import EvaluationMapper
+try:
+    from fparser.two.Fortran2003 import Intrinsic_Name
+
+    FORTRAN_INTRINSIC_PROCEDURES = Intrinsic_Name.function_names
+    """list of intrinsic fortran procedure(s) names"""
+except ImportError:
+    FORTRAN_INTRINSIC_PROCEDURES = ()
+
+from loki.expression import symbols as sym
+from loki.tools.util import CaseInsensitiveDict, as_tuple
+
+__all__ = ['LokiEvaluationMapper']
+
+class LokiEvaluationMapper(EvaluationMapper):
+    """
+    A mapper for evaluating expressions, based on
+    :any:`pymbolic.mapper.evaluator.EvaluationMapper`.
+
+    Parameters
+    ----------
+    strict : bool
+        Raise exception for unknown symbols/expressions (default: `False`).
+    """
+
+    @staticmethod
+    def case_insensitive_getattr(obj, attr):
+        """
+        Case-insensitive version of `getattr`.
+        """
+        for elem in dir(obj):
+            if elem.lower() == attr.lower():
+                return getattr(obj, elem)
+        return getattr(obj, attr)
+
+    def __init__(self, strict=False, **kwargs):
+        self.strict = strict
+        super().__init__(**kwargs)
+
+    def map_comparison(self, expr):
+        import operator # pylint: disable=import-outside-toplevel
+        left = self.rec(expr.left)
+        right = self.rec(expr.right)
+        rel_types = (sym._Literal, float, int)
+        if isinstance(left, rel_types) and isinstance(right, rel_types):
+            return getattr(operator, expr.operator_to_name[expr.operator])(
+                self.rec(expr.left), self.rec(expr.right))
+        return sym.Comparison(left=left, operator=expr.operator, right=right)
+
+    def map_logical_and(self, expr):
+        children = [self.rec(ch) for ch in expr.children]
+        if not all(isinstance(ch, bool) for ch in children):
+            new_children = [ch for ch in children if not isinstance(ch, bool) and ch]
+            return sym.LogicalAnd(as_tuple(new_children))
+        return all(children)
+
+    def map_logic_literal(self, expr):
+        return expr.value
+
+    def map_float_literal(self, expr):
+        return expr.value
+    map_int_literal = map_float_literal
+
+    def map_variable(self, expr):
+        _, obj = self._recurse_parent(expr)
+        if obj is not None:
+            try:
+                return self.case_insensitive_getattr(obj, expr.name.split('%')[-1])
+            except: # pylint: disable=bare-except
+                return expr
+        if expr.name.upper() in FORTRAN_INTRINSIC_PROCEDURES:
+            return self.map_call(expr)
+        if self.strict:
+            return super().map_variable(expr)
+        if expr.name in self.context:
+            return super().map_variable(expr)
+        return expr
+
+    def _recurse_parent(self, expr):
+        current_expr = expr
+        while hasattr(current_expr, 'parent') and current_expr.parent is not None:
+            current_expr = current_expr.parent
+            obj = self.rec(current_expr)
+            return current_expr, obj
+        return expr, None
+
+    @staticmethod
+    def _evaluate_array(arr, dims):
+        """
+        Evaluate arrays by converting to numpy array and
+        adapting the dimensions corresponding to the different
+        starting index.
+        """
+        return np.array(arr, order='F').item(*[dim-1 for dim in dims])
+
+    def map_array(self, expr):
+        new_dims = as_tuple(self.rec(dim) for dim in expr.dimensions)
+        return self.map_call(expr.clone(dimensions=new_dims), name=expr.name.lower(), parameters=new_dims)
+
+    def map_call(self, expr, name=None, parameters=None):
+        _, obj = self._recurse_parent(expr)
+        if obj is not None:
+            try:
+                _call = self.case_insensitive_getattr(obj, expr.name.split('%')[-1])
+                if callable(_call):
+                    return _call(*[self.rec(par) for par in expr.dimensions])
+                try:
+                    return self._evaluate_array(_call,
+                            [self.rec(par) for par in expr.dimensions])
+                except: # pylint: disable=bare-except
+                    pass
+                return expr
+            except Exception as e:
+                if self.strict:
+                    raise e
+                return expr
+        call_name = name or expr.function.name.lower()
+        expr_parameters = parameters or expr.parameters
+        if call_name == 'min':
+            return min(self.rec(par) for par in expr_parameters)
+        if call_name == 'max':
+            return max(self.rec(par) for par in expr_parameters)
+        if call_name == 'modulo':
+            args = [self.rec(par) for par in expr_parameters]
+            return args[0]%args[1]
+        if call_name == 'abs':
+            return abs(float([self.rec(par) for par in expr_parameters][0]))
+        if call_name == 'int':
+            return int(float([self.rec(par) for par in expr_parameters][0]))
+        if call_name == 'real':
+            return float([self.rec(par) for par in expr_parameters][0])
+        if call_name == 'sqrt':
+            return math.sqrt(float([self.rec(par) for par in expr_parameters][0]))
+        if call_name == 'exp':
+            return math.exp(float([self.rec(par) for par in expr_parameters][0]))
+        if call_name in self.context:  # and not callable(self.context[call_name]):
+            if not callable(self.context[call_name]):
+                return self._evaluate_array(self.context[call_name],
+                        [self.rec(par) for par in expr_parameters])
+            kwargs = CaseInsensitiveDict(expr.kw_parameters) if hasattr(expr, 'kw_parameters') else {}
+            return self.rec(self.context[call_name](*[self.rec(par) for par in expr_parameters], **kwargs))
+        try:
+            return super().map_call(expr)
+        except: # pylint: disable=bare-except
+            return expr
+
+    def map_inline_call(self, expr):
+        _, obj = self._recurse_parent(expr.function)
+        if obj is not None:
+            try:
+                kwargs = {
+                    k: self.rec(v)
+                    for k, v in expr.kw_parameters.items()}
+                return self.case_insensitive_getattr(obj,
+                        expr.name.split('%')[-1])(*[self.rec(par) for par in expr.parameters], **kwargs)
+            except: # pylint: disable=bare-except
+                return expr
+        return self.map_call(expr, name=expr.name.lower(),
+                parameters=as_tuple(self.rec(param) for param in expr.parameters))
+
+    def map_call_with_kwargs(self, expr):
+        args = [self.rec(par) for par in expr.parameters]
+        kwargs = {
+                k: self.rec(v)
+                for k, v in expr.kw_parameters.items()}
+        kwargs = CaseInsensitiveDict(kwargs)
+        return self.rec(expr.function)(*args, **kwargs)

--- a/loki/expression/evaluation.py
+++ b/loki/expression/evaluation.py
@@ -19,7 +19,7 @@ except ImportError:
 from loki.expression import symbols as sym
 from loki.tools.util import CaseInsensitiveDict, as_tuple
 
-__all__ = ['LokiEvaluationMapper']
+__all__ = ['LokiEvaluationMapper', 'eval_expr']
 
 class LokiEvaluationMapper(EvaluationMapper):
     """
@@ -174,3 +174,29 @@ class LokiEvaluationMapper(EvaluationMapper):
                 for k, v in expr.kw_parameters.items()}
         kwargs = CaseInsensitiveDict(kwargs)
         return self.rec(expr.function)(*args, **kwargs)
+
+
+def eval_expr(expr, context=None, strict=False):
+    """
+    Call Loki Evaluation Mapper to evaluate expression(s).
+
+    Parameters
+    ----------
+    expr : :any:`Expression`
+        The expression as a string
+    strict : bool, optional
+        Whether to raise exception for unknown variables/symbols when
+        evaluating an expression (default: `False`)
+    context : dict, optional
+        Symbol context, defining variables/symbols/procedures to help/support
+        evaluating an expression
+
+    Returns
+    -------
+    :any:`Expression`
+        The evaluated expression tree corresponding to the expression
+    """
+    context = context or {}
+    context = CaseInsensitiveDict(context)
+    mapper = LokiEvaluationMapper(context=context, strict=strict)
+    return mapper(expr)

--- a/loki/expression/parser.py
+++ b/loki/expression/parser.py
@@ -7,13 +7,10 @@
 
 from sys import intern
 import re
-import math
 import pytools.lex
-import numpy as np
 from pymbolic.parser import Parser as ParserBase
 from pymbolic.mapper import Mapper
 import pymbolic.primitives as pmbl
-from pymbolic.mapper.evaluator import EvaluationMapper
 from pymbolic.parser import (
     _openpar, _closepar, _minus, FinalizedTuple, _PREC_UNARY,
     _PREC_TIMES, _PREC_PLUS, _PREC_CALL, _times, _plus
@@ -27,10 +24,11 @@ except ImportError:
     FORTRAN_INTRINSIC_PROCEDURES = ()
 
 from loki.expression import symbols as sym, operations as sym_ops
+from loki.expression.evaluation import eval_expr
 from loki.scope import Scope
-from loki.tools.util import CaseInsensitiveDict, as_tuple
+from loki.tools.util import CaseInsensitiveDict
 
-__all__ = ['ExpressionParser', 'parse_expr', 'FORTRAN_INTRINSIC_PROCEDURES', 'LokiPymbolicEvaluationMapper']
+__all__ = ['ExpressionParser', 'parse_expr', 'FORTRAN_INTRINSIC_PROCEDURES']
 
 
 class PymbolicMapper(Mapper):
@@ -170,139 +168,6 @@ class PymbolicMapper(Mapper):
         parent = kwargs.pop('parent', None)
         parent = self.rec(expr.aggregate, parent=parent)
         return self.rec(expr.name, parent=parent)
-
-
-class LokiPymbolicEvaluationMapper(EvaluationMapper):
-    """
-    A mapper for evaluating expressions, based on
-    :any:`pymbolic.mapper.evaluator.EvaluationMapper`.
-    
-    Parameters
-    ----------
-    strict : bool
-        Raise exception for unknown symbols/expressions (default: `False`).
-    """
-
-    @staticmethod
-    def case_insensitive_getattr(obj, attr):
-        """
-        Case-insensitive version of `getattr`.
-        """
-        for elem in dir(obj):
-            if elem.lower() == attr.lower():
-                return getattr(obj, elem)
-        return getattr(obj, attr)
-
-    def __init__(self, strict=False, **kwargs):
-        self.strict = strict
-        super().__init__(**kwargs)
-
-    def map_comparison(self, expr):
-        import operator # pylint: disable=import-outside-toplevel
-        left = self.rec(expr.left)
-        right = self.rec(expr.right)
-        if isinstance(left, (sym._Literal, float, int)) and isinstance(right, (sym._Literal, float, int)):
-            return getattr(operator, expr.operator_to_name[expr.operator])(
-                self.rec(expr.left), self.rec(expr.right))
-        return sym.Comparison(left=left, operator=expr.operator, right=right)
-
-    def map_logical_and(self, expr):
-        children = [self.rec(ch) for ch in expr.children]
-        if not all(isinstance(ch, bool) for ch in children):
-            return sym.LogicalAnd(as_tuple(children))
-        return all(children)
-
-    def map_logic_literal(self, expr):
-        return expr.value
-
-    def map_float_literal(self, expr):
-        return expr.value
-    map_int_literal = map_float_literal
-
-    def map_variable(self, expr):
-        if expr.name.upper() in FORTRAN_INTRINSIC_PROCEDURES:
-            return self.map_call(expr)
-        if self.strict:
-            return super().map_variable(expr)
-        if expr.name in self.context:
-            return super().map_variable(expr)
-        return expr
-
-    @staticmethod
-    def _evaluate_array(arr, dims):
-        """
-        Evaluate arrays by converting to numpy array and
-        adapting the dimensions corresponding to the different
-        starting index.
-        """
-        return np.array(arr, order='F').item(*[dim-1 for dim in dims])
-
-    def map_call(self, expr):
-        if expr.function.name.lower() == 'min':
-            return min(self.rec(par) for par in expr.parameters)
-        if expr.function.name.lower() == 'max':
-            return max(self.rec(par) for par in expr.parameters)
-        if expr.function.name.lower() == 'modulo':
-            args = [self.rec(par) for par in expr.parameters]
-            return args[0]%args[1]
-        if expr.function.name.lower() == 'abs':
-            return abs(float([self.rec(par) for par in expr.parameters][0]))
-        if expr.function.name.lower() == 'int':
-            return int(float([self.rec(par) for par in expr.parameters][0]))
-        if expr.function.name.lower() == 'real':
-            return float([self.rec(par) for par in expr.parameters][0])
-        if expr.function.name.lower() == 'sqrt':
-            return math.sqrt(float([self.rec(par) for par in expr.parameters][0]))
-        if expr.function.name.lower() == 'exp':
-            return math.exp(float([self.rec(par) for par in expr.parameters][0]))
-        if expr.function.name in self.context and not callable(self.context[expr.function.name]):
-            return self._evaluate_array(self.context[expr.function.name],
-                    [self.rec(par) for par in expr.parameters])
-        return super().map_call(expr)
-
-    def map_call_with_kwargs(self, expr):
-        args = [self.rec(par) for par in expr.parameters]
-        kwargs = {
-                k: self.rec(v)
-                for k, v in expr.kw_parameters.items()}
-        kwargs = CaseInsensitiveDict(kwargs)
-        return self.rec(expr.function)(*args, **kwargs)
-
-    def map_lookup(self, expr):
-
-        def rec_lookup(expr, obj, name):
-            return expr.name, self.case_insensitive_getattr(obj, name)
-
-        try:
-            current_expr = expr
-            obj = self.rec(expr.aggregate)
-            while isinstance(current_expr.name, pmbl.Lookup):
-                current_expr, obj = rec_lookup(current_expr, obj, current_expr.name.aggregate.name)
-            if isinstance(current_expr.name, pmbl.Variable):
-                _, obj = rec_lookup(current_expr, obj, current_expr.name.name)
-                return obj
-            if isinstance(current_expr.name, pmbl.Call):
-                name = current_expr.name.function.name
-                _, obj = rec_lookup(current_expr, obj, name)
-                if callable(obj):
-                    return obj(*[self.rec(par) for par in current_expr.name.parameters])
-                return self._evaluate_array(obj, [self.rec(par) for par in current_expr.name.parameters])
-            if isinstance(current_expr.name, pmbl.CallWithKwargs):
-                name = current_expr.name.function.name
-                _, obj = rec_lookup(current_expr, obj, name)
-                args = [self.rec(par) for par in current_expr.name.parameters]
-                kwargs = CaseInsensitiveDict(
-                    (k, self.rec(v))
-                    for k, v in current_expr.name.kw_parameters.items()
-                )
-                return obj(*args, **kwargs)
-        except Exception as e:
-            if self.strict:
-                raise e
-            return expr
-        if self.strict:
-            raise NotImplementedError
-        return expr
 
 
 class ExpressionParser(ParserBase):
@@ -535,11 +400,9 @@ class ExpressionParser(ParserBase):
         """
         from loki.ir import AttachScopes  # pylint: disable=import-outside-toplevel,cyclic-import
         result = super().__call__(expr_str)
-        context = context or {}
-        context = CaseInsensitiveDict(context)
-        if evaluate:
-            result = LokiPymbolicEvaluationMapper(context=context, strict=strict)(result)
         ir = PymbolicMapper()(result)
+        if evaluate:
+            ir = eval_expr(ir, context=context, strict=strict)
         return AttachScopes().visit(ir, scope=scope or Scope())
 
     def parse_float(self, s):

--- a/loki/expression/parser.py
+++ b/loki/expression/parser.py
@@ -24,7 +24,6 @@ except ImportError:
     FORTRAN_INTRINSIC_PROCEDURES = ()
 
 from loki.expression import symbols as sym, operations as sym_ops
-from loki.expression.evaluation import eval_expr
 from loki.scope import Scope
 from loki.tools.util import CaseInsensitiveDict
 
@@ -150,7 +149,6 @@ class PymbolicMapper(Mapper):
                 in CaseInsensitiveDict(expr.kw_parameters).items()}
         if expr.function.name.lower() in ('real', 'int'):
             return sym.Cast(name, parameters, kind=kw_parameters['kind'])
-        # print(f"PymbolicMapper - map_call_with_kwargs: {expr} | kwargs {kwargs}")
         return sym.InlineCall(function=name, parameters=parameters, kw_parameters=kw_parameters)
 
     def map_tuple(self, expr, *args, **kwargs):
@@ -399,6 +397,7 @@ class ExpressionParser(ParserBase):
             The expression tree corresponding to the expression
         """
         from loki.ir import AttachScopes  # pylint: disable=import-outside-toplevel,cyclic-import
+        from loki.expression.evaluation import eval_expr # pylint: disable=import-outside-toplevel,cyclic-import
         result = super().__call__(expr_str)
         ir = PymbolicMapper()(result)
         if evaluate:

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -14,7 +14,7 @@ import numpy as np
 import pymbolic.primitives as pmbl
 
 from loki.expression.mappers import LokiIdentityMapper
-from loki.expression.parser import LokiEvaluationMapper
+from loki.expression.evaluation import LokiEvaluationMapper
 import loki.expression.symbols as sym
 from loki.tools import as_tuple
 

--- a/loki/expression/tests/test_symbolic.py
+++ b/loki/expression/tests/test_symbolic.py
@@ -18,7 +18,7 @@ import pymbolic.primitives as pmbl
 from loki import Scope, is_dimension_constant, Subroutine
 from loki.expression import symbols as sym, simplify, Simplification, symbolic_op, parse_expr
 from loki.expression import iteration_number, iteration_index, get_pyrange
-from loki.expression.parser import LokiEvaluationMapper
+from loki.expression.evaluation import LokiEvaluationMapper
 from loki.frontend import available_frontends
 
 


### PR DESCRIPTION
Some fixes and extensions.
Moreover, the old approach when evaluating an expression was:

> "parse expression to pymbolic symbols (with some Loki symbols enhanced)" -> "evaluate this expression (as far as possible)" -> "convert pymbolic symbols to Loki symbols"

With this PR it is now possible to:

> "parse expression to pymbolic symbols (with some Loki symbols enhanced)" -> "convert pymbolic symbols to Loki symbols" -> "evaluate this expression being Loki symbols (as far as possible)"

So the plan would be to (either now or later) remove `LokiPymbolicEvaluationMapper` and further improve and extend `LokiEvaluationMapper`.