### PR TITLE
Bugfix: Do not raise assertion when there are unresolved array components of derived type accesses 

### DIFF
--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -559,9 +559,8 @@ class LokiIdentityMapper(IdentityMapper):
         kwargs['recurse_to_declaration_attributes'] = False
 
         new_type = expr.type
-        if recurse_to_declaration_attributes:
+        if recurse_to_declaration_attributes and expr.type is not None:
             old_type = expr.type
-            assert expr.type is not None
             kind = self.rec(old_type.kind, *args, **kwargs)
 
             if expr.scope and expr.name == old_type.initial:

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -2038,6 +2038,22 @@ end module field_array_module
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_enrich_unresolved_component_array_access(tmp_path, frontend):
+    fcode = """
+subroutine test_enrich_unresolved_component_array_access
+implicit none
+untyped_array%len(1) = 1
+end subroutine test_enrich_unresolved_component_array_access
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine.enrich(())
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    assert len(assigns) == 1
+    assert isinstance(assigns[0].lhs, sym.Array)
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_subroutine_deep_clone(frontend, tmp_path):
     """
     Test that deep-cloning a subroutine actually ensures clean scope separation.


### PR DESCRIPTION
Fixes #650 , the idea of ​​the fix is ​​to avoid entering the conditional statement in which the assertion is launched when an element cannot be resolved.

Although I had the original problem with the use of the scheduler, internally the attached test is simpler and would follow the same flow.