### PR TITLE
Fix inclusion of internal functions to scheduler

### DIFF
--- a/loki/batch/item.py
+++ b/loki/batch/item.py
@@ -732,13 +732,15 @@ class ProcedureItem(Item):
 
         calls = tuple({call.name.name: call for call in FindNodes(CallStatement).visit(self_ir.ir)}.values())
         internal_procedures = [routine.name.lower() for routine in self_ir.routines]
-        if internal_procedures and self.ignore_internal_procedures:
-            calls = tuple(call for call in calls if call.name.name.lower() not in internal_procedures)
         inline_calls = tuple({
             call.function.name: call.function
             for call in FindInlineCalls().visit(self_ir.ir)
             if isinstance(call.function, ProcedureSymbol) and not call.function.type.is_intrinsic
         }.values())
+        if internal_procedures and self.ignore_internal_procedures:
+            calls = tuple(call for call in calls if call.name.name.lower() not in internal_procedures)
+            inline_calls = tuple(func for func in inline_calls
+                                 if not func.name.lower() in internal_procedures)
         imports = tuple(
             imprt for imprt in self_ir.imports
             if not imprt.c_import and str(imprt.nature).lower() != 'intrinsic'

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -1687,11 +1687,16 @@ contains
         integer :: val
         call my_member
         write(*,*) val
+        val = my_func(val)
         call kernel
     contains
         subroutine my_member
             call my_routine(val)
         end subroutine my_member
+        integer function my_func(val0)
+           integer, intent(in) :: val0
+           my_func = val0 + 1
+        end function
     end subroutine driver
 end module member_mod
     """.strip()
@@ -1756,19 +1761,20 @@ end subroutine kernel
         #   2) we override the config for the driver to include internal procedures
         #   3) we include internal procedures but disable it for the driver
         # and mark the corresponding excpected dependencies in case 1 and 2
-        include_driver_my_member = (
+        include_driver_internals = (
             (ignore_internal_procedures_driver is None and not ignore_internal_procedures) or
             ignore_internal_procedures_driver is False
         )
 
-        if include_driver_my_member:
-            expected += ['member_mod#driver#my_member::my_member']
-            expected_dependencies_driver = ['my_member', *expected_dependencies_driver]
-
-        expected += ['#kernel::kernel']
+        if include_driver_internals:
+            expected += ['member_mod#driver#my_member::my_member', '#kernel::kernel',
+                         'member_mod#driver#my_func::my_func']
+            expected_dependencies_driver = ['my_member', *expected_dependencies_driver, 'my_func']
+        else:
+            expected += ['#kernel::kernel']
         expected_dependencies_kernel = []
 
-        if include_driver_my_member:
+        if include_driver_internals:
             expected += ['member_mod#my_routine::my_routine']
 
         if not ignore_internal_procedures:


### PR DESCRIPTION
This PR fixes the logic for including internal functions in the scheduler so that now they are only included upon request.