### PR TITLE
Reduce JIT-heavy structural test coverage in transformation tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS
+
+## Purpose
+
+This repository contains Loki source code and tests. When editing or adding tests, prefer assertions that match Loki's native IR and expression semantics rather than assertions that depend on rendered source formatting.
+
+## Loki Test Assertions
+
+- In structural IR tests, prefer native Loki node comparisons over `str(...)`.
+- Loki symbols and expressions compare directly to strings, so prefer:
+  - `node == 'a + b'` over `str(node) == 'a + b'`
+  - `loop.variable == 'i'` over `str(loop.variable) == 'i'`
+- Loki numeric literals compare directly to Python numbers, so prefer:
+  - `loop.bounds.start == 1` over `str(loop.bounds.start) == '1'`
+  - `literal == 5` over `str(literal) == '5'`
+- When creating local test helpers, return native nodes whenever possible.
+  - Good: `(assign.lhs, assign.rhs)`
+  - Good: `(loop.variable, loop.bounds.start, loop.bounds.stop, loop.bounds.step)`
+  - Avoid: `(str(assign.lhs), str(assign.rhs))`
+  - Avoid: `(str(loop.variable), str(loop.bounds.start), str(loop.bounds.stop), ... )`
+- Use stringification only when the test is explicitly about rendered output, pretty-printing, or a node type that does not compare reliably through Loki's native equality support.
+- If stringification is still necessary in a structural test, keep it narrowly scoped and document why.

--- a/loki/transformations/extract/tests/test_outline.py
+++ b/loki/transformations/extract/tests/test_outline.py
@@ -56,7 +56,7 @@ subroutine test_outline(a, b, c)
 !$loki end outline
 
   c = a + b
-    end subroutine test_outline
+end subroutine test_outline
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
 

--- a/loki/transformations/extract/tests/test_outline.py
+++ b/loki/transformations/extract/tests/test_outline.py
@@ -24,8 +24,24 @@ def fixture_builder(tmp_path):
     Obj.clear_cache()
 
 
+def assignment_symbols(node):
+    return [(assign.lhs, assign.rhs) for assign in FindNodes(Assignment).visit(node)]
+
+
+def call_symbols(node):
+    return [(call.name, call.arguments) for call in FindNodes(CallStatement).visit(node)]
+
+
+def argument_symbols(routine):
+    return tuple(routine.arguments)
+
+
+def argument_intents(routine):
+    return {arg.name: arg.type.intent for arg in routine.arguments}
+
+
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_outline_pragma_regions(tmp_path, frontend):
+def test_outline_pragma_regions(frontend):
     """
     A very simple :any:`outline_pragma_regions` test case
     """
@@ -41,40 +57,29 @@ subroutine test_outline(a, b, c)
 !$loki end outline
 
   c = a + b
-end subroutine test_outline
+    end subroutine test_outline
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
-    # Test the reference solution
-    a, b, c = function()
-    assert a == 1 and b == 1 and c == 2
 
     assert len(FindNodes(Assignment).visit(routine.body)) == 4
     assert len(FindNodes(CallStatement).visit(routine.body)) == 0
+    assert assignment_symbols(routine.body) == [('a', 5), ('a', 1), ('b', 'a'), ('c', 'a + b')]
 
-    # Apply transformation
     routines = outline_pragma_regions(routine)
     assert len(routines) == 1 and routines[0].name == f'{routine.name}_outlined_0'
 
     assert len(FindNodes(Assignment).visit(routine.body)) == 3
     assert len(FindNodes(Assignment).visit(routines[0].body)) == 1
     assert len(FindNodes(CallStatement).visit(routine.body)) == 1
-
-    # Test transformation
-    contains = Section(body=as_tuple([Intrinsic('CONTAINS'), *routines, routine]))
-    module = Module(name=f'{routine.name}_mod', spec=None, contains=contains)
-    mod_filepath = tmp_path/(f'{module.name}_converted_{frontend}.f90')
-    mod = jit_compile(module, filepath=mod_filepath, objname=module.name)
-    mod_function = getattr(mod, routine.name)
-
-    a, b, c = mod_function()
-    assert a == 1 and b == 1 and c == 2
+    assert assignment_symbols(routine.body) == [('a', 5), ('a', 1), ('c', 'a + b')]
+    assert assignment_symbols(routines[0].body) == [('b', 'a')]
+    assert call_symbols(routine.body) == [(f'{routine.name}_outlined_0', ('a', 'b'))]
+    assert argument_symbols(routines[0]) == ('a', 'b')
+    assert argument_intents(routines[0]) == {'a': 'in', 'b': 'out'}
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_outline_pragma_regions_multiple(tmp_path, frontend):
+def test_outline_pragma_regions_multiple(frontend):
     """
     Test hoisting with multiple groups and multiple regions per group
     """
@@ -100,17 +105,14 @@ subroutine test_outline_mult(a, b, c)
 end subroutine test_outline_mult
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
-    # Test the reference solution
-    a, b, c = function()
-    assert a == 5 and b == 5 and c == 10
 
     assert len(FindNodes(Assignment).visit(routine.body)) == 7
     assert len(FindNodes(CallStatement).visit(routine.body)) == 0
+    assert assignment_symbols(routine.body) == [
+        ('a', 1), ('a', 'a + 1'), ('a', 'a + 1'), ('a', 'a + 1'),
+        ('a', 'a + 1'), ('b', 'a'), ('c', 'a + b')
+    ]
 
-    # Apply transformation
     routines = outline_pragma_regions(routine)
     assert len(routines) == 3
     assert routines[0].name == 'oiwjfklsf'
@@ -119,20 +121,23 @@ end subroutine test_outline_mult
     assert len(FindNodes(Assignment).visit(routine.body)) == 4
     assert all(len(FindNodes(Assignment).visit(r.body)) == 1 for r in routines)
     assert len(FindNodes(CallStatement).visit(routine.body)) == 3
-
-    # Test transformation
-    contains = Section(body=as_tuple([Intrinsic('CONTAINS'), *routines, routine]))
-    module = Module(name=f'{routine.name}_mod', spec=None, contains=contains)
-    mod_filepath = tmp_path/(f'{module.name}_converted_{frontend}.f90')
-    mod = jit_compile(module, filepath=mod_filepath, objname=module.name)
-    mod_function = getattr(mod, routine.name)
-
-    a, b, c = mod_function()
-    assert a == 5 and b == 5 and c == 10
+    assert assignment_symbols(routine.body) == [('a', 1), ('a', 'a + 1'), ('a', 'a + 1'), ('a', 'a + 1')]
+    assert [assignment_symbols(r.body) for r in routines] == [[('a', 'a + 1')], [('b', 'a')], [('c', 'a + b')]]
+    assert call_symbols(routine.body) == [
+        ('oiwjfklsf', ('a',)),
+        (f'{routine.name}_outlined_1', ('a', 'b')),
+        (f'{routine.name}_outlined_2', ('a', 'b', 'c'))
+    ]
+    assert argument_symbols(routines[0]) == ('a',)
+    assert argument_intents(routines[0]) == {'a': 'inout'}
+    assert argument_symbols(routines[1]) == ('a', 'b')
+    assert argument_intents(routines[1]) == {'a': 'in', 'b': 'out'}
+    assert argument_symbols(routines[2]) == ('a', 'b', 'c')
+    assert argument_intents(routines[2]) == {'a': 'in', 'b': 'in', 'c': 'out'}
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_outline_pragma_regions_arguments(tmp_path, frontend):
+def test_outline_pragma_regions_arguments(frontend):
     """
     Test hoisting with multiple groups and multiple regions per group
     and automatic derivation of arguments
@@ -160,17 +165,14 @@ subroutine test_outline_args(a, b, c)
 end subroutine test_outline_args
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
-    # Test the reference solution
-    a, b, c = function()
-    assert a == 5 and b == 5 and c == 10
 
     assert len(FindNodes(Assignment).visit(routine.body)) == 7
     assert len(FindNodes(CallStatement).visit(routine.body)) == 0
+    assert assignment_symbols(routine.body) == [
+        ('a', 1), ('a', 'a + 1'), ('a', 'a + 1'), ('a', 'a + 1'),
+        ('a', 'a + 1'), ('b', 'a'), ('c', 'a + b')
+    ]
 
-    # Apply transformation
     routines = outline_pragma_regions(routine)
     assert len(routines) == 3
     assert [r.name for r in routines] == ['func_a', 'func_b', 'func_c']
@@ -178,11 +180,11 @@ end subroutine test_outline_args
     assert len(routines[0].arguments) == 1
     assert routines[0].arguments[0] == 'a' and routines[0].arguments[0].type.intent == 'inout'
 
-    assert {str(a) for a in routines[1].arguments} == {'a', 'b'}
+    assert set(argument_symbols(routines[1])) == {'a', 'b'}
     assert routines[1].variable_map['a'].type.intent == 'in'
     assert routines[1].variable_map['b'].type.intent == 'out'
 
-    assert {str(a) for a in routines[2].arguments} == {'a', 'b', 'c'}
+    assert set(argument_symbols(routines[2])) == {'a', 'b', 'c'}
     assert routines[2].variable_map['a'].type.intent == 'in'
     assert routines[2].variable_map['b'].type.intent == 'inout'
     assert routines[2].variable_map['c'].type.intent == 'out'
@@ -190,20 +192,13 @@ end subroutine test_outline_args
     assert len(FindNodes(Assignment).visit(routine.body)) == 4
     assert all(len(FindNodes(Assignment).visit(r.body)) == 1 for r in routines)
     assert len(FindNodes(CallStatement).visit(routine.body)) == 3
-
-    # Test transformation
-    contains = Section(body=as_tuple([Intrinsic('CONTAINS'), *routines, routine]))
-    module = Module(name=f'{routine.name}_mod', spec=None, contains=contains)
-    mod_filepath = tmp_path/(f'{module.name}_converted_{frontend}.f90')
-    mod = jit_compile(module, filepath=mod_filepath, objname=module.name)
-    mod_function = getattr(mod, routine.name)
-
-    a, b, c = mod_function()
-    assert a == 5 and b == 5 and c == 10
+    assert assignment_symbols(routine.body) == [('a', 1), ('a', 'a + 1'), ('a', 'a + 1'), ('a', 'a + 1')]
+    assert [assignment_symbols(r.body) for r in routines] == [[('a', 'a + 1')], [('b', 'a')], [('c', 'a + b')]]
+    assert call_symbols(routine.body) == [('func_a', ('a',)), ('func_b', ('a', 'b')), ('func_c', ('a', 'b', 'c'))]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_outline_pragma_regions_arrays(tmp_path, frontend):
+def test_outline_pragma_regions_arrays(frontend):
     """
     Test hoisting with array variables
     """
@@ -235,21 +230,12 @@ end subroutine test_outline_arr
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
-    # Test the reference solution
-    n = 10
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    function(a, b, n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == [1] * n)
-
     assert len(FindNodes(Assignment).visit(routine.body)) == 4
     assert len(FindNodes(CallStatement).visit(routine.body)) == 0
+    assert assignment_symbols(routine.body) == [
+        ('a(j)', 'j'), ('b(j)', 'j'), ('b(j)', 'b(j + 1) - a(j)'), ('b(n)', 1)
+    ]
 
-    # Apply transformation
     routines = outline_pragma_regions(routine)
 
     assert len(FindNodes(Assignment).visit(routine.body)) == 0
@@ -257,23 +243,18 @@ end subroutine test_outline_arr
 
     assert len(routines) == 3
 
-    assert {(str(a), a.type.intent) for a in routines[0].arguments} == {('a(n)', 'out'), ('n', 'in')}
-    assert {(str(a), a.type.intent) for a in routines[1].arguments} == {('b(n)', 'out'), ('n', 'in')}
-    assert {(str(a), a.type.intent) for a in routines[2].arguments} == {('a(n)', 'in'), ('b(n)', 'inout'), ('n', 'in')}
+    assert {(arg, arg.type.intent) for arg in routines[0].arguments} == {('a(n)', 'out'), ('n', 'in')}
+    assert {(arg, arg.type.intent) for arg in routines[1].arguments} == {('b(n)', 'out'), ('n', 'in')}
+    assert {(arg, arg.type.intent) for arg in routines[2].arguments} == {('a(n)', 'in'), ('b(n)', 'inout'), ('n', 'in')}
     assert routines[0].variable_map['a'].dimensions[0].scope is routines[0]
-
-    # Test transformation
-    contains = Section(body=as_tuple([Intrinsic('CONTAINS'), *routines, routine]))
-    module = Module(name=f'{routine.name}_mod', spec=None, contains=contains)
-    mod_filepath = tmp_path/(f'{module.name}_converted_{frontend}.f90')
-    mod = jit_compile(module, filepath=mod_filepath, objname=module.name)
-    mod_function = getattr(mod, routine.name)
-
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    mod_function(a, b, n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == [1] * n)
+    assert [assignment_symbols(r.body) for r in routines] == [
+        [('a(j)', 'j')], [('b(j)', 'j')], [('b(j)', 'b(j + 1) - a(j)'), ('b(n)', 1)]
+    ]
+    assert call_symbols(routine.body) == [
+        (f'{routine.name}_outlined_0', ('a', 'n')),
+        (f'{routine.name}_outlined_1', ('b', 'n')),
+        (f'{routine.name}_outlined_2', ('a', 'b', 'n'))
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/extract/tests/test_outline.py
+++ b/loki/transformations/extract/tests/test_outline.py
@@ -9,10 +9,9 @@ import pytest
 import numpy as np
 
 from loki import Module, Subroutine
-from loki.jit_build import jit_compile, jit_compile_lib, Builder, Obj
+from loki.jit_build import jit_compile_lib, Builder, Obj
 from loki.frontend import available_frontends
-from loki.ir import FindNodes, Section, Assignment, CallStatement, Intrinsic
-from loki.tools import as_tuple
+from loki.ir import FindNodes, Assignment, CallStatement
 from loki.types import BasicType
 
 from loki.transformations.extract.outline import outline_pragma_regions

--- a/loki/transformations/tests/test_loop_blocking.py
+++ b/loki/transformations/tests/test_loop_blocking.py
@@ -83,9 +83,7 @@ def test_loop_splitting_vars(caplog):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-@pytest.mark.parametrize('block_size', [10, 117])
-@pytest.mark.parametrize('n', [50, 1200])
-def test_1d_splitting(frontend, block_size, n):
+def test_1d_splitting(frontend):
     """
     Apply loop blocking of simple loops into two loops
     """
@@ -100,8 +98,9 @@ subroutine test_1d_splitting(a, b, n)
   do i=1,n
     a(i) = real(i, kind=8)
   end do
-end subroutine test_1d_splitting
+    end subroutine test_1d_splitting
     """
+    block_size = 117
     routine = Subroutine.from_source(fcode, frontend=frontend)
     loops = FindNodes(ir.Loop).visit(routine.ir)
     num_loops = len(loops)
@@ -132,9 +131,7 @@ end subroutine test_1d_splitting
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-@pytest.mark.parametrize('block_size', [117])
-@pytest.mark.parametrize('n', [500])
-def test_1d_splitting_multi_var(frontend, block_size, n):
+def test_1d_splitting_multi_var(frontend):
     """
     Apply loop blocking of simple loops into two loops
     """
@@ -153,6 +150,7 @@ subroutine test_1d_splitting_multi_var(a, b, n)
   end do
 end subroutine test_1d_splitting_multi_var
     """
+    block_size = 117
     routine = Subroutine.from_source(fcode, frontend=frontend)
     loops = FindNodes(ir.Loop).visit(routine.ir)
     num_loops = len(loops)
@@ -183,9 +181,7 @@ end subroutine test_1d_splitting_multi_var
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-@pytest.mark.parametrize('block_size', [117])
-@pytest.mark.parametrize('n', [500])
-def test_2d_splitting(frontend, block_size, n):
+def test_2d_splitting(frontend):
     fcode = """
     subroutine test_2d_splitting(a, b, n)
       implicit none
@@ -202,6 +198,7 @@ def test_2d_splitting(frontend, block_size, n):
       end do
     end subroutine test_2d_splitting
         """
+    block_size = 117
     routine = Subroutine.from_source(fcode, frontend=frontend)
     loops = FindNodes(ir.Loop).visit(routine.ir)
     num_loops = len(loops)
@@ -294,9 +291,7 @@ the correct output.
 """
 
 @pytest.mark.parametrize('frontend', available_frontends())
-@pytest.mark.parametrize('block_size', [117])
-@pytest.mark.parametrize('n', [500])
-def test_1d_blocking(frontend, block_size, n):
+def test_1d_blocking(frontend):
     """
     Apply loop blocking of simple loops into two loops
     """
@@ -313,6 +308,7 @@ subroutine test_1d_blocking(a, b, n)
   end do
 end subroutine test_1d_blocking
     """
+    block_size = 117
     routine = Subroutine.from_source(fcode, frontend=frontend)
     loops = FindNodes(ir.Loop).visit(routine.ir)
     with pragmas_attached(routine, ir.Loop):

--- a/loki/transformations/tests/test_loop_blocking.py
+++ b/loki/transformations/tests/test_loop_blocking.py
@@ -98,7 +98,7 @@ subroutine test_1d_splitting(a, b, n)
   do i=1,n
     a(i) = real(i, kind=8)
   end do
-    end subroutine test_1d_splitting
+end subroutine test_1d_splitting
     """
     block_size = 117
     routine = Subroutine.from_source(fcode, frontend=frontend)
@@ -121,6 +121,9 @@ subroutine test_1d_splitting(a, b, n)
         ('i_loop_block_idx', 1, 'i_loop_num_blocks', None),
         ('i_loop_local', 1, 'i_loop_block_end - i_loop_block_start + 1', None)
     ]
+    # Ensure inner loop bound has been parametrised correctly
+    assert routine.variable_map['i_loop_block_size'].type.initial == block_size
+
     assert assignment_symbols(routine.body) == [
         ('i_loop_num_blocks', '1 + (-1 + n) / i_loop_block_size'),
         ('i_loop_block_start', '(i_loop_block_idx - 1)*i_loop_block_size + 1'),
@@ -171,6 +174,9 @@ end subroutine test_1d_splitting_multi_var
         ('i_loop_block_idx', 1, 'i_loop_num_blocks', None),
         ('i_loop_local', 1, 'i_loop_block_end - i_loop_block_start + 1', None)
     ]
+    # Ensure inner loop bound has been parametrised correctly
+    assert routine.variable_map['i_loop_block_size'].type.initial == block_size
+
     assert assignment_symbols(routine.body) == [
         ('i_loop_num_blocks', '1 + (-1 + n) / i_loop_block_size'),
         ('i_loop_block_start', '(i_loop_block_idx - 1)*i_loop_block_size + 1'),
@@ -219,6 +225,9 @@ def test_2d_splitting(frontend):
         ('i_loop_block_idx', 1, 'i_loop_num_blocks', None),
         ('i_loop_local', 1, 'i_loop_block_end - i_loop_block_start + 1', None)
     ]
+    # Ensure inner loop bound has been parametrised correctly
+    assert routine.variable_map['i_loop_block_size'].type.initial == block_size
+
     assert assignment_symbols(routine.body) == [
         ('i_loop_num_blocks', '1 + (-1 + n) / i_loop_block_size'),
         ('i_loop_block_start', '(i_loop_block_idx - 1)*i_loop_block_size + 1'),
@@ -341,6 +350,9 @@ end subroutine test_1d_blocking
         ('i_loop_block_idx', 1, 'i_loop_num_blocks', None),
         ('i_loop_local', 1, 'i_loop_block_end - i_loop_block_start + 1', None)
     ]
+    # Ensure inner loop bound has been parametrised correctly
+    assert routine.variable_map['i_loop_block_size'].type.initial == block_size
+
     assert assignment_symbols(routine.body) == [
         ('i_loop_num_blocks', '1 + (-1 + n) / i_loop_block_size'),
         ('i_loop_block_start', '(i_loop_block_idx - 1)*i_loop_block_size + 1'),

--- a/loki/transformations/tests/test_loop_blocking.py
+++ b/loki/transformations/tests/test_loop_blocking.py
@@ -33,6 +33,24 @@ Tests for loop splitting and blocking utilities.
 LOKI_LOOP_SLIT_VAR_ADDITION = 7
 
 
+def loop_symbols(node):
+    return [
+        (loop.variable, loop.bounds.start, loop.bounds.stop, loop.bounds.step)
+        for loop in FindNodes(ir.Loop).visit(node)
+    ]
+
+
+def assignment_symbols(node):
+    return [(assign.lhs, assign.rhs) for assign in FindNodes(ir.Assignment).visit(node)]
+
+
+def array_access_symbols(node):
+    return [
+        (var.name, var.dimensions) for var in FindVariables().visit(node)
+        if isinstance(var, Array)
+    ]
+
+
 def test_loop_splitting_vars(caplog):
     loop_var = sym.Variable(name='i', type=SymbolAttributes(BasicType.INTEGER))
 
@@ -67,7 +85,7 @@ def test_loop_splitting_vars(caplog):
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('block_size', [10, 117])
 @pytest.mark.parametrize('n', [50, 1200])
-def test_1d_splitting(tmp_path, frontend, block_size, n):
+def test_1d_splitting(frontend, block_size, n):
     """
     Apply loop blocking of simple loops into two loops
     """
@@ -100,23 +118,23 @@ end subroutine test_1d_splitting
         f"but expected {num_vars + LOKI_LOOP_SLIT_VAR_ADDITION}"
     )
 
-    filepath = tmp_path / (f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
-    a = np.zeros(n, order='F')
-    b = np.zeros(n, order='F')
-    function(a, b, n)
-    assert np.all(b == 0.), "b array should not be modified."
-    a_ref = np.linspace(1, n, n)
-    assert np.array_equal(a, a_ref), "a should be equal to a_ref=(1, 2, ..., n)"
-
-    clean_test(filepath)
+    assert loop_symbols(routine.ir) == [
+        ('i_loop_block_idx', 1, 'i_loop_num_blocks', None),
+        ('i_loop_local', 1, 'i_loop_block_end - i_loop_block_start + 1', None)
+    ]
+    assert assignment_symbols(routine.body) == [
+        ('i_loop_num_blocks', '1 + (-1 + n) / i_loop_block_size'),
+        ('i_loop_block_start', '(i_loop_block_idx - 1)*i_loop_block_size + 1'),
+        ('i_loop_block_end', 'min(i_loop_block_idx*i_loop_block_size, n)'),
+        ('i_loop_iter_num', 'i_loop_block_start + i_loop_local - 1'),
+        ('i', 'i_loop_iter_num'), ('a(i)', 'real(i, kind=8)')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('block_size', [117])
 @pytest.mark.parametrize('n', [500])
-def test_1d_splitting_multi_var(tmp_path, frontend, block_size, n):
+def test_1d_splitting_multi_var(frontend, block_size, n):
     """
     Apply loop blocking of simple loops into two loops
     """
@@ -151,23 +169,23 @@ end subroutine test_1d_splitting_multi_var
         f"but expected {num_vars + LOKI_LOOP_SLIT_VAR_ADDITION}"
     )
 
-    filepath = tmp_path / (f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
-    a = np.zeros(n, order='F')
-    b = np.zeros(n, order='F')
-    function(a, b, n)
-    assert np.all(b == 0.), "b array should not be modified."
-    a_ref = np.linspace(1, n, n)
-    assert np.array_equal(a, a_ref), "a should be equal to a_ref=(1, 2, ..., n)"
-
-    clean_test(filepath)
+    assert loop_symbols(routine.ir) == [
+        ('i_loop_block_idx', 1, 'i_loop_num_blocks', None),
+        ('i_loop_local', 1, 'i_loop_block_end - i_loop_block_start + 1', None)
+    ]
+    assert assignment_symbols(routine.body) == [
+        ('i_loop_num_blocks', '1 + (-1 + n) / i_loop_block_size'),
+        ('i_loop_block_start', '(i_loop_block_idx - 1)*i_loop_block_size + 1'),
+        ('i_loop_block_end', 'min(i_loop_block_idx*i_loop_block_size, n)'),
+        ('i_loop_iter_num', 'i_loop_block_start + i_loop_local - 1'),
+        ('i', 'i_loop_iter_num'), ('c(1)', 'c(1) + i'), ('a(i)', 'real(i)')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('block_size', [117])
 @pytest.mark.parametrize('n', [500])
-def test_2d_splitting(tmp_path, frontend, block_size, n):
+def test_2d_splitting(frontend, block_size, n):
     fcode = """
     subroutine test_2d_splitting(a, b, n)
       implicit none
@@ -200,18 +218,17 @@ def test_2d_splitting(tmp_path, frontend, block_size, n):
         f"but expected {num_vars + LOKI_LOOP_SLIT_VAR_ADDITION}"
     )
 
-    filepath = tmp_path / (f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
-    a = np.zeros(n, order='F')
-    b = np.zeros((n,n), order='F')
-    function(a, b, n)
-    a_ref = np.linspace(1, n, n)
-    b_ref = np.tile(a_ref, (n,1))
-    assert np.array_equal(a, a_ref), "a should be equal to a_ref=(1, 2, ..., n)"
-    assert np.array_equal(b, b_ref), "b should equal b_ref"
-
-    clean_test(filepath)
+    assert loop_symbols(routine.ir) == [
+        ('i_loop_block_idx', 1, 'i_loop_num_blocks', None),
+        ('i_loop_local', 1, 'i_loop_block_end - i_loop_block_start + 1', None)
+    ]
+    assert assignment_symbols(routine.body) == [
+        ('i_loop_num_blocks', '1 + (-1 + n) / i_loop_block_size'),
+        ('i_loop_block_start', '(i_loop_block_idx - 1)*i_loop_block_size + 1'),
+        ('i_loop_block_end', 'min(i_loop_block_idx*i_loop_block_size, n)'),
+        ('i_loop_iter_num', 'i_loop_block_start + i_loop_local - 1'),
+        ('i', 'i_loop_iter_num'), ('a(i)', 'i'), ('c(1)', 'a(i)'), ('b(:, i)', 'a(i)')
+    ]
 
 
 
@@ -279,7 +296,7 @@ the correct output.
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('block_size', [117])
 @pytest.mark.parametrize('n', [500])
-def test_1d_blocking(tmp_path, frontend, block_size, n):
+def test_1d_blocking(frontend, block_size, n):
     """
     Apply loop blocking of simple loops into two loops
     """
@@ -324,17 +341,20 @@ end subroutine test_1d_blocking
 
     assert len(routine.variable_map) == num_vars+1, "Expected 1 loop blocking to be added"
 
-    filepath = tmp_path / (f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
-    a = np.zeros(n, order='F')
-    b = np.zeros(n, order='F')
-    a_ref = np.linspace(1, n, n)
-    function(a, b, n)
-    assert np.all(b == 0.), "b array should not be modified."
-    assert np.array_equal(a, a_ref), "a should be equal to a_ref=(1, 2, ..., n)"
-
-    clean_test(filepath)
+    assert loop_symbols(routine.ir) == [
+        ('i_loop_block_idx', 1, 'i_loop_num_blocks', None),
+        ('i_loop_local', 1, 'i_loop_block_end - i_loop_block_start + 1', None)
+    ]
+    assert assignment_symbols(routine.body) == [
+        ('i_loop_num_blocks', '1 + (-1 + n) / i_loop_block_size'),
+        ('i_loop_block_start', '(i_loop_block_idx - 1)*i_loop_block_size + 1'),
+        ('i_loop_block_end', 'min(i_loop_block_idx*i_loop_block_size, n)'),
+        ('a_block(1:i_loop_block_end - i_loop_block_start + 1)', 'a(i_loop_block_start:i_loop_block_end)'),
+        ('i_loop_iter_num', 'i_loop_block_start + i_loop_local - 1'),
+        ('i', 'i_loop_iter_num'), ('a_block(i_loop_local)', 'real(i)'),
+        ('a(i_loop_block_start:i_loop_block_end)', 'a_block(1:i_loop_block_end - i_loop_block_start + 1)')
+    ]
+    assert array_access_symbols(inner_loop.body) == [('a_block', ('i_loop_local',))]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -39,8 +39,8 @@ def loop_bounds(node):
     ]
 
 
-def assignment_strs(node):
-    return [(str(assign.lhs), str(assign.rhs)) for assign in FindNodes(Assignment).visit(node)]
+def assignment_symbols(node):
+    return [(assign.lhs, assign.rhs) for assign in FindNodes(Assignment).visit(node)]
 
 
 def conditional_strs(node):
@@ -87,7 +87,7 @@ end subroutine transform_loop_interchange_plain
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 4
     assert loop_var_names(routine.body) == ['i', 'j', 'i', 'j']
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('a(j, i)', 'i + j'), ('a(j, i)', 'a(j, i) - 2')
     ]
 
@@ -100,7 +100,7 @@ end subroutine transform_loop_interchange_plain
         ('j', '1', 'm', None), ('i', '1', 'n', None),
         ('i', '1', 'n', None), ('j', '1', 'm', None)
     ]
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('a(j, i)', 'i + j'), ('a(j, i)', 'a(j, i) - 2')
     ]
 
@@ -143,7 +143,7 @@ subroutine transform_loop_interchange(a, m, n, nclv)
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
     assert loop_var_names(routine.body) == ['k', 'i', 'j', 'k', 'i', 'j']
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('a(j, i, k)', 'i + j + k'), ('a(j, i, k)', 'a(j, i, k) - 3')
     ]
     with pragmas_attached(routine, Loop):
@@ -160,7 +160,7 @@ subroutine transform_loop_interchange(a, m, n, nclv)
         ('j', '1', 'm', None), ('i', '1', 'n', None), ('k', '1', 'nclv', None),
         ('k', '1', 'nclv', None), ('i', '1', 'n', None), ('j', '1', 'm', None)
     ]
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('a(j, i, k)', 'i + j + k'), ('a(j, i, k)', 'a(j, i, k) - 3')
     ]
 
@@ -195,7 +195,7 @@ subroutine transform_loop_interchange_project(a, m, n)
     assert len(loops) == 2
     assert loop_var_names(routine.body) == ['i', 'j']
     assert loop_bounds(routine.body) == [('i', '1', 'n', None), ('j', 'i', 'm', None)]
-    assert assignment_strs(routine.body) == [('a(j, i)', 'i + j')]
+    assert assignment_symbols(routine.body) == [('a(j, i)', 'i + j')]
 
     do_loop_interchange(routine, project_bounds=True)
 
@@ -203,7 +203,7 @@ subroutine transform_loop_interchange_project(a, m, n)
     assert len(loops) == 2
     assert loop_var_names(routine.body) == ['j', 'i']
     assert loop_bounds(routine.body) == [('j', '1', 'm', None), ('i', '1', 'min(n, j)', None)]
-    assert assignment_strs(routine.body) == [('a(j, i)', 'i + j')]
+    assert assignment_symbols(routine.body) == [('a(j, i)', 'i + j')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -286,7 +286,7 @@ end subroutine transform_loop_fuse_matching
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
     assert loop_bounds(routine.body) == [('i', '1', 'n', None)]
-    assert assignment_strs(routine.body) == [('a(i)', 'i'), ('b(i)', 'n - i + 1')]
+    assert assignment_symbols(routine.body) == [('a(i)', 'i'), ('b(i)', 'n - i + 1')]
     assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
 
@@ -327,7 +327,7 @@ end subroutine transform_loop_fuse_subranges
     do_loop_fusion(routine)
     assert loop_bounds(routine.body) == [('i', '1', 'n', None)]
     assert conditional_strs(routine.body) == ['i <= 15', 'i >= 16']
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('a(:)', '0'), ('b(:)', '0'), ('a(i)', 'a(i) + i'),
         ('b(i)', 'b(i) + n - i + 1'), ('b(i)', 'b(i) + n - i + 1')
     ]
@@ -379,7 +379,7 @@ end subroutine transform_loop_fuse_groups
     do_loop_fusion(routine)
     assert loop_bounds(routine.body) == [('i', '1', 'n', None), ('i', '1', 'n', None)]
     assert conditional_strs(routine.body) == ['i >= 2']
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('c(1)', '1'), ('a(i)', 'i'), ('b(i)', 'n - i + 1'),
         ('c(i)', 'c(i - 1) + 1'), ('a(i)', 'a(i) + 1'), ('b(i)', 'b(i) + 1')
     ]
@@ -438,7 +438,7 @@ end subroutine transform_loop_fuse_alignment
     do_loop_fusion(routine)
     assert loop_bounds(routine.body) == [('i', '0', 'n', None)]
     assert conditional_strs(routine.body) == ['i >= 1', 'i <= n - 1']
-    assert assignment_strs(routine.body) == [('a(i)', 'i'), ('b(i + 1)', 'n - i')]
+    assert assignment_symbols(routine.body) == [('a(i)', 'i'), ('b(i + 1)', 'n - i')]
     assert pragma_strs(routine.body) == ['fused-loop group(1)']
 
 
@@ -468,7 +468,7 @@ end subroutine transform_loop_fuse_nonmatching_lower
 
     assert loop_bounds(routine.body) == [('jl', 'min(1, nclv)', 'klev', None)]
     assert conditional_strs(routine.body) == ['jl >= 1', 'jl >= nclv']
-    assert assignment_strs(routine.body) == [('a(jl)', 'jl'), ('b(jl)', 'jl - nclv')]
+    assert assignment_symbols(routine.body) == [('a(jl)', 'jl'), ('b(jl)', 'jl - nclv')]
     assert pragma_strs(routine.body) == ['fused-loop group(1)']
 
 
@@ -498,7 +498,7 @@ end subroutine transform_loop_fuse_nonmatching_lower_annotated
 
     assert loop_bounds(routine.body) == [('jl', '1', 'klev', None)]
     assert conditional_strs(routine.body) == ['jl >= nclv']
-    assert assignment_strs(routine.body) == [('a(jl)', 'jl'), ('b(jl)', 'jl - nclv')]
+    assert assignment_symbols(routine.body) == [('a(jl)', 'jl'), ('b(jl)', 'jl - nclv')]
     assert pragma_strs(routine.body) == ['fused-loop group(1)']
 
 
@@ -528,7 +528,7 @@ end subroutine transform_loop_fuse_nonmatching_upper
 
     assert loop_bounds(routine.body) == [('jl', '1', '1 + klev', None)]
     assert conditional_strs(routine.body) == ['jl <= klev']
-    assert assignment_strs(routine.body) == [('a(jl)', 'jl'), ('b(jl)', '2*jl')]
+    assert assignment_symbols(routine.body) == [('a(jl)', 'jl'), ('b(jl)', '2*jl')]
     assert pragma_strs(routine.body) == ['fused-loop group(1)']
 
 
@@ -560,7 +560,7 @@ end subroutine transform_loop_fuse_collapse
     assert len(FindNodes(Loop).visit(routine.body)) == 4
     do_loop_fusion(routine)
     assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None)]
-    assert assignment_strs(routine.body) == [('a(jl, jk)', 'jk'), ('b(jl, jk)', 'jl + jk')]
+    assert assignment_symbols(routine.body) == [('a(jl, jk)', 'jk'), ('b(jl, jk)', 'jl + jk')]
     assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
 
@@ -593,7 +593,7 @@ end subroutine transform_loop_fuse_collapse_nonmatching
     do_loop_fusion(routine)
     assert loop_bounds(routine.body) == [('jk', '1', '1 + klev', None), ('jl', '1', '1 + klon', None)]
     assert conditional_strs(routine.body) == ['jl <= klon', 'jk <= klev']
-    assert assignment_strs(routine.body) == [('a(jl, jk)', 'jk'), ('b(jl, jk)', 'jl + jk')]
+    assert assignment_symbols(routine.body) == [('a(jl, jk)', 'jk'), ('b(jl, jk)', 'jl + jk')]
     assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
 
@@ -679,7 +679,7 @@ end subroutine transform_loop_fission_single
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_fission(routine)
     assert loop_bounds(routine.body) == [('j', '1', 'n', None), ('j', '1', 'n', None)]
-    assert assignment_strs(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j')]
+    assert assignment_symbols(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -706,7 +706,7 @@ end subroutine transform_loop_fission_nested
     do_loop_fission(routine)
     assert loop_bounds(routine.body) == [('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)]
     assert conditional_strs(routine.body) == ['j <= n', 'j <= n']
-    assert assignment_strs(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j')]
+    assert assignment_symbols(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -737,7 +737,7 @@ end subroutine transform_loop_fission_nested_promote
     do_loop_fission(routine)
     assert loop_bounds(routine.body) == [('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)]
     assert conditional_strs(routine.body) == ['j <= n', 'zqxfg(2, j) <= n']
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('zqxfg(2, j)', 'j'), ('a(j)', 'zqxfg(2, j)'), ('b(j)', 'n - zqxfg(2, j)')
     ]
     assert variable_shape(routine, 'zqxfg') == ('5', '1 + n')
@@ -780,7 +780,7 @@ end subroutine transform_loop_fission_collapse
         ('k', '1', 'n', None), ('k', '1', 'n', None),
         ('j', '1', 'n + 1', None), ('k', '1', 'n', None)
     ]
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('tmp(:)', '0'), ('tmp(j)', 'j'), ('tmp2(:, j)', '0'), ('tmp2(k, j)', 'tmp(j) + k'),
         ('a(k, j)', 'tmp2(k, j)'), ('a(k, j)', 'a(k, j) - 1'), ('a(k, j)', '-1 + a(k, j)'), ('tmp(j)', '0')
     ]
@@ -810,7 +810,7 @@ end subroutine transform_loop_fission_multiple
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_fission(routine)
     assert loop_bounds(routine.body) == [('j', '1', 'n', None), ('j', '1', 'n', None), ('j', '1', 'n', None)]
-    assert assignment_strs(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j'), ('c(j)', 'a(j) + b(j)')]
+    assert assignment_symbols(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j'), ('c(j)', 'a(j) + b(j)')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -896,7 +896,7 @@ end subroutine transform_loop_fission_promote_conflicting_lengths
         ('j', '1', 'n', None), ('j', '1', 'n', None),
         ('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)
     ]
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('tmp(j)', 'j - 1'), ('a(j)', 'tmp(j) + 1'), ('tmp(j)', 'j - 1'), ('b(j)', 'n - tmp(j)')
     ]
     assert variable_shape(routine, 'tmp') == ('1 + n',)
@@ -925,7 +925,7 @@ end subroutine transform_loop_fission_promote_array
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fission(routine)
     assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None)]
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('a(:, jk)', 'zsupsat(:, jk)')
     ]
     assert variable_shape(routine, 'zsupsat') == ('klon', 'klev')
@@ -955,7 +955,7 @@ end subroutine transform_loop_fission_promote_multiple
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fission(routine)
     assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None)]
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('tmp(jk)', 'jk'), ('a(:, jk)', 'zsupsat(:, jk) + tmp(jk)')
     ]
     assert variable_shape(routine, 'zsupsat') == ('klon', 'klev')
@@ -999,7 +999,7 @@ end subroutine transform_loop_fission_multiple_promote
         ('jm', '1', 'nclv', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None),
         ('jk', '1', 'klev', None), ('jm', '1', 'nclv', None)
     ]
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('zqxn(jl, jm, jk)', 'jm + jl'),
         ('a(:, jk)', 'zsupsat(:, jk)'), ('b(:, jk, jm)', 'zqxn(:, jm, jk)')
     ]
@@ -1222,7 +1222,7 @@ end subroutine test_transform_loop_unroll
     do_loop_unroll(routine)
     assert not FindNodes(Loop).visit(routine.body)
     assert len(FindNodes(Assignment).visit(routine.body)) == 10
-    assert assignment_strs(routine.body) == [('s', f's + {i} + 1') for i in range(1, 11)]
+    assert assignment_symbols(routine.body) == [('s', f's + {i} + 1') for i in range(1, 11)]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1247,7 +1247,7 @@ end subroutine test_transform_loop_unroll_step
     do_loop_unroll(routine)
     assert not FindNodes(Loop).visit(routine.body)
     assert len(FindNodes(Assignment).visit(routine.body)) == 5
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('s', 's + -2 + 1'), ('s', 's + 0 + 1'), ('s', 's + 2 + 1'), ('s', 's + 4 + 1'), ('s', 's + 6 + 1')
     ]
 
@@ -1275,7 +1275,7 @@ end subroutine test_transform_loop_unroll_non_literal_range
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_unroll(routine)
     assert loop_bounds(routine.body) == [('a', '1', 'i', None)]
-    assert assignment_strs(routine.body) == [('i', '10'), ('s', 's + a + 1')]
+    assert assignment_symbols(routine.body) == [('i', '10'), ('s', 's + a + 1')]
     assert not pragma_strs(routine.body)
 
 
@@ -1304,10 +1304,10 @@ end subroutine test_transform_loop_unroll_nested
     do_loop_unroll(routine)
     assert not FindNodes(Loop).visit(routine.body)
     assert len(FindNodes(Assignment).visit(routine.body)) == 50
-    assert assignment_strs(routine.body)[:3] == [
+    assert assignment_symbols(routine.body)[:3] == [
         ('s', 's + 1 + 1 + 1'), ('s', 's + 1 + 2 + 1'), ('s', 's + 1 + 3 + 1')
     ]
-    assert assignment_strs(routine.body)[-3:] == [
+    assert assignment_symbols(routine.body)[-3:] == [
         ('s', 's + 10 + 3 + 1'), ('s', 's + 10 + 4 + 1'), ('s', 's + 10 + 5 + 1')
     ]
 
@@ -1337,7 +1337,7 @@ end subroutine test_transform_loop_unroll_nested_restricted_depth
     do_loop_unroll(routine)
     assert loop_bounds(routine.body) == [('b', '1', '5', None)] * 10
     assert len(FindNodes(Assignment).visit(routine.body)) == 10
-    assert assignment_strs(routine.body)[:3] == [
+    assert assignment_symbols(routine.body)[:3] == [
         ('s', 's + 1 + b + 1'), ('s', 's + 2 + b + 1'), ('s', 's + 3 + b + 1')
     ]
     assert not pragma_strs(routine.body)
@@ -1370,7 +1370,7 @@ end subroutine test_transform_loop_unroll_nested_restricted_depth
     do_loop_unroll(routine)
     assert loop_bounds(routine.body) == [('a', '1', 'i', None)]
     assert len(FindNodes(Assignment).visit(routine.body)) == 6
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('i', '10'), ('s', 's + a + 1 + 1'), ('s', 's + a + 2 + 1'),
         ('s', 's + a + 3 + 1'), ('s', 's + a + 4 + 1'), ('s', 's + a + 5 + 1')
     ]
@@ -1455,7 +1455,7 @@ end subroutine test_transform_loop_unroll_nested_neighbours
     do_loop_unroll(routine)
     assert loop_bounds(routine.body) == [('c', '1', '5', None)] * 10
     assert len(FindNodes(Assignment).visit(routine.body)) == 60
-    assert assignment_strs(routine.body)[:6] == [
+    assert assignment_symbols(routine.body)[:6] == [
         ('s', 's + 1 + 1 + 1'), ('s', 's + 1 + 2 + 1'), ('s', 's + 1 + 3 + 1'),
         ('s', 's + 1 + 4 + 1'), ('s', 's + 1 + 5 + 1'), ('s', 's + 1 + c + 1')
     ]

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -132,7 +132,7 @@ subroutine transform_loop_interchange(a, m, n, nclv)
       end do
     end do
   end do
-    end subroutine transform_loop_interchange
+end subroutine transform_loop_interchange
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
@@ -183,7 +183,7 @@ subroutine transform_loop_interchange_project(a, m, n)
       a(j, i) = i + j
     end do
   end do
-    end subroutine transform_loop_interchange_project
+end subroutine transform_loop_interchange_project
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
 

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -12,7 +12,6 @@ import numpy as np
 
 from loki import Subroutine
 from loki.jit_build import jit_compile, clean_test
-from loki.expression import symbols as sym
 from loki.frontend import available_frontends
 from loki.ir import (
     is_loki_pragma, pragmas_attached, FindNodes, Loop, Conditional,

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -25,16 +25,13 @@ from loki.transformations.transform_loop import (
 )
 
 
-def loop_var_names(node):
-    return [str(loop.variable) for loop in FindNodes(Loop).visit(node)]
+def loop_variables(node):
+    return [loop.variable for loop in FindNodes(Loop).visit(node)]
 
 
-def loop_bounds(node):
+def loop_symbols(node):
     return [
-        (
-            str(loop.variable), str(loop.bounds.start), str(loop.bounds.stop),
-            None if loop.bounds.step is None else str(loop.bounds.step)
-        )
+        (loop.variable, loop.bounds.start, loop.bounds.stop, loop.bounds.step)
         for loop in FindNodes(Loop).visit(node)
     ]
 
@@ -86,7 +83,7 @@ end subroutine transform_loop_interchange_plain
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 4
-    assert loop_var_names(routine.body) == ['i', 'j', 'i', 'j']
+    assert loop_variables(routine.body) == ['i', 'j', 'i', 'j']
     assert assignment_symbols(routine.body) == [
         ('a(j, i)', 'i + j'), ('a(j, i)', 'a(j, i) - 2')
     ]
@@ -95,10 +92,10 @@ end subroutine transform_loop_interchange_plain
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 4
-    assert loop_var_names(routine.body) == ['j', 'i', 'i', 'j']
-    assert loop_bounds(routine.body) == [
-        ('j', '1', 'm', None), ('i', '1', 'n', None),
-        ('i', '1', 'n', None), ('j', '1', 'm', None)
+    assert loop_variables(routine.body) == ['j', 'i', 'i', 'j']
+    assert loop_symbols(routine.body) == [
+        ('j', 1, 'm', None), ('i', 1, 'n', None),
+        ('i', 1, 'n', None), ('j', 1, 'm', None)
     ]
     assert assignment_symbols(routine.body) == [
         ('a(j, i)', 'i + j'), ('a(j, i)', 'a(j, i) - 2')
@@ -142,7 +139,7 @@ subroutine transform_loop_interchange(a, m, n, nclv)
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
-    assert loop_var_names(routine.body) == ['k', 'i', 'j', 'k', 'i', 'j']
+    assert loop_variables(routine.body) == ['k', 'i', 'j', 'k', 'i', 'j']
     assert assignment_symbols(routine.body) == [
         ('a(j, i, k)', 'i + j + k'), ('a(j, i, k)', 'a(j, i, k) - 3')
     ]
@@ -155,10 +152,10 @@ subroutine transform_loop_interchange(a, m, n, nclv)
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
-    assert loop_var_names(routine.body) == ['j', 'i', 'k', 'k', 'i', 'j']
-    assert loop_bounds(routine.body) == [
-        ('j', '1', 'm', None), ('i', '1', 'n', None), ('k', '1', 'nclv', None),
-        ('k', '1', 'nclv', None), ('i', '1', 'n', None), ('j', '1', 'm', None)
+    assert loop_variables(routine.body) == ['j', 'i', 'k', 'k', 'i', 'j']
+    assert loop_symbols(routine.body) == [
+        ('j', 1, 'm', None), ('i', 1, 'n', None), ('k', 1, 'nclv', None),
+        ('k', 1, 'nclv', None), ('i', 1, 'n', None), ('j', 1, 'm', None)
     ]
     assert assignment_symbols(routine.body) == [
         ('a(j, i, k)', 'i + j + k'), ('a(j, i, k)', 'a(j, i, k) - 3')
@@ -193,16 +190,16 @@ subroutine transform_loop_interchange_project(a, m, n)
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 2
-    assert loop_var_names(routine.body) == ['i', 'j']
-    assert loop_bounds(routine.body) == [('i', '1', 'n', None), ('j', 'i', 'm', None)]
+    assert loop_variables(routine.body) == ['i', 'j']
+    assert loop_symbols(routine.body) == [('i', 1, 'n', None), ('j', 'i', 'm', None)]
     assert assignment_symbols(routine.body) == [('a(j, i)', 'i + j')]
 
     do_loop_interchange(routine, project_bounds=True)
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 2
-    assert loop_var_names(routine.body) == ['j', 'i']
-    assert loop_bounds(routine.body) == [('j', '1', 'm', None), ('i', '1', 'min(n, j)', None)]
+    assert loop_variables(routine.body) == ['j', 'i']
+    assert loop_symbols(routine.body) == [('j', 1, 'm', None), ('i', 1, 'min(n, j)', None)]
     assert assignment_symbols(routine.body) == [('a(j, i)', 'i + j')]
 
 
@@ -285,7 +282,7 @@ end subroutine transform_loop_fuse_matching
 
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
-    assert loop_bounds(routine.body) == [('i', '1', 'n', None)]
+    assert loop_symbols(routine.body) == [('i', 1, 'n', None)]
     assert assignment_symbols(routine.body) == [('a(i)', 'i'), ('b(i)', 'n - i + 1')]
     assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
@@ -325,7 +322,7 @@ end subroutine transform_loop_fuse_subranges
 
     assert len(FindNodes(Loop).visit(routine.body)) == 3
     do_loop_fusion(routine)
-    assert loop_bounds(routine.body) == [('i', '1', 'n', None)]
+    assert loop_symbols(routine.body) == [('i', 1, 'n', None)]
     assert conditional_strs(routine.body) == ['i <= 15', 'i >= 16']
     assert assignment_symbols(routine.body) == [
         ('a(:)', '0'), ('b(:)', '0'), ('a(i)', 'a(i) + i'),
@@ -377,7 +374,7 @@ end subroutine transform_loop_fuse_groups
 
     assert len(FindNodes(Loop).visit(routine.body)) == 5
     do_loop_fusion(routine)
-    assert loop_bounds(routine.body) == [('i', '1', 'n', None), ('i', '1', 'n', None)]
+    assert loop_symbols(routine.body) == [('i', 1, 'n', None), ('i', 1, 'n', None)]
     assert conditional_strs(routine.body) == ['i >= 2']
     assert assignment_symbols(routine.body) == [
         ('c(1)', '1'), ('a(i)', 'i'), ('b(i)', 'n - i + 1'),
@@ -436,7 +433,7 @@ end subroutine transform_loop_fuse_alignment
 
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
-    assert loop_bounds(routine.body) == [('i', '0', 'n', None)]
+    assert loop_symbols(routine.body) == [('i', 0, 'n', None)]
     assert conditional_strs(routine.body) == ['i >= 1', 'i <= n - 1']
     assert assignment_symbols(routine.body) == [('a(i)', 'i'), ('b(i + 1)', 'n - i')]
     assert pragma_strs(routine.body) == ['fused-loop group(1)']
@@ -466,7 +463,7 @@ end subroutine transform_loop_fuse_nonmatching_lower
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
 
-    assert loop_bounds(routine.body) == [('jl', 'min(1, nclv)', 'klev', None)]
+    assert loop_symbols(routine.body) == [('jl', 'min(1, nclv)', 'klev', None)]
     assert conditional_strs(routine.body) == ['jl >= 1', 'jl >= nclv']
     assert assignment_symbols(routine.body) == [('a(jl)', 'jl'), ('b(jl)', 'jl - nclv')]
     assert pragma_strs(routine.body) == ['fused-loop group(1)']
@@ -496,7 +493,7 @@ end subroutine transform_loop_fuse_nonmatching_lower_annotated
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
 
-    assert loop_bounds(routine.body) == [('jl', '1', 'klev', None)]
+    assert loop_symbols(routine.body) == [('jl', 1, 'klev', None)]
     assert conditional_strs(routine.body) == ['jl >= nclv']
     assert assignment_symbols(routine.body) == [('a(jl)', 'jl'), ('b(jl)', 'jl - nclv')]
     assert pragma_strs(routine.body) == ['fused-loop group(1)']
@@ -526,7 +523,7 @@ end subroutine transform_loop_fuse_nonmatching_upper
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
 
-    assert loop_bounds(routine.body) == [('jl', '1', '1 + klev', None)]
+    assert loop_symbols(routine.body) == [('jl', 1, '1 + klev', None)]
     assert conditional_strs(routine.body) == ['jl <= klev']
     assert assignment_symbols(routine.body) == [('a(jl)', 'jl'), ('b(jl)', '2*jl')]
     assert pragma_strs(routine.body) == ['fused-loop group(1)']
@@ -559,7 +556,7 @@ end subroutine transform_loop_fuse_collapse
 
     assert len(FindNodes(Loop).visit(routine.body)) == 4
     do_loop_fusion(routine)
-    assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None)]
+    assert loop_symbols(routine.body) == [('jk', 1, 'klev', None), ('jl', 1, 'klon', None)]
     assert assignment_symbols(routine.body) == [('a(jl, jk)', 'jk'), ('b(jl, jk)', 'jl + jk')]
     assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
@@ -591,7 +588,7 @@ end subroutine transform_loop_fuse_collapse_nonmatching
 
     assert len(FindNodes(Loop).visit(routine.body)) == 4
     do_loop_fusion(routine)
-    assert loop_bounds(routine.body) == [('jk', '1', '1 + klev', None), ('jl', '1', '1 + klon', None)]
+    assert loop_symbols(routine.body) == [('jk', 1, '1 + klev', None), ('jl', 1, '1 + klon', None)]
     assert conditional_strs(routine.body) == ['jl <= klon', 'jk <= klev']
     assert assignment_symbols(routine.body) == [('a(jl, jk)', 'jk'), ('b(jl, jk)', 'jl + jk')]
     assert pragma_strs(routine.body) == ['fused-loop group(default)']
@@ -638,7 +635,7 @@ end subroutine transform_loop_fuse_collapse_range
     do_loop_fusion(routine)
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 2
-    assert all(loop.bounds.start == '1' for loop in loops)
+    assert all(loop.bounds.start == 1 for loop in loops)
     assert sum(loop.bounds.stop == '1 + klev' for loop in loops) == 1
     assert sum(loop.bounds.stop == 'klon + 1' for loop in loops) == 1
     assert len(FindNodes(Conditional).visit(routine.body)) == 2
@@ -678,7 +675,7 @@ end subroutine transform_loop_fission_single
 
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [('j', '1', 'n', None), ('j', '1', 'n', None)]
+    assert loop_symbols(routine.body) == [('j', 1, 'n', None), ('j', 1, 'n', None)]
     assert assignment_symbols(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j')]
 
 
@@ -704,7 +701,7 @@ end subroutine transform_loop_fission_nested
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     assert len(FindNodes(Conditional).visit(routine.body)) == 1
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)]
+    assert loop_symbols(routine.body) == [('j', 1, 'n + 1', None), ('j', 1, 'n + 1', None)]
     assert conditional_strs(routine.body) == ['j <= n', 'j <= n']
     assert assignment_symbols(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j')]
 
@@ -735,7 +732,7 @@ end subroutine transform_loop_fission_nested_promote
     assert len(FindNodes(Conditional).visit(routine.body)) == 2
     assert len(FindNodes(Assignment).visit(routine.body)) == 3
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)]
+    assert loop_symbols(routine.body) == [('j', 1, 'n + 1', None), ('j', 1, 'n + 1', None)]
     assert conditional_strs(routine.body) == ['j <= n', 'zqxfg(2, j) <= n']
     assert assignment_symbols(routine.body) == [
         ('zqxfg(2, j)', 'j'), ('a(j)', 'zqxfg(2, j)'), ('b(j)', 'n - zqxfg(2, j)')
@@ -774,11 +771,11 @@ end subroutine transform_loop_fission_collapse
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     assert len(FindNodes(Assignment).visit(routine.body)) == 8
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [
-        ('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None),
-        ('k', '1', 'n', None), ('j', '1', 'n + 1', None),
-        ('k', '1', 'n', None), ('k', '1', 'n', None),
-        ('j', '1', 'n + 1', None), ('k', '1', 'n', None)
+    assert loop_symbols(routine.body) == [
+        ('j', 1, 'n + 1', None), ('j', 1, 'n + 1', None),
+        ('k', 1, 'n', None), ('j', 1, 'n + 1', None),
+        ('k', 1, 'n', None), ('k', 1, 'n', None),
+        ('j', 1, 'n + 1', None), ('k', 1, 'n', None)
     ]
     assert assignment_symbols(routine.body) == [
         ('tmp(:)', '0'), ('tmp(j)', 'j'), ('tmp2(:, j)', '0'), ('tmp2(k, j)', 'tmp(j) + k'),
@@ -809,7 +806,7 @@ end subroutine transform_loop_fission_multiple
 
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [('j', '1', 'n', None), ('j', '1', 'n', None), ('j', '1', 'n', None)]
+    assert loop_symbols(routine.body) == [('j', 1, 'n', None), ('j', 1, 'n', None), ('j', 1, 'n', None)]
     assert assignment_symbols(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j'), ('c(j)', 'a(j) + b(j)')]
 
 
@@ -848,7 +845,7 @@ end subroutine transform_loop_fission_promote
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 2
     for loop in loops:
-        assert loop.bounds.start == '1'
+        assert loop.bounds.start == 1
         assert loop.bounds.stop == 'n'
     assert [str(d) for d in routine.variable_map['tmp'].shape] == ['n']
 
@@ -892,9 +889,9 @@ end subroutine transform_loop_fission_promote_conflicting_lengths
 
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [
-        ('j', '1', 'n', None), ('j', '1', 'n', None),
-        ('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)
+    assert loop_symbols(routine.body) == [
+        ('j', 1, 'n', None), ('j', 1, 'n', None),
+        ('j', 1, 'n + 1', None), ('j', 1, 'n + 1', None)
     ]
     assert assignment_symbols(routine.body) == [
         ('tmp(j)', 'j - 1'), ('a(j)', 'tmp(j) + 1'), ('tmp(j)', 'j - 1'), ('b(j)', 'n - tmp(j)')
@@ -924,7 +921,7 @@ end subroutine transform_loop_fission_promote_array
 
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None)]
+    assert loop_symbols(routine.body) == [('jk', 1, 'klev', None), ('jl', 1, 'klon', None), ('jk', 1, 'klev', None)]
     assert assignment_symbols(routine.body) == [
         ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('a(:, jk)', 'zsupsat(:, jk)')
     ]
@@ -954,7 +951,7 @@ end subroutine transform_loop_fission_promote_multiple
 
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None)]
+    assert loop_symbols(routine.body) == [('jk', 1, 'klev', None), ('jl', 1, 'klon', None), ('jk', 1, 'klev', None)]
     assert assignment_symbols(routine.body) == [
         ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('tmp(jk)', 'jk'), ('a(:, jk)', 'zsupsat(:, jk) + tmp(jk)')
     ]
@@ -994,10 +991,10 @@ end subroutine transform_loop_fission_multiple_promote
 
     assert len(FindNodes(Loop).visit(routine.body)) == 5
     do_loop_fission(routine)
-    assert loop_bounds(routine.body) == [
-        ('jk', '1', 'klev', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None),
-        ('jm', '1', 'nclv', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None),
-        ('jk', '1', 'klev', None), ('jm', '1', 'nclv', None)
+    assert loop_symbols(routine.body) == [
+        ('jk', 1, 'klev', None), ('jl', 1, 'klon', None), ('jk', 1, 'klev', None),
+        ('jm', 1, 'nclv', None), ('jl', 1, 'klon', None), ('jk', 1, 'klev', None),
+        ('jk', 1, 'klev', None), ('jm', 1, 'nclv', None)
     ]
     assert assignment_symbols(routine.body) == [
         ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('zqxn(jl, jm, jk)', 'jm + jl'),
@@ -1043,7 +1040,7 @@ end subroutine transform_loop_fission_promote_read_after_write
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 3
-    assert all(loop.bounds.start == '1' for loop in loops)
+    assert all(loop.bounds.start == 1 for loop in loops)
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 2
     assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
     assert routine.variable_map['tmp'].shape == ('klev',)
@@ -1110,7 +1107,7 @@ end subroutine transform_loop_fission_promote_mult_r_a_w
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 8
-    assert all(loop.bounds.start == '1' for loop in loops)
+    assert all(loop.bounds.start == 1 for loop in loops)
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 4
     assert sum(loop.bounds.stop == 'klon' for loop in loops) == 2
     assert sum(loop.bounds.stop == 'nclv' for loop in loops) == 2
@@ -1179,7 +1176,7 @@ end subroutine transform_loop_fusion_fission
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 4
-    assert all(loop.bounds.start == '1' for loop in loops)
+    assert all(loop.bounds.start == 1 for loop in loops)
     assert sum(loop.bounds.stop == 'klev' for loop in loops) == 2
     assert sum(loop.bounds.stop == 'klon' for loop in loops) == 2
     assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
@@ -1274,7 +1271,7 @@ end subroutine test_transform_loop_unroll_non_literal_range
 
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_unroll(routine)
-    assert loop_bounds(routine.body) == [('a', '1', 'i', None)]
+    assert loop_symbols(routine.body) == [('a', 1, 'i', None)]
     assert assignment_symbols(routine.body) == [('i', '10'), ('s', 's + a + 1')]
     assert not pragma_strs(routine.body)
 
@@ -1335,7 +1332,7 @@ end subroutine test_transform_loop_unroll_nested_restricted_depth
 
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_unroll(routine)
-    assert loop_bounds(routine.body) == [('b', '1', '5', None)] * 10
+    assert loop_symbols(routine.body) == [('b', 1, 5, None)] * 10
     assert len(FindNodes(Assignment).visit(routine.body)) == 10
     assert assignment_symbols(routine.body)[:3] == [
         ('s', 's + 1 + b + 1'), ('s', 's + 2 + b + 1'), ('s', 's + 3 + b + 1')
@@ -1368,7 +1365,7 @@ end subroutine test_transform_loop_unroll_nested_restricted_depth
 
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_unroll(routine)
-    assert loop_bounds(routine.body) == [('a', '1', 'i', None)]
+    assert loop_symbols(routine.body) == [('a', 1, 'i', None)]
     assert len(FindNodes(Assignment).visit(routine.body)) == 6
     assert assignment_symbols(routine.body) == [
         ('i', '10'), ('s', 's + a + 1 + 1'), ('s', 's + a + 2 + 1'),
@@ -1453,7 +1450,7 @@ end subroutine test_transform_loop_unroll_nested_neighbours
 
     assert len(FindNodes(Loop).visit(routine.body)) == 3
     do_loop_unroll(routine)
-    assert loop_bounds(routine.body) == [('c', '1', '5', None)] * 10
+    assert loop_symbols(routine.body) == [('c', 1, 5, None)] * 10
     assert len(FindNodes(Assignment).visit(routine.body)) == 60
     assert assignment_symbols(routine.body)[:6] == [
         ('s', 's + 1 + 1 + 1'), ('s', 's + 1 + 2 + 1'), ('s', 's + 1 + 3 + 1'),

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -41,7 +41,7 @@ def assignment_symbols(node):
 
 
 def conditional_strs(node):
-    return [str(cond.condition) for cond in FindNodes(Conditional).visit(node)]
+    return [cond.condition for cond in FindNodes(Conditional).visit(node)]
 
 
 def pragma_strs(node):
@@ -50,7 +50,7 @@ def pragma_strs(node):
 
 def variable_shape(routine, name):
     shape = routine.variable_map[name].shape
-    return tuple(str(dim) for dim in shape) if shape else None
+    return tuple(shape) if shape else None
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -847,7 +847,7 @@ end subroutine transform_loop_fission_promote
     for loop in loops:
         assert loop.bounds.start == 1
         assert loop.bounds.stop == 'n'
-    assert [str(d) for d in routine.variable_map['tmp'].shape] == ['n']
+    assert routine.variable_map['tmp'].shape == ('n',)
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
     fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -25,8 +25,39 @@ from loki.transformations.transform_loop import (
 )
 
 
+def loop_var_names(node):
+    return [str(loop.variable) for loop in FindNodes(Loop).visit(node)]
+
+
+def loop_bounds(node):
+    return [
+        (
+            str(loop.variable), str(loop.bounds.start), str(loop.bounds.stop),
+            None if loop.bounds.step is None else str(loop.bounds.step)
+        )
+        for loop in FindNodes(Loop).visit(node)
+    ]
+
+
+def assignment_strs(node):
+    return [(str(assign.lhs), str(assign.rhs)) for assign in FindNodes(Assignment).visit(node)]
+
+
+def conditional_strs(node):
+    return [str(cond.condition) for cond in FindNodes(Conditional).visit(node)]
+
+
+def pragma_strs(node):
+    return [pragma.content for pragma in FindNodes(ir.Pragma).visit(node)]
+
+
+def variable_shape(routine, name):
+    shape = routine.variable_map[name].shape
+    return tuple(str(dim) for dim in shape) if shape else None
+
+
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_interchange_plain(tmp_path, frontend):
+def test_transform_loop_interchange_plain(frontend):
     """
     Apply loop interchange for two loops without further arguments.
     """
@@ -52,41 +83,30 @@ subroutine transform_loop_interchange_plain(a, m, n)
 end subroutine transform_loop_interchange_plain
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-    m, n = 10, 20
-    ref = np.array([[i+j for i in range(n)] for j in range(m)], order='F')
 
-    # Test the reference solution
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 4
-    assert [str(loop.variable) for loop in loops] == ['i', 'j', 'i', 'j']
+    assert loop_var_names(routine.body) == ['i', 'j', 'i', 'j']
+    assert assignment_strs(routine.body) == [
+        ('a(j, i)', 'i + j'), ('a(j, i)', 'a(j, i) - 2')
+    ]
 
-    a = np.zeros(shape=(m, n), dtype=np.int32, order='F')
-    function(a=a, m=m, n=n)
-    assert np.all(a == ref)
-
-    # Apply transformation
     do_loop_interchange(routine)
 
-    interchanged_filepath = tmp_path/(f'{routine.name}_interchanged_{frontend}.f90')
-    interchanged_function = jit_compile(routine, filepath=interchanged_filepath, objname=routine.name)
-
-    # Test transformation
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 4
-    assert [str(loop.variable) for loop in loops] == ['j', 'i', 'i', 'j']
-
-    a = np.zeros(shape=(m, n), dtype=np.int32, order='F')
-    interchanged_function(a=a, m=m, n=n)
-    assert np.all(a == ref)
-
-    clean_test(filepath)
-    clean_test(interchanged_filepath)
+    assert loop_var_names(routine.body) == ['j', 'i', 'i', 'j']
+    assert loop_bounds(routine.body) == [
+        ('j', '1', 'm', None), ('i', '1', 'n', None),
+        ('i', '1', 'n', None), ('j', '1', 'm', None)
+    ]
+    assert assignment_strs(routine.body) == [
+        ('a(j, i)', 'i + j'), ('a(j, i)', 'a(j, i) - 2')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_interchange(tmp_path, frontend):
+def test_transform_loop_interchange(frontend):
     """
     Apply loop interchange for three loops with specified order.
     """
@@ -116,54 +136,42 @@ subroutine transform_loop_interchange(a, m, n, nclv)
       end do
     end do
   end do
-end subroutine transform_loop_interchange
+    end subroutine transform_loop_interchange
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-    m, n, nclv = 10, 20, 5
-    ref = np.array([[[i+j+k for k in range(nclv)] for i in range(n)] for j in range(m)], order='F')
 
-    # Test the reference solution
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
-    assert [str(loop.variable) for loop in loops] == ['k', 'i', 'j', 'k', 'i', 'j']
+    assert loop_var_names(routine.body) == ['k', 'i', 'j', 'k', 'i', 'j']
+    assert assignment_strs(routine.body) == [
+        ('a(j, i, k)', 'i + j + k'), ('a(j, i, k)', 'a(j, i, k) - 3')
+    ]
     with pragmas_attached(routine, Loop):
         assert is_loki_pragma(loops[0].pragma, starts_with='some-pragma')
         assert is_loki_pragma(loops[1].pragma, starts_with='more-pragma')
         assert is_loki_pragma(loops[2].pragma, starts_with='other-pragma')
 
-    a = np.zeros(shape=(m, n, nclv), dtype=np.int32, order='F')
-    function(a=a, m=m, n=n, nclv=nclv)
-    assert np.all(a == ref)
-
-    # Apply transformation
     do_loop_interchange(routine)
 
-    interchanged_filepath = tmp_path/(f'{routine.name}_interchanged_{frontend}.f90')
-    interchanged_function = jit_compile(routine, filepath=interchanged_filepath, objname=routine.name)
-
-    # Test transformation
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
-    assert [str(loop.variable) for loop in loops] == ['j', 'i', 'k', 'k', 'i', 'j']
+    assert loop_var_names(routine.body) == ['j', 'i', 'k', 'k', 'i', 'j']
+    assert loop_bounds(routine.body) == [
+        ('j', '1', 'm', None), ('i', '1', 'n', None), ('k', '1', 'nclv', None),
+        ('k', '1', 'nclv', None), ('i', '1', 'n', None), ('j', '1', 'm', None)
+    ]
+    assert assignment_strs(routine.body) == [
+        ('a(j, i, k)', 'i + j + k'), ('a(j, i, k)', 'a(j, i, k) - 3')
+    ]
 
-    # Make sure other pragmas remain in place
     with pragmas_attached(routine, Loop):
         assert is_loki_pragma(loops[0].pragma, starts_with='some-pragma')
         assert is_loki_pragma(loops[1].pragma, starts_with='more-pragma')
         assert is_loki_pragma(loops[2].pragma, starts_with='other-pragma')
-
-    a = np.zeros(shape=(m, n, nclv), dtype=np.int32, order='F')
-    interchanged_function(a=a, m=m, n=n, nclv=nclv)
-    assert np.all(a == ref)
-
-    clean_test(filepath)
-    clean_test(interchanged_filepath)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_interchange_project(tmp_path, frontend):
+def test_transform_loop_interchange_project(frontend):
     """
     Apply loop interchange for two loops with bounds projection.
     """
@@ -179,41 +187,23 @@ subroutine transform_loop_interchange_project(a, m, n)
       a(j, i) = i + j
     end do
   end do
-end subroutine transform_loop_interchange_project
+    end subroutine transform_loop_interchange_project
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-    m, n = 10, 20
-    ref = np.array([[i+j if j>=i else 0 for i in range(1, n+1)]
-                    for j in range(1, m+1)], order='F')
 
-    # Test the reference solution
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 2
-    assert [str(loop.variable) for loop in loops] == ['i', 'j']
+    assert loop_var_names(routine.body) == ['i', 'j']
+    assert loop_bounds(routine.body) == [('i', '1', 'n', None), ('j', 'i', 'm', None)]
+    assert assignment_strs(routine.body) == [('a(j, i)', 'i + j')]
 
-    a = np.zeros(shape=(m, n), dtype=np.int32, order='F')
-    function(a=a, m=m, n=n)
-    assert np.all(a == ref)
-
-    # Apply transformation
     do_loop_interchange(routine, project_bounds=True)
 
-    interchanged_filepath = tmp_path/(f'{routine.name}_interchanged_{frontend}.f90')
-    interchanged_function = jit_compile(routine, filepath=interchanged_filepath, objname=routine.name)
-
-    # Test transformation
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 2
-    assert [str(loop.variable) for loop in loops] == ['j', 'i']
-
-    a = np.zeros(shape=(m, n), dtype=np.int32, order='F')
-    interchanged_function(a=a, m=m, n=n)
-    assert np.all(a == ref)
-
-    clean_test(filepath)
-    clean_test(interchanged_filepath)
+    assert loop_var_names(routine.body) == ['j', 'i']
+    assert loop_bounds(routine.body) == [('j', '1', 'm', None), ('i', '1', 'min(n, j)', None)]
+    assert assignment_strs(routine.body) == [('a(j, i)', 'i + j')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -270,7 +260,7 @@ end subroutine transform_loop_fuse_ordering
         assert 'c' not in loop_0_vars
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_matching(tmp_path, frontend):
+def test_transform_loop_fuse_matching(frontend):
     """
     Apply loop fusion for two loops with matching iteration spaces.
     """
@@ -292,38 +282,16 @@ subroutine transform_loop_fuse_matching(a, b, n)
 end subroutine transform_loop_fuse_matching
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, n=n)
-    assert np.all(a == range(1, n+1))
-    assert np.all(b == range(n, 0, -1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 1
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    fused_function(a=a, b=b, n=n)
-    assert np.all(a == range(1, n+1))
-    assert np.all(b == range(n, 0, -1))
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('i', '1', 'n', None)]
+    assert assignment_strs(routine.body) == [('a(i)', 'i'), ('b(i)', 'n - i + 1')]
+    assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_subranges(tmp_path, frontend):
+def test_transform_loop_fuse_subranges(frontend):
     """
     Apply loop fusion with annotated range for loops with
     non-matching iteration spaces.
@@ -354,38 +322,20 @@ subroutine transform_loop_fuse_subranges(a, b, n)
 end subroutine transform_loop_fuse_subranges
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, n=n)
-    assert np.all(a == range(1, n+1))
-    assert np.all(b == range(n, 0, -1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 3
     do_loop_fusion(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 1
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    fused_function(a=a, b=b, n=n)
-    assert np.all(a == range(1, n+1))
-    assert np.all(b == range(n, 0, -1))
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('i', '1', 'n', None)]
+    assert conditional_strs(routine.body) == ['i <= 15', 'i >= 16']
+    assert assignment_strs(routine.body) == [
+        ('a(:)', '0'), ('b(:)', '0'), ('a(i)', 'a(i) + i'),
+        ('b(i)', 'b(i) + n - i + 1'), ('b(i)', 'b(i) + n - i + 1')
+    ]
+    assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_groups(tmp_path, frontend):
+def test_transform_loop_fuse_groups(frontend):
     """
     Apply loop fusion for multiple loop fusion groups.
     """
@@ -424,38 +374,16 @@ subroutine transform_loop_fuse_groups(a, b, c, n)
 end subroutine transform_loop_fuse_groups
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    c = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, c=c, n=n)
-    assert np.all(a == range(2, n+2))
-    assert np.all(b == range(n+1, 1, -1))
-    assert np.all(c == range(1, n+1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 5
     do_loop_fusion(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 2
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    c = np.zeros(shape=(n,), dtype=np.int32)
-    fused_function(a=a, b=b, c=c, n=n)
-    assert np.all(a == range(2, n+2))
-    assert np.all(b == range(n+1, 1, -1))
-    assert np.all(c == range(1, n+1))
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('i', '1', 'n', None), ('i', '1', 'n', None)]
+    assert conditional_strs(routine.body) == ['i >= 2']
+    assert assignment_strs(routine.body) == [
+        ('c(1)', '1'), ('a(i)', 'i'), ('b(i)', 'n - i + 1'),
+        ('c(i)', 'c(i - 1) + 1'), ('a(i)', 'a(i) + 1'), ('b(i)', 'b(i) + 1')
+    ]
+    assert pragma_strs(routine.body) == ['fused-loop group(g1)', 'fused-loop group(loop-group2)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -486,7 +414,7 @@ end subroutine transform_loop_fuse_failures
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_alignment(tmp_path, frontend):
+def test_transform_loop_fuse_alignment(frontend):
     fcode = """
 subroutine transform_loop_fuse_alignment(a, b, n)
   integer, intent(out) :: a(n), b(n)
@@ -505,38 +433,17 @@ subroutine transform_loop_fuse_alignment(a, b, n)
 end subroutine transform_loop_fuse_alignment
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, n=n)
-    assert np.all(a == range(1, n+1))
-    assert np.all(b == range(n, 0, -1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 1
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    fused_function(a=a, b=b, n=n)
-    assert np.all(a == range(1, n+1))
-    assert np.all(b == range(n, 0, -1))
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('i', '0', 'n', None)]
+    assert conditional_strs(routine.body) == ['i >= 1', 'i <= n - 1']
+    assert assignment_strs(routine.body) == [('a(i)', 'i'), ('b(i + 1)', 'n - i')]
+    assert pragma_strs(routine.body) == ['fused-loop group(1)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_nonmatching_lower(tmp_path, frontend):
+def test_transform_loop_fuse_nonmatching_lower(frontend):
     fcode = """
 subroutine transform_loop_fuse_nonmatching_lower(a, b, nclv, klev)
   integer, intent(out) :: a(klev), b(klev)
@@ -555,44 +462,18 @@ subroutine transform_loop_fuse_nonmatching_lower(a, b, nclv, klev)
 end subroutine transform_loop_fuse_nonmatching_lower
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    klev, nclv = 100, 15
-    a = np.zeros(shape=(klev,), dtype=np.int32)
-    b = np.zeros(shape=(klev,), dtype=np.int32)
-    function(a=a, b=b, klev=klev, nclv=nclv)
-    assert np.all(a == range(1, klev+1))
-    assert np.all(b[nclv:klev+1] == range(1, klev-nclv+1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
 
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 1
-    assert isinstance(loops[0].bounds.start, sym.InlineCall) and loops[0].bounds.start.name == 'min'
-    assert loops[0].bounds.stop == 'klev'
-    assert len(FindNodes(Conditional).visit(routine.body)) == 2
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    klev, nclv = 100, 15
-    a = np.zeros(shape=(klev,), dtype=np.int32)
-    b = np.zeros(shape=(klev,), dtype=np.int32)
-    fused_function(a=a, b=b, klev=klev, nclv=nclv)
-    assert np.all(a == range(1, klev+1))
-    assert np.all(b[nclv:klev+1] == range(1, klev-nclv+1))
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('jl', 'min(1, nclv)', 'klev', None)]
+    assert conditional_strs(routine.body) == ['jl >= 1', 'jl >= nclv']
+    assert assignment_strs(routine.body) == [('a(jl)', 'jl'), ('b(jl)', 'jl - nclv')]
+    assert pragma_strs(routine.body) == ['fused-loop group(1)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_nonmatching_lower_annotated(tmp_path, frontend):
+def test_transform_loop_fuse_nonmatching_lower_annotated(frontend):
     fcode = """
 subroutine transform_loop_fuse_nonmatching_lower_annotated(a, b, nclv, klev)
   integer, intent(out) :: a(klev), b(klev)
@@ -611,44 +492,18 @@ subroutine transform_loop_fuse_nonmatching_lower_annotated(a, b, nclv, klev)
 end subroutine transform_loop_fuse_nonmatching_lower_annotated
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    klev, nclv = 100, 15
-    a = np.zeros(shape=(klev,), dtype=np.int32)
-    b = np.zeros(shape=(klev,), dtype=np.int32)
-    function(a=a, b=b, klev=klev, nclv=nclv)
-    assert np.all(a == range(1, klev+1))
-    assert np.all(b[nclv:klev+1] == range(1, klev-nclv+1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
 
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 1
-    assert loops[0].bounds.start == '1'
-    assert loops[0].bounds.stop == 'klev'
-    assert len(FindNodes(Conditional).visit(routine.body)) == 1
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    klev, nclv = 100, 15
-    a = np.zeros(shape=(klev,), dtype=np.int32)
-    b = np.zeros(shape=(klev,), dtype=np.int32)
-    fused_function(a=a, b=b, klev=klev, nclv=nclv)
-    assert np.all(a == range(1, klev+1))
-    assert np.all(b[nclv:klev+1] == range(1, klev-nclv+1))
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('jl', '1', 'klev', None)]
+    assert conditional_strs(routine.body) == ['jl >= nclv']
+    assert assignment_strs(routine.body) == [('a(jl)', 'jl'), ('b(jl)', 'jl - nclv')]
+    assert pragma_strs(routine.body) == ['fused-loop group(1)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_nonmatching_upper(tmp_path, frontend):
+def test_transform_loop_fuse_nonmatching_upper(frontend):
     fcode = """
 subroutine transform_loop_fuse_nonmatching_upper(a, b, klev)
   integer, intent(out) :: a(klev), b(klev+1)
@@ -667,44 +522,18 @@ subroutine transform_loop_fuse_nonmatching_upper(a, b, klev)
 end subroutine transform_loop_fuse_nonmatching_upper
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    klev = 100
-    a = np.zeros(shape=(klev,), dtype=np.int32)
-    b = np.zeros(shape=(klev+1,), dtype=np.int32)
-    function(a=a, b=b, klev=klev)
-    assert np.all(a == range(1, klev+1))
-    assert np.all(b == np.array(list(range(1, klev+2))) * 2)
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fusion(routine)
 
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 1
-    assert loops[0].bounds.start == '1'
-    assert loops[0].bounds.stop == '1 + klev'
-    assert len(FindNodes(Conditional).visit(routine.body)) == 1
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    klev = 100
-    a = np.zeros(shape=(klev,), dtype=np.int32)
-    b = np.zeros(shape=(klev+1,), dtype=np.int32)
-    fused_function(a=a, b=b, klev=klev)
-    assert np.all(a == range(1, klev+1))
-    assert np.all(b == np.array(list(range(1, klev+2))) * 2)
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('jl', '1', '1 + klev', None)]
+    assert conditional_strs(routine.body) == ['jl <= klev']
+    assert assignment_strs(routine.body) == [('a(jl)', 'jl'), ('b(jl)', '2*jl')]
+    assert pragma_strs(routine.body) == ['fused-loop group(1)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_collapse(tmp_path, frontend):
+def test_transform_loop_fuse_collapse(frontend):
     fcode = """
 subroutine transform_loop_fuse_collapse(a, b, klon, klev)
   integer, intent(inout) :: a(klon, klev), b(klon, klev)
@@ -727,45 +556,16 @@ subroutine transform_loop_fuse_collapse(a, b, klon, klev)
 end subroutine transform_loop_fuse_collapse
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev)
-    assert np.all(a == np.array([list(range(1, klev+1))] * klon, order='F'))
-    assert np.all(b == np.array([[jl + jk for jk in range(1, klev+1)]
-                                for jl in range(1, klon+1)], order='F'))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 4
     do_loop_fusion(routine)
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 2
-    assert all(loop.bounds.start == '1' for loop in loops)
-    assert sum(loop.bounds.stop == 'klev' for loop in loops) == 1
-    assert sum(loop.bounds.stop == 'klon' for loop in loops) == 1
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    fused_function(a=a, b=b, klon=klon, klev=klev)
-    assert np.all(a == np.array([list(range(1, klev+1))] * klon, order='F'))
-    assert np.all(b == np.array([[jl + jk for jk in range(1, klev+1)]
-                                for jl in range(1, klon+1)], order='F'))
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None)]
+    assert assignment_strs(routine.body) == [('a(jl, jk)', 'jk'), ('b(jl, jk)', 'jl + jk')]
+    assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fuse_collapse_nonmatching(tmp_path, frontend):
+def test_transform_loop_fuse_collapse_nonmatching(frontend):
     fcode = """
 subroutine transform_loop_fuse_collapse_nonmatching(a, b, klon, klev)
   integer, intent(inout) :: a(klon, klev+1), b(klon+1, klev)
@@ -788,42 +588,13 @@ subroutine transform_loop_fuse_collapse_nonmatching(a, b, klon, klev)
 end subroutine transform_loop_fuse_collapse_nonmatching
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev+1), order='F', dtype=np.int32)
-    b = np.zeros(shape=(klon+1, klev), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev)
-    assert np.all(a == np.array([list(range(1, klev+2))] * klon, order='F'))
-    assert np.all(b == np.array([[jl + jk for jk in range(1, klev+1)]
-                                for jl in range(1, klon+2)], order='F'))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 4
     do_loop_fusion(routine)
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 2
-    assert all(loop.bounds.start == '1' for loop in loops)
-    assert sum(loop.bounds.stop == '1 + klev' for loop in loops) == 1
-    assert sum(loop.bounds.stop == '1 + klon' for loop in loops) == 1
-    assert len(FindNodes(Conditional).visit(routine.body)) == 2
-
-    fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
-
-    # Test transformation
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev+1), order='F', dtype=np.int32)
-    b = np.zeros(shape=(klon+1, klev), order='F', dtype=np.int32)
-    fused_function(a=a, b=b, klon=klon, klev=klev)
-    assert np.all(a == np.array([list(range(1, klev+2))] * klon, order='F'))
-    assert np.all(b == np.array([[jl + jk for jk in range(1, klev+1)]
-                                for jl in range(1, klon+2)], order='F'))
-
-    clean_test(filepath)
-    clean_test(fused_filepath)
+    assert loop_bounds(routine.body) == [('jk', '1', '1 + klev', None), ('jl', '1', '1 + klon', None)]
+    assert conditional_strs(routine.body) == ['jl <= klon', 'jk <= klev']
+    assert assignment_strs(routine.body) == [('a(jl, jk)', 'jk'), ('b(jl, jk)', 'jl + jk')]
+    assert pragma_strs(routine.body) == ['fused-loop group(default)']
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -889,7 +660,7 @@ end subroutine transform_loop_fuse_collapse_range
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_single(tmp_path, frontend):
+def test_transform_loop_fission_single(frontend):
     fcode = """
 subroutine transform_loop_fission_single(a, b, n)
   integer, intent(out) :: a(n), b(n)
@@ -904,44 +675,15 @@ subroutine transform_loop_fission_single(a, b, n)
 end subroutine transform_loop_fission_single
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n-1, -1, -1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 2
-    for loop in loops:
-        assert loop.bounds.start == '1'
-        assert loop.bounds.stop == 'n'
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    fissioned_function(a=a, b=b, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n-1, -1, -1))
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [('j', '1', 'n', None), ('j', '1', 'n', None)]
+    assert assignment_strs(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_nested(tmp_path, frontend):
+def test_transform_loop_fission_nested(frontend):
     fcode = """
 subroutine transform_loop_fission_nested(a, b, n)
   integer, intent(out) :: a(n), b(n)
@@ -958,46 +700,17 @@ subroutine transform_loop_fission_nested(a, b, n)
 end subroutine transform_loop_fission_nested
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n-1, -1, -1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     assert len(FindNodes(Conditional).visit(routine.body)) == 1
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 2
-    for loop in loops:
-        assert loop.bounds.start == '1'
-        assert loop.bounds.stop == 'n + 1'
-    assert len(FindNodes(Conditional).visit(routine.body)) == 2
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    fissioned_function(a=a, b=b, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n-1, -1, -1))
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)]
+    assert conditional_strs(routine.body) == ['j <= n', 'j <= n']
+    assert assignment_strs(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_nested_promote(tmp_path, frontend):
+def test_transform_loop_fission_nested_promote(frontend):
     fcode = """
 subroutine transform_loop_fission_nested_promote(a, b, n)
   integer, intent(out) :: a(n), b(n)
@@ -1017,49 +730,21 @@ subroutine transform_loop_fission_nested_promote(a, b, n)
 end subroutine transform_loop_fission_nested_promote
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n-1, -1, -1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     assert len(FindNodes(Conditional).visit(routine.body)) == 2
     assert len(FindNodes(Assignment).visit(routine.body)) == 3
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 2
-    for loop in loops:
-        assert loop.bounds.start == '1'
-        assert loop.bounds.stop == 'n + 1'
-    assert len(FindNodes(Conditional).visit(routine.body)) == 2
-    assert len(FindNodes(Assignment).visit(routine.body)) == 3
-    assert all(d == ref for d, ref in zip(routine.variable_map['zqxfg'].shape, ['5', '1 + n']))
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    fissioned_function(a=a, b=b, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n-1, -1, -1))
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)]
+    assert conditional_strs(routine.body) == ['j <= n', 'zqxfg(2, j) <= n']
+    assert assignment_strs(routine.body) == [
+        ('zqxfg(2, j)', 'j'), ('a(j)', 'zqxfg(2, j)'), ('b(j)', 'n - zqxfg(2, j)')
+    ]
+    assert variable_shape(routine, 'zqxfg') == ('5', '1 + n')
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_collapse(tmp_path, frontend):
+def test_transform_loop_fission_collapse(frontend):
     fcode = """
 subroutine transform_loop_fission_collapse(a, n)
   integer, intent(out) :: a(n, n+1)
@@ -1085,42 +770,26 @@ subroutine transform_loop_fission_collapse(a, n)
 end subroutine transform_loop_fission_collapse
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 11
-    a = np.zeros(shape=(n, n+1), order='F', dtype=np.int32)
-    function(a=a, n=n)
-    assert np.all(a == np.array([[j+k for j in range(n+1)] for k in range(n)], dtype=np.int32))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     assert len(FindNodes(Assignment).visit(routine.body)) == 8
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 8
-    for loop in loops:
-        assert loop.bounds.start == '1'
-        assert loop.bounds.stop == {'j': 'n + 1', 'k': 'n'}[str(loop.variable).lower()]
-    assert len(FindNodes(Assignment).visit(routine.body)) == 8
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    n = 11
-    a = np.zeros(shape=(n, n+1), order='F', dtype=np.int32)
-    fissioned_function(a=a, n=n)
-    assert np.all(a == np.array([[j+k for j in range(n+1)] for k in range(n)], dtype=np.int32))
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [
+        ('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None),
+        ('k', '1', 'n', None), ('j', '1', 'n + 1', None),
+        ('k', '1', 'n', None), ('k', '1', 'n', None),
+        ('j', '1', 'n + 1', None), ('k', '1', 'n', None)
+    ]
+    assert assignment_strs(routine.body) == [
+        ('tmp(:)', '0'), ('tmp(j)', 'j'), ('tmp2(:, j)', '0'), ('tmp2(k, j)', 'tmp(j) + k'),
+        ('a(k, j)', 'tmp2(k, j)'), ('a(k, j)', 'a(k, j) - 1'), ('a(k, j)', '-1 + a(k, j)'), ('tmp(j)', '0')
+    ]
+    assert variable_shape(routine, 'tmp') == ('1 + n',)
+    assert variable_shape(routine, 'tmp2') == ('n', '1 + n')
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_multiple(tmp_path, frontend):
+def test_transform_loop_fission_multiple(frontend):
     fcode = """
 subroutine transform_loop_fission_multiple(a, b, c, n)
   integer, intent(out) :: a(n), b(n), c(n)
@@ -1137,44 +806,11 @@ subroutine transform_loop_fission_multiple(a, b, c, n)
 end subroutine transform_loop_fission_multiple
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    c = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, c=c, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n-1, -1, -1))
-    assert np.all(c == n)
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 3
-    for loop in loops:
-        assert loop.bounds.start == '1'
-        assert loop.bounds.stop == 'n'
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n,), dtype=np.int32)
-    c = np.zeros(shape=(n,), dtype=np.int32)
-    fissioned_function(a=a, b=b, c=c, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n-1, -1, -1))
-    assert np.all(c == n)
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [('j', '1', 'n', None), ('j', '1', 'n', None), ('j', '1', 'n', None)]
+    assert assignment_strs(routine.body) == [('a(j)', 'j'), ('b(j)', 'n - j'), ('c(j)', 'a(j) + b(j)')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1232,7 +868,7 @@ end subroutine transform_loop_fission_promote
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_promote_conflicting_lengths(tmp_path, frontend):
+def test_transform_loop_fission_promote_conflicting_lengths(frontend):
     fcode = """
 subroutine transform_loop_fission_promote_conflicting_lengths(a, b, n)
   integer, intent(out) :: a(n), b(n+1)
@@ -1253,48 +889,21 @@ subroutine transform_loop_fission_promote_conflicting_lengths(a, b, n)
 end subroutine transform_loop_fission_promote_conflicting_lengths
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n+1,), dtype=np.int32)
-    function(a=a, b=b, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n, -1, -1))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 4
-    for loop in loops:
-        assert loop.bounds.start == '1'
-    assert loops[0].bounds.stop == 'n'
-    assert loops[1].bounds.stop == 'n'
-    assert loops[2].bounds.stop == 'n + 1'
-    assert loops[3].bounds.stop == 'n + 1'
-    assert [str(d) for d in routine.variable_map['tmp'].shape] == ['1 + n']
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    n = 100
-    a = np.zeros(shape=(n,), dtype=np.int32)
-    b = np.zeros(shape=(n+1,), dtype=np.int32)
-    fissioned_function(a=a, b=b, n=n)
-    assert np.all(a == range(1,n+1))
-    assert np.all(b == range(n, -1, -1))
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [
+        ('j', '1', 'n', None), ('j', '1', 'n', None),
+        ('j', '1', 'n + 1', None), ('j', '1', 'n + 1', None)
+    ]
+    assert assignment_strs(routine.body) == [
+        ('tmp(j)', 'j - 1'), ('a(j)', 'tmp(j) + 1'), ('tmp(j)', 'j - 1'), ('b(j)', 'n - tmp(j)')
+    ]
+    assert variable_shape(routine, 'tmp') == ('1 + n',)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_promote_array(tmp_path, frontend):
+def test_transform_loop_fission_promote_array(frontend):
     fcode = """
 subroutine transform_loop_fission_promote_array(a, klon, klev)
   integer, intent(inout) :: a(klon, klev)
@@ -1312,40 +921,18 @@ subroutine transform_loop_fission_promote_array(a, klon, klev)
 end subroutine transform_loop_fission_promote_array
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    function(a=a, klon=klon, klev=klev)
-    assert np.all(a == np.array([[jl] * klev for jl in range(1, klon+1)], order='F'))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 3
-    assert all(loop.bounds.start == '1' for loop in loops)
-    assert sum(loop.bounds.stop == 'klev' for loop in loops) == 2
-    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    fissioned_function(a=a, klon=klon, klev=klev)
-    assert np.all(a == np.array([[jl] * klev for jl in range(1, klon+1)], order='F'))
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None)]
+    assert assignment_strs(routine.body) == [
+        ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('a(:, jk)', 'zsupsat(:, jk)')
+    ]
+    assert variable_shape(routine, 'zsupsat') == ('klon', 'klev')
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_promote_multiple(tmp_path, frontend):
+def test_transform_loop_fission_promote_multiple(frontend):
     fcode = """
 subroutine transform_loop_fission_promote_multiple(a, klon, klev)
   integer, intent(inout) :: a(klon, klev)
@@ -1364,43 +951,19 @@ subroutine transform_loop_fission_promote_multiple(a, klon, klev)
 end subroutine transform_loop_fission_promote_multiple
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    function(a=a, klon=klon, klev=klev)
-    assert np.all(a == np.array([[jl + jk for jk in range(1, klev+1)]
-                                for jl in range(1, klon+1)], order='F'))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 3
-    assert all(loop.bounds.start == '1' for loop in loops)
-    assert sum(loop.bounds.stop == 'klev' for loop in loops) == 2
-    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
-    assert routine.variable_map['tmp'].shape == ('klev',)
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    fissioned_function(a=a, klon=klon, klev=klev)
-    assert np.all(a == np.array([[jl + jk for jk in range(1, klev+1)]
-                                for jl in range(1, klon+1)], order='F'))
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [('jk', '1', 'klev', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None)]
+    assert assignment_strs(routine.body) == [
+        ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('tmp(jk)', 'jk'), ('a(:, jk)', 'zsupsat(:, jk) + tmp(jk)')
+    ]
+    assert variable_shape(routine, 'zsupsat') == ('klon', 'klev')
+    assert variable_shape(routine, 'tmp') == ('klev',)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_fission_multiple_promote(tmp_path, frontend):
+def test_transform_loop_fission_multiple_promote(frontend):
     fcode = """
 subroutine transform_loop_fission_multiple_promote(a, b, klon, klev, nclv)
   integer, intent(inout) :: a(klon, klev), b(klon, klev, nclv)
@@ -1428,45 +991,20 @@ subroutine transform_loop_fission_multiple_promote(a, b, klon, klev, nclv)
 end subroutine transform_loop_fission_multiple_promote
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    klon, klev, nclv = 32, 100, 5
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    b = np.zeros(shape=(klon, klev, nclv), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev, nclv=nclv)
-    assert np.all(a == np.array([[jl] * klev for jl in range(1, klon+1)], order='F'))
-    assert np.all(b == np.array([[[jl + jm for jm in range(1, nclv+1)]] * klev
-                                for jl in range(1, klon+1)], order='F'))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 5
     do_loop_fission(routine)
-
-    loops = FindNodes(Loop).visit(routine.body)
-    assert len(loops) == 8
-    assert all(loop.bounds.start == '1' for loop in loops)
-    assert sum(loop.bounds.stop == 'klev' for loop in loops) == 4
-    assert sum(loop.bounds.stop == 'klon' for loop in loops) == 2
-    assert sum(loop.bounds.stop == 'nclv' for loop in loops) == 2
-    assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
-    assert routine.variable_map['zqxn'].shape == ('klon', 'nclv', 'klev')
-
-    fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
-
-    # Test transformation
-    klon, klev, nclv = 32, 100, 5
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    b = np.zeros(shape=(klon, klev, nclv), order='F', dtype=np.int32)
-    fissioned_function(a=a, b=b, klon=klon, klev=klev, nclv=nclv)
-    assert np.all(a == np.array([[jl] * klev for jl in range(1, klon+1)], order='F'))
-    assert np.all(b == np.array([[[jl + jm for jm in range(1, nclv+1)]] * klev
-                                for jl in range(1, klon+1)], order='F'))
-
-    clean_test(filepath)
-    clean_test(fissioned_filepath)
+    assert loop_bounds(routine.body) == [
+        ('jk', '1', 'klev', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None),
+        ('jm', '1', 'nclv', None), ('jl', '1', 'klon', None), ('jk', '1', 'klev', None),
+        ('jk', '1', 'klev', None), ('jm', '1', 'nclv', None)
+    ]
+    assert assignment_strs(routine.body) == [
+        ('zsupsat(:, jk)', '0'), ('zsupsat(jl, jk)', 'jl'), ('zqxn(jl, jm, jk)', 'jm + jl'),
+        ('a(:, jk)', 'zsupsat(:, jk)'), ('b(:, jk, jm)', 'zqxn(:, jm, jk)')
+    ]
+    assert variable_shape(routine, 'zsupsat') == ('klon', 'klev')
+    assert variable_shape(routine, 'zqxn') == ('klon', 'nclv', 'klev')
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1663,7 +1201,7 @@ end subroutine transform_loop_fusion_fission
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_unroll(tmp_path, frontend):
+def test_transform_loop_unroll(frontend):
     fcode = """
 subroutine test_transform_loop_unroll(s)
     implicit none
@@ -1679,33 +1217,16 @@ subroutine test_transform_loop_unroll(s)
 end subroutine test_transform_loop_unroll
  """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path / f'{routine.name}_{frontend}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    s = np.array(0)
-    function(s=s)
-    assert s == sum(x + 1 for x in range(1, 11))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_unroll(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 0 and len(FindNodes(Assignment).visit(routine.body)) == 10
-
-    unrolled_filepath = tmp_path / f'{routine.name}_unrolled_{frontend}.f90'
-    unrolled_function = jit_compile(routine, filepath=unrolled_filepath, objname=routine.name)
-
-    # Test transformation
-    s = np.array(0)
-    unrolled_function(s=s)
-    assert s == sum(x + 1 for x in range(1, 11))
-
-    clean_test(filepath)
-    clean_test(unrolled_filepath)
+    assert not FindNodes(Loop).visit(routine.body)
+    assert len(FindNodes(Assignment).visit(routine.body)) == 10
+    assert assignment_strs(routine.body) == [('s', f's + {i} + 1') for i in range(1, 11)]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_unroll_step(tmp_path, frontend):
+def test_transform_loop_unroll_step(frontend):
     fcode = """
 subroutine test_transform_loop_unroll_step(s)
     implicit none
@@ -1721,33 +1242,18 @@ subroutine test_transform_loop_unroll_step(s)
 end subroutine test_transform_loop_unroll_step
  """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path / f'{routine.name}_{frontend}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    s = np.array(0)
-    function(s=s)
-    assert s == sum(x + 1 for x in range(-2, 8, 2))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_unroll(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 0 and len(FindNodes(Assignment).visit(routine.body)) == 5
-
-    unrolled_filepath = tmp_path / f'{routine.name}_unrolled_{frontend}.f90'
-    unrolled_function = jit_compile(routine, filepath=unrolled_filepath, objname=routine.name)
-
-    # Test transformation
-    s = np.array(0)
-    unrolled_function(s=s)
-    assert s == sum(x + 1 for x in range(-2, 8, 2))
-
-    clean_test(filepath)
-    clean_test(unrolled_filepath)
+    assert not FindNodes(Loop).visit(routine.body)
+    assert len(FindNodes(Assignment).visit(routine.body)) == 5
+    assert assignment_strs(routine.body) == [
+        ('s', 's + -2 + 1'), ('s', 's + 0 + 1'), ('s', 's + 2 + 1'), ('s', 's + 4 + 1'), ('s', 's + 6 + 1')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_unroll_non_literal_range(tmp_path, frontend):
+def test_transform_loop_unroll_non_literal_range(frontend):
     fcode = """
 subroutine test_transform_loop_unroll_non_literal_range(s)
     implicit none
@@ -1765,33 +1271,16 @@ subroutine test_transform_loop_unroll_non_literal_range(s)
 end subroutine test_transform_loop_unroll_non_literal_range
  """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path / f'{routine.name}_{frontend}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    s = np.array(0)
-    function(s=s)
-    assert s == sum(x + 1 for x in range(1, 11))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 1
     do_loop_unroll(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 1 and len(FindNodes(Assignment).visit(routine.body)) == 2
-
-    unrolled_filepath = tmp_path / f'{routine.name}_unrolled_{frontend}.f90'
-    unrolled_function = jit_compile(routine, filepath=unrolled_filepath, objname=routine.name)
-
-    # Test transformation
-    s = np.array(0)
-    unrolled_function(s=s)
-    assert s == sum(x + 1 for x in range(1, 11))
-
-    clean_test(filepath)
-    clean_test(unrolled_filepath)
+    assert loop_bounds(routine.body) == [('a', '1', 'i', None)]
+    assert assignment_strs(routine.body) == [('i', '10'), ('s', 's + a + 1')]
+    assert not pragma_strs(routine.body)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_unroll_nested(tmp_path, frontend):
+def test_transform_loop_unroll_nested(frontend):
     fcode = """
 subroutine test_transform_loop_unroll_nested(s)
     implicit none
@@ -1810,33 +1299,21 @@ subroutine test_transform_loop_unroll_nested(s)
 end subroutine test_transform_loop_unroll_nested
  """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path / f'{routine.name}_{frontend}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    s = np.array(0)
-    function(s=s)
-    assert s == sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 6)))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_unroll(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 0 and len(FindNodes(Assignment).visit(routine.body)) == 50
-
-    unrolled_filepath = tmp_path / f'{routine.name}_unrolled_{frontend}.f90'
-    unrolled_function = jit_compile(routine, filepath=unrolled_filepath, objname=routine.name)
-
-    # Test transformation
-    s = np.array(0)
-    unrolled_function(s=s)
-    assert s == sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 6)))
-
-    clean_test(filepath)
-    clean_test(unrolled_filepath)
+    assert not FindNodes(Loop).visit(routine.body)
+    assert len(FindNodes(Assignment).visit(routine.body)) == 50
+    assert assignment_strs(routine.body)[:3] == [
+        ('s', 's + 1 + 1 + 1'), ('s', 's + 1 + 2 + 1'), ('s', 's + 1 + 3 + 1')
+    ]
+    assert assignment_strs(routine.body)[-3:] == [
+        ('s', 's + 10 + 3 + 1'), ('s', 's + 10 + 4 + 1'), ('s', 's + 10 + 5 + 1')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_unroll_nested_restricted_depth(tmp_path, frontend):
+def test_transform_loop_unroll_nested_restricted_depth(frontend):
     fcode = """
 subroutine test_transform_loop_unroll_nested_restricted_depth(s)
     implicit none
@@ -1855,36 +1332,19 @@ subroutine test_transform_loop_unroll_nested_restricted_depth(s)
 end subroutine test_transform_loop_unroll_nested_restricted_depth
  """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path / f'{routine.name}_{frontend}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    s = np.array(0)
-    function(s=s)
-    assert s == sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 6)))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_unroll(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 10 and len(FindNodes(Assignment).visit(routine.body)) == 10
-
-    unrolled_filepath = tmp_path / f'{routine.name}_unrolled_{frontend}.f90'
-    unrolled_function = jit_compile(routine, filepath=unrolled_filepath, objname=routine.name)
-
-    # Test transformation
-    s = np.array(0)
-    unrolled_function(s=s)
-    assert s == sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 6)))
-
-    # check unroll pragma has been removed
-    assert not FindNodes(ir.Pragma).visit(routine.body)
-
-    clean_test(filepath)
-    clean_test(unrolled_filepath)
+    assert loop_bounds(routine.body) == [('b', '1', '5', None)] * 10
+    assert len(FindNodes(Assignment).visit(routine.body)) == 10
+    assert assignment_strs(routine.body)[:3] == [
+        ('s', 's + 1 + b + 1'), ('s', 's + 2 + b + 1'), ('s', 's + 3 + b + 1')
+    ]
+    assert not pragma_strs(routine.body)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_unroll_nested_restricted_depth_unrollable(tmp_path, frontend):
+def test_transform_loop_unroll_nested_restricted_depth_unrollable(frontend):
     fcode = """
 subroutine test_transform_loop_unroll_nested_restricted_depth(s)
     implicit none
@@ -1905,29 +1365,15 @@ subroutine test_transform_loop_unroll_nested_restricted_depth(s)
 end subroutine test_transform_loop_unroll_nested_restricted_depth
  """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path / f'{routine.name}_{frontend}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    s = np.array(0)
-    function(s=s)
-    assert s == sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 6)))
-
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 2
     do_loop_unroll(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 1 and len(FindNodes(Assignment).visit(routine.body)) == 6
-
-    unrolled_filepath = tmp_path / f'{routine.name}_unrolled_{frontend}.f90'
-    unrolled_function = jit_compile(routine, filepath=unrolled_filepath, objname=routine.name)
-
-    # Test transformation
-    s = np.array(0)
-    unrolled_function(s=s)
-    assert s == sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 6)))
-
-    clean_test(filepath)
-    clean_test(unrolled_filepath)
+    assert loop_bounds(routine.body) == [('a', '1', 'i', None)]
+    assert len(FindNodes(Assignment).visit(routine.body)) == 6
+    assert assignment_strs(routine.body) == [
+        ('i', '10'), ('s', 's + a + 1 + 1'), ('s', 's + a + 2 + 1'),
+        ('s', 's + a + 3 + 1'), ('s', 's + a + 4 + 1'), ('s', 's + a + 5 + 1')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1979,7 +1425,7 @@ end subroutine test_transform_loop_unroll_nested_counters
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_loop_unroll_nested_neighbours(tmp_path, frontend):
+def test_transform_loop_unroll_nested_neighbours(frontend):
     fcode = """
 subroutine test_transform_loop_unroll_nested_neighbours(s)
     implicit none
@@ -2004,28 +1450,15 @@ subroutine test_transform_loop_unroll_nested_neighbours(s)
 end subroutine test_transform_loop_unroll_nested_neighbours
  """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path / f'{routine.name}_{frontend}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
-    # Test the reference solution
-    s = np.array(0)
-    function(s=s)
-    assert s == 2 * sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 6)))
-    # Apply transformation
     assert len(FindNodes(Loop).visit(routine.body)) == 3
     do_loop_unroll(routine)
-    assert len(FindNodes(Loop).visit(routine.body)) == 10 and len(FindNodes(Assignment).visit(routine.body)) == 60
-
-    unrolled_filepath = tmp_path / f'{routine.name}_unrolled_{frontend}.f90'
-    unrolled_function = jit_compile(routine, filepath=unrolled_filepath, objname=routine.name)
-
-    # Test transformation
-    s = np.array(0)
-    unrolled_function(s=s)
-    assert s == 2 * sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 6)))
-
-    clean_test(filepath)
-    clean_test(unrolled_filepath)
+    assert loop_bounds(routine.body) == [('c', '1', '5', None)] * 10
+    assert len(FindNodes(Assignment).visit(routine.body)) == 60
+    assert assignment_strs(routine.body)[:6] == [
+        ('s', 's + 1 + 1 + 1'), ('s', 's + 1 + 2 + 1'), ('s', 's + 1 + 3 + 1'),
+        ('s', 's + 1 + 4 + 1'), ('s', 's + 1 + 5 + 1'), ('s', 's + 1 + c + 1')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/tests/test_transform_region.py
+++ b/loki/transformations/tests/test_transform_region.py
@@ -31,8 +31,8 @@ def loop_bounds(node):
     ]
 
 
-def assignment_strs(node):
-    return [(str(assign.lhs), str(assign.rhs)) for assign in FindNodes(Assignment).visit(node)]
+def assignment_symbols(node):
+    return [(assign.lhs, assign.rhs) for assign in FindNodes(Assignment).visit(node)]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -58,10 +58,10 @@ subroutine transform_region_hoist(a, b, c)
 end subroutine transform_region_hoist
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    assert assignment_strs(routine.body) == [('a', '5'), ('a', '1'), ('b', 'a'), ('c', 'a + b')]
+    assert assignment_symbols(routine.body) == [('a', '5'), ('a', '1'), ('b', 'a'), ('c', 'a + b')]
 
     region_hoist(routine)
-    assert assignment_strs(routine.body) == [('a', '5'), ('b', 'a'), ('a', '1'), ('c', 'a + b')]
+    assert assignment_symbols(routine.body) == [('a', '5'), ('b', 'a'), ('a', '1'), ('c', 'a + b')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -168,13 +168,13 @@ subroutine transform_region_hoist_multiple(a, b, c)
 end subroutine transform_region_hoist_multiple
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('a', '1'), ('a', 'a + 1'), ('a', 'a + 1'), ('a', 'a + 1'),
         ('a', 'a + 1'), ('b', 'a'), ('c', 'a + b')
     ]
 
     region_hoist(routine)
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('a', '1'), ('b', 'a'), ('a', 'a + 1'), ('c', 'a + b'),
         ('a', 'a + 1'), ('a', 'a + 1'), ('a', 'a + 1')
     ]
@@ -221,7 +221,7 @@ end subroutine transform_region_hoist_collapse
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
     assert loop_var_names(routine.body) == ['jl', 'jk', 'jl', 'jk', 'jk', 'jl']
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('a(jl, 1)', 'jl'), ('a(jl, jk)', 'a(jl, jk - 1)'),
         ('b(1, jk)', 'jk'), ('b(jl, jk)', 'b(jl - 1, jk)')
     ]
@@ -237,7 +237,7 @@ end subroutine transform_region_hoist_collapse
         ('jk', '1', 'klev', None), ('jk', '1', 'klev', None),
         ('jl', '2', 'klon', None)
     ]
-    assert assignment_strs(routine.body) == [
+    assert assignment_symbols(routine.body) == [
         ('b(1, jk)', 'jk'), ('a(jl, 1)', 'jl'), ('a(jl, jk)', 'a(jl, jk - 1)'), ('b(jl, jk)', 'b(jl - 1, jk)')
     ]
 

--- a/loki/transformations/tests/test_transform_region.py
+++ b/loki/transformations/tests/test_transform_region.py
@@ -11,13 +11,32 @@ import numpy as np
 from loki import Subroutine, FindNodes, Loop
 from loki.jit_build import jit_compile
 from loki.expression import symbols as sym
+from loki.ir import Assignment
 from loki.frontend import available_frontends
 
 from loki.transformations.transform_region import region_hoist
 
 
+def loop_var_names(node):
+    return [str(loop.variable) for loop in FindNodes(Loop).visit(node)]
+
+
+def loop_bounds(node):
+    return [
+        (
+            str(loop.variable), str(loop.bounds.start), str(loop.bounds.stop),
+            None if loop.bounds.step is None else str(loop.bounds.step)
+        )
+        for loop in FindNodes(Loop).visit(node)
+    ]
+
+
+def assignment_strs(node):
+    return [(str(assign.lhs), str(assign.rhs)) for assign in FindNodes(Assignment).visit(node)]
+
+
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_region_hoist(tmp_path, frontend):
+def test_transform_region_hoist(frontend):
     """
     A very simple hoisting example
     """
@@ -39,21 +58,10 @@ subroutine transform_region_hoist(a, b, c)
 end subroutine transform_region_hoist
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
+    assert assignment_strs(routine.body) == [('a', '5'), ('a', '1'), ('b', 'a'), ('c', 'a + b')]
 
-    # Test the reference solution
-    a, b, c = function()
-    assert a == 1 and b == 1 and c == 2
-
-    # Apply transformation
     region_hoist(routine)
-    hoisted_filepath = tmp_path/(f'{routine.name}_hoisted_{frontend}.f90')
-    hoisted_function = jit_compile(routine, filepath=hoisted_filepath, objname=routine.name)
-
-    # Test transformation
-    a, b, c = hoisted_function()
-    assert a == 1 and b == 5 and c == 6
+    assert assignment_strs(routine.body) == [('a', '5'), ('b', 'a'), ('a', '1'), ('c', 'a + b')]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -130,7 +138,7 @@ end subroutine transform_region_hoist_inlined_pragma
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_region_hoist_multiple(tmp_path, frontend):
+def test_transform_region_hoist_multiple(frontend):
     """
     Test hoisting with multiple groups and multiple regions per group
     """
@@ -160,25 +168,20 @@ subroutine transform_region_hoist_multiple(a, b, c)
 end subroutine transform_region_hoist_multiple
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
+    assert assignment_strs(routine.body) == [
+        ('a', '1'), ('a', 'a + 1'), ('a', 'a + 1'), ('a', 'a + 1'),
+        ('a', 'a + 1'), ('b', 'a'), ('c', 'a + b')
+    ]
 
-    # Test the reference solution
-    a, b, c = function()
-    assert a == 5 and b == 5 and c == 10
-
-    # Apply transformation
     region_hoist(routine)
-    hoisted_filepath = tmp_path/(f'{routine.name}_hoisted_{frontend}.f90')
-    hoisted_function = jit_compile(routine, filepath=hoisted_filepath, objname=routine.name)
-
-    # Test transformation
-    a, b, c = hoisted_function()
-    assert a == 5 and b == 1 and c == 3
+    assert assignment_strs(routine.body) == [
+        ('a', '1'), ('b', 'a'), ('a', 'a + 1'), ('c', 'a + b'),
+        ('a', 'a + 1'), ('a', 'a + 1'), ('a', 'a + 1')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_transform_region_hoist_collapse(tmp_path, frontend):
+def test_transform_region_hoist_collapse(frontend):
     """
     Use collapse with region-hoist.
     """
@@ -214,40 +217,29 @@ subroutine transform_region_hoist_collapse(a, b, klon, klev)
 end subroutine transform_region_hoist_collapse
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-    klon, klev = 32, 100
-    ref_a = np.array([[jl + 1] * klev for jl in range(klon)], order='F')
-    ref_b = np.array([[jk + 1 for jk in range(klev)] for _ in range(klon)], order='F')
-
-    # Test the reference solution
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev)
-    assert np.all(a == ref_a)
-    assert np.all(b == ref_b)
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
-    assert [str(loop.variable) for loop in loops] == ['jl', 'jk', 'jl', 'jk', 'jk', 'jl']
+    assert loop_var_names(routine.body) == ['jl', 'jk', 'jl', 'jk', 'jk', 'jl']
+    assert assignment_strs(routine.body) == [
+        ('a(jl, 1)', 'jl'), ('a(jl, jk)', 'a(jl, jk - 1)'),
+        ('b(1, jk)', 'jk'), ('b(jl, jk)', 'b(jl - 1, jk)')
+    ]
 
-    # Apply transformation
     region_hoist(routine)
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 7
-    assert [str(loop.variable) for loop in loops] == ['jk', 'jl', 'jk', 'jl', 'jk', 'jk', 'jl']
-
-    hoisted_filepath = tmp_path/(f'{routine.name}_hoisted_{frontend}.f90')
-    hoisted_function = jit_compile(routine, filepath=hoisted_filepath, objname=routine.name)
-
-    # Test transformation
-    klon, klev = 32, 100
-    a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    hoisted_function(a=a, b=b, klon=klon, klev=klev)
-    assert np.all(a == ref_a)
-    assert np.all(b == ref_b)
+    assert loop_var_names(routine.body) == ['jk', 'jl', 'jk', 'jl', 'jk', 'jk', 'jl']
+    assert loop_bounds(routine.body) == [
+        ('jk', '1', 'klev', None), ('jl', '1', 'klon', None),
+        ('jk', '2', 'klev', None), ('jl', '1', 'klon', None),
+        ('jk', '1', 'klev', None), ('jk', '1', 'klev', None),
+        ('jl', '2', 'klon', None)
+    ]
+    assert assignment_strs(routine.body) == [
+        ('b(1, jk)', 'jk'), ('a(jl, 1)', 'jl'), ('a(jl, jk)', 'a(jl, jk - 1)'), ('b(jl, jk)', 'b(jl - 1, jk)')
+    ]
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/tests/test_transform_region.py
+++ b/loki/transformations/tests/test_transform_region.py
@@ -17,16 +17,13 @@ from loki.frontend import available_frontends
 from loki.transformations.transform_region import region_hoist
 
 
-def loop_var_names(node):
-    return [str(loop.variable) for loop in FindNodes(Loop).visit(node)]
+def loop_variables(node):
+    return [loop.variable for loop in FindNodes(Loop).visit(node)]
 
 
-def loop_bounds(node):
+def loop_symbols(node):
     return [
-        (
-            str(loop.variable), str(loop.bounds.start), str(loop.bounds.stop),
-            None if loop.bounds.step is None else str(loop.bounds.step)
-        )
+        (loop.variable, loop.bounds.start, loop.bounds.stop, loop.bounds.step)
         for loop in FindNodes(Loop).visit(node)
     ]
 
@@ -116,14 +113,14 @@ end subroutine transform_region_hoist_inlined_pragma
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
-    assert [str(loop.variable) for loop in loops] == ['jl', 'jk', 'jl', 'jk', 'jk', 'jl']
+    assert loop_variables(routine.body) == ['jl', 'jk', 'jl', 'jk', 'jk', 'jl']
 
     # Apply transformation
     region_hoist(routine)
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
-    assert [str(loop.variable) for loop in loops] == ['jk', 'jl', 'jk', 'jl', 'jk', 'jl']
+    assert loop_variables(routine.body) == ['jk', 'jl', 'jk', 'jl', 'jk', 'jl']
 
     hoisted_filepath = tmp_path/(f'{routine.name}_hoisted_{frontend}.f90')
     hoisted_function = jit_compile(routine, filepath=hoisted_filepath, objname=routine.name)
@@ -220,7 +217,7 @@ end subroutine transform_region_hoist_collapse
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 6
-    assert loop_var_names(routine.body) == ['jl', 'jk', 'jl', 'jk', 'jk', 'jl']
+    assert loop_variables(routine.body) == ['jl', 'jk', 'jl', 'jk', 'jk', 'jl']
     assert assignment_symbols(routine.body) == [
         ('a(jl, 1)', 'jl'), ('a(jl, jk)', 'a(jl, jk - 1)'),
         ('b(1, jk)', 'jk'), ('b(jl, jk)', 'b(jl - 1, jk)')
@@ -230,12 +227,12 @@ end subroutine transform_region_hoist_collapse
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 7
-    assert loop_var_names(routine.body) == ['jk', 'jl', 'jk', 'jl', 'jk', 'jk', 'jl']
-    assert loop_bounds(routine.body) == [
-        ('jk', '1', 'klev', None), ('jl', '1', 'klon', None),
-        ('jk', '2', 'klev', None), ('jl', '1', 'klon', None),
-        ('jk', '1', 'klev', None), ('jk', '1', 'klev', None),
-        ('jl', '2', 'klon', None)
+    assert loop_variables(routine.body) == ['jk', 'jl', 'jk', 'jl', 'jk', 'jk', 'jl']
+    assert loop_symbols(routine.body) == [
+        ('jk', 1, 'klev', None), ('jl', 1, 'klon', None),
+        ('jk', 2, 'klev', None), ('jl', 1, 'klon', None),
+        ('jk', 1, 'klev', None), ('jk', 1, 'klev', None),
+        ('jl', 2, 'klon', None)
     ]
     assert assignment_symbols(routine.body) == [
         ('b(1, jk)', 'jk'), ('a(jl, 1)', 'jl'), ('a(jl, jk)', 'a(jl, jk - 1)'), ('b(jl, jk)', 'b(jl - 1, jk)')
@@ -299,7 +296,7 @@ end subroutine transform_region_hoist_promote
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 7
-    assert [str(loop.variable) for loop in loops] == ['jl', 'jk', 'jl', 'jk', 'jk', 'jk', 'jl']
+    assert loop_variables(routine.body) == ['jl', 'jk', 'jl', 'jk', 'jk', 'jk', 'jl']
 
     assert isinstance(routine.variable_map['b_tmp'], sym.Scalar)
 
@@ -308,11 +305,11 @@ end subroutine transform_region_hoist_promote
 
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 8
-    assert [str(loop.variable) for loop in loops] == ['jk', 'jl', 'jk', 'jl', 'jk', 'jk', 'jk', 'jl']
+    assert loop_variables(routine.body) == ['jk', 'jl', 'jk', 'jl', 'jk', 'jk', 'jk', 'jl']
 
     b_tmp = routine.variable_map['b_tmp']
     assert isinstance(b_tmp, sym.Array) and len(b_tmp.type.shape) == 1
-    assert str(b_tmp.type.shape[0]) == 'klev'
+    assert b_tmp.type.shape[0] == 'klev'
 
     hoisted_filepath = tmp_path/(f'{routine.name}_hoisted_{frontend}.f90')
     hoisted_function = jit_compile(routine, filepath=hoisted_filepath, objname=routine.name)


### PR DESCRIPTION
## Summary
- replace several JIT-backed transformation tests with structural IR assertions in loop, region, outline, and loop-blocking test modules
- keep targeted JIT smoke tests for cases where runtime semantics still add meaningful coverage
- add AGENTS guidance for using Loki's native symbol, expression, and numeric comparison support in structural tests

## Details
This change reduces the amount of runtime compilation used in tests whose main purpose is to validate transformation structure rather than compiled behavior.

The refactor focuses on:
- `loki/transformations/tests/test_transform_loop.py`
- `loki/transformations/tests/test_transform_region.py`
- `loki/transformations/extract/tests/test_outline.py`
- `loki/transformations/tests/test_loop_blocking.py`

Across these files, simple end-to-end JIT checks are replaced with direct assertions on:
- assignments
- loop variables and bounds
- outlined calls and inferred arguments
- promoted variables and shapes
- blocked array accesses

The remaining JIT tests act as smoke coverage for cases that still benefit from runtime validation, such as:
- dataflow-sensitive promotion behavior
- more complex fusion/fission interactions
- cross-module import behavior
- derived-type and associate handling
- higher-dimensional blocking cases

The branch also updates the local testing style to prefer Loki's native comparison semantics over stringification in structural assertions, and documents that guidance in `AGENTS.md`.

## Validation
- `pytest loki/transformations/tests/test_transform_loop.py`
- `pytest loki/transformations/tests/test_transform_region.py`
- `pytest loki/transformations/extract/tests/test_outline.py`
- `pytest loki/transformations/tests/test_loop_blocking.py`