### PR TITLE
Always use generic interface based FIELD_API accessors in `DataOffloadDeepcopyTransformation`

### DIFF
--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -269,8 +269,8 @@ class DataOffloadDeepcopyAnalysis(Transformation):
 
             loop_analyses[loop] = layered_dict
 
-            if HAVE_YAML:
-                if self.output_analysis:
+            if self.output_analysis:
+                if HAVE_YAML:
                     str_layered_dict = self.stringify_dict(layered_dict)
                     base_dir = Path(kwargs['build_args']['output_dir'])
                     if successor_map:
@@ -279,8 +279,8 @@ class DataOffloadDeepcopyAnalysis(Transformation):
                         target_routine_name = routine.name
                     with open(base_dir/f'driver_{target_routine_name}_dataoffload_analysis.yaml', 'w') as f:
                         yaml.dump(str_layered_dict, f)
-            else:
-                warning('[Loki::DataOffloadDeepcopyAnalysis] cannot output analysis because yaml is not available.')
+                else:
+                    warning('[Loki::DataOffloadDeepcopyAnalysis] cannot output analysis because yaml is not available.')
 
 
         # We store the collected analyses on item.trafo_data
@@ -300,8 +300,8 @@ class DataOffloadDeepcopyAnalysis(Transformation):
 
         self.process_body(routine.name, item, successors, successor_map, routine)
 
-        if HAVE_YAML:
-            if self.output_analysis:
+        if self.output_analysis:
+            if HAVE_YAML:
                 layered_dict = {}
                 for k, v in item.trafo_data[self._key]['analysis'].items():
                     _temp_dict = create_nested_dict(k, v, routine.symbol_map)
@@ -311,8 +311,8 @@ class DataOffloadDeepcopyAnalysis(Transformation):
                 with open(base_dir/f'{routine.name.lower()}_dataoffload_analysis.yaml', 'w') as file:
                     str_layered_dict = self.stringify_dict(layered_dict)
                     yaml.dump(str_layered_dict, file)
-        else:
-            warning('[Loki::DataOffloadDeepcopyAnalysis] cannot output analysis because yaml is not available.')
+            else:
+                warning('[Loki::DataOffloadDeepcopyAnalysis] cannot output analysis because yaml is not available.')
 
     def process_body(self, routine_name, item, successors, successor_map, scope_node):
         # gather typedef configs from successors

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -793,6 +793,11 @@ def test_offload_deepcopy_transformation(frontend, config, deepcopy_code, presen
     if not present and mode == 'offload':
         check_geometry(conds, pragmas, driver)
 
+    # check FIELD_ACCESS_MODULE host accessor imports
+    assert any(_import.module.lower() == 'field_access_module' for _import in driver.imports)
+    imported_symbols = driver.imported_symbols
+    assert 'sget_host_data_rdwr' in imported_symbols
+
     if mode == 'offload':
         # check dims copyin
         pragma = [p for p in pragmas if
@@ -800,6 +805,10 @@ def test_offload_deepcopy_transformation(frontend, config, deepcopy_code, presen
         assert pragma
         pragma = [p for p in pragmas if
                   'unstructured-data delete' in p.content and '(dims)' in p.content]
+
+        # check FIELD_ACCESS_MODULE device accessor imports
+        assert all(f'sget_device_data_{access}' in imported_symbols
+                   for access in ['rdwr', 'rdonly', 'wronly'])
 
         # check data present region
         with pragma_regions_attached(driver):


### PR DESCRIPTION
As described in #632, this PR updates the `DataOffloadDeepcopyTransformation` to always use the generic interface based FIELD_API accessors. Not only does this lead to code safer from 0-sized and uninitialised fields, but it also significantly reduces the amount of boilerplate generated. I've also included a fix requested a fix in a previous PR to make the dependency on pyyaml optional. 