### PR TITLE
resolve vector notation: fix for inline calls

### DIFF
--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -189,7 +189,10 @@ class IterationRangeShapeMapper(LokiIdentityMapper):
             self._shape_to_range(s) if isinstance(d, sym.RangeIndex) and d == ':' else d
             for i, d, s in zip(count(), expr.dimensions, as_tuple(expr.shape))
         )
-        return expr.clone(dimensions=new_dims)
+        # make sure it is not a inline call that was misread as array access ...
+        if new_dims:
+            return expr.clone(dimensions=new_dims)
+        return expr
 
 
 class IterationRangeIndexMapper(LokiIdentityMapper):


### PR DESCRIPTION
(that are assumed to be array accesses)

Fixes the problem for CLOUDSC Loki SCC CUF variants.