### PR TITLE
Add Section label to its string representation

### DIFF
--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -453,6 +453,8 @@ class Section(InternalNode, _SectionBase):
         self._update(body=as_tuple(node) + self.body)
 
     def __repr__(self):
+        if self.label is not None:
+            return f'Section:: {self.label}'
         return 'Section::'
 
 


### PR DESCRIPTION
This PR adds the label of a Section node to its string representation. If the section does not have a label the output looks like before.