### PR TITLE
Transformation: Add "replacement call" mechanics to marked region code removal 

### DIFF
--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -15,9 +15,7 @@ import operator as op
 from loki.analyse import dataflow_analysis_attached
 from loki.batch import Transformation
 from loki.expression import simplify, symbols as sym, symbolic_op
-from loki.ir import (
-    nodes as ir, Conditional, Transformer, Comment, CallStatement, FindNodes, FindVariables
-)
+from loki.ir import nodes as ir, Transformer, FindNodes, FindVariables
 from loki.ir.pragma_utils import is_loki_pragma, pragma_regions_attached
 from loki.tools import flatten, as_tuple
 from loki.types import BasicType
@@ -204,7 +202,7 @@ def do_remove_unused_call_args(routine, unused_args_map):
        utility.
     """
 
-    for call in FindNodes(CallStatement).visit(routine.body):
+    for call in FindNodes(ir.CallStatement).visit(routine.body):
         if call.routine is BasicType.DEFERRED or not unused_args_map.get(call.routine, None):
             continue
 
@@ -300,7 +298,7 @@ class RemoveDeadCodeTransformer(Transformer):
         if condition == 'False':
             return else_body
 
-        has_elseif = o.has_elseif and else_body and isinstance(else_body[0], Conditional)
+        has_elseif = o.has_elseif and else_body and isinstance(else_body[0], ir.Conditional)
         return self._rebuild(o, tuple((condition,) + (body,) + (else_body,)), has_elseif=has_elseif)
 
     def visit_MultiConditional(self, o, **kwargs):
@@ -433,7 +431,7 @@ class RemoveRegionTransformer(Transformer):
             # Leave a comment to mark the removed region in source
             replacement = []
             if self.mark_with_comment:
-                replacement.append(Comment(text='! [Loki] Removed content of pragma-marked region!'))
+                replacement.append(ir.Comment(text='! [Loki] Removed content of pragma-marked region!'))
 
             if self.replacement_call:
                 # If requested add a call to a simple subroutine with an error message arg

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -53,6 +53,9 @@ end subroutine
 
     fcode_kernel = """
 module rick_rolled
+  type a_type
+    integer :: b
+  end type
 contains
 subroutine never_gonna_give
     use parkind1, only: jprb
@@ -60,8 +63,10 @@ subroutine never_gonna_give
     use abor2_mod, only: not_my_abor
     implicit none
 
+    type(a_type) :: a
     real(kind=jprb) :: zhook_handle
 
+    associate(b=>a%b)
     if (lhook) call dr_hook('never_gonna_give',0,zhook_handle)
 
     CALL ABOR1('[SUBROUTINE CALL]')
@@ -80,7 +85,7 @@ subroutine never_gonna_give
     if (.not. dave) WRITE(NULOUT, *) "[WRITE INTRINSIC]"
 
     if (lhook) call dr_hook('never_gonna_give',1,zhook_handle)
-
+    end associate
 contains
 
 subroutine never_gonna_run_around
@@ -412,7 +417,9 @@ subroutine test_remove_code(a, b, n, flag)
   end do
   !$loki end remove
 
+  !$loki remove no-replacement-call
   b(:) = 1.0
+  !$loki end remove
 
   !$acc parallel
   do i=1, n

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -430,7 +430,7 @@ end subroutine test_remove_code
         do_remove_marked_regions(
             routine, mark_with_comment=mark_with_comment,
             replacement_call='ABOR1', replacement_module='ABOR1_MOD',
-            replacement_msg='Unsupported code path',
+            replacement_msg='Unsupported code path in {}',
         )
     else:
         do_remove_marked_regions(routine, mark_with_comment=mark_with_comment)
@@ -459,7 +459,7 @@ end subroutine test_remove_code
             # Check that the replacement calls have been inserted
             assert c.name == 'ABOR1'
             assert len(c.arguments) == 1 and not c.kwarguments
-            assert c.arguments[0] == 'Unsupported code path'
+            assert c.arguments[0] == 'Unsupported code path in test_remove_code'
 
         # Check that only one C-import was inserted
         assert len(imports) == 1


### PR DESCRIPTION
This PR adds additional options to the `do_remove_marked_regions` utility and associated transformation, so that we may inject "abort" calls into unsupported code regions. The new mechanics allow specifying a subroutine name to call and an optional message string that gets passed as the single argument. A third option then allows the insertion of a ~C-import~ module import, which only gets performed if a substitution has happened.

~Note, I'm filing this as draft, as I have not tested this in a full setup yet.~