### PR TITLE
Add support for derived-type assignment to `DataoffloadDeepcopy`

### DIFF
--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -715,8 +715,12 @@ class DataOffloadDeepcopyTransformation(Transformation):
             if isinstance(var.type.dtype, DerivedType):
 
                 var_with_parent = var.clone(parent=parent)
-                _copy, _host, _wipe = self.generate_deepcopy(routine, analysis=analysis[var], parent=var_with_parent,
-                                                             **kwargs)
+
+                # If we are directly assigning derived-types, rather than operating on members,
+                # then we are the lowest level of the analysis and don't want to recurse further
+                if not isinstance(analysis[var], str):
+                    _copy, _host, _wipe = self.generate_deepcopy(routine, analysis=analysis[var],
+                                                                 parent=var_with_parent, **kwargs)
 
                 #wrap in loop
                 if var.type.shape:

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -199,11 +199,10 @@ subroutine driver(dims, struct, array_arg, geometry, variable)
    type(dims_type) :: local_dims
    integer :: ibl, ij
 
-   local_dims = dims
-
 #ifdef geometry_present
 !$loki data private(local_dims) present(geometry) write(struct%c%p)
    do ibl=1,local_dims%ngpblks
+     local_dims = dims
      local_dims%kbl = ibl
      ij = 0
 
@@ -217,6 +216,7 @@ subroutine driver(dims, struct, array_arg, geometry, variable)
 #else
 !$loki data private(local_dims) write(struct%c%p)
    do ibl=1,local_dims%ngpblks
+     local_dims = dims
      local_dims%kbl = ibl
      ij = 0
 
@@ -255,6 +255,7 @@ def fixture_expected_analysis():
             'kst': 'read',
             'ngpblks': 'read'
         },
+        'dims': 'read',
         'geometry': {
             'dim': {
                 'nproma': 'read'
@@ -669,6 +670,13 @@ def test_offload_deepcopy_transformation(frontend, config, deepcopy_code, presen
         check_geometry(conds, pragmas, driver)
 
     if mode == 'offload':
+        # check dims copyin
+        pragma = [p for p in pragmas if
+                  'unstructured-data in' in p.content and '(dims)' in p.content]
+        assert pragma
+        pragma = [p for p in pragmas if
+                  'unstructured-data delete' in p.content and '(dims)' in p.content]
+
         # check data present region
         with pragma_regions_attached(driver):
 
@@ -679,7 +687,7 @@ def test_offload_deepcopy_transformation(frontend, config, deepcopy_code, presen
 
             parameters = get_pragma_parameters(region.pragma)
             present_vars = [v.strip().lower() for v in parameters['present'].split(',')]
-            assert all(v in present_vars for v in ['geometry', 'struct', 'variable'])
+            assert all(v in present_vars for v in ['geometry', 'struct', 'variable', 'dims'])
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
This PR adds support for whole derived-type assignment, rather than accessing members of derived-types, to the `DataoffloadDeepcopyTransformation`.