### PR TITLE
Expression: Small re-organisation and moar tests

### DIFF
--- a/loki/expression/__init__.py
+++ b/loki/expression/__init__.py
@@ -9,9 +9,10 @@ Expression layer of the two-level Loki IR based on `Pymbolic
 <https://github.com/inducer/pymbolic>`_.
 """
 
-from loki.expression.symbols import *  # noqa
-from loki.expression.operations import *  # noqa
-from loki.expression.mappers import *  # noqa
-from loki.expression.symbolic import *  # noqa
-from loki.expression.parser import *  # noqa
 from loki.expression.evaluation import *  # noqa
+from loki.expression.mappers import *  # noqa
+from loki.expression.mixins import *  # noqa
+from loki.expression.operations import *  # noqa
+from loki.expression.parser import *  # noqa
+from loki.expression.symbolic import *  # noqa
+from loki.expression.symbols import *  # noqa

--- a/loki/expression/__init__.py
+++ b/loki/expression/__init__.py
@@ -10,6 +10,7 @@ Expression layer of the two-level Loki IR based on `Pymbolic
 """
 
 from loki.expression.evaluation import *  # noqa
+from loki.expression.literals import *  # noqa
 from loki.expression.mappers import *  # noqa
 from loki.expression.mixins import *  # noqa
 from loki.expression.operations import *  # noqa

--- a/loki/expression/literals.py
+++ b/loki/expression/literals.py
@@ -1,0 +1,348 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Literal symbols representing numbers, strings and logicals.
+"""
+
+from sys import intern
+import pymbolic.primitives as pmbl
+from pymbolic.mapper.evaluator import UnknownVariableError
+
+from loki.types import BasicType
+from loki.expression.mixins import StrCompareMixin
+
+
+__all__ = [
+    '_Literal', 'FloatLiteral', 'IntLiteral', 'LogicLiteral',
+    'StringLiteral', 'IntrinsicLiteral', 'Literal', 'LiteralList'
+]
+
+
+class _Literal(pmbl.Leaf):
+    """
+    Base class for literals.
+
+    This exists to overcome the problem of a disfunctional
+    :meth:`__getinitargs__` in any:`pymbolic.primitives.Leaf`.
+    """
+
+    def __getinitargs__(self):
+        return ()
+
+
+class FloatLiteral(StrCompareMixin, _Literal):
+    """
+    A floating point constant in an expression.
+
+    Note that its :data:`value` is stored as a string to avoid any
+    representation issues that could stem from converting it to a
+    Python floating point number.
+
+    It can have a specific type associated, which backends can use to cast
+    or annotate the constant to make sure the specified type is used.
+
+    Parameters
+    ----------
+    value : str
+        The value of that literal.
+    kind : optional
+        The kind information for that literal.
+    """
+
+    def __init__(self, value, **kwargs):
+        # We store float literals as strings to make sure no information gets
+        # lost in the conversion
+        self.value = str(value)
+        self.kind = kwargs.pop('kind', None)
+        super().__init__(**kwargs)
+
+    def __hash__(self):
+        return hash((self.value, self.kind))
+
+    def __eq__(self, other):
+        if isinstance(other, FloatLiteral):
+            return self.value == other.value and self.kind == other.kind
+
+        try:
+            return float(self.value) == float(other)
+        except (TypeError, ValueError, UnknownVariableError):
+            return False
+
+    def __lt__(self, other):
+        if isinstance(other, FloatLiteral):
+            return float(self.value) < float(other.value)
+        try:
+            return float(self.value) < float(other)
+        except ValueError:
+            return super().__lt__(other)
+
+    def __le__(self, other):
+        if isinstance(other, FloatLiteral):
+            return float(self.value) <= float(other.value)
+        try:
+            return float(self.value) <= float(other)
+        except ValueError:
+            return super().__le__(other)
+
+    def __gt__(self, other):
+        if isinstance(other, FloatLiteral):
+            return float(self.value) > float(other.value)
+        try:
+            return float(self.value) > float(other)
+        except ValueError:
+            return super().__gt__(other)
+
+    def __ge__(self, other):
+        if isinstance(other, FloatLiteral):
+            return float(self.value) >= float(other.value)
+        try:
+            return float(self.value) >= float(other)
+        except ValueError:
+            return super().__ge__(other)
+
+    init_arg_names = ('value', 'kind')
+
+    def __getinitargs__(self):
+        return (self.value, self.kind)
+
+    mapper_method = intern('map_float_literal')
+
+
+class IntLiteral(StrCompareMixin, _Literal):
+    """
+    An integer constant in an expression.
+
+    It can have a specific type associated, which backends can use to cast
+    or annotate the constant to make sure the specified type is used.
+
+    Parameters
+    ----------
+    value : int
+        The value of that literal.
+    kind : optional
+        The kind information for that literal.
+    """
+
+    def __init__(self, value, **kwargs):
+        self.value = int(value)
+        self.kind = kwargs.pop('kind', None)
+        super().__init__(**kwargs)
+
+    def __hash__(self):
+        return hash((self.value, self.kind))
+
+    def __eq__(self, other):
+        if isinstance(other, IntLiteral):
+            return self.value == other.value and self.kind == other.kind
+        if isinstance(other, (int, float, complex)):
+            return self.value == other
+
+        try:
+            return self.value == int(other)
+        except (TypeError, ValueError):
+            return False
+
+    def __lt__(self, other):
+        if isinstance(other, IntLiteral):
+            return self.value < other.value
+        if isinstance(other, int):
+            return self.value < other
+        return super().__lt__(other)
+
+    def __le__(self, other):
+        if isinstance(other, IntLiteral):
+            return self.value <= other.value
+        if isinstance(other, int):
+            return self.value <= other
+        return super().__le__(other)
+
+    def __gt__(self, other):
+        if isinstance(other, IntLiteral):
+            return self.value > other.value
+        if isinstance(other, int):
+            return self.value > other
+        return super().__gt__(other)
+
+    def __ge__(self, other):
+        if isinstance(other, IntLiteral):
+            return self.value >= other.value
+        if isinstance(other, int):
+            return self.value >= other
+        return super().__ge__(other)
+
+    init_arg_names = ('value', 'kind')
+
+    def __getinitargs__(self):
+        return (self.value, self.kind)
+
+    def __int__(self):
+        return self.value
+
+    def __bool__(self):
+        return bool(self.value)
+
+    mapper_method = intern('map_int_literal')
+
+
+# Register IntLiteral as a constant class in Pymbolic
+pmbl.register_constant_class(IntLiteral)
+
+
+class LogicLiteral(StrCompareMixin, _Literal):
+    """
+    A boolean constant in an expression.
+
+    Parameters
+    ----------
+    value : bool
+        The value of that literal.
+    """
+
+    def __init__(self, value, **kwargs):
+        self.value = str(value).lower() in ('true', '.true.')
+        super().__init__(**kwargs)
+
+    init_arg_names = ('value', )
+
+    def __getinitargs__(self):
+        return (self.value, )
+
+    def __bool__(self):
+        return self.value
+
+    mapper_method = intern('map_logic_literal')
+
+
+class StringLiteral(StrCompareMixin, _Literal):
+    """
+    A string constant in an expression.
+
+    Parameters
+    ----------
+    value : str
+        The value of that literal. Enclosing quotes are removed.
+    """
+
+    def __init__(self, value, **kwargs):
+        # Remove quotation marks
+        if value[0] == value[-1] and value[0] in '"\'':
+            value = value[1:-1]
+
+        self.value = value
+
+        super().__init__(**kwargs)
+
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other):
+        if isinstance(other, StringLiteral):
+            return self.value == other.value
+        if isinstance(other, str):
+            return self.value == other
+        return False
+
+    init_arg_names = ('value', )
+
+    def __getinitargs__(self):
+        return (self.value, )
+
+    mapper_method = intern('map_string_literal')
+
+
+class IntrinsicLiteral(StrCompareMixin, _Literal):
+    """
+    Any literal not represented by a dedicated class.
+
+    Its value is stored as string and returned unaltered.
+    This is currently used for complex and BOZ constants and to retain
+    array constructor expressions with type spec or implied-do.
+
+    Parameters
+    ----------
+    value : str
+        The value of that literal.
+    """
+
+    def __init__(self, value, **kwargs):
+        self.value = value
+        super().__init__(**kwargs)
+
+    init_arg_names = ('value', )
+
+    def __getinitargs__(self):
+        return (self.value, )
+
+    mapper_method = intern('map_intrinsic_literal')
+
+
+class Literal:
+    """
+    Factory class to instantiate the best-matching literal node.
+
+    This always returns a :class:`IntLiteral`, :class:`FloatLiteral`,
+    :class:`StringLiteral`, :class:`LogicLiteral` or, as a fallback,
+    :class:`IntrinsicLiteral`, selected by using any provided :data:`type`
+    information or inspecting the Python data type of :data: value.
+
+    Parameters
+    ----------
+    value :
+        The value of that literal.
+    kind : optional
+        The kind information for that literal.
+    """
+
+    @staticmethod
+    def _from_literal(value, **kwargs):
+
+        cls_map = {BasicType.INTEGER: IntLiteral, BasicType.REAL: FloatLiteral,
+                   BasicType.LOGICAL: LogicLiteral, BasicType.CHARACTER: StringLiteral}
+
+        _type = kwargs.pop('type', None)
+        if _type is None:
+            if isinstance(value, int):
+                _type = BasicType.INTEGER
+            elif isinstance(value, float):
+                _type = BasicType.REAL
+            elif isinstance(value, str):
+                if str(value).lower() in ('.true.', 'true', '.false.', 'false'):
+                    _type = BasicType.LOGICAL
+                else:
+                    _type = BasicType.CHARACTER
+
+        return cls_map[_type](value, **kwargs)
+
+    def __new__(cls, value, **kwargs):
+        try:
+            obj = cls._from_literal(value, **kwargs)
+        except KeyError:
+            obj = IntrinsicLiteral(value, **kwargs)
+
+        # And attach our own meta-data
+        if hasattr(obj, 'kind'):
+            obj.kind = kwargs.get('kind', None)
+        return obj
+
+
+class LiteralList(StrCompareMixin, pmbl.AlgebraicLeaf):
+    """
+    A list of constant literals, e.g., as used in Array Initialization Lists.
+    """
+
+    init_arg_names = ('values', 'dtype')
+
+    def __init__(self, values, dtype=None, **kwargs):
+        self.elements = values
+        self.dtype = dtype
+        super().__init__(**kwargs)
+
+    mapper_method = intern('map_literal_list')
+
+    def __getinitargs__(self):
+        return (self.elements, self.dtype)

--- a/loki/expression/mixins.py
+++ b/loki/expression/mixins.py
@@ -1,0 +1,56 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki.config import config
+from loki.expression.mappers import ExpressionRetriever
+
+
+__all__ = ['loki_make_stringifier', 'StrCompareMixin']
+
+
+def loki_make_stringifier(self, originating_stringifier=None):  # pylint: disable=unused-argument
+    """
+    Return a :any:`LokiStringifyMapper` instance that can be used to generate a
+    human-readable representation of :data:`self`.
+
+    This is used as common abstraction for the :meth:`make_stringifier` method in
+    Pymbolic expression nodes.
+    """
+    from loki.expression.mappers import LokiStringifyMapper  # pylint: disable=import-outside-toplevel
+    return LokiStringifyMapper()
+
+
+class StrCompareMixin:
+    """
+    Mixin to enable comparing expressions to strings.
+
+    The purpose of the string comparison override is to reliably and flexibly
+    identify expression symbols from equivalent strings.
+    """
+
+    @staticmethod
+    def _canonical(s):
+        """ Define canonical string representations (lower-case, no spaces) """
+        if config['case-sensitive']:
+            return str(s).replace(' ', '')
+        return str(s).lower().replace(' ', '')
+
+    def __hash__(self):
+        return hash(self._canonical(self))
+
+    def __eq__(self, other):
+        if isinstance(other, (str, type(self))):
+            # Do comparsion based on canonical string representations
+            return self._canonical(self) == self._canonical(other)
+
+        return super().__eq__(other)
+
+    def __contains__(self, other):
+        # Assess containment via a retriver with node-wise string comparison
+        return len(ExpressionRetriever(lambda x: x == other).retrieve(self)) > 0
+
+    make_stringifier = loki_make_stringifier

--- a/loki/expression/operations.py
+++ b/loki/expression/operations.py
@@ -17,6 +17,7 @@ import pymbolic.primitives as pmbl
 
 from loki.tools import as_tuple
 
+from loki.expression.literals import StringLiteral
 from loki.expression.mixins import loki_make_stringifier, StrCompareMixin
 
 

--- a/loki/expression/operations.py
+++ b/loki/expression/operations.py
@@ -14,9 +14,9 @@ nevertheless change code results.
 from sys import intern
 import pymbolic.primitives as pmbl
 
+from loki.expression.mixins import loki_make_stringifier
 from loki.expression.symbols import (
-    StringLiteral, Sum, Product, Quotient, Power,
-    loki_make_stringifier
+    StringLiteral, Sum, Product, Quotient, Power
 )
 
 

--- a/loki/expression/operations.py
+++ b/loki/expression/operations.py
@@ -6,18 +6,57 @@
 # nor does it submit to any jurisdiction.
 
 """
-Sub-classes of Pymbolic's native operations that allow us to express
-niche things like mathematically irrelevant parenthesis that
-nevertheless change code results.
+Sub-classes of Pymbolic's native operations that allow us to inject
+Fortran-specific features, such as case-insensitive string comparison
+and bracket-aware and sub-expression grouping. Here we also add
+additional technical operations, such as cast and references.
 """
 
 from sys import intern
 import pymbolic.primitives as pmbl
 
-from loki.expression.mixins import loki_make_stringifier
-from loki.expression.symbols import (
-    StringLiteral, Sum, Product, Quotient, Power
-)
+from loki.tools import as_tuple
+
+from loki.expression.mixins import loki_make_stringifier, StrCompareMixin
+
+
+__all__ = [
+    'Sum', 'Product', 'Quotient', 'Power',
+    'Comparison', 'LogicalAnd', 'LogicalOr', 'LogicalNot',
+    'StringConcat', 'Cast', 'Reference', 'Dereference'
+]
+
+
+class Sum(StrCompareMixin, pmbl.Sum):
+    """Representation of a sum."""
+
+
+class Product(StrCompareMixin, pmbl.Product):
+    """Representation of a product."""
+
+
+class Quotient(StrCompareMixin, pmbl.Quotient):
+    """Representation of a quotient."""
+
+
+class Power(StrCompareMixin, pmbl.Power):
+    """Representation of a power."""
+
+
+class Comparison(StrCompareMixin, pmbl.Comparison):
+    """Representation of a comparison operation."""
+
+
+class LogicalAnd(StrCompareMixin, pmbl.LogicalAnd):
+    """Representation of an 'and' in a logical expression."""
+
+
+class LogicalOr(StrCompareMixin, pmbl.LogicalOr):
+    """Representation of an 'or' in a logical expression."""
+
+
+class LogicalNot(StrCompareMixin, pmbl.LogicalNot):
+    """Representation of a negation in a logical expression."""
 
 
 class ParenthesisedAdd(Sum):
@@ -87,3 +126,143 @@ class StringConcat(pmbl._MultiChildExpression):
     __nonzero__ = __bool__
 
     mapper_method = intern("map_string_concat")
+
+
+class Cast(StrCompareMixin, pmbl.Call):
+    """
+    Internal representation of a data type cast.
+    """
+
+    init_arg_names = ('name', 'expression', 'kind')
+
+    def __init__(self, name, expression, kind=None, **kwargs):
+        assert kind is None or isinstance(kind, pmbl.Expression)
+        self.kind = kind
+        super().__init__(pmbl.make_variable(name), as_tuple(expression), **kwargs)
+
+    def __getinitargs__(self):
+        return (self.name, self.expression, self.kind)
+
+    mapper_method = intern('map_cast')
+
+    @property
+    def name(self):
+        return self.function.name
+
+    @property
+    def expression(self):
+        return self.parameters
+
+
+class Reference(StrCompareMixin, pmbl.Expression):
+    """
+    Internal representation of a Reference.
+
+    .. warning:: Experimental! Allowing compound
+        ``Reference(Variable(...))`` to appear
+        with behaviour akin to a symbol itself
+        for easier processing in mappers.
+
+    **C/C++ only**, no corresponding concept in Fortran.
+    Referencing refers to taking the address of an
+    existing variable (to set a pointer variable).
+    """
+    init_arg_names = ('expression',)
+
+    def __getinitargs__(self):
+        return (self.expression, )
+
+    def __init__(self, expression):
+        assert isinstance(expression, pmbl.Expression)
+        self.expression = expression
+
+    @property
+    def name(self):
+        """
+        Allowing the compound ``Reference(Variable(name))`` to appear
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
+        return self.expression.name
+
+    @property
+    def type(self):
+        """
+        Allowing the compound ``Reference(Variable(type))`` to appear
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
+        return self.expression.type
+
+    @property
+    def scope(self):
+        """
+        Allowing the compound ``Reference(Variable(scope))`` to appear
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
+        return self.expression.scope
+
+    @property
+    def initial(self):
+        """
+        Allowing the compound ``Reference(Variable(initial))`` to appear
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
+        return self.expression.initial
+
+    mapper_method = intern('map_c_reference')
+
+
+class Dereference(StrCompareMixin, pmbl.Expression):
+    """
+    Internal representation of a Dereference.
+
+    .. warning:: Experimental! Allowing compound
+        ``Dereference(Variable(...))`` to appear
+        with behaviour akin to a symbol itself
+        for easier processing in mappers.
+
+    **C/C++ only**, no corresponding concept in Fortran.
+    Dereferencing (a pointer) refers to retrieving the value
+    from a memory address (that is pointed by the pointer).
+    """
+    init_arg_names = ('expression', )
+
+    def __getinitargs__(self):
+        return (self.expression, )
+
+    def __init__(self, expression):
+        assert isinstance(expression, pmbl.Expression)
+        self.expression = expression
+
+    @property
+    def name(self):
+        """
+        Allowing the compound ``Dereference(Variable(name))`` to appear
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
+        return self.expression.name
+
+    @property
+    def type(self):
+        """
+        Allowing the compound ``Dereference(Variable(type))`` to appear
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
+        return self.expression.type
+
+    @property
+    def scope(self):
+        """
+        Allowing the compound ``Dereference(Variable(scope))`` to appear
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
+        return self.expression.scope
+
+    @property
+    def initial(self):
+        """
+        Allowing the compound ``Dereference(Variable(initial))`` to appear
+        with behaviour akin to a symbol itself for easier processing in mappers.
+        """
+        return self.expression.initial
+
+    mapper_method = intern('map_c_dereference')

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1338,7 +1338,7 @@ class InlineCall(pmbl.CallWithKwargs):
     init_arg_names = ('function', 'parameters', 'kw_parameters')
 
     def __getinitargs__(self):
-        return (self.function, self.parameters, self.kw_parameters)
+        return (self.function, self.parameters, as_tuple(self.kw_parameters))
 
 
     def __init__(self, function, parameters=None, kw_parameters=None, **kwargs):
@@ -1357,14 +1357,10 @@ class InlineCall(pmbl.CallWithKwargs):
     mapper_method = intern('map_inline_call')
     make_stringifier = loki_make_stringifier
 
-    @property
-    def _canonical(self):
-        return (self.function, self.parameters, as_tuple(self.kw_parameters))
-
     def __hash__(self):
         # A custom `__hash__` function to protect us from unhashasble
         # dicts that `pmbl.CallWithKwargs` uses internally
-        return hash(self._canonical)
+        return hash(self.__getinitargs__())
 
     @property
     def name(self):

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -16,29 +16,34 @@ from itertools import chain
 import weakref
 from sys import intern
 import pymbolic.primitives as pmbl
-from pymbolic.mapper.evaluator import UnknownVariableError
 
 from loki.tools import as_tuple, CaseInsensitiveDict
 from loki.types import BasicType, DerivedType, ProcedureType, SymbolAttributes
 from loki.scope import Scope
 from loki.config import config
 
+from loki.expression.literals import (
+    _Literal, FloatLiteral, IntLiteral, LogicLiteral, StringLiteral,
+    IntrinsicLiteral, Literal, LiteralList,
+)
 from loki.expression.mixins import StrCompareMixin
 from loki.expression.operations import (
     Sum, Product, Quotient, Power, Comparison, LogicalAnd,
     LogicalOr, LogicalNot, StringConcat, Cast, Reference, Dereference
 )
 
+
 __all__ = [
     # Typed leaf nodes
     'TypedSymbol', 'DeferredTypeSymbol', 'VariableSymbol', 'ProcedureSymbol', 'DerivedTypeSymbol',
     'MetaSymbol', 'Scalar', 'Array', 'Variable',
-    # Non-typed leaf nodes
-    'FloatLiteral', 'IntLiteral', 'LogicLiteral', 'StringLiteral',
-    'IntrinsicLiteral', 'Literal', 'LiteralList', 'InlineDo',
     # Internal nodes
-    'InlineCall', 'Range', 'LoopRange', 'RangeIndex', 'ArraySubscript', 'StringSubscript',
-    # Operations (importedm but exposed here for convenience)
+    'InlineCall', 'InlineDo', 'Range', 'LoopRange', 'RangeIndex',
+    'ArraySubscript', 'StringSubscript',
+    # Literals (imported but exposed here for convenience)
+    '_Literal', 'FloatLiteral', 'IntLiteral', 'LogicLiteral',
+    'StringLiteral', 'IntrinsicLiteral', 'Literal', 'LiteralList',
+    # Operations (imported but exposed here for convenience)
     'Sum', 'Product', 'Quotient', 'Power', 'Comparison', 'LogicalAnd', 'LogicalOr',
     'LogicalNot', 'StringConcat', 'Cast', 'Reference', 'Dereference',
 ]
@@ -906,331 +911,6 @@ class Variable:
                     return tdef_var.type
 
         return stored_type
-
-
-class _Literal(pmbl.Leaf):
-    """
-    Base class for literals.
-
-    This exists to overcome the problem of a disfunctional
-    :meth:`__getinitargs__` in any:`pymbolic.primitives.Leaf`.
-    """
-
-    def __getinitargs__(self):
-        return ()
-
-
-class FloatLiteral(StrCompareMixin, _Literal):
-    """
-    A floating point constant in an expression.
-
-    Note that its :data:`value` is stored as a string to avoid any
-    representation issues that could stem from converting it to a
-    Python floating point number.
-
-    It can have a specific type associated, which backends can use to cast
-    or annotate the constant to make sure the specified type is used.
-
-    Parameters
-    ----------
-    value : str
-        The value of that literal.
-    kind : optional
-        The kind information for that literal.
-    """
-
-    def __init__(self, value, **kwargs):
-        # We store float literals as strings to make sure no information gets
-        # lost in the conversion
-        self.value = str(value)
-        self.kind = kwargs.pop('kind', None)
-        super().__init__(**kwargs)
-
-    def __hash__(self):
-        return hash((self.value, self.kind))
-
-    def __eq__(self, other):
-        if isinstance(other, FloatLiteral):
-            return self.value == other.value and self.kind == other.kind
-
-        try:
-            return float(self.value) == float(other)
-        except (TypeError, ValueError, UnknownVariableError):
-            return False
-
-    def __lt__(self, other):
-        if isinstance(other, FloatLiteral):
-            return float(self.value) < float(other.value)
-        try:
-            return float(self.value) < float(other)
-        except ValueError:
-            return super().__lt__(other)
-
-    def __le__(self, other):
-        if isinstance(other, FloatLiteral):
-            return float(self.value) <= float(other.value)
-        try:
-            return float(self.value) <= float(other)
-        except ValueError:
-            return super().__le__(other)
-
-    def __gt__(self, other):
-        if isinstance(other, FloatLiteral):
-            return float(self.value) > float(other.value)
-        try:
-            return float(self.value) > float(other)
-        except ValueError:
-            return super().__gt__(other)
-
-    def __ge__(self, other):
-        if isinstance(other, FloatLiteral):
-            return float(self.value) >= float(other.value)
-        try:
-            return float(self.value) >= float(other)
-        except ValueError:
-            return super().__ge__(other)
-
-    init_arg_names = ('value', 'kind')
-
-    def __getinitargs__(self):
-        return (self.value, self.kind)
-
-    mapper_method = intern('map_float_literal')
-
-
-class IntLiteral(StrCompareMixin, _Literal):
-    """
-    An integer constant in an expression.
-
-    It can have a specific type associated, which backends can use to cast
-    or annotate the constant to make sure the specified type is used.
-
-    Parameters
-    ----------
-    value : int
-        The value of that literal.
-    kind : optional
-        The kind information for that literal.
-    """
-
-    def __init__(self, value, **kwargs):
-        self.value = int(value)
-        self.kind = kwargs.pop('kind', None)
-        super().__init__(**kwargs)
-
-    def __hash__(self):
-        return hash((self.value, self.kind))
-
-    def __eq__(self, other):
-        if isinstance(other, IntLiteral):
-            return self.value == other.value and self.kind == other.kind
-        if isinstance(other, (int, float, complex)):
-            return self.value == other
-
-        try:
-            return self.value == int(other)
-        except (TypeError, ValueError):
-            return False
-
-    def __lt__(self, other):
-        if isinstance(other, IntLiteral):
-            return self.value < other.value
-        if isinstance(other, int):
-            return self.value < other
-        return super().__lt__(other)
-
-    def __le__(self, other):
-        if isinstance(other, IntLiteral):
-            return self.value <= other.value
-        if isinstance(other, int):
-            return self.value <= other
-        return super().__le__(other)
-
-    def __gt__(self, other):
-        if isinstance(other, IntLiteral):
-            return self.value > other.value
-        if isinstance(other, int):
-            return self.value > other
-        return super().__gt__(other)
-
-    def __ge__(self, other):
-        if isinstance(other, IntLiteral):
-            return self.value >= other.value
-        if isinstance(other, int):
-            return self.value >= other
-        return super().__ge__(other)
-
-    init_arg_names = ('value', 'kind')
-
-    def __getinitargs__(self):
-        return (self.value, self.kind)
-
-    def __int__(self):
-        return self.value
-
-    def __bool__(self):
-        return bool(self.value)
-
-    mapper_method = intern('map_int_literal')
-
-
-# Register IntLiteral as a constant class in Pymbolic
-pmbl.register_constant_class(IntLiteral)
-
-
-class LogicLiteral(StrCompareMixin, _Literal):
-    """
-    A boolean constant in an expression.
-
-    Parameters
-    ----------
-    value : bool
-        The value of that literal.
-    """
-
-    def __init__(self, value, **kwargs):
-        self.value = str(value).lower() in ('true', '.true.')
-        super().__init__(**kwargs)
-
-    init_arg_names = ('value', )
-
-    def __getinitargs__(self):
-        return (self.value, )
-
-    def __bool__(self):
-        return self.value
-
-    mapper_method = intern('map_logic_literal')
-
-
-class StringLiteral(StrCompareMixin, _Literal):
-    """
-    A string constant in an expression.
-
-    Parameters
-    ----------
-    value : str
-        The value of that literal. Enclosing quotes are removed.
-    """
-
-    def __init__(self, value, **kwargs):
-        # Remove quotation marks
-        if value[0] == value[-1] and value[0] in '"\'':
-            value = value[1:-1]
-
-        self.value = value
-
-        super().__init__(**kwargs)
-
-    def __hash__(self):
-        return hash(self.value)
-
-    def __eq__(self, other):
-        if isinstance(other, StringLiteral):
-            return self.value == other.value
-        if isinstance(other, str):
-            return self.value == other
-        return False
-
-    init_arg_names = ('value', )
-
-    def __getinitargs__(self):
-        return (self.value, )
-
-    mapper_method = intern('map_string_literal')
-
-
-class IntrinsicLiteral(StrCompareMixin, _Literal):
-    """
-    Any literal not represented by a dedicated class.
-
-    Its value is stored as string and returned unaltered.
-    This is currently used for complex and BOZ constants and to retain
-    array constructor expressions with type spec or implied-do.
-
-    Parameters
-    ----------
-    value : str
-        The value of that literal.
-    """
-
-    def __init__(self, value, **kwargs):
-        self.value = value
-        super().__init__(**kwargs)
-
-    init_arg_names = ('value', )
-
-    def __getinitargs__(self):
-        return (self.value, )
-
-    mapper_method = intern('map_intrinsic_literal')
-
-
-class Literal:
-    """
-    Factory class to instantiate the best-matching literal node.
-
-    This always returns a :class:`IntLiteral`, :class:`FloatLiteral`,
-    :class:`StringLiteral`, :class:`LogicLiteral` or, as a fallback,
-    :class:`IntrinsicLiteral`, selected by using any provided :data:`type`
-    information or inspecting the Python data type of :data: value.
-
-    Parameters
-    ----------
-    value :
-        The value of that literal.
-    kind : optional
-        The kind information for that literal.
-    """
-
-    @staticmethod
-    def _from_literal(value, **kwargs):
-
-        cls_map = {BasicType.INTEGER: IntLiteral, BasicType.REAL: FloatLiteral,
-                   BasicType.LOGICAL: LogicLiteral, BasicType.CHARACTER: StringLiteral}
-
-        _type = kwargs.pop('type', None)
-        if _type is None:
-            if isinstance(value, int):
-                _type = BasicType.INTEGER
-            elif isinstance(value, float):
-                _type = BasicType.REAL
-            elif isinstance(value, str):
-                if str(value).lower() in ('.true.', 'true', '.false.', 'false'):
-                    _type = BasicType.LOGICAL
-                else:
-                    _type = BasicType.CHARACTER
-
-        return cls_map[_type](value, **kwargs)
-
-    def __new__(cls, value, **kwargs):
-        try:
-            obj = cls._from_literal(value, **kwargs)
-        except KeyError:
-            obj = IntrinsicLiteral(value, **kwargs)
-
-        # And attach our own meta-data
-        if hasattr(obj, 'kind'):
-            obj.kind = kwargs.get('kind', None)
-        return obj
-
-
-class LiteralList(StrCompareMixin, pmbl.AlgebraicLeaf):
-    """
-    A list of constant literals, e.g., as used in Array Initialization Lists.
-    """
-
-    init_arg_names = ('values', 'dtype')
-
-    def __init__(self, values, dtype=None, **kwargs):
-        self.elements = values
-        self.dtype = dtype
-        super().__init__(**kwargs)
-
-    mapper_method = intern('map_literal_list')
-
-    def __getinitargs__(self):
-        return (self.elements, self.dtype)
 
 
 class InlineDo(StrCompareMixin, pmbl.AlgebraicLeaf):

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -1261,7 +1261,7 @@ class Literal:
         return obj
 
 
-class LiteralList(pmbl.AlgebraicLeaf):
+class LiteralList(StrCompareMixin, pmbl.AlgebraicLeaf):
     """
     A list of constant literals, e.g., as used in Array Initialization Lists.
     """
@@ -1274,13 +1274,12 @@ class LiteralList(pmbl.AlgebraicLeaf):
         super().__init__(**kwargs)
 
     mapper_method = intern('map_literal_list')
-    make_stringifier = loki_make_stringifier
 
     def __getinitargs__(self):
         return (self.elements, self.dtype)
 
 
-class InlineDo(pmbl.AlgebraicLeaf):
+class InlineDo(StrCompareMixin, pmbl.AlgebraicLeaf):
     """
     An inlined do, e.g., implied-do as used in array constructors
     """
@@ -1292,7 +1291,6 @@ class InlineDo(pmbl.AlgebraicLeaf):
         super().__init__(**kwargs)
 
     mapper_method = intern('map_inline_do')
-    make_stringifier = loki_make_stringifier
 
     def __getinitargs__(self):
         return (self.values, self.variable, self.bounds)
@@ -1330,7 +1328,7 @@ class LogicalNot(StrCompareMixin, pmbl.LogicalNot):
     """Representation of a negation in a logical expression."""
 
 
-class InlineCall(pmbl.CallWithKwargs):
+class InlineCall(StrCompareMixin, pmbl.CallWithKwargs):
     """
     Internal representation of an in-line function call.
     """
@@ -1355,7 +1353,6 @@ class InlineCall(pmbl.CallWithKwargs):
                          kw_parameters=kw_parameters, **kwargs)
 
     mapper_method = intern('map_inline_call')
-    make_stringifier = loki_make_stringifier
 
     def __hash__(self):
         # A custom `__hash__` function to protect us from unhashasble
@@ -1485,7 +1482,7 @@ class InlineCall(pmbl.CallWithKwargs):
         new_args = tuple(arg[1] for arg in new_kwarguments)
         return self.clone(parameters=self.arguments + new_args, kw_parameters=())
 
-class Cast(pmbl.Call):
+class Cast(StrCompareMixin, pmbl.Call):
     """
     Internal representation of a data type cast.
     """
@@ -1614,7 +1611,7 @@ class StringSubscript(StrCompareMixin, pmbl.Subscript):
     def symbol(self):
         return self.aggregate
 
-class Reference(pmbl.Expression):
+class Reference(StrCompareMixin, pmbl.Expression):
     """
     Internal representation of a Reference.
 
@@ -1669,10 +1666,9 @@ class Reference(pmbl.Expression):
         return self.expression.initial
 
     mapper_method = intern('map_c_reference')
-    make_stringifier = loki_make_stringifier
 
 
-class Dereference(pmbl.Expression):
+class Dereference(StrCompareMixin, pmbl.Expression):
     """
     Internal representation of a Dereference.
 
@@ -1727,4 +1723,3 @@ class Dereference(pmbl.Expression):
         return self.expression.initial
 
     mapper_method = intern('map_c_dereference')
-    make_stringifier = loki_make_stringifier

--- a/loki/expression/tests/test_parser.py
+++ b/loki/expression/tests/test_parser.py
@@ -333,7 +333,7 @@ end module external_mod
     assert parsed.name.lower() == 'real'
     assert all(isinstance(_parsed, sym.IntLiteral) for _parsed in parsed.parameters)
     assert parsed.kind.name.lower() == 'jprb'
-    assert to_str(parsed) == 'real(6)'
+    assert to_str(parsed) == 'real(6,kind=jprb)'
 
     parsed = parse_expr(convert_to_case('2.4', mode=case))
     assert isinstance(parsed, sym.FloatLiteral)

--- a/loki/expression/tests/test_symbols.py
+++ b/loki/expression/tests/test_symbols.py
@@ -5,6 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from loki.backend import cgen, fgen
 from loki.expression import symbols as sym
 from loki.scope import Scope
 from loki.types import BasicType, DerivedType, ProcedureType, SymbolAttributes
@@ -68,6 +69,66 @@ def test_variable_symbols():
     assert isinstance(c.symbol, sym.VariableSymbol)
     assert c.parent == 'r' and c.parent.type.dtype.name == 'DerDieDas'
     assert c.type.kind == 'rick' and c.dimensions == ('i', 'i')
+
+
+def test_procedure_symbols():
+    """ Test produre symbols and internal function call operators """
+
+    # pylint: disable=no-member
+
+    scope = Scope()
+    int_type = SymbolAttributes(BasicType.INTEGER)
+    real_type = SymbolAttributes(BasicType.REAL, kind='rick')
+    func_type = SymbolAttributes(
+        ProcedureType(name='f', is_function=True, return_type=real_type)
+    )
+    x = sym.Variable(name='x', type=real_type, scope=scope)
+    i = sym.Variable(name='i', type=int_type, scope=scope)
+    n = sym.Variable(name='n', type=int_type, scope=scope)
+    r_n = sym.LoopRange((sym.IntLiteral(1), n))
+
+    # A simple procedure symbol created via the generic ``Variable``
+    f = sym.Variable(name='f', type=func_type, scope=scope)
+    assert isinstance(f, sym.ProcedureSymbol) and f == 'f'
+    assert isinstance(f.type.dtype, ProcedureType)
+    assert f.type.dtype.is_function
+    assert f.type.dtype.return_type.kind == 'rick'
+
+    # An inline function call expression with named and unnamed arguments
+    f_x_i = sym.InlineCall(function=f, parameters=(x,), kw_parameters={'i': i})
+    assert f_x_i == 'f(x, i=i)' and f_x_i == 'F(x,i=I)'
+    assert f_x_i.function.type.dtype.is_function
+    assert f_x_i.function.type.dtype.return_type.kind == 'rick'
+
+    ido = sym.InlineDo(
+        values=(sym.Quotient(sym.FloatLiteral(42.0), i),), variable=i, bounds=r_n
+    )
+    # TODO: Because all `sym.Range` sub-types render to `1:n`, the
+    # correct mapping here is only captured in fgen! This needs fixing!
+    assert fgen(ido) == '( 42.0 / i, i = 1,n )'
+    assert len(ido.values) == 1 and ido.values[0] == '42.0/I'
+    assert ido.variable == 'I' and ido.bounds == '1:n'  # Which range is `i:n` and which `1,n`?
+
+    # A simple cast with an expression defining the type "kind"
+    cast = sym.Cast('int', expression=sym.Quotient(n, i), kind=n)
+    assert cast == 'int(n / i, kind=n)' and cast == 'INt(N/i, KiNd=N  )'
+    assert len(cast.expression) == 1 and cast.expression[0] == 'n / i'
+
+    # Native C reference and dereference inline intrinsics
+    g_type = real_type.clone(parameter=True, initial=sym.Literal(9.81))
+    g = sym.Variable(name='g', type=g_type, scope=scope)
+
+    ref = sym.Reference(expression=g)
+    assert ref.expression == 'g' and ref.name =='g'
+    assert cgen(ref) == ' (&g)'
+    assert ref.type.dtype == BasicType.REAL and ref.type.kind == 'rick'
+    assert ref.scope == scope and ref.initial == 9.81
+
+    deref = sym.Dereference(expression=g)
+    assert deref.expression == 'g' and deref.name =='g'
+    assert cgen(deref) == ' (*g)'
+    assert deref.type.dtype == BasicType.REAL and deref.type.kind == 'rick'
+    assert deref.scope == scope and deref.initial == 9.81
 
 
 def test_symbol_recreation():


### PR DESCRIPTION
A small housekeeping PR that moves various symbol definitions in our expression sub-package in further sub-packages, enforces the strict usage of the `StrComparisonMixin` throughout and adds some property tests for the most commonly used symbols. This is aimed at a more thorough re-design of expression symbols towards future pymbolic compatibility.

In particular, reorganisation does:
* Makes all symbols strictly adhere to string-comparison via the `StrCompareMixin`
* Moves `StrCompareMixin` and its utility metheod into `loki.expressions.mixins`
* Moves algebraic and technical operations over to the existing `loki.expressions.operations`
* Moves all literal class definitions to `loki.expressions.mixins`
* Exposes all literals and operations via imports in `loki.expression.symbols`, so that the use of `sym.Literal` and `sym.Sum` is unchanged
* Adds additional tests for variable symbols and the most commonly used procedure / call-type symbols, so that we test the string-comparison and most common properties.