### PR TITLE
Driver-specific Loki pipelines

### DIFF
--- a/cmake/loki_transform.cmake
+++ b/cmake/loki_transform.cmake
@@ -42,7 +42,7 @@ include( loki_transform_helpers )
 
 function( loki_transform )
 
-    set( options CPP )
+    set( options CPP MULTIMODE )
     set( oneValueArgs COMMAND MODE FRONTEND CONFIG BUILDDIR )
     set( multiValueArgs OUTPUT DEPENDS SOURCES HEADERS INCLUDES DEFINITIONS OMNI_INCLUDE XMOD )
 
@@ -71,6 +71,10 @@ function( loki_transform )
 
     if( _PAR_CPP )
         list( APPEND _ARGS --cpp )
+    endif()
+
+    if ( _PAR_MULTIMODE )
+        list( APPEND _ARGS --multimode )
     endif()
 
     # Ensure transformation script and environment is available
@@ -115,7 +119,7 @@ endfunction()
 
 function( loki_transform_plan )
 
-    set( options NO_SOURCEDIR CPP )
+    set( options NO_SOURCEDIR CPP MULTIMODE )
     set( oneValueArgs MODE FRONTEND CONFIG BUILDDIR SOURCEDIR CALLGRAPH PLAN )
     set( multiValueArgs SOURCES HEADERS )
 
@@ -150,6 +154,10 @@ function( loki_transform_plan )
         list( APPEND _ARGS --plan-file ${_PAR_PLAN} )
     else()
         ecbuild_critical( "No PLAN file specified for loki_transform_plan()" )
+    endif()
+
+    if ( _PAR_MULTIMODE )
+        list( APPEND _ARGS --multimode )
     endif()
 
     _loki_transform_env_setup()
@@ -300,7 +308,7 @@ endfunction()
 
 function( loki_transform_target )
 
-    set( options NO_PLAN_SOURCEDIR COPY_UNMODIFIED CPP CPP_PLAN )
+    set( options NO_PLAN_SOURCEDIR COPY_UNMODIFIED CPP CPP_PLAN MULTIMODE )
     set( single_value_args COMMAND MODE FRONTEND CONFIG PLAN )
     set( multi_value_args TARGET SOURCES HEADERS DEFINITIONS INCLUDES )
 
@@ -334,6 +342,9 @@ function( loki_transform_target )
     if( _PAR_T_CPP_PLAN )
         list( APPEND _PLAN_OPTIONS CPP )
     endif()
+    if ( _PAR_T_MULTIMODE )
+        list( APPEND _PLAN_OPTIONS MULTIMODE )
+    endif()
     if( _PAR_T_NO_PLAN_SOURCEDIR )
         list( APPEND _PLAN_OPTIONS NO_SOURCEDIR )
     endif()
@@ -366,6 +377,9 @@ function( loki_transform_target )
         set( _TRANSFORM_OPTIONS "" )
         if( _PAR_T_CPP )
             list( APPEND _TRANSFORM_OPTIONS CPP )
+        endif()
+        if ( _PAR_T_MULTIMODE )
+            list( APPEND _TRANSFORM_OPTIONS MULTIMODE )
         endif()
 
         loki_transform(

--- a/cmake/loki_transform.cmake
+++ b/cmake/loki_transform.cmake
@@ -42,7 +42,7 @@ include( loki_transform_helpers )
 
 function( loki_transform )
 
-    set( options CPP MULTIMODE )
+    set( options CPP MULTIPIPELINE )
     set( oneValueArgs COMMAND MODE FRONTEND CONFIG BUILDDIR )
     set( multiValueArgs OUTPUT DEPENDS SOURCES HEADERS INCLUDES DEFINITIONS OMNI_INCLUDE XMOD )
 
@@ -73,8 +73,8 @@ function( loki_transform )
         list( APPEND _ARGS --cpp )
     endif()
 
-    if ( _PAR_MULTIMODE )
-        list( APPEND _ARGS --multimode )
+    if ( _PAR_MULTIPIPELINE )
+        list( APPEND _ARGS --multipipeline )
     endif()
 
     # Ensure transformation script and environment is available
@@ -119,7 +119,7 @@ endfunction()
 
 function( loki_transform_plan )
 
-    set( options NO_SOURCEDIR CPP MULTIMODE )
+    set( options NO_SOURCEDIR CPP MULTIPIPELINE )
     set( oneValueArgs MODE FRONTEND CONFIG BUILDDIR SOURCEDIR CALLGRAPH PLAN )
     set( multiValueArgs SOURCES HEADERS )
 
@@ -156,8 +156,8 @@ function( loki_transform_plan )
         ecbuild_critical( "No PLAN file specified for loki_transform_plan()" )
     endif()
 
-    if ( _PAR_MULTIMODE )
-        list( APPEND _ARGS --multimode )
+    if ( _PAR_MULTIPIPELINE )
+        list( APPEND _ARGS --multipipeline )
     endif()
 
     _loki_transform_env_setup()
@@ -308,7 +308,7 @@ endfunction()
 
 function( loki_transform_target )
 
-    set( options NO_PLAN_SOURCEDIR COPY_UNMODIFIED CPP CPP_PLAN MULTIMODE )
+    set( options NO_PLAN_SOURCEDIR COPY_UNMODIFIED CPP CPP_PLAN MULTIPIPELINE )
     set( single_value_args COMMAND MODE FRONTEND CONFIG PLAN )
     set( multi_value_args TARGET SOURCES HEADERS DEFINITIONS INCLUDES )
 
@@ -342,8 +342,8 @@ function( loki_transform_target )
     if( _PAR_T_CPP_PLAN )
         list( APPEND _PLAN_OPTIONS CPP )
     endif()
-    if ( _PAR_T_MULTIMODE )
-        list( APPEND _PLAN_OPTIONS MULTIMODE )
+    if ( _PAR_T_MULTIPIPELINE )
+        list( APPEND _PLAN_OPTIONS MULTIPIPELINE )
     endif()
     if( _PAR_T_NO_PLAN_SOURCEDIR )
         list( APPEND _PLAN_OPTIONS NO_SOURCEDIR )
@@ -378,8 +378,8 @@ function( loki_transform_target )
         if( _PAR_T_CPP )
             list( APPEND _TRANSFORM_OPTIONS CPP )
         endif()
-        if ( _PAR_T_MULTIMODE )
-            list( APPEND _TRANSFORM_OPTIONS MULTIMODE )
+        if ( _PAR_T_MULTIPIPELINE )
+            list( APPEND _TRANSFORM_OPTIONS MULTIPIPELINE )
         endif()
 
         loki_transform(

--- a/loki/batch/configure.py
+++ b/loki/batch/configure.py
@@ -433,6 +433,13 @@ class ItemConfig:
         return self.config.get('mode', None)
 
     @property
+    def inherited_mode(self):
+        """
+        Transformation "inherited_mode" for multi-mode processing
+        """
+        return self.config.get('inherited_mode', None)
+
+    @property
     def expand(self):
         """
         Flag to trigger expansion of children under this node

--- a/loki/batch/configure.py
+++ b/loki/batch/configure.py
@@ -433,13 +433,6 @@ class ItemConfig:
         return self.config.get('mode', None)
 
     @property
-    def inherited_mode(self):
-        """
-        Transformation "inherited_mode" for multi-mode processing
-        """
-        return self.config.get('inherited_mode', None)
-
-    @property
     def expand(self):
         """
         Flag to trigger expansion of children under this node

--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -564,6 +564,14 @@ class Item(ItemConfig):
         """
         return self.source.path
 
+    @property
+    def orig_path(self):
+        """
+        The original filepath of the associated source file
+        necessary for planning when duplicating/renaming items
+        """
+        return self.source.orig_path
+
 
 class FileItem(Item):
     """

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -290,6 +290,7 @@ class ItemFactory:
 
             # Create a new FileItem for the new source
             new_source.path = item.path.with_name(f'{scope_name or local_name}{item.path.suffix}')
+            new_source.orig_path = item.path
             file_item = self.get_or_create_file_item_from_source(new_source, config=config)
 
             # Get the definition items for the FileItem and return the new item

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -347,6 +347,13 @@ class ItemFactory:
         self.item_cache[item_name] = file_item
         return file_item
 
+    def get_file_item_from_source(self, source):
+        # Check for file item with the same source object
+        for item in self.item_cache.values():
+            if isinstance(item, FileItem) and item.source is source:
+                return item
+        return None
+
     def get_or_create_file_item_from_source(self, source, config):
         """
         Utility method to create a :any:`FileItem` corresponding to a given source object
@@ -369,9 +376,9 @@ class ItemFactory:
             The config object from which the item configuration will be derived
         """
         # Check for file item with the same source object
-        for item in self.item_cache.values():
-            if isinstance(item, FileItem) and item.source is source:
-                return item
+        item_ = self.get_file_item_from_source(source)
+        if item_ is not None:
+            return item_
 
         if not source.path:
             raise RuntimeError('Cannot create FileItem from source: Sourcefile has no path')

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -290,7 +290,7 @@ class ItemFactory:
 
             # Create a new FileItem for the new source
             new_source.path = item.path.with_name(f'{scope_name or local_name}{item.path.suffix}')
-            new_source.orig_path = item.path
+            new_source.orig_path = item.orig_path
             file_item = self.get_or_create_file_item_from_source(new_source, config=config)
 
             # Get the definition items for the FileItem and return the new item

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -348,6 +348,14 @@ class ItemFactory:
         return file_item
 
     def get_file_item_from_source(self, source):
+        """
+        Utility method to get a :any:`FileItem` from a given source object
+
+        Parameters
+        ----------
+        source : :any:`Sourcefile`
+            The existing sourcefile object for which to create the file item
+        """
         # Check for file item with the same source object
         for item in self.item_cache.values():
             if isinstance(item, FileItem) and item.source is source:
@@ -621,6 +629,20 @@ class ItemFactory:
                 )
                 items += [_it for _it in definition_items if _it.name[_it.name.index('#')+1:] == name.lower()]
         return tuple(items)
+
+    def get_scope_and_file_items(self, item):
+        """
+        Get corresponding module and file item of a given :data:`item`.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            The item node in the dependency graph for which to determine the successors
+        """
+        mod_item = self.item_cache.get(item.scope_name)
+        _items = (mod_item,) if mod_item is not None else ()
+        _items += (self.get_file_item_from_source(item.source),)
+        return _items
 
     @staticmethod
     def _get_imported_symbol_name(imprt, symbol_name):

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -5,7 +5,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import sys
 from enum import Enum, auto
 from os.path import commonpath
 from pathlib import Path
@@ -224,7 +223,6 @@ class Scheduler:
         self.process_transformation(SeparateModesKernel(), proc_strategy=proc_strategy)
         modes = {item.mode for item in self.items}
         return as_tuple(modes)
-
 
     def _propagate_modes(self):
         """
@@ -489,8 +487,8 @@ class Scheduler:
             # check if all required pipelines are available
             for mode in modes:
                 if mode not in transformation:
-                    msg = f'[Loki] ERROR: Pipeline or transformation mode {mode} not found in config file.\n'
-                    sys.exit(msg)
+                    error('[Loki] ERROR: Pipeline or transformation mode %s not found in config file.', mode)
+                    raise RuntimeError(f'Could not find pipeline or transformation mode {mode}')
             # apply those pipelines
             for mode in modes:
                 self.process_pipeline(pipeline=self.config.pipelines[mode], proc_strategy=proc_strategy, mode=mode)

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -5,6 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import sys
 from enum import Enum, auto
 from os.path import commonpath
 from pathlib import Path
@@ -461,7 +462,7 @@ class Scheduler:
 
         Parameters
         ----------
-        transformation : :any:`Transformation` or :any:`Pipeline`
+        transformation : :any:`Transformation` or :any:`Pipeline` or dict of :any:`Pipeline`s
             The transformation or transformation pipeline to apply
         proc_strategy : :any:`ProcessingStrategy`
             The processing strategy to use when applying the given
@@ -473,24 +474,20 @@ class Scheduler:
         elif isinstance(transformation, Pipeline):
             self.process_pipeline(pipeline=transformation, proc_strategy=proc_strategy)
 
+        elif isinstance(transformation, dict):
+            assert all(isinstance(trafo, Pipeline) for trafo in transformation.values())
+            modes = self.propagate_and_separate_modes(proc_strategy=proc_strategy)
+            # check if all required pipelines are available
+            for mode in modes:
+                if mode not in transformation:
+                    msg = f'[Loki] ERROR: Pipeline or transformation mode {mode} not found in config file.\n'
+                    sys.exit(msg)
+            # apply those pipelines
+            for mode in modes:
+                self.process_pipeline(pipeline=self.config.pipelines[mode], proc_strategy=proc_strategy, mode=mode)
         else:
             error('[Loki::Scheduler] Batch processing requires Transformation or Pipeline object')
             raise RuntimeError(f'Could not batch process {transformation}')
-
-    def process_config(self, proc_strategy=ProcessingStrategy.DEFAULT):
-        """
-        Process a given config by applying pipelines in dependence
-        of the given mode (per (driver) item).
-
-        Parameters
-        ----------
-        proc_strategy : :any:`ProcessingStrategy`
-            The processing strategy to use when applying the given
-            :data:`pipeline` to the scheduler's graph.
-        """
-        modes = {item.mode for item in self.items}
-        for mode_ in modes:
-            self.process_pipeline(pipeline=self.config.pipelines[mode_], proc_strategy=proc_strategy, mode=mode_)
 
     def process_pipeline(self, pipeline, proc_strategy=ProcessingStrategy.DEFAULT, mode=None):
         """

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -26,7 +26,6 @@ from loki.frontend import FP, REGEX, RegexParserClass
 from loki.tools import as_tuple, CaseInsensitiveDict, flatten
 
 from loki.logging import info, perf, warning, error
-from loki.transformations.dependency import SeparateModesKernel
 
 __all__ = ['ProcessingStrategy', 'Scheduler']
 
@@ -205,6 +204,7 @@ class Scheduler:
             self._enrich()
 
     def propagate_and_separate_modes(self, proc_strategy=ProcessingStrategy.DEFAULT):
+        from loki.transformations.dependency import SeparateModesKernel # pylint: disable=import-outside-toplevel
         self._propagate_modes()
         self.process_transformation(SeparateModesKernel(), proc_strategy=proc_strategy)
         self._propagate_modes_set()

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -8,6 +8,7 @@
 from enum import Enum, auto
 from os.path import commonpath
 from pathlib import Path
+
 from codetiming import Timer
 
 from loki.batch.configure import SchedulerConfig

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -204,36 +204,45 @@ class Scheduler:
             self._enrich()
 
     def propagate_and_separate_modes(self, proc_strategy=ProcessingStrategy.DEFAULT):
+        """
+        If in "MULTIPIPELINE" mode, different driver items can have different transformation pipelines assigned to them,
+        this utility:
+
+        * propagates the transformation pipeline modes to all descendants, where some could end up with multiple
+          being assigned to them
+        * seaparates the call tree via duplication to make sure every item in the tree is only assigned
+          a single transformation pipeline to
+
+        Parameters
+        ----------
+        proc_strategy : :any:`ProcessingStrategy`
+            The processing strategy to use when applying the given
+            :data:`transformation` to the scheduler's graph.
+        """
         from loki.transformations.dependency import SeparateModesKernel # pylint: disable=import-outside-toplevel
         self._propagate_modes()
         self.process_transformation(SeparateModesKernel(), proc_strategy=proc_strategy)
-        self._propagate_modes_set()
         modes = {item.mode for item in self.items}
         return as_tuple(modes)
 
 
     def _propagate_modes(self):
+        """
+        If in "MULTIPIPELINE" mode, different driver items can have different transformation pipelines assigned to them,
+        this utility routine propagates this information to all descendants, whereas some could end up being targeted
+        by different transformation pipelines.
+        """
         driver_items = [item for item in self.items if item.role == 'driver']
         for item in driver_items:
-            module_file_items = self.sgraph.get_corresponding_module_and_file_item(item, self.item_factory)
+            module_file_items = self.item_factory.get_scope_and_file_items(item)
             for _item in module_file_items:
                 if _item is not None:
                     _item.config['mode'] = item.mode
             descendants = self.sgraph.descendants(item, self.item_factory,
-                    include_module_items=True, include_file_items=True)
+                    include_scope_items=True)
             for descendant in descendants:
                 if descendant is not None:
-                    descendant.config.setdefault('inherited_mode', set()).add(item.mode)
-
-    def _propagate_modes_set(self):
-        driver_items = [item for item in self.items if item.role == 'driver']
-        for item in driver_items:
-            descendants = self.sgraph.descendants(item, self.item_factory,
-                    include_module_items=True, include_file_items=True)
-            for descendant in descendants:
-                if descendant is not None:
-                    descendant.config['mode'] = item.mode
-                    descendant.config['inherited_mode'] = set()
+                    descendant.trafo_data.setdefault('inherited_mode', set()).add(item.mode)
 
     @Timer(logger=info, text='[Loki::Scheduler] Performed initial source scan in {:.2f}s')
     def _discover(self):

--- a/loki/batch/sfilter.py
+++ b/loki/batch/sfilter.py
@@ -7,7 +7,7 @@
 
 import networkx as nx
 
-from loki.batch.item import Item, ExternalItem
+from loki.batch.item import Item, ExternalItem, TypeDefItem, InterfaceItem
 
 
 __all__ = ['SFilter']
@@ -38,9 +38,12 @@ class SFilter:
         Exclude :any:`Item` objects that have the ``is_ignored`` property
     include_external : bool, optional
         Do not skip :any:`ExternalItem` in the iterator
+    mode : str, optional
+        Only include items having corresponding mode.
     """
 
-    def __init__(self, sgraph, item_filter=None, reverse=False, exclude_ignored=False, include_external=False):
+    def __init__(self, sgraph, item_filter=None, reverse=False, exclude_ignored=False, include_external=False,
+            mode=None):
         self.sgraph = sgraph
         self.reverse = reverse
         if item_filter:
@@ -49,6 +52,7 @@ class SFilter:
             self.item_filter = Item
         self.exclude_ignored = exclude_ignored
         self.include_external = include_external
+        self.mode = mode
 
     def __iter__(self):
         if self.reverse:
@@ -68,5 +72,10 @@ class SFilter:
                 node_cls = type(node)
             if issubclass(node_cls, self.item_filter) and not (self.exclude_ignored and node.is_ignored):
                 # We found the next item matching the filter (and which is not ignored, if applicable)
-                break
+                if self.mode is None:
+                    break
+                if isinstance(node, (ExternalItem, TypeDefItem, InterfaceItem)):
+                    break
+                if node.mode == self.mode:
+                    break
         return node

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -491,3 +491,44 @@ class SGraph:
             graph.render(path, view=False)
         except gviz.ExecutableNotFound as e:
             warning(f'[Loki] Failed to render callgraph due to graphviz error:\n  {e}')
+
+    def descendants(self, item, item_factory, include_module_items=False, include_file_items=False):
+        """
+        Get all descendants of a given :data:`item`.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            The item node in the dependency graph for which to determine the successors
+        item_factory : :any:`ItemFactory`
+            The item factory to use.
+        include_module_items : bool, optional
+            Whether to include module items.
+        include_file_items : bool, optional
+            Whether to include file items.
+        """
+        item_descendants = list(nx.descendants(self._graph, item))
+        module_items = []
+        file_items = []
+        if include_module_items:
+            module_items = [item_factory.item_cache.get(_item.scope_name)
+                    for _item in item_descendants if not _item.is_ignored]
+        if include_file_items:
+            file_items = [item_factory.get_file_item_from_source(_item.source)
+                    for _item in item_descendants if not _item.is_ignored]
+        return item_descendants + module_items + file_items
+
+    def get_corresponding_module_and_file_item(self, item, item_factory):
+        """
+        Get corresponding module and file item of a given :data:`item`.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            The item node in the dependency graph for which to determine the successors
+        item_factory : :any:`ItemFactory`
+            The item factory to use.
+        """
+        _items = (item_factory.item_cache.get(item.scope_name),)
+        _items += (item_factory.get_file_item_from_source(item.source),)
+        return _items

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -492,7 +492,7 @@ class SGraph:
         except gviz.ExecutableNotFound as e:
             warning(f'[Loki] Failed to render callgraph due to graphviz error:\n  {e}')
 
-    def descendants(self, item, item_factory, include_module_items=False, include_file_items=False):
+    def descendants(self, item, item_factory, include_scope_items=False):
         """
         Get all descendants of a given :data:`item`.
 
@@ -502,33 +502,12 @@ class SGraph:
             The item node in the dependency graph for which to determine the successors
         item_factory : :any:`ItemFactory`
             The item factory to use.
-        include_module_items : bool, optional
-            Whether to include module items.
-        include_file_items : bool, optional
-            Whether to include file items.
+        include_scope_items : bool, optional
+            Whether to scope items like module and file items.
         """
         item_descendants = list(nx.descendants(self._graph, item))
-        module_items = []
-        file_items = []
-        if include_module_items:
-            module_items = [item_factory.item_cache.get(_item.scope_name)
-                    for _item in item_descendants if not _item.is_ignored]
-        if include_file_items:
-            file_items = [item_factory.get_file_item_from_source(_item.source)
-                    for _item in item_descendants if not _item.is_ignored]
-        return item_descendants + module_items + file_items
-
-    def get_corresponding_module_and_file_item(self, item, item_factory):
-        """
-        Get corresponding module and file item of a given :data:`item`.
-
-        Parameters
-        ----------
-        item : :any:`Item`
-            The item node in the dependency graph for which to determine the successors
-        item_factory : :any:`ItemFactory`
-            The item factory to use.
-        """
-        _items = (item_factory.item_cache.get(item.scope_name),)
-        _items += (item_factory.get_file_item_from_source(item.source),)
-        return _items
+        scope_items = []
+        if include_scope_items:
+            for _item in item_descendants:
+                scope_items.extend(item_factory.get_scope_and_file_items(_item))
+        return item_descendants + scope_items

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -503,7 +503,7 @@ class SGraph:
         item_factory : :any:`ItemFactory`
             The item factory to use.
         include_scope_items : bool, optional
-            Whether to scope items like module and file items.
+            Whether to include scope items like module and file items.
         """
         item_descendants = list(nx.descendants(self._graph, item))
         scope_items = []

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -3722,7 +3722,7 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, 
             output_dir=builddir)
     if wrong_pipeline_name:
         # check failure since pipeline 'm1' can't be found
-        with pytest.raises(SystemExit):
+        with pytest.raises(RuntimeError):
             scheduler.process(config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
         return
     scheduler.process(config.pipelines, proc_strategy=ProcessingStrategy.PLAN)

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -1324,9 +1324,9 @@ def test_scheduler_item_dependencies(testdir, tmp_path):
         }
     })
 
-    proj_hoist = testdir/'sources/projHoist'
+    proj_multi_mode = testdir/'sources/projHoist'
 
-    scheduler = Scheduler(paths=proj_hoist, config=config, xmods=[tmp_path])
+    scheduler = Scheduler(paths=proj_multi_mode, config=config, xmods=[tmp_path])
 
     assert tuple(
         call.name for call in scheduler['transformation_module_hoist#driver'].dependencies
@@ -3711,14 +3711,14 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, 
     })
 
     if as_modules:
-        proj_hoist = testdir/'sources/projMultiModeModules'
+        proj_multi_mode = testdir/'sources/projMultiModeModules'
     else:
-        proj_hoist = testdir/'sources/projMultiMode'
+        proj_multi_mode = testdir/'sources/projMultiMode'
 
     builddir = tmp_path/'scheduler_multi_driver_modes_dir'
     builddir.mkdir(exist_ok=True)
 
-    scheduler = Scheduler(paths=proj_hoist, config=config, xmods=[tmp_path],
+    scheduler = Scheduler(paths=proj_multi_mode, config=config, xmods=[tmp_path],
             output_dir=builddir)
     if wrong_pipeline_name:
         # check failure since pipeline 'm1' can't be found
@@ -3773,7 +3773,7 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, 
     for transformation in transformations:
         scheduler.process(transformation, proc_strategy=ProcessingStrategy.PLAN)
 
-    plan_trafo = CMakePlanTransformation(rootpath=proj_hoist)
+    plan_trafo = CMakePlanTransformation(rootpath=proj_multi_mode)
     scheduler.process(
         transformation=plan_trafo,
         proc_strategy=ProcessingStrategy.PLAN
@@ -3824,7 +3824,7 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, 
     assert set(plan_dict['LOKI_SOURCES_TO_REMOVE']) == expected_files_to_remove
 
     if reinit_scheduler:
-        scheduler = Scheduler(paths=proj_hoist, config=config, xmods=[tmp_path],
+        scheduler = Scheduler(paths=proj_multi_mode, config=config, xmods=[tmp_path],
                 output_dir=builddir)
     scheduler.propagate_and_separate_modes()
     for transformation in transformations:

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -3683,7 +3683,8 @@ end subroutine test_scheduler
 
 @pytest.mark.parametrize('as_modules', [False, True])
 @pytest.mark.parametrize('reinit_scheduler', [True, False])
-def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules):
+@pytest.mark.parametrize('wrong_pipeline_name', [True, False])
+def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, wrong_pipeline_name):
     """
     Make sure children are correct and unique for items
     """
@@ -3703,7 +3704,7 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules):
             'Idem3': {'classname': 'IdemTransformation', 'module': 'loki.transformations'}
         },
         'pipelines': {
-            'm1': {'transformations': {'Idem1'}},
+            f'{"m1x" if wrong_pipeline_name else "m1"}': {'transformations': {'Idem1'}},
             'm2': {'transformations': {'Idem2'}},
             'm3': {'transformations': {'Idem3'}}
         },
@@ -3719,7 +3720,12 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules):
 
     scheduler = Scheduler(paths=proj_hoist, config=config, xmods=[tmp_path],
             output_dir=builddir)
-    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+    if wrong_pipeline_name:
+        # check failure since pipeline 'm1' can't be found
+        with pytest.raises(SystemExit):
+            scheduler.process(config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
+        return
+    scheduler.process(config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
 
     _expected_item_mode_dic = {
         'm1': {
@@ -3773,7 +3779,7 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules):
         proc_strategy=ProcessingStrategy.PLAN
     )
     ## checking planfile
-    planfile = Path('/perm/nams/loki-separate-modes-2') / 'planfile' # tmp_path/'planfile'
+    planfile = tmp_path/'planfile'
     plan_trafo.write_plan(planfile)
 
     loki_plan = planfile.read_text()

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -76,9 +76,9 @@ from loki.ir import (
     nodes as ir, FindNodes, FindInlineCalls, FindVariables
 )
 from loki.transformations import (
-    DependencyTransformation, ModuleWrapTransformation, FileWriteTransformation
+    DependencyTransformation, ModuleWrapTransformation, FileWriteTransformation,
+    CMakePlanTransformation
 )
-
 
 pytestmark = pytest.mark.skipif(not HAVE_FP, reason='Fparser not available')
 
@@ -3680,3 +3680,206 @@ end subroutine test_scheduler
         ('#test_scheduler', 'mod_a#outer_type'),
         ('mod_a#outer_type', 'mod_b#inner_type')
     )
+
+@pytest.mark.parametrize('as_modules', [False, True])
+@pytest.mark.parametrize('reinit_scheduler', [True, False])
+def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules):
+    """
+    Make sure children are correct and unique for items
+    """
+    config = SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm1', 'replicate': True},
+        'routines': {
+            'driver_0': {'role': 'driver', 'mode': 'm1', 'replicate': False},
+            'driver_1': {'role': 'driver', 'mode': 'm1', 'replicate': False},
+            'driver_2': {'role': 'driver', 'mode': 'm2', 'replicate': False},
+            'driver_3': {'role': 'driver', 'mode': 'm3', 'replicate': False},
+            'driver_4': {'role': 'driver', 'mode': 'm3', 'replicate': False},
+            'nested_subroutine_3': {'ignore': ['test1', 'test2']}
+        },
+        'transformations': {
+            'Idem1': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'Idem2': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'Idem3': {'classname': 'IdemTransformation', 'module': 'loki.transformations'}
+        },
+        'pipelines': {
+            'm1': {'transformations': {'Idem1'}},
+            'm2': {'transformations': {'Idem2'}},
+            'm3': {'transformations': {'Idem3'}}
+        },
+    })
+
+    if as_modules:
+        proj_hoist = testdir/'sources/projMultiModeModules'
+    else:
+        proj_hoist = testdir/'sources/projMultiMode'
+
+    builddir = tmp_path/'scheduler_multi_driver_modes_dir'
+    builddir.mkdir(exist_ok=True)
+
+    scheduler = Scheduler(paths=proj_hoist, config=config, xmods=[tmp_path],
+            output_dir=builddir)
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+
+    _expected_item_mode_dic = {
+        'm1': {
+            'nested_subroutine_3_lokim1_mod#nested_subroutine_3_lokim1',
+            'driver_0_mod#driver_0',
+            'nested_subroutine_1_lokim1_mod#nested_subroutine_1_lokim1',
+            'subroutine_3_lokim1_mod#subroutine_3_lokim1',
+            'driver_1_mod#driver_1',
+            'subroutine_1_mod#subroutine_1'
+        },
+        'm2': {
+            'subroutine_2_mod#subroutine_2',
+            'driver_2_mod#driver_2',
+            'nested_subroutine_3_lokim2_mod#nested_subroutine_3_lokim2',
+            'nested_subroutine_2_mod#nested_subroutine_2'
+        },
+        'm3': {
+            'nested_subroutine_3_mod#nested_subroutine_3',
+            'driver_3_mod#driver_3',
+            'driver_4_mod#driver_4',
+            'nested_subroutine_1_mod#nested_subroutine_1',
+            'subroutine_3_mod#subroutine_3'
+        }
+    }
+    if as_modules:
+        expected_item_mode_dic = _expected_item_mode_dic
+    else:
+        expected_item_mode_dic = {k: {f"#{v.split('#')[-1]}" if 'routine' in v else v for v in vals}
+                for k, vals in _expected_item_mode_dic.items()}
+
+    items = scheduler.items
+    item_mode_dic = {}
+    for item in items:
+        item_mode_dic.setdefault(item.mode, set()).add(item.name)
+
+    assert set(item_mode_dic.keys()) == set(expected_item_mode_dic.keys())
+    for _mode, _val in item_mode_dic.items():
+        assert expected_item_mode_dic[_mode] == _val
+
+    transformations = (
+        ModuleWrapTransformation(module_suffix='_mod'),
+        DependencyTransformation(suffix='_test', module_suffix='_mod'),
+        FileWriteTransformation()
+    )
+    for transformation in transformations:
+        scheduler.process(transformation, proc_strategy=ProcessingStrategy.PLAN)
+
+    plan_trafo = CMakePlanTransformation(rootpath=proj_hoist)
+    scheduler.process(
+        transformation=plan_trafo,
+        proc_strategy=ProcessingStrategy.PLAN
+    )
+    ## checking planfile
+    planfile = Path('/perm/nams/loki-separate-modes-2') / 'planfile' # tmp_path/'planfile'
+    plan_trafo.write_plan(planfile)
+
+    loki_plan = planfile.read_text()
+
+    # Validate the plan file content
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+
+    # loki_plan = planfile.read_text()
+    plan_dict = {k: v.split() for k, v in plan_pattern.findall(loki_plan)}
+    plan_dict = {k: {Path(s).stem for s in v} for k, v in plan_dict.items()}
+
+    expected_keys = {'LOKI_SOURCES_TO_TRANSFORM', 'LOKI_SOURCES_TO_APPEND', 'LOKI_SOURCES_TO_REMOVE'}
+    assert set(plan_dict.keys()) == expected_keys
+
+    _expected_files_to_transform = {
+        'driver_0_mod', 'driver_1_mod', 'driver_2_mod', 'driver_3_mod', 'driver_4_mod',
+        'nested_subroutine_1_mod', 'nested_subroutine_2_mod', 'nested_subroutine_3_mod',
+        'subroutine_1_mod', 'subroutine_2_mod', 'subroutine_3_mod'
+    }
+    if as_modules:
+        expected_files_to_transform = _expected_files_to_transform
+    else:
+        expected_files_to_transform = {v.replace('_mod', '')
+                if 'routine' in v else v for v in _expected_files_to_transform}
+    _expected_files_to_append = {
+        'driver_0_mod.m1', 'driver_1_mod.m1', 'driver_2_mod.m2', 'driver_3_mod.m3',
+        'driver_4_mod.m3', 'nested_subroutine_1_mod.m3', 'nested_subroutine_1_lokim1_mod.m1',
+        'nested_subroutine_2_mod.m2', 'nested_subroutine_3_mod.m3', 'nested_subroutine_3_lokim1_mod.m1',
+        'nested_subroutine_3_lokim2_mod.m2', 'subroutine_1_mod.m1', 'subroutine_2_mod.m2',
+        'subroutine_3_mod.m3', 'subroutine_3_lokim1_mod.m1'        
+    }
+    if as_modules:
+        expected_files_to_append = _expected_files_to_append
+    else:
+        expected_files_to_append = {v.replace('_mod', '') if 'routine' in v else v for v in _expected_files_to_append}
+    expected_files_to_remove = {
+        'driver_0_mod', 'driver_1_mod', 'driver_2_mod', 'driver_3_mod', 'driver_4_mod'        
+    }
+
+    assert set(plan_dict['LOKI_SOURCES_TO_TRANSFORM']) == expected_files_to_transform
+    assert set(plan_dict['LOKI_SOURCES_TO_APPEND']) == expected_files_to_append
+    assert set(plan_dict['LOKI_SOURCES_TO_REMOVE']) == expected_files_to_remove
+
+    if reinit_scheduler:
+        scheduler = Scheduler(paths=proj_hoist, config=config, xmods=[tmp_path],
+                output_dir=builddir)
+    scheduler.propagate_and_separate_modes()
+    for transformation in transformations:
+        scheduler.process(transformation)
+
+    expected_callgraph = {
+        'driver_0_mod#driver_0': {
+            'subroutine_1_test_mod#subroutine_1_test' : {
+                'nested_subroutine_1_lokim1_test_mod#nested_subroutine_1_lokim1_test',
+            },
+            'subroutine_3_lokim1_test_mod#subroutine_3_lokim1_test': {
+                'nested_subroutine_1_lokim1_test_mod#nested_subroutine_1_lokim1_test',
+                'nested_subroutine_3_lokim1_test_mod#nested_subroutine_3_lokim1_test',
+            },
+        },
+        'driver_1_mod#driver_1': {
+            'subroutine_1_test_mod#subroutine_1_test' : {
+                'nested_subroutine_1_lokim1_test_mod#nested_subroutine_1_lokim1_test',
+            },
+            'subroutine_3_lokim1_test_mod#subroutine_3_lokim1_test': {
+                'nested_subroutine_1_lokim1_test_mod#nested_subroutine_1_lokim1_test',
+                'nested_subroutine_3_lokim1_test_mod#nested_subroutine_3_lokim1_test',
+            }
+        },
+        'driver_2_mod#driver_2': {
+            'subroutine_2_test_mod#subroutine_2_test' : {
+                'nested_subroutine_2_test_mod#nested_subroutine_2_test',
+                'nested_subroutine_3_lokim2_test_mod#nested_subroutine_3_lokim2_test'
+            }
+        },
+        'driver_3_mod#driver_3': {
+            'subroutine_3_test_mod#subroutine_3_test': {
+                'nested_subroutine_1_test_mod#nested_subroutine_1_test',
+                'nested_subroutine_3_test_mod#nested_subroutine_3_test',
+            }
+        },
+        'driver_4_mod#driver_4': {
+            'subroutine_3_test_mod#subroutine_3_test': {
+                'nested_subroutine_1_test_mod#nested_subroutine_1_test',
+                'nested_subroutine_3_test_mod#nested_subroutine_3_test',
+            }
+        }
+    }
+
+    def check_callgraph(callgraph):
+        if not isinstance(callgraph, dict) or not callgraph:
+            return
+        for routine in callgraph.keys():
+            routine_ir = scheduler[routine].ir
+            imports = routine_ir.imports
+            imported_symbols = ()
+            for imp in imports:
+                imported_symbols += imp.symbols
+            successors = []
+            for successor in callgraph[routine]:
+                successors.append(scheduler[successor].ir)
+            successors_local_name = [str(successor.name).lower() for successor in successors]
+            calls = FindNodes(ir.CallStatement).visit(routine_ir.body)
+            for call in calls:
+                assert str(call.name).lower() in successors_local_name
+                assert str(call.name).lower() in imported_symbols
+            check_callgraph(callgraph[routine])
+
+    check_callgraph(expected_callgraph)

--- a/loki/cli/loki_transform.py
+++ b/loki/cli/loki_transform.py
@@ -91,15 +91,9 @@ def convert(
     )
 
     if multimode:
-        _modes = scheduler.propagate_and_separate_modes(proc_strategy=processing_strategy)
-        scheduler.process_config(proc_strategy=processing_strategy)
-        info('[Loki-transform] Applying multiple custom pipelines from config:')
-        for _mode in _modes:
-            if _mode not in config.pipelines:
-                msg = f'[Loki] ERROR: Pipeline or transformation mode {_mode} not found in config file.\n'
-                msg += '[Loki] Please provide a config file with configured transformation or pipelines instead.\n'
-                sys.exit(msg)
-            info(str(config.pipelines[_mode]))
+        # multimode, therefore pass all available pipelines and let process handle the rest
+        info('[Loki-transform] Applying custom pipelines from config')
+        scheduler.process(config.pipelines, proc_strategy=processing_strategy)
     else:
         # If requested, apply a custom pipeline from the scheduler config
         # Note that this new entry point will bypass all other default

--- a/loki/cli/loki_transform.py
+++ b/loki/cli/loki_transform.py
@@ -39,10 +39,10 @@ from loki.transformations.build_system import FileWriteTransformation
 @click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
               type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
               help='Log level to output during batch processing')
-@click.option('--multimode', '-z', is_flag=True, help="Multi-mode processing.")
+@click.option('--multipipeline', '-z', is_flag=True, help="Multi-pipeline processing.")
 def convert(
         frontend_opts, scheduler_opts, mode, config, plan_file, callgraph, root, log_level,
-        multimode
+        multipipeline
 ):
     """
     Batch-processing mode for Fortran-to-Fortran transformations that
@@ -90,8 +90,8 @@ def convert(
         definitions=definitions, output_dir=scheduler_opts.build, **frontend_opts.asdict
     )
 
-    if multimode:
-        # multimode, therefore pass all available pipelines and let process handle the rest
+    if multipipeline:
+        # multipipeline, therefore pass all available pipelines and let process handle the rest
         info('[Loki-transform] Applying custom pipelines from config')
         scheduler.process(config.pipelines, proc_strategy=processing_strategy)
     else:
@@ -139,7 +139,7 @@ def convert(
 @click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
               type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
               help='Log level to output during batch processing')
-@click.option('--multimode', '-z', is_flag=True, help="Multi-mode processing.")
+@click.option('--multipipeline', '-z', is_flag=True, help="Multi-pipeline processing.")
 @click.pass_context
 def plan(ctx, *_args, **_kwargs):
     """

--- a/loki/sourcefile.py
+++ b/loki/sourcefile.py
@@ -61,6 +61,7 @@ class Sourcefile:
 
     def __init__(self, path, ir=None, ast=None, source=None, incomplete=False, parser_classes=None):
         self.path = Path(path) if path is not None else path
+        self.orig_path = self.path
         if ir is not None and not isinstance(ir, Section):
             ir = Section(body=ir)
         self.ir = ir

--- a/loki/tests/sources/projMultiMode/driver_0_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_0_mod.F90
@@ -1,0 +1,12 @@
+module driver_0_mod
+  implicit none
+contains
+
+   subroutine driver_0()
+     #include "subroutine_1.intfb.h"
+     #include "subroutine_3.intfb.h"
+     call subroutine_1()
+     call subroutine_3()
+     call subroutine_3()
+   end subroutine driver_0
+end module driver_0_mod

--- a/loki/tests/sources/projMultiMode/driver_0_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_0_mod.F90
@@ -3,8 +3,8 @@ module driver_0_mod
 contains
 
    subroutine driver_0()
-     #include "subroutine_1.intfb.h"
-     #include "subroutine_3.intfb.h"
+#include "subroutine_1.intfb.h"
+#include "subroutine_3.intfb.h"
      call subroutine_1()
      call subroutine_3()
      call subroutine_3()

--- a/loki/tests/sources/projMultiMode/driver_1_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_1_mod.F90
@@ -3,8 +3,8 @@ module driver_1_mod
 contains
 
    subroutine driver_1()
-     #include "subroutine_1.intfb.h"
-     #include "subroutine_3.intfb.h"
+#include "subroutine_1.intfb.h"
+#include "subroutine_3.intfb.h"
      call subroutine_1()
      call subroutine_3()
      call subroutine_3()

--- a/loki/tests/sources/projMultiMode/driver_1_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_1_mod.F90
@@ -1,0 +1,12 @@
+module driver_1_mod
+  implicit none
+contains
+
+   subroutine driver_1()
+     #include "subroutine_1.intfb.h"
+     #include "subroutine_3.intfb.h"
+     call subroutine_1()
+     call subroutine_3()
+     call subroutine_3()
+   end subroutine driver_1
+end module driver_1_mod

--- a/loki/tests/sources/projMultiMode/driver_2_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_2_mod.F90
@@ -4,7 +4,7 @@ module driver_2_mod
 contains
 
    subroutine driver_2()
-     #include "subroutine_2.intfb.h"
+#include "subroutine_2.intfb.h"
      call subroutine_2()
    end subroutine driver_2
 end module driver_2_mod

--- a/loki/tests/sources/projMultiMode/driver_2_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_2_mod.F90
@@ -1,0 +1,10 @@
+module driver_2_mod
+  implicit none
+
+contains
+
+   subroutine driver_2()
+     #include "subroutine_2.intfb.h"
+     call subroutine_2()
+   end subroutine driver_2
+end module driver_2_mod

--- a/loki/tests/sources/projMultiMode/driver_3_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_3_mod.F90
@@ -4,7 +4,7 @@ module driver_3_mod
 contains
 
    subroutine driver_3()
-     #include "subroutine_3.intfb.h"
+#include "subroutine_3.intfb.h"
      call subroutine_3()
    end subroutine driver_3
 end module driver_3_mod

--- a/loki/tests/sources/projMultiMode/driver_3_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_3_mod.F90
@@ -1,0 +1,10 @@
+module driver_3_mod
+  implicit none
+
+contains
+
+   subroutine driver_3()
+     #include "subroutine_3.intfb.h"
+     call subroutine_3()
+   end subroutine driver_3
+end module driver_3_mod

--- a/loki/tests/sources/projMultiMode/driver_4_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_4_mod.F90
@@ -4,7 +4,7 @@ module driver_4_mod
 contains
 
    subroutine driver_4()
-     #include "subroutine_3.intfb.h"
+#include "subroutine_3.intfb.h"
      call subroutine_3()
    end subroutine driver_4
 end module driver_4_mod

--- a/loki/tests/sources/projMultiMode/driver_4_mod.F90
+++ b/loki/tests/sources/projMultiMode/driver_4_mod.F90
@@ -1,0 +1,10 @@
+module driver_4_mod
+  implicit none
+
+contains
+
+   subroutine driver_4()
+     #include "subroutine_3.intfb.h"
+     call subroutine_3()
+   end subroutine driver_4
+end module driver_4_mod

--- a/loki/tests/sources/projMultiMode/nested_subroutine_1.F90
+++ b/loki/tests/sources/projMultiMode/nested_subroutine_1.F90
@@ -1,0 +1,2 @@
+subroutine nested_subroutine_1()
+end subroutine nested_subroutine_1

--- a/loki/tests/sources/projMultiMode/nested_subroutine_2.F90
+++ b/loki/tests/sources/projMultiMode/nested_subroutine_2.F90
@@ -1,0 +1,2 @@
+subroutine nested_subroutine_2()
+end subroutine nested_subroutine_2

--- a/loki/tests/sources/projMultiMode/nested_subroutine_3.F90
+++ b/loki/tests/sources/projMultiMode/nested_subroutine_3.F90
@@ -1,0 +1,2 @@
+subroutine nested_subroutine_3()
+end subroutine nested_subroutine_3

--- a/loki/tests/sources/projMultiMode/subroutine_1.F90
+++ b/loki/tests/sources/projMultiMode/subroutine_1.F90
@@ -1,0 +1,4 @@
+subroutine subroutine_1()
+  #include "nested_subroutine_1.intfb.h"
+  call nested_subroutine_1()
+end subroutine subroutine_1

--- a/loki/tests/sources/projMultiMode/subroutine_1.F90
+++ b/loki/tests/sources/projMultiMode/subroutine_1.F90
@@ -1,4 +1,4 @@
 subroutine subroutine_1()
-  #include "nested_subroutine_1.intfb.h"
+#include "nested_subroutine_1.intfb.h"
   call nested_subroutine_1()
 end subroutine subroutine_1

--- a/loki/tests/sources/projMultiMode/subroutine_2.F90
+++ b/loki/tests/sources/projMultiMode/subroutine_2.F90
@@ -1,6 +1,6 @@
 subroutine subroutine_2()
-  #include "nested_subroutine_2.intfb.h"
-  #include "nested_subroutine_3.intfb.h"
+#include "nested_subroutine_2.intfb.h"
+#include "nested_subroutine_3.intfb.h"
   call nested_subroutine_2()
   call nested_subroutine_3()
 end subroutine subroutine_2

--- a/loki/tests/sources/projMultiMode/subroutine_2.F90
+++ b/loki/tests/sources/projMultiMode/subroutine_2.F90
@@ -1,0 +1,6 @@
+subroutine subroutine_2()
+  #include "nested_subroutine_2.intfb.h"
+  #include "nested_subroutine_3.intfb.h"
+  call nested_subroutine_2()
+  call nested_subroutine_3()
+end subroutine subroutine_2

--- a/loki/tests/sources/projMultiMode/subroutine_3.F90
+++ b/loki/tests/sources/projMultiMode/subroutine_3.F90
@@ -1,11 +1,6 @@
 subroutine subroutine_3()
-  #include "nested_subroutine_1.intfb.h"
-  #include "nested_subroutine_3.intfb.h"
-
-! INTERFACE
-!   SUBROUTINE nested_subroutine_3()
-!   END SUBROUTINE nested_subroutine_3
-! END INTERFACE
+#include "nested_subroutine_1.intfb.h"
+#include "nested_subroutine_3.intfb.h"
 
   call nested_subroutine_1()
   call nested_subroutine_3()

--- a/loki/tests/sources/projMultiMode/subroutine_3.F90
+++ b/loki/tests/sources/projMultiMode/subroutine_3.F90
@@ -1,0 +1,12 @@
+subroutine subroutine_3()
+  #include "nested_subroutine_1.intfb.h"
+  #include "nested_subroutine_3.intfb.h"
+
+! INTERFACE
+!   SUBROUTINE nested_subroutine_3()
+!   END SUBROUTINE nested_subroutine_3
+! END INTERFACE
+
+  call nested_subroutine_1()
+  call nested_subroutine_3()
+end subroutine subroutine_3

--- a/loki/tests/sources/projMultiModeModules/driver_0_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/driver_0_mod.F90
@@ -1,0 +1,12 @@
+module driver_0_mod
+  implicit none
+contains
+
+   subroutine driver_0()
+     use subroutine_1_mod, only: subroutine_1
+     use subroutine_3_mod, only: subroutine_3
+     call subroutine_1()
+     call subroutine_3()
+     call subroutine_3()
+   end subroutine driver_0
+end module driver_0_mod

--- a/loki/tests/sources/projMultiModeModules/driver_1_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/driver_1_mod.F90
@@ -1,0 +1,12 @@
+module driver_1_mod
+  implicit none
+contains
+
+   subroutine driver_1()
+     use subroutine_1_mod, only: subroutine_1
+     use subroutine_3_mod, only: subroutine_3
+     call subroutine_1()
+     call subroutine_3()
+     call subroutine_3()
+   end subroutine driver_1
+end module driver_1_mod

--- a/loki/tests/sources/projMultiModeModules/driver_2_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/driver_2_mod.F90
@@ -1,0 +1,10 @@
+module driver_2_mod
+  implicit none
+
+contains
+
+   subroutine driver_2()
+     use subroutine_2_mod, only: subroutine_2
+     call subroutine_2()
+   end subroutine driver_2
+end module driver_2_mod

--- a/loki/tests/sources/projMultiModeModules/driver_3_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/driver_3_mod.F90
@@ -1,0 +1,10 @@
+module driver_3_mod
+  implicit none
+
+contains
+
+   subroutine driver_3()
+     use subroutine_3_mod, only: subroutine_3
+     call subroutine_3()
+   end subroutine driver_3
+end module driver_3_mod

--- a/loki/tests/sources/projMultiModeModules/driver_4_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/driver_4_mod.F90
@@ -1,0 +1,10 @@
+module driver_4_mod
+  implicit none
+
+contains
+
+   subroutine driver_4()
+     use subroutine_3_mod, only: subroutine_3
+     call subroutine_3()
+   end subroutine driver_4
+end module driver_4_mod

--- a/loki/tests/sources/projMultiModeModules/nested_subroutine_1_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/nested_subroutine_1_mod.F90
@@ -1,0 +1,6 @@
+module nested_subroutine_1_mod
+implicit none
+contains
+subroutine nested_subroutine_1()
+end subroutine nested_subroutine_1
+end module nested_subroutine_1_mod

--- a/loki/tests/sources/projMultiModeModules/nested_subroutine_2_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/nested_subroutine_2_mod.F90
@@ -1,0 +1,6 @@
+module nested_subroutine_2_mod
+implicit none
+contains
+subroutine nested_subroutine_2()
+end subroutine nested_subroutine_2
+end module nested_subroutine_2_mod

--- a/loki/tests/sources/projMultiModeModules/nested_subroutine_3_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/nested_subroutine_3_mod.F90
@@ -1,0 +1,6 @@
+module nested_subroutine_3_mod
+implicit none
+contains
+subroutine nested_subroutine_3()
+end subroutine nested_subroutine_3
+end module nested_subroutine_3_mod

--- a/loki/tests/sources/projMultiModeModules/subroutine_1_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/subroutine_1_mod.F90
@@ -1,0 +1,8 @@
+module subroutine_1_mod
+implicit none
+contains
+subroutine subroutine_1()
+  use nested_subroutine_1_mod, only: nested_subroutine_1
+  call nested_subroutine_1()
+end subroutine subroutine_1
+end module subroutine_1_mod

--- a/loki/tests/sources/projMultiModeModules/subroutine_2_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/subroutine_2_mod.F90
@@ -1,0 +1,10 @@
+module subroutine_2_mod
+implicit none
+contains
+subroutine subroutine_2()
+  use nested_subroutine_2_mod, only: nested_subroutine_2
+  use nested_subroutine_3_mod, only: nested_subroutine_3
+  call nested_subroutine_2()
+  call nested_subroutine_3()
+end subroutine subroutine_2
+end module subroutine_2_mod

--- a/loki/tests/sources/projMultiModeModules/subroutine_3_mod.F90
+++ b/loki/tests/sources/projMultiModeModules/subroutine_3_mod.F90
@@ -1,0 +1,11 @@
+module subroutine_3_mod
+implicit none
+contains
+subroutine subroutine_3()
+  use nested_subroutine_1_mod, only: nested_subroutine_1
+  use nested_subroutine_3_mod, only: nested_subroutine_3
+
+  call nested_subroutine_1()
+  call nested_subroutine_3()
+end subroutine subroutine_3
+end module subroutine_3_mod

--- a/loki/transformations/build_system/dependency.py
+++ b/loki/transformations/build_system/dependency.py
@@ -305,8 +305,14 @@ class DependencyTransformation(Transformation):
             calls = {str(c.name).lower() for c in FindNodes(CallStatement).visit(source.body)}
             calls |= {str(c.name).lower() for c in FindInlineCalls().visit(source.body)}
 
+        def replace_last(s, old, new):
+            index = s.rfind(old)
+            if index == -1:
+                return s
+            return s[:index] + new + s[index + len(old):]
+
         # Import statements still point to unmodified call names
-        calls = {call.replace(f'{self.suffix.lower()}', '') for call in calls}
+        calls = {replace_last(call, f'{self.suffix.lower()}', '') for call in calls}
         call_targets = {call for call in calls if call in as_tuple(targets)}
 
         # We go through the IR, as C-imports can be attributed to the body
@@ -340,7 +346,6 @@ class DependencyTransformation(Transformation):
                         im._update(module=new_module_name, symbols=symbols)
 
                 # TODO: Deal with unqualified blanket imports
-
         if import_map:
             source.spec = Transformer(import_map).visit(source.spec)
 

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -8,8 +8,9 @@
 from loki.batch import Transformation
 from loki.ir import nodes as ir, Transformer, FindNodes
 from loki.tools.util import as_tuple, CaseInsensitiveDict
+from loki.subroutine import Subroutine
 
-__all__ = ['DuplicateKernel', 'RemoveKernel']
+__all__ = ['DuplicateKernel', 'RemoveKernel', 'SeparateModesKernel']
 
 
 class DuplicateKernel(Transformation):
@@ -330,3 +331,292 @@ class RemoveKernel(Transformation):
         item.plan_data['removed_dependencies'] += tuple(
             child for child in successors if child.local_name in self.remove_kernels
         )
+
+class SeparateModesKernel(Transformation):
+    """
+    Duplicate subroutines which includes the creation of new :any:`Item`s
+    as well as the addition of the corresponding new dependencies.
+
+    Therefore, this transformation creates a new item and also implements
+    the relevant routines for dry-run pipeline planning runs.
+
+    Parameters
+    ----------
+    duplicate_kernels : str|tuple|list, optional
+        Kernel name(s) to be duplicated.
+    duplicate_suffix : str, optional
+        Suffix to be used to append the original kernel name(s).
+    duplicate_module_suffix : str, optional
+        Suffix to be used to append the original module name(s),
+        if defined, otherwise `duplicate_suffix`
+    duplicate_subgraph : bool, optional
+        Whether or not duplicate the subgraph beneath the kernel(s)
+        that are duplicated.
+    """
+
+    creates_items = True
+    renames_items = True
+    reverse_traversal = False
+
+    def __init__(self):
+        self.mapping = {}
+
+    def _get_new_item_name(self, item, mode):
+        """
+        Get new/duplicated item name, more specifically ``local_name``,
+        ``scope_name`` and ``new_item_name``.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            The item used to derive ``local_name``,
+            ``scope_name`` and ``new_item_name``.
+        Returns
+        -------
+        mode : TODO
+        scope_name : str
+            New item scope name.
+        new_item_name : str
+            New item name.
+        local_name : str
+            New item local name.
+        """
+        if mode in self.mapping:
+            mode_rename = self.mapping[mode]
+        else:
+            mode_rename = f'_loki{mode.replace("-", "_")}'
+            self.mapping[mode] = mode_rename
+
+        # Determine new item name
+        scope_name = item.scope_name
+        local_name = f'{item.local_name}{mode_rename}'
+        if scope_name:
+            if "_mod" in scope_name:
+                scope_name = scope_name.replace('_mod', f'_{mode_rename}_mod').replace('__', '_')
+            else:
+                scope_name = f'{scope_name}{mode_rename}'
+
+        # Try to get existing item from cache
+        new_item_name = f'{scope_name or ""}#{local_name}'
+        return scope_name, local_name, new_item_name
+
+    def _get_or_create_or_rename_item(self, item, mode, item_factory, config):
+        """
+        Get, create or rename item including the scope item if there is a
+        scope.
+
+        Parameters
+        ----------
+        mode : TODO
+        item : :any:`Item`
+            Item to duplicate/to use to derive new item.
+        item_factory : :any:`ItemFactory`
+            The :any:`ItemFactory` to use when creating the items.
+        config : :any:`SchedulerConfig`
+            The scheduler config to use when instantiating new items.
+        Returns
+        -------
+        :any:`Item`
+            Newly created item.
+        """
+        scope_name, local_name, new_item_name = self._get_new_item_name(item, mode)
+        new_item = item_factory.item_cache.get(new_item_name)
+        # Try to get an item for the scope or create that first
+        if new_item is None and scope_name:
+            scope_item = item_factory.item_cache.get(scope_name)
+            if scope_item:
+                scope = scope_item.ir
+                if local_name not in scope and item.local_name in scope:
+                    # Rename the existing item to the new name
+                    scope[item.local_name].name = local_name
+
+                if local_name in scope:
+                    new_item = item_factory.create_from_ir(
+                        scope[local_name], scope, config=config
+                    )
+        # Create new item
+        if new_item is None:
+            new_item = as_tuple(item_factory.get_or_create_item_from_item(new_item_name, item, config=config))[0]
+        return new_item
+
+    @staticmethod
+    def get_parent_items(item, item_factory):
+        item_cache = item_factory.item_cache
+        parent_items = ()
+        if item.scope_name in item_cache:
+            parent_items += (item_cache[item.scope_name],)
+        if str(item.source.path) in item_cache:
+            parent_items += (item_cache[str(item.source.path)],)
+        return parent_items
+
+    def _create_new_items(self, successors, item_factory, config, item, sub_sgraph,
+            rename_calls=False, ignore=None):
+        """
+        Create new/duplicated items.
+
+        Parameters
+        ----------
+        successors : tuple
+            Tuple of :any:`Item`s representing the successor items for which
+            new/duplicated items are created..
+        item_factory : :any:`ItemFactory`
+            The :any:`ItemFactory` to use when creating the items.
+        config : :any:`SchedulerConfig`
+            The scheduler config to use when instantiating new items.
+        item : :any:`Item`
+            Starting point/source item from which the successors
+            originate from
+        sub_sgraph : :any:`SGraph`
+            Sgraph (copy) representing the subgraph of the directed
+            overall graph.
+        rename_calls : bool, optional
+            Rename calls/imports in accordance to the duplicated
+            kernels.
+        Returns
+        -------
+        tuple
+            Tuple of newly created items.
+        """
+        ignore = as_tuple(ignore)
+        new_items = ()
+        removed_items = ()
+        item.trafo_data.setdefault('SeparateModes', {})
+        for child in successors:
+            if child.local_name in ignore:
+                continue
+            child.trafo_data.setdefault('SeparateModes', {})
+            modes_to_duplicate = sorted(list(set(self._get_item_modes(child))))
+            if item.mode in child.trafo_data['SeparateModes']:
+                new_item = child.trafo_data['SeparateModes'][item.mode]
+                removed_items += (child,)
+                new_items += as_tuple(new_item)
+                item.trafo_data['SeparateModes'][child] = new_item
+            elif len(modes_to_duplicate) > 1:
+                mode_to_duplicate = item.mode
+                new_item = self._get_or_create_or_rename_item(child, mode_to_duplicate, item_factory, config)
+                new_item.config = child.config.copy()
+                new_item.config['mode'] = mode_to_duplicate
+                parent_items = self.get_parent_items(new_item, item_factory)
+                for parent_item in parent_items:
+                    parent_item.config['mode'] = mode_to_duplicate
+                child.inherited_mode.discard(mode_to_duplicate)
+                removed_items += (child,)
+                new_items += as_tuple(new_item)
+                item.trafo_data['SeparateModes'][child] = new_item
+                child.trafo_data['SeparateModes'][mode_to_duplicate] = new_item
+                # recurse
+                new_item.plan_data.setdefault('removed_dependencies', ())
+                new_item.plan_data.setdefault('additional_dependencies', ())
+                new_item_new_items, new_item_removed_items = self._create_new_items(sub_sgraph.successors(child),
+                        item_factory, config, new_item, sub_sgraph)
+                new_item.plan_data['additional_dependencies'] += new_item_new_items
+                new_item.plan_data['removed_dependencies'] += new_item_removed_items
+                if rename_calls:
+                    new_dependencies = CaseInsensitiveDict((new_item.local_name, new_item)
+                            for new_item in new_item_new_items)
+                    new_dependencies = CaseInsensitiveDict((k.local_name, v) for k, v in
+                            new_item.trafo_data.get('SeparateModes', {}).items() if not isinstance(k, str))
+                    self._adapt_calls_imports(new_item.ir, new_dependencies)
+            else:
+                mode_to_duplicate = modes_to_duplicate[0]
+                child.config['mode'] = item.mode
+                parent_items = self.get_parent_items(child, item_factory)
+                for parent_item in parent_items:
+                    parent_item.config['mode'] = mode_to_duplicate
+
+        return tuple(new_items), tuple(removed_items)
+
+    def rename_interfaces(self, intfs, new_dependencies):
+        for i in intfs:
+            for routine in i.body:
+                if isinstance(routine, Subroutine):
+                    if new_dependencies and routine.name.lower() in new_dependencies:
+                        routine.name = new_dependencies[routine.name.lower()].local_name
+
+    def rename_imports(self, imports, new_dependencies=None):
+        # We go through the IR, as C-imports can be attributed to the body
+        for im in imports:
+            if im.c_import:
+                target_symbol, *suffixes = im.module.lower().split('.', maxsplit=1)
+                if new_dependencies and target_symbol.lower() in new_dependencies and not 'func.h' in suffixes:
+                    # Modify the the basename of the C-style header import
+                    s = '.'.join(im.module.split('.')[1:])
+                    im._update(module=f'{new_dependencies[target_symbol].local_name}.{s}')
+            else:
+                # Modify module import if it imports any call targets
+                if new_dependencies and im.symbols and any(s in new_dependencies for s in im.symbols):
+                    relevant_symbol = [s for s in im.symbols if s in new_dependencies][0]
+                    _new_symbol = new_dependencies[relevant_symbol]
+                    new_symbol = _new_symbol.scope_ir.procedure_symbol # local_name
+                    new_module_name = _new_symbol.scope_name
+                    im._update(module=new_module_name, symbols=(new_symbol,))
+            # TODO: Deal with unqualified blanket imports
+
+    def _adapt_calls_imports(self, routine, new_dependencies):
+        call_map = {}
+        if not new_dependencies:
+            return
+        for call in FindNodes(ir.CallStatement).visit(routine.body):
+            call_name = str(call.name).lower()
+            if call_name in new_dependencies:
+                new_item = as_tuple(new_dependencies[call_name])[0]
+                # new_call_name = (new_item.name).lower() # str(new_item.local_name).lower()
+                proc_symbol = new_item.ir.procedure_symbol.rescope(scope=routine)
+                call_map[call] = call.clone(name=proc_symbol)
+        if call_map:
+            routine.body = Transformer(call_map).visit(routine.body)
+
+        self.rename_imports(imports=routine.imports, new_dependencies=new_dependencies)
+        intfs = FindNodes(ir.Interface).visit(routine.spec)
+        self.rename_interfaces(intfs, new_dependencies=new_dependencies)
+
+    def transform_subroutine(self, routine, **kwargs):
+        # Create new dependency items
+        item = kwargs.get('item')
+        sub_sgraph = kwargs.get('sub_sgraph', None)
+        successors = sub_sgraph.successors(item) if sub_sgraph is not None else ()
+        ignore = tuple(str(t).lower() for t in as_tuple(kwargs.get('ignore', None)))
+
+        item.plan_data.setdefault('removed_dependencies', ())
+        item.plan_data.setdefault('additional_dependencies', ())
+
+        new_dependencies, removed_dependencies = self._create_new_items(
+            successors=successors,
+            item_factory=kwargs.get('item_factory'),
+            config=kwargs.get('scheduler_config'),
+            item=kwargs.get('item'),
+            sub_sgraph=sub_sgraph,
+            rename_calls=True, ignore=ignore
+        )
+
+        item.plan_data['additional_dependencies'] += new_dependencies
+        item.plan_data['removed_dependencies'] += removed_dependencies
+
+        new_dependencies = CaseInsensitiveDict((k.local_name, v) for k, v in
+                item.trafo_data.get('SeparateModes', {}).items() if not isinstance(k, str))
+        self._adapt_calls_imports(routine, new_dependencies)
+
+    def _get_item_modes(self, item):
+        inherited_modes = item.inherited_mode
+        modes_to_duplicate = inherited_modes.copy() if inherited_modes is not None else set()
+        return modes_to_duplicate
+
+    def plan_subroutine(self, routine, **kwargs):
+        item = kwargs.get('item')
+
+        sub_sgraph = kwargs.get('sub_sgraph', None)
+        successors = sub_sgraph.successors(item) if sub_sgraph is not None else ()
+        ignore = tuple(str(t).lower() for t in as_tuple(kwargs.get('ignore', None)))
+        item.plan_data.setdefault('removed_dependencies', ())
+        item.plan_data.setdefault('additional_dependencies', ())
+
+        additional_dep, removed_dep = self._create_new_items(
+                successors=successors,
+                item_factory=kwargs.get('item_factory'),
+                config=kwargs.get('scheduler_config'),
+                item=item,
+                sub_sgraph=sub_sgraph,
+                ignore=ignore
+        )
+        item.plan_data['additional_dependencies'] += additional_dep
+        item.plan_data['removed_dependencies'] += removed_dep

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -5,7 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from loki.batch import Transformation
+from loki.batch.transformation import Transformation
 from loki.ir import nodes as ir, Transformer, FindNodes
 from loki.tools.util import as_tuple, CaseInsensitiveDict
 from loki.subroutine import Subroutine

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -340,19 +340,6 @@ class SeparateModesKernel(Transformation):
 
     Therefore, this transformation creates a new item and also implements
     the relevant routines for dry-run pipeline planning runs.
-
-    Parameters
-    ----------
-    duplicate_kernels : str|tuple|list, optional
-        Kernel name(s) to be duplicated.
-    duplicate_suffix : str, optional
-        Suffix to be used to append the original kernel name(s).
-    duplicate_module_suffix : str, optional
-        Suffix to be used to append the original module name(s),
-        if defined, otherwise `duplicate_suffix`
-    duplicate_subgraph : bool, optional
-        Whether or not duplicate the subgraph beneath the kernel(s)
-        that are duplicated.
     """
 
     creates_items = True
@@ -551,6 +538,7 @@ class SeparateModesKernel(Transformation):
     def _adapt_calls_imports(self, routine, new_dependencies):
         call_map = {}
         if not new_dependencies:
+            warning('[Loki] SeparateModesKernel: _adapt_calls_imports called with empty new_dependencies')
             return
         for call in FindNodes(ir.CallStatement).visit(routine.body):
             call_name = str(call.name).lower()

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -9,6 +9,7 @@ from loki.batch.transformation import Transformation
 from loki.ir import nodes as ir, Transformer, FindNodes
 from loki.tools.util import as_tuple, CaseInsensitiveDict
 from loki.subroutine import Subroutine
+from loki.logging import warning
 
 __all__ = ['DuplicateKernel', 'RemoveKernel', 'SeparateModesKernel']
 
@@ -371,9 +372,11 @@ class SeparateModesKernel(Transformation):
         item : :any:`Item`
             The item used to derive ``local_name``,
             ``scope_name`` and ``new_item_name``.
+        mode : str
+           Transformation mode.
+
         Returns
         -------
-        mode : TODO
         scope_name : str
             New item scope name.
         new_item_name : str
@@ -407,9 +410,10 @@ class SeparateModesKernel(Transformation):
 
         Parameters
         ----------
-        mode : TODO
         item : :any:`Item`
             Item to duplicate/to use to derive new item.
+        mode : str
+            Transformation mode.
         item_factory : :any:`ItemFactory`
             The :any:`ItemFactory` to use when creating the items.
         config : :any:`SchedulerConfig`
@@ -438,16 +442,6 @@ class SeparateModesKernel(Transformation):
         if new_item is None:
             new_item = as_tuple(item_factory.get_or_create_item_from_item(new_item_name, item, config=config))[0]
         return new_item
-
-    @staticmethod
-    def get_parent_items(item, item_factory):
-        item_cache = item_factory.item_cache
-        parent_items = ()
-        if item.scope_name in item_cache:
-            parent_items += (item_cache[item.scope_name],)
-        if str(item.source.path) in item_cache:
-            parent_items += (item_cache[str(item.source.path)],)
-        return parent_items
 
     def _create_new_items(self, successors, item_factory, config, item, sub_sgraph,
             rename_calls=False, ignore=None):
@@ -496,10 +490,10 @@ class SeparateModesKernel(Transformation):
                 new_item = self._get_or_create_or_rename_item(child, mode_to_duplicate, item_factory, config)
                 new_item.config = child.config.copy()
                 new_item.config['mode'] = mode_to_duplicate
-                parent_items = self.get_parent_items(new_item, item_factory)
+                parent_items = item_factory.get_scope_and_file_items(new_item)
                 for parent_item in parent_items:
                     parent_item.config['mode'] = mode_to_duplicate
-                child.inherited_mode.discard(mode_to_duplicate)
+                child.trafo_data['inherited_mode'].discard(mode_to_duplicate)
                 removed_items += (child,)
                 new_items += as_tuple(new_item)
                 item.trafo_data['SeparateModes'][child] = new_item
@@ -512,15 +506,15 @@ class SeparateModesKernel(Transformation):
                 new_item.plan_data['additional_dependencies'] += new_item_new_items
                 new_item.plan_data['removed_dependencies'] += new_item_removed_items
                 if rename_calls:
-                    new_dependencies = CaseInsensitiveDict((new_item.local_name, new_item)
-                            for new_item in new_item_new_items)
                     new_dependencies = CaseInsensitiveDict((k.local_name, v) for k, v in
                             new_item.trafo_data.get('SeparateModes', {}).items() if not isinstance(k, str))
                     self._adapt_calls_imports(new_item.ir, new_dependencies)
             else:
+                # like this we keep for one transformation pipeline mode the original item
+                # this is not strictly necessary but currently the MO
                 mode_to_duplicate = modes_to_duplicate[0]
                 child.config['mode'] = item.mode
-                parent_items = self.get_parent_items(child, item_factory)
+                parent_items = item_factory.get_scope_and_file_items(child)
                 for parent_item in parent_items:
                     parent_item.config['mode'] = mode_to_duplicate
 
@@ -550,7 +544,9 @@ class SeparateModesKernel(Transformation):
                     new_symbol = _new_symbol.scope_ir.procedure_symbol # local_name
                     new_module_name = _new_symbol.scope_name
                     im._update(module=new_module_name, symbols=(new_symbol,))
-            # TODO: Deal with unqualified blanket imports
+                if not im.symbols:
+                    warning('[Loki] SeparateModesKernel: encountered unqualified blank import' +
+                            f' for {im.module}')
 
     def _adapt_calls_imports(self, routine, new_dependencies):
         call_map = {}
@@ -560,7 +556,6 @@ class SeparateModesKernel(Transformation):
             call_name = str(call.name).lower()
             if call_name in new_dependencies:
                 new_item = as_tuple(new_dependencies[call_name])[0]
-                # new_call_name = (new_item.name).lower() # str(new_item.local_name).lower()
                 proc_symbol = new_item.ir.procedure_symbol.rescope(scope=routine)
                 call_map[call] = call.clone(name=proc_symbol)
         if call_map:
@@ -597,7 +592,7 @@ class SeparateModesKernel(Transformation):
         self._adapt_calls_imports(routine, new_dependencies)
 
     def _get_item_modes(self, item):
-        inherited_modes = item.inherited_mode
+        inherited_modes = item.trafo_data['inherited_mode']
         modes_to_duplicate = inherited_modes.copy() if inherited_modes is not None else set()
         return modes_to_duplicate
 


### PR DESCRIPTION
allow for multi-mode/driver-specific Loki pipelines, which includes possibly making the graph more tree-like for relevant routines/items.

E.g, starting from:

![callgraph_before.pdf](https://github.com/user-attachments/files/25066014/callgraph_before.pdf)

with 

```py
'driver_0': {'role': 'driver', 'mode': 'm1', 'replicate': False},
'driver_1': {'role': 'driver', 'mode': 'm1', 'replicate': False},
'driver_2': {'role': 'driver', 'mode': 'm2', 'replicate': False},
'driver_3': {'role': 'driver', 'mode': 'm3', 'replicate': False},
'driver_4': {'role': 'driver', 'mode': 'm3', 'replicate': False},
```

getting to:

![callgraph_after.pdf](https://github.com/user-attachments/files/25066079/callgraph_after.pdf)
