### PR TITLE
Gang privatisation of array components of derived-types

### DIFF
--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -297,6 +297,10 @@ class SCCAnnotateTransformation(Transformation):
             structs = [v for v in structs if not v.name_parts[0].lower() in acc_vars]
             structs = [v for v in structs if not v.type.intent]
             structs = [v for v in structs if not v in arrays]
+
+            # only privatise derived-type parent
+            private_sym = [v for v in private_sym if not v.name_parts[0].lower() in structs]
+
             if (dynamic_structs := [v.name for v in structs if (v.type.pointer or v.type.allocatable)]):
                 warning(f'[Loki-SCC::Annotate] dynamically allocated structs are being privatised: {dynamic_structs}')
 

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -908,6 +908,7 @@ def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking, dims_type, tmp
       integer :: ist
       integer :: iend
       integer :: kbl
+      integer :: wrk(100)
     end type
 
     contains
@@ -930,6 +931,7 @@ def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking, dims_type, tmp
            local_dims%ist = 1
            local_dims%iend = dims%klon
            local_dims%kbl = b
+           local_dims%wrk = 0
            call some_kernel(local_dims, local_dims%klon, work(:,b))
         enddo
       !$omp end parallel do


### PR DESCRIPTION
If the encompassing derived-type is being declared as gang private in the driver loop, then its array components should not be privatised individually.