### PR TITLE
REGEX frontend: Correctly handle nested parentheses/brackets

### DIFF
--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -340,10 +340,11 @@ class Pattern:
 
         # We should now be left with no parentheses anymore and can build the new string
         # by using everything between these parenthesis "spans"
-        new_string = string[:spans[0][0]]
+        starts, ends = zip(*spans)
+        new_string = string[:min(starts)]
         for (_, start), (end, _) in zip(spans[:-1], spans[1:]):
             new_string += string[start+1:end]
-        new_string += string[spans[-1][1]+1:]
+        new_string += string[max(ends)+1:]
         return new_string
 
 

--- a/loki/frontend/tests/test_regex_frontend.py
+++ b/loki/frontend/tests/test_regex_frontend.py
@@ -1018,6 +1018,23 @@ end subroutine definitely_not_allfpos
     assert routine.symbol_map['cloud_type_name'].type.dtype is BasicType.CHARACTER
 
 
+def test_regex_call_statement_parentheses():
+    """Correct handling of nested parentheses, reported in #585"""
+    fcode = """
+subroutine a_function(arg1, arg3)
+    implicit none
+    integer, intent(inout) :: arg1, arg3
+    call parse_me_wrong(arg1, arg2=[1,2,3], arg3)
+    call parse_me_wrong2(arg1, arg2=(/1,2,3/), arg3)
+end subroutine a_function
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=REGEX)
+    routine = source['a_function']
+    calls = FindNodes(ir.CallStatement).visit(routine.ir)
+    assert [call.name for call in calls] == ['parse_me_wrong', 'parse_me_wrong2']
+
+
 def test_regex_preproc_in_contains():
     fcode = """
 module preproc_in_contains


### PR DESCRIPTION
Fixes #585, which reported an edge case in the removal of parentheses and brackets, which occurs when the last parenthesis/bracket is actually nested inside another pair. Thanks to @wertysas for reporting and providing a reproducer.