### PR TITLE
Transform driver loop in block-index injection and deepcopy pipeline

### DIFF
--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -233,7 +233,10 @@ class DataOffloadDeepcopyAnalysis(Transformation):
 
         item.trafo_data[self._key] = defaultdict(dict)
 
-        for loop in find_driver_loops(routine.body, targets):
+        driver_loops = find_driver_loops(routine.body, targets)
+        loop_analyses = {}
+
+        for loop in driver_loops:
 
             # We can't simply map successor.ir: successor here because we may call a routine twice with different
             # arguments
@@ -243,17 +246,17 @@ class DataOffloadDeepcopyAnalysis(Transformation):
                 if (successor := [s for s in successors if call.routine == s.ir]):
                     successor_map[call] = successor[0]
 
-            # gather analysis from children
-            analysis = self.gather_analysis_from_children(successor_map)
-            # gather typedef configs from children
-            self.gather_typedef_configs(successors, item.trafo_data[self._key]['typedef_configs'])
+            # The analysis is accumulated on item.trafo_data, so to ensure each driver loop has an independent,
+            # analysis we reset it here.
+            item.trafo_data[self._key]['analysis'] = {}
+            self.process_body(routine.name, item, successors, successor_map, loop)
 
             layered_dict = {}
-            for k, v in analysis.items():
+            for k, v in item.trafo_data[self._key]['analysis'].items():
                 _temp_dict = create_nested_dict(k, v, routine.symbol_map)
                 layered_dict = merge_nested_dict(layered_dict, _temp_dict)
 
-            item.trafo_data[self._key]['analysis'][loop] = layered_dict
+            loop_analyses[loop] = layered_dict
 
             if self.output_analysis:
                 str_layered_dict = self.stringify_dict(layered_dict)
@@ -261,20 +264,13 @@ class DataOffloadDeepcopyAnalysis(Transformation):
                 with open(base_dir/f'driver_{list(successor_map.keys())[0].name}_dataoffload_analysis.yaml', 'w') as f:
                     yaml.dump(str_layered_dict, f)
 
+        # We store the collected analyses on item.trafo_data
+        for loop in driver_loops:
+            item.trafo_data[self._key]['analysis'][loop] = loop_analyses[loop]
+
     def process_kernel(self, routine, item, successors, **kwargs):
 
         item.trafo_data[self._key] = defaultdict(dict)
-
-        # gather typedef configs from successors
-        self.gather_typedef_configs(successors, item.trafo_data[self._key]['typedef_configs'])
-
-        # Pointer indirection completely breaks the dataflow analysis, as the target
-        # simply appears as if its being "read", regardless of how the pointer is used.
-        # Since resolving pointer association is (super) hard, we just warn the user
-        # here to double check the dataflow and provide overrides if necessary.
-        pointers = any(a.ptr for a in FindNodes(ir.Assignment).visit(routine.body))
-        if pointers:
-            warning(f'[Loki::DataOffloadDeepcopyAnalysis] Pointer associations found in {routine.name}')
 
         # We can't simply map successor.ir: successor here because we may call a routine twice with different
         # arguments
@@ -283,30 +279,7 @@ class DataOffloadDeepcopyAnalysis(Transformation):
             if (successor := [s for s in successors if call.routine == s.ir]):
                 successor_map[call] = successor[0]
 
-        # We make do here (lazily) without a context manager, as this override of the
-        # DataflowAnalysisAttacher is not meant for use outside of the current module.
-        DeepcopyDataflowAnalysisAttacher().visit(routine.spec, successor_map=successor_map)
-        DeepcopyDataflowAnalysisAttacher().visit(routine.body, successor_map=successor_map)
-
-        #gather used symbols in specification
-        for v in routine.spec.uses_symbols:
-            if v.name_parts[0].lower() in routine._dummies:
-                item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'read'
-
-        #gather used and defined symbols in body
-        for v in routine.body.uses_symbols:
-            if v.name_parts[0].lower() in routine._dummies:
-                item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'read'
-
-        for v in routine.body.defines_symbols:
-            if v.name_parts[0].lower() in routine._dummies:
-                if v in (routine.spec.uses_symbols | routine.body.uses_symbols):
-                    item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'readwrite'
-                else:
-                    item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'write'
-
-        DataflowAnalysisDetacher().visit(routine.spec)
-        DataflowAnalysisDetacher().visit(routine.body)
+        self.process_body(routine.name, item, successors, successor_map, routine)
 
         if self.output_analysis:
             layered_dict = {}
@@ -319,26 +292,66 @@ class DataOffloadDeepcopyAnalysis(Transformation):
                 str_layered_dict = self.stringify_dict(layered_dict)
                 yaml.dump(str_layered_dict, file)
 
-    def gather_analysis_from_children(self, successor_map):
-        """Gather analysis from callees."""
+    def process_body(self, routine_name, item, successors, successor_map, scope_node):
+        # gather typedef configs from successors
+        self.gather_typedef_configs(successors, item.trafo_data[self._key]['typedef_configs'])
 
-        analysis = {}
-        for call, child in successor_map.items():
+        has_spec = hasattr(scope_node, 'spec')
 
-            arg_map = get_sanitised_arg_map(call.arg_map)
-            child_analysis = child.trafo_data[self._key]['analysis']
-            child_analysis = map_derived_type_arguments(arg_map, child_analysis)
+        # Pointer indirection completely breaks the dataflow analysis, as the target
+        # simply appears as if its being "read", regardless of how the pointer is used.
+        # Since resolving pointer association is (super) hard, we just warn the user
+        # here to double check the dataflow and provide overrides if necessary.
+        pointers = any(a.ptr for a in FindNodes(ir.Assignment).visit(scope_node.body))
+        if pointers:
+            warning(f'[Loki::DataOffloadDeepcopyAnalysis] Pointer associations found in {routine_name}')
 
-            for k, v in child_analysis.items():
-                _v = analysis.get(k, v)
-                if _v != v:
-                    if _v == 'write':
-                        continue
-                    analysis[k] = 'readwrite'
+        # We make do here (lazily) without a context manager, as this override of the
+        # DataflowAnalysisAttacher is not meant for use outside of the current module.
+        if has_spec:
+            DeepcopyDataflowAnalysisAttacher().visit(scope_node.spec, successor_map=successor_map)
+            DeepcopyDataflowAnalysisAttacher().visit(scope_node.body, successor_map=successor_map)
+        else:
+            DeepcopyDataflowAnalysisAttacher().visit(scope_node, successor_map=successor_map)
+
+        #gather used symbols in specification
+        if has_spec:
+            spec_uses_symbols = scope_node.body.uses_symbols
+        else:
+            spec_uses_symbols = set()
+
+        if has_spec:
+            for v in scope_node.spec.uses_symbols:
+                if v.name_parts[0].lower() in getattr(scope_node, '_dummies', []):
+                    item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'read'
+
+        #gather used and defined symbols in body
+        if has_spec:
+            uses_symbols = scope_node.body.uses_symbols
+        else:
+            uses_symbols = scope_node.uses_symbols
+
+        for v in uses_symbols:
+            if v.name_parts[0].lower() in getattr(scope_node, '_dummies', []) or not has_spec:
+                item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'read'
+
+        if has_spec:
+            defines_symbols = scope_node.body.defines_symbols
+        else:
+            defines_symbols = scope_node.defines_symbols
+
+        for v in defines_symbols:
+            if v.name_parts[0].lower() in getattr(scope_node, '_dummies', []) or not has_spec:
+                if v in (spec_uses_symbols | uses_symbols):
+                    item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'readwrite'
                 else:
-                    analysis[k] = _v
+                    item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'write'
 
-        return analysis
+        if has_spec:
+            DataflowAnalysisDetacher().visit(scope_node.spec)
+            DataflowAnalysisDetacher().visit(scope_node.body)
+        else:
+            DataflowAnalysisDetacher().visit(scope_node)
 
     def gather_typedef_configs(self, successors, typedef_configs):
         """Gather typedef configs from children."""


### PR DESCRIPTION
One of the biggest limitations of the block-index and deepcopy pipelines was the missing transformation of code in the driver loop. This PR addresses this limitation for both pipelines (it should probably be 2 PRs, sorry for being lazy 😅). 