### PR TITLE
Include array argument dimensions in `DeepcopyDataflowAnalysis`

### DIFF
--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -135,7 +135,11 @@ class DeepcopyDataflowAnalysisAttacher(DataflowAnalysisAttacher):
         child_analysis = child.trafo_data['DataOffloadDeepcopyAnalysis']['analysis']
         child_analysis = map_derived_type_arguments(arg_map, child_analysis)
 
-        defines, uses = set(), set()
+        # Dimensions of array arguments must also be included in uses_symbols set
+        defines = set()
+        array_args = [v for v in o.arg_map.values() if isinstance(v, sym.Array)]
+        uses = set(v for a in array_args
+                   for v in self._symbols_from_expr(a.dimensions))
         for k, v in child_analysis.items():
 
             if 'read' in v:

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -73,6 +73,7 @@ module type_def_mod
       integer :: kend
       integer :: kbl
       integer :: ngpblks
+      integer :: m
    end type
 
    type :: geom_dims
@@ -210,7 +211,7 @@ subroutine driver(dims, struct, array_arg, geometry, variable)
      variable%vt0_field(:,:,ibl) = 0._real64
 
      call kernel(geometry, local_dims, struct, variable)
-     call nested_kernel_write(struct%e%p(:,:,local_dims%kbl))
+     call nested_kernel_write(struct%e%p(:,local_dims%m,local_dims%kbl))
      call nested_kernel_write(array_arg)
    enddo
 !$loki end data
@@ -223,7 +224,7 @@ subroutine driver(dims, struct, array_arg, geometry, variable)
      variable%vt0_field(:,:,ibl) = 0._real64
 
      call kernel(geometry, local_dims, struct, variable)
-     call nested_kernel_write(struct%e%p(:,:,local_dims%kbl))
+     call nested_kernel_write(struct%e%p(:,local_dims%m,local_dims%kbl))
      call nested_kernel_write(array_arg)
    enddo
 !$loki end data
@@ -253,7 +254,8 @@ def fixture_expected_analysis():
             'kbl': 'write',
             'kend': 'read',
             'kst': 'read',
-            'ngpblks': 'read'
+            'ngpblks': 'read',
+            'm': 'read'
         },
         'geometry': {
             'dim': {


### PR DESCRIPTION
The current PR extends the `DeepcopyDataflowAnalysis` to also include symbols used to define dimensions of array arguments, e.g.:
```
call kernel(a(:,:,dims%a))
```

`dims%a` will now be included in the analysis.