### PR TITLE
replace ancient "toml" with newer "tomli"/"tomli_w" couple

### DIFF
--- a/loki/batch/configure.py
+++ b/loki/batch/configure.py
@@ -116,10 +116,10 @@ class SchedulerConfig:
 
     @classmethod
     def from_file(cls, path):
-        import toml  # pylint: disable=import-outside-toplevel
+        import tomli  # pylint: disable=import-outside-toplevel
         # Load configuration file and process options
-        with Path(path).open('r') as f:
-            config = toml.load(f)
+        with Path(path).open('rb') as f:
+            config = tomli.load(f)
 
         return cls.from_dict(config)
 

--- a/loki/batch/configure.py
+++ b/loki/batch/configure.py
@@ -116,10 +116,14 @@ class SchedulerConfig:
 
     @classmethod
     def from_file(cls, path):
-        import tomli  # pylint: disable=import-outside-toplevel
+        try:
+            import tomllib as toml  # pylint: disable=import-outside-toplevel
+        except ModuleNotFoundError:
+            import tomli as toml  # pylint: disable=import-outside-toplevel
+
         # Load configuration file and process options
         with Path(path).open('rb') as f:
-            config = tomli.load(f)
+            config = toml.load(f)
 
         return cls.from_dict(config)
 

--- a/loki/tests/test_cmake.py
+++ b/loki/tests/test_cmake.py
@@ -16,7 +16,7 @@ import shutil
 from subprocess import CalledProcessError, run, PIPE, STDOUT
 from contextlib import contextmanager
 import pytest
-import toml
+import tomli_w
 
 from loki import gettempdir, execute, graphviz_present
 
@@ -101,7 +101,7 @@ def fixture_config(tmp_dir):
         }
     }
     filepath = tmp_dir/'test_cmake_loki.config'
-    filepath.write_text(toml.dumps(default_config))
+    filepath.write_text(tomli_w.dumps(default_config))
     yield filepath
     filepath.unlink()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "pcpp",  # essential for preprocessing
   "more-itertools",  # essential for SCC transformation
   "click",  # essential for CLI scripts
-  "tomli",  # essential for scheduler configuration
+  "tomli ; python_version < '3.11'",  # essential for scheduler configuration
   "networkx",  # essential for scheduler and build utilities
   "fparser>=0.0.15",  # (almost) essential as frontend
   "graphviz",  # optional for scheduler callgraph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "pcpp",  # essential for preprocessing
   "more-itertools",  # essential for SCC transformation
   "click",  # essential for CLI scripts
-  "toml",  # essential for scheduler configuration
+  "tomli",  # essential for scheduler configuration
   "networkx",  # essential for scheduler and build utilities
   "fparser>=0.0.15",  # (almost) essential as frontend
   "graphviz",  # optional for scheduler callgraph
@@ -43,6 +43,7 @@ tests = [
   "pandas",
   "f90wrap>=0.2.15",
   "nbconvert",
+  "tomli_w",
 ]
 dace = [
   "dace>=1.0; python_version < '3.13'",


### PR DESCRIPTION
Hi,

This replace usage of the old `toml` library from the Python2 era with the newer & maitained `tomli` & `tomli_w` couple.

https://wiki.debian.org/Python/Backports

Later when support for obsolete Python3 versions is dropped, `tomli` can be replaced with builtin ``tomllib`