### PR TITLE
Limit f90wrap to below 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ tests = [
   "coverage2clover",
   "pylint!=2.11.0,!=2.11.1",
   "pandas",
-  "f90wrap>=0.2.15",
+  "f90wrap>=0.2.15,<0.3.0",
   "nbconvert",
   "tomli_w",
 ]


### PR DESCRIPTION
f90wrap 0.3.0 introduced a bug that breaks our CI, I've filed an issue here: https://github.com/jameskermode/f90wrap/issues/353.

In the meanwhile, this PR limits f90wrap to below 0.3.0 in order to restore the CI. 