### PR TITLE
Loki: Better error message on a key assert

### DIFF
--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -561,7 +561,7 @@ class LokiIdentityMapper(IdentityMapper):
         new_type = expr.type
         if recurse_to_declaration_attributes:
             old_type = expr.type
-            assert expr.type is not None
+            assert expr.type is not None, f'[Loki] Missing type information for variable symbol "{expr}"'
             kind = self.rec(old_type.kind, *args, **kwargs)
 
             if expr.scope and expr.name == old_type.initial:

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -394,6 +394,7 @@ class FParser2IR(GenericVisitor):
         scope = kwargs.get('scope', None)
         parent = kwargs.get('parent')
         if parent:
+            assert hasattr(parent, 'scope'), f'[Loki::Frontend] Parent "{parent}" for AST node "{o}" has no scope!'
             scope = parent.scope
         if scope:
             scope = scope.get_symbol_scope(name)


### PR DESCRIPTION
One of the key asserts in Loki that triggers on erroneous type information from an inconsistent IR without any meaningful error message. This PR adds a short message that highlights the symbol in question.

I've also added another assert on parent-symbol lookup in FParser that came from investigating the examples provided by @rommelDB in issue #650 .