### PR TITLE
Loki: Bug fixing on _get_procedure_item

### DIFF
--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -542,16 +542,16 @@ class ItemFactory:
         if unqualified_imports:
             # We try to find the ProcedureItem in the unqualified module imports
             module_names = [imprt.module for imprt in unqualified_imports]
-            candidates = self.get_or_create_module_definitions_from_candidates(
+            candidates = set(self.get_or_create_module_definitions_from_candidates(
                 proc_name, config, module_names=module_names, only=ProcedureItem
-            )
+            ))
             if candidates:
                 if len(candidates) > 1:
                     candidate_modules = [it.scope_name for it in candidates]
                     raise RuntimeError(
-                        f'Procedure {item_name} defined in multiple imported modules: {", ".join(candidate_modules)}'
+                        f'Procedure {proc_name} defined in multiple imported modules: {", ".join(candidate_modules)}'
                     )
-                return candidates[0]
+                return list(candidates)[0]
 
         # This is a call to a subroutine declared via header-included interface
         item_name = f'#{proc_name}'.lower()


### PR DESCRIPTION
- The issue on line 552 is trivial, since item_name is not declared at that point, we got a 'referenced before assignment' error.

- Then, somehow the output from get_or_create_module_definitions_from_candidates might be a list with duplicated items, so we could get something like: 'RuntimeError: Procedure XXX defined in multiple imported modules: YYY, YYY'. So, it might be better to handle the list as a set.