### PR TITLE
IR: Add direct sequence semantics for Section and Associate

### DIFF
--- a/loki/backend/tests/test_fgen.py
+++ b/loki/backend/tests/test_fgen.py
@@ -133,7 +133,7 @@ end subroutine data_stmt
     """.strip()
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    assert isinstance(routine.spec.body[-1], DataDeclaration)
+    assert isinstance(routine.spec[-1], DataDeclaration)
     spec_code = fgen(routine.spec)
     assert spec_code.lower().count('data ') == 2
     assert spec_code.count('/') == 4

--- a/loki/batch/tests/test_transformation.py
+++ b/loki/batch/tests/test_transformation.py
@@ -500,10 +500,10 @@ end subroutine test_pipeline
     routine = Subroutine.from_source(fcode)
     pipeline.apply(routine)
 
-    assert isinstance(routine.body.body[0], ir.Comment)
-    assert routine.body.body[0].text == '! Whazzup Bob'
-    assert isinstance(routine.body.body[-1], ir.Comment)
-    assert routine.body.body[-1].text == '! Au revoir, Bob'
+    assert isinstance(routine.body[0], ir.Comment)
+    assert routine.body[0].text == '! Whazzup Bob'
+    assert isinstance(routine.body[-1], ir.Comment)
+    assert routine.body[-1].text == '! Au revoir, Bob'
 
 
 def test_transformation_pipeline_constructor():

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -426,6 +426,11 @@ class Section(InternalNode, _SectionBase):
     def __contains__(self, item):
         return item in self.body
 
+    def index(self, item, start=0, stop=None):
+        if stop is None:
+            return self.body.index(item, start)
+        return self.body.index(item, start, stop)
+
     def append(self, node):
         """
         Append the given node(s) to the section's body.

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -499,20 +499,8 @@ class Associate(ScopedNode, Section, _AssociateBase):  # pylint: disable=too-man
 
     _traversable = ['body', 'associations']
 
-    def __iter__(self):
-        raise TypeError('Associate nodes can not be traversed. Try `body` instead.')
-
     def __bool__(self):
         return True
-
-    def __getitem__(self, index):
-        raise TypeError('Associate nodes do not support item access. Try `body` instead.')
-
-    def __len__(self):
-        raise TypeError('Associate nodes do not define a sequence length. Try `body` instead.')
-
-    def __contains__(self, item):
-        raise TypeError('Associate nodes do not support sequence membership. Try `body` instead.')
 
     def __post_init__(self, parent=None):
         super(ScopedNode, self).__post_init__(parent=parent)

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -414,6 +414,18 @@ class Section(InternalNode, _SectionBase):
     Internal representation of a single code region.
     """
 
+    def __iter__(self):
+        return iter(self.body)
+
+    def __getitem__(self, index):
+        return self.body[index]
+
+    def __len__(self):
+        return len(self.body)
+
+    def __contains__(self, item):
+        return item in self.body
+
     def append(self, node):
         """
         Append the given node(s) to the section's body.
@@ -486,6 +498,21 @@ class Associate(ScopedNode, Section, _AssociateBase):  # pylint: disable=too-man
     """
 
     _traversable = ['body', 'associations']
+
+    def __iter__(self):
+        raise TypeError('Associate nodes can not be traversed. Try `body` instead.')
+
+    def __bool__(self):
+        return True
+
+    def __getitem__(self, index):
+        raise TypeError('Associate nodes do not support item access. Try `body` instead.')
+
+    def __len__(self):
+        raise TypeError('Associate nodes do not define a sequence length. Try `body` instead.')
+
+    def __contains__(self, item):
+        raise TypeError('Associate nodes do not support sequence membership. Try `body` instead.')
 
     def __post_init__(self, parent=None):
         super(ScopedNode, self).__post_init__(parent=parent)

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 from loki.expression import symbols as sym, parse_expr
 from loki.function import Function
 from loki.ir import nodes as ir
+from loki.tools import as_tuple, flatten
 from loki.types import Scope
 
 
@@ -264,13 +265,12 @@ def test_section(n, a_n, a_i):
     assert sec.body == (assign, func, assign, func, assign)
 
 
-def test_internal_node_iterable(one, i, n, a_i):
+def test_section_iterable(a_i):
     """
-    Test iterable-style access for :any:`InternalNode` subclasses.
+    Test iterable-style access for :any:`Section`.
     """
     assign1 = ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
     assign2 = ir.Assignment(lhs=a_i, rhs=sym.Literal(24.0))
-    bounds = sym.Range((one, n))
 
     section = ir.Section(body=(assign1, assign2))
     assert list(section) == list(section.body)
@@ -278,13 +278,23 @@ def test_internal_node_iterable(one, i, n, a_i):
     assert section[-1] is assign2
     assert assign1 in section
     assert len(section) == len(section.body) == 2
+    assert as_tuple(section) == (section,)
+    assert flatten([section]) == [section]
 
-    loop = ir.Loop(variable=i, bounds=bounds, body=(assign1, assign2))
-    assert list(loop) == list(loop.body)
-    assert loop[0] is assign1
-    assert loop[-1] is assign2
-    assert assign2 in loop
-    assert len(loop) == len(loop.body) == 2
+
+def test_loop_is_not_iterable(one, i, n, a_i):
+    """
+    Test that iterable access remains specific to :any:`Section`.
+    """
+    assign = ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
+    loop = ir.Loop(variable=i, bounds=sym.Range((one, n)), body=(assign,))
+
+    with pytest.raises(TypeError):
+        iter(loop)
+    with pytest.raises(TypeError):
+        _ = loop[0]
+    with pytest.raises(TypeError):
+        len(loop)
 
 
 def test_callstatement(scope, one, i, n, a_i):

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -284,7 +284,7 @@ def test_section_iterable(a_i):
 
 def test_loop_is_not_iterable(one, i, n, a_i):
     """
-    Test that iterable access remains specific to :any:`Section`.
+    Test that iterable access is not enabled for unrelated internal nodes.
     """
     assign = ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
     loop = ir.Loop(variable=i, bounds=sym.Range((one, n)), body=(assign,))
@@ -295,6 +295,27 @@ def test_loop_is_not_iterable(one, i, n, a_i):
         _ = loop[0]
     with pytest.raises(TypeError):
         len(loop)
+
+
+def test_associate_iterable(scope, a_i):
+    """
+    Test iterable-style access for :any:`Associate` while keeping it atomic.
+    """
+    b = sym.Scalar(name='b', scope=scope)
+    b_a = sym.Array(name='a', parent=b, scope=scope)
+    a = sym.Array(name='a', scope=scope)
+    assign1 = ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
+    assign2 = ir.Assignment(lhs=a_i.clone(parent=b), rhs=sym.Literal(66.6))
+
+    assoc = ir.Associate(associations=((b_a, a),), body=(assign1, assign2), parent=scope)
+
+    assert list(assoc) == list(assoc.body)
+    assert assoc[0] is assign1
+    assert assoc[-1] is assign2
+    assert assign1 in assoc
+    assert len(assoc) == len(assoc.body) == 2
+    assert as_tuple(assoc) == (assoc,)
+    assert flatten([assoc]) == [assoc]
 
 
 def test_callstatement(scope, one, i, n, a_i):

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -311,7 +311,7 @@ def test_associate_iterable(scope, a_i):
     assign1 = ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
     assign2 = ir.Assignment(lhs=a_i.clone(parent=b), rhs=sym.Literal(66.6))
 
-    assoc = ir.Associate(associations=((b_a, a),), body=(assign1, assign2), parent=scope)
+    assoc = ir.Associate(associations=((b_a, a),), body=(assign1, assign2), parent=scope)  # pylint: disable=unexpected-keyword-arg
 
     assert list(assoc) == list(assoc.body)
     assert assoc[0] is assign1

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -264,6 +264,29 @@ def test_section(n, a_n, a_i):
     assert sec.body == (assign, func, assign, func, assign)
 
 
+def test_internal_node_iterable(one, i, n, a_i):
+    """
+    Test iterable-style access for :any:`InternalNode` subclasses.
+    """
+    assign1 = ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
+    assign2 = ir.Assignment(lhs=a_i, rhs=sym.Literal(24.0))
+    bounds = sym.Range((one, n))
+
+    section = ir.Section(body=(assign1, assign2))
+    assert list(section) == list(section.body)
+    assert section[0] is assign1
+    assert section[-1] is assign2
+    assert assign1 in section
+    assert len(section) == len(section.body) == 2
+
+    loop = ir.Loop(variable=i, bounds=bounds, body=(assign1, assign2))
+    assert list(loop) == list(loop.body)
+    assert loop[0] is assign1
+    assert loop[-1] is assign2
+    assert assign2 in loop
+    assert len(loop) == len(loop.body) == 2
+
+
 def test_callstatement(scope, one, i, n, a_i):
     """ Test constructor of :any:`CallStatement` nodes. """
 

--- a/loki/ir/tests/test_ir_nodes.py
+++ b/loki/ir/tests/test_ir_nodes.py
@@ -271,13 +271,17 @@ def test_section_iterable(a_i):
     """
     assign1 = ir.Assignment(lhs=a_i, rhs=sym.Literal(42.0))
     assign2 = ir.Assignment(lhs=a_i, rhs=sym.Literal(24.0))
+    assign3 = ir.Assignment(lhs=a_i, rhs=sym.Literal(12.0))
 
-    section = ir.Section(body=(assign1, assign2))
+    section = ir.Section(body=(assign1, assign2, assign1, assign3))
     assert list(section) == list(section.body)
     assert section[0] is assign1
-    assert section[-1] is assign2
+    assert section[-1] is assign3
     assert assign1 in section
-    assert len(section) == len(section.body) == 2
+    assert len(section) == len(section.body) == 4
+    assert section.index(assign1) == 0
+    assert section.index(assign1, 1) == 2
+    assert section.index(assign3, 0, 4) == 3
     assert as_tuple(section) == (section,)
     assert flatten([section]) == [section]
 

--- a/loki/ir/tests/test_transformer.py
+++ b/loki/ir/tests/test_transformer.py
@@ -14,6 +14,7 @@ from loki.ir import (
     MaskedTransformer, NestedMaskedTransformer, SubstituteExpressions
 )
 from loki.expression import symbols as sym
+from loki.tools import as_tuple
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -287,6 +288,33 @@ end subroutine routine_simple
     assert len(new_loops) == 1
     assert len(FindNodes(ir.Assignment).visit(new_loops)) == 2
     assert len(FindNodes(ir.Assignment).visit(transformed)) == 4
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transformer_section_replacement_is_atomic(frontend):
+    """
+    Test that iterable :any:`Section` replacements remain atomic nodes.
+    """
+    fcode = """
+subroutine routine_simple(a)
+  integer, intent(inout) :: a
+
+  a = a + 1
+  a = a + 2
+end subroutine routine_simple
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    section = ir.Section(body=(assigns[1].clone(),), label='wrapped')
+
+    transformed = Transformer({assigns[0]: section}).visit(routine.body)
+
+    sections = FindNodes(ir.Section).visit(transformed)
+    assert len(sections) == 2
+    assert any(s.label == 'wrapped' for s in sections)
+    wrapped = next(s for s in sections if s.label == 'wrapped')
+    assert as_tuple(wrapped) == (wrapped,)
+    assert len(FindNodes(ir.Assignment).visit(wrapped)) == 1
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/ir/tests/test_transformer.py
+++ b/loki/ir/tests/test_transformer.py
@@ -333,7 +333,7 @@ end subroutine routine_simple
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     assigns = FindNodes(ir.Assignment).visit(routine.body)
-    associate = ir.Associate(
+    associate = ir.Associate(  # pylint: disable=unexpected-keyword-arg
         associations=((routine.variable_map['a'], routine.variable_map['b']),),
         body=(assigns[1].clone(),), parent=routine
     )

--- a/loki/ir/tests/test_transformer.py
+++ b/loki/ir/tests/test_transformer.py
@@ -318,6 +318,35 @@ end subroutine routine_simple
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_transformer_associate_replacement_is_atomic(frontend):
+    """
+    Test that iterable :any:`Associate` replacements remain atomic nodes.
+    """
+    fcode = """
+subroutine routine_simple(a)
+  integer, intent(inout) :: a
+  integer :: b
+
+  a = a + 1
+  b = a + 2
+end subroutine routine_simple
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    associate = ir.Associate(
+        associations=((routine.variable_map['a'], routine.variable_map['b']),),
+        body=(assigns[1].clone(),), parent=routine
+    )
+
+    transformed = Transformer({assigns[0]: associate}).visit(routine.body)
+
+    associates = FindNodes(ir.Associate).visit(transformed)
+    assert len(associates) == 1
+    assert as_tuple(associates[0]) == (associates[0],)
+    assert len(FindNodes(ir.Assignment).visit(associates[0])) == 1
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_masked_transformer(frontend):
     """
     A very basic sanity test for the MaskedTransformer class.

--- a/loki/ir/tests/test_transformer.py
+++ b/loki/ir/tests/test_transformer.py
@@ -534,8 +534,8 @@ end subroutine masked_transformer
     assert len(FindNodes(ir.Assignment).visit(body)) == len(assignments) - 1
     assocs = FindNodes(ir.Associate).visit(body)
     assert len(assocs) == 1
-    assert len(assocs[0].body) == len(assignments) - 1
-    assert all(isinstance(n, ir.Assignment) for n in assocs[0].body)
+    assert len(assocs[0]) == len(assignments) - 1
+    assert all(isinstance(n, ir.Assignment) for n in assocs[0])
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/tests/test_sourcefile.py
+++ b/loki/tests/test_sourcefile.py
@@ -340,14 +340,14 @@ end subroutine myroutine
     assert isinstance(source.ir.body[2], RawSource)
 
     myroutine = source['myroutine']
-    assert isinstance(myroutine.spec.body[0], RawSource)
+    assert isinstance(myroutine.spec[0], RawSource)
 
     source.make_complete(frontend=frontend)
 
     assert isinstance(source.ir.body[0], Comment)
     assert isinstance(source.ir.body[2], Comment)
     if frontend == OMNI:
-        assert isinstance(myroutine.body.body[0], Comment)
+        assert isinstance(myroutine.body[0], Comment)
     else:
         assert isinstance(myroutine.docstring[0], Comment)
 

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -83,27 +83,27 @@ end subroutine routine_simple
     # Check the spec
     assert isinstance(routine.body, ir.Section)
     if frontend == OMNI:
-        assert len(routine.spec.body) == 9
-        assert isinstance(routine.spec.body[0], ir.Intrinsic)
-        assert isinstance(routine.spec.body[1], ir.Pragma)
-        assert all(isinstance(n, ir.VariableDeclaration) for n in routine.spec.body[2:])
-        assert routine.spec.body[2].symbols == ('jprb',)
-        assert routine.spec.body[3].symbols == ('x',)
-        assert routine.spec.body[4].symbols == ('y',)
-        assert routine.spec.body[5].symbols == ('scalar',)
-        assert routine.spec.body[6].symbols == ('vector(x)',)
-        assert routine.spec.body[7].symbols == ('matrix(x, y)',)
-        assert routine.spec.body[8].symbols == ('i',)
+        assert len(routine.spec) == 9
+        assert isinstance(routine.spec[0], ir.Intrinsic)
+        assert isinstance(routine.spec[1], ir.Pragma)
+        assert all(isinstance(n, ir.VariableDeclaration) for n in routine.spec[2:])
+        assert routine.spec[2].symbols == ('jprb',)
+        assert routine.spec[3].symbols == ('x',)
+        assert routine.spec[4].symbols == ('y',)
+        assert routine.spec[5].symbols == ('scalar',)
+        assert routine.spec[6].symbols == ('vector(x)',)
+        assert routine.spec[7].symbols == ('matrix(x, y)',)
+        assert routine.spec[8].symbols == ('i',)
     else:
-        assert len(routine.spec.body) == 7
-        assert isinstance(routine.spec.body[0], ir.Pragma)
-        assert isinstance(routine.spec.body[1], ir.Comment)
-        assert all(isinstance(n, ir.VariableDeclaration) for n in routine.spec.body[2:])
-        assert routine.spec.body[2].symbols == ('jprb',)
-        assert routine.spec.body[3].symbols == ('x', 'y')
-        assert routine.spec.body[4].symbols == ('scalar',)
-        assert routine.spec.body[5].symbols == ('vector(x)', 'matrix(x, y)')
-        assert routine.spec.body[6].symbols == ('i',)
+        assert len(routine.spec) == 7
+        assert isinstance(routine.spec[0], ir.Pragma)
+        assert isinstance(routine.spec[1], ir.Comment)
+        assert all(isinstance(n, ir.VariableDeclaration) for n in routine.spec[2:])
+        assert routine.spec[2].symbols == ('jprb',)
+        assert routine.spec[3].symbols == ('x', 'y')
+        assert routine.spec[4].symbols == ('scalar',)
+        assert routine.spec[5].symbols == ('vector(x)', 'matrix(x, y)')
+        assert routine.spec[6].symbols == ('i',)
 
     # Check the routine body
     assert isinstance(routine.spec, ir.Section)
@@ -133,9 +133,9 @@ end subroutine my_routine
     assert routine.prefix == ('PURE', 'ELEMENTAL')
 
     # Check that routine was parsed completely
-    assert isinstance(routine.body.body[-1], ir.Assignment)
-    assert routine.body.body[-1].lhs == 'x'
-    assert routine.body.body[-1].rhs == 'x + y'
+    assert isinstance(routine.body[-1], ir.Assignment)
+    assert routine.body[-1].lhs == 'x'
+    assert routine.body[-1].rhs == 'x + y'
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
@@ -179,9 +179,9 @@ end module my_module
     assert intf_routine == routine
 
     # Check that module routine was parsed completely
-    assert isinstance(routine.body.body[-1], ir.Assignment)
-    assert routine.body.body[-1].lhs == 'x'
-    assert routine.body.body[-1].rhs == 'x + y'
+    assert isinstance(routine.body[-1], ir.Assignment)
+    assert routine.body[-1].lhs == 'x'
+    assert routine.body[-1].rhs == 'x + y'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -924,10 +924,10 @@ end subroutine routine_empty_spec
 """)
     if frontend == OMNI:
         # OMNI inserts IMPLICIT NONE into spec
-        assert len(routine.spec.body) == 1
+        assert len(routine.spec) == 1
     else:
-        assert not routine.spec.body
-    assert len(routine.body.body) == 1
+        assert not routine.spec
+    assert len(routine.body) == 1
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -50,9 +50,10 @@ def _is_atomic_iterable_ir_node(obj):
     nodes_module = sys.modules.get('loki.ir.nodes')
     section_type = getattr(nodes_module, 'Section', None)
     associate_type = getattr(nodes_module, 'Associate', None)
+    obj_type = obj.__class__
     return (
-        (section_type is not None and type(obj) is section_type)
-        or (associate_type is not None and type(obj) is associate_type)
+        (section_type is not None and obj_type is section_type)
+        or (associate_type is not None and obj_type is associate_type)
     )
 
 

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -43,6 +43,15 @@ __all__ = [
 ]
 
 
+def _is_loki_section(obj):
+    """
+    Return ``True`` for plain ``ir.Section`` objects while avoiding import cycles.
+    """
+    nodes_module = sys.modules.get('loki.ir.nodes')
+    section_type = getattr(nodes_module, 'Section', None)
+    return section_type is not None and type(obj) is section_type
+
+
 def as_tuple(item, type=None, length=None):
     """
     Force item to a tuple, even if `None` is provided.
@@ -55,6 +64,8 @@ def as_tuple(item, type=None, length=None):
         t = ()
     elif isinstance(item, str):
         t = (item,)
+    elif _is_loki_section(item):
+        t = (item,) * (length or 1)
     else:
         # Convert iterable to list...
         try:
@@ -78,6 +89,8 @@ def is_iterable(o):
     identified as a :class:`collections.Iterable` and thus this is a much more reliable test than
     ``isinstance(obj, collections.Iterable)``.
     """
+    if _is_loki_section(o):
+        return False
     try:
         iter(o)
     except TypeError:

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -47,14 +47,8 @@ def _is_atomic_iterable_ir_node(obj):
     """
     Return ``True`` for iterable IR nodes that should stay atomic in helpers.
     """
-    nodes_module = sys.modules.get('loki.ir.nodes')
-    section_type = getattr(nodes_module, 'Section', None)
-    associate_type = getattr(nodes_module, 'Associate', None)
-    obj_type = obj.__class__
-    return (
-        (section_type is not None and obj_type is section_type)
-        or (associate_type is not None and obj_type is associate_type)
-    )
+    from loki.ir import nodes as ir  # pylint: disable=import-outside-toplevel, cyclic-import
+    return isinstance(obj, (ir.Section, ir.Associate))
 
 
 def as_tuple(item, type=None, length=None):

--- a/loki/tools/util.py
+++ b/loki/tools/util.py
@@ -43,13 +43,17 @@ __all__ = [
 ]
 
 
-def _is_loki_section(obj):
+def _is_atomic_iterable_ir_node(obj):
     """
-    Return ``True`` for plain ``ir.Section`` objects while avoiding import cycles.
+    Return ``True`` for iterable IR nodes that should stay atomic in helpers.
     """
     nodes_module = sys.modules.get('loki.ir.nodes')
     section_type = getattr(nodes_module, 'Section', None)
-    return section_type is not None and type(obj) is section_type
+    associate_type = getattr(nodes_module, 'Associate', None)
+    return (
+        (section_type is not None and type(obj) is section_type)
+        or (associate_type is not None and type(obj) is associate_type)
+    )
 
 
 def as_tuple(item, type=None, length=None):
@@ -64,7 +68,7 @@ def as_tuple(item, type=None, length=None):
         t = ()
     elif isinstance(item, str):
         t = (item,)
-    elif _is_loki_section(item):
+    elif _is_atomic_iterable_ir_node(item):
         t = (item,) * (length or 1)
     else:
         # Convert iterable to list...
@@ -89,7 +93,7 @@ def is_iterable(o):
     identified as a :class:`collections.Iterable` and thus this is a much more reliable test than
     ``isinstance(obj, collections.Iterable)``.
     """
-    if _is_loki_section(o):
+    if _is_atomic_iterable_ir_node(o):
         return False
     try:
         iter(o)

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -461,7 +461,7 @@ def check_variable_type_device(var, routine, calls, pragmas, access):
     pragmas = [pragma for pragma in pragmas
                if 'unstructured-data attach' in pragma.content and f'{var}%p' in pragma.content]
     if calls and pragmas:
-        assert routine.body.body.index(calls[0]) < routine.body.body.index(pragmas[0])
+        assert routine.body.index(calls[0]) < routine.body.index(pragmas[0])
         _pass += 1
 
     assert _pass == 1
@@ -504,12 +504,12 @@ def check_other_variable_type(mode, conds, calls, pragmas, routine):
         # Check copy to device of struct
         pragma = [p for p in pragmas if
                   'unstructured-data in' in p.content and '(variable)' in p.content][0]
-        assert routine.body.body.index(pragma) < routine.body.body.index(conds[0])
+        assert routine.body.index(pragma) < routine.body.index(conds[0])
 
         # Check deletion of struct from device
         pragma = [p for p in pragmas if
                   'exit unstructured-data delete' in p.content and '(variable)' in p.content][0]
-        assert routine.body.body.index(pragma) > routine.body.body.index(conds[-1])
+        assert routine.body.index(pragma) > routine.body.index(conds[-1])
 
         # Check FIELD_API boilerplate for copying to device
         _pass = 0
@@ -520,7 +520,7 @@ def check_other_variable_type(mode, conds, calls, pragmas, routine):
         pragmas = [pragma for pragma in pragmas
                    if 'unstructured-data attach' in pragma.content and 'variable%vt0_field' in pragma.content]
         if calls and pragmas:
-            assert routine.body.body.index(calls[0]) < routine.body.body.index(pragmas[0])
+            assert routine.body.index(calls[0]) < routine.body.index(pragmas[0])
             _pass += 1
 
         # Check FIELD_API boilerplate for wiping device
@@ -557,12 +557,12 @@ def check_view_prefix_variable_type(mode, conds, calls, pragmas, routine):
         # Check copy to device of struct
         pragma = [p for p in pragmas if 'unstructured-data in' in p.content and
                   '(another_variable)' in p.content][0]
-        assert routine.body.body.index(pragma) < routine.body.body.index(conds[0])
+        assert routine.body.index(pragma) < routine.body.index(conds[0])
 
         # Check deletion of struct from device
         pragma = [p for p in pragmas if 'exit unstructured-data delete' in p.content and
                   '(another_variable)' in p.content][0]
-        assert routine.body.body.index(pragma) > routine.body.body.index(conds[-1])
+        assert routine.body.index(pragma) > routine.body.index(conds[-1])
 
         # Check FIELD_API boilerplate for copying to device
         call_name = 'sget_device_data_rdonly'
@@ -577,7 +577,7 @@ def check_view_prefix_variable_type(mode, conds, calls, pragmas, routine):
                    and 'another_variable%pt1_field' in pragma.content]
 
         if calls and pragmas:
-            assert routine.body.body.index(calls[0]) < routine.body.body.index(pragmas[0])
+            assert routine.body.index(calls[0]) < routine.body.index(pragmas[0])
             _pass += 1
 
         # Check FIELD_API boilerplate for wiping device
@@ -612,7 +612,7 @@ def check_geometry(conds, pragmas, routine):
     # Check copy to device of struct
     pragma = [p for p in pragmas if
               'unstructured-data in' in p.content and '(geometry)' in p.content][0]
-    assert routine.body.body.index(pragma) < routine.body.body.index(conds[0])
+    assert routine.body.index(pragma) < routine.body.index(conds[0])
 
     # Check copy to device of member
     assert 'unstructured-data in' in conds[0].body[0].content
@@ -621,7 +621,7 @@ def check_geometry(conds, pragmas, routine):
     # Check deletion of struct from device
     pragma = [p for p in pragmas if 'exit unstructured-data delete' in p.content
               and '(geometry)' in p.content and 'finalize' in p.content][0]
-    assert routine.body.body.index(pragma) > routine.body.body.index(conds[-1])
+    assert routine.body.index(pragma) > routine.body.index(conds[-1])
 
     # Check deletion of member from device
     assert 'exit unstructured-data delete' in conds[-1].body[0].content
@@ -657,12 +657,12 @@ def check_struct(mode, conds, calls, pragmas, routine):
         # Check copy to device of struct
         pragma = [p for p in pragmas if
                   'unstructured-data in' in p.content and '(struct)' in p.content][0]
-        assert routine.body.body.index(pragma) < routine.body.body.index(struct_conds[0])
+        assert routine.body.index(pragma) < routine.body.index(struct_conds[0])
 
         # Check deletion of struct from device
         pragma = [p for p in pragmas if
                   'exit unstructured-data delete' in p.content and '(struct)' in p.content][0]
-        assert routine.body.body.index(pragma) > routine.body.body.index(struct_conds[-1])
+        assert routine.body.index(pragma) > routine.body.index(struct_conds[-1])
 
         check_variable_type_device('struct%a', routine, calls, pragmas, 'wronly')
         check_variable_type_device('struct%b', routine, calls, pragmas, 'rdwr')

--- a/loki/transformations/parametrise.py
+++ b/loki/transformations/parametrise.py
@@ -341,7 +341,7 @@ class ParametriseTransformation(Transformation):
             # introduce parameter declarations
             declarations = FindNodes(ir.VariableDeclaration).visit(routine.spec)
             for parameter_declaration in parameter_declarations:
-                routine.spec.insert(routine.spec.body.index(declarations[0]), parameter_declaration)
+                routine.spec.insert(routine.spec.index(declarations[0]), parameter_declaration)
 
             # replace all parameter variables with their corresponding value (inline constant parameters)
             if self.replace_by_value:

--- a/loki/transformations/single_column/scc_cuf.py
+++ b/loki/transformations/single_column/scc_cuf.py
@@ -59,13 +59,13 @@ class HoistTemporaryArraysDeviceAllocatableTransformation(HoistVariablesTransfor
 
             allocations = FindNodes(ir.Allocation).visit(routine.body)
             if allocations:
-                insert_index = routine.body.body.index(allocations[-1])
+                insert_index = routine.body.index(allocations[-1])
                 routine.body.insert(insert_index + 1, ir.Allocation((var.clone(),)))
             else:
                 routine.body.prepend(ir.Allocation((var.clone(),)))
             de_allocations = FindNodes(ir.Deallocation).visit(routine.body)
             if de_allocations:
-                insert_index = routine.body.body.index(de_allocations[-1])
+                insert_index = routine.body.index(de_allocations[-1])
                 routine.body.insert(insert_index + 1, ir.Deallocation((var.clone(dimensions=None),)))
             else:
                 routine.body.append(ir.Deallocation((var.clone(dimensions=None),)))
@@ -815,7 +815,7 @@ class SccLowLevelDataOffload(Transformation):
 
             allocations = FindNodes(ir.Allocation).visit(routine.body)
             if allocations:
-                insert_index = routine.body.body.index(allocations[-1]) + 1
+                insert_index = routine.body.index(allocations[-1]) + 1
             else:
                 insert_index = None
             # or: insert_index = routine.body.body.index(calls[0])
@@ -836,7 +836,7 @@ class SccLowLevelDataOffload(Transformation):
             insert_index = None
             for call in FindNodes(ir.CallStatement).visit(routine.body):
                 if "THREAD_END" in str(call.name):  # TODO: fix/check: very specific to CLOUDSC
-                    insert_index = routine.body.body.index(call) + 1
+                    insert_index = routine.body.index(call) + 1
 
             if insert_index is None:
                 routine.body.append(ir.Comment(''))

--- a/loki/transformations/single_column/tests/test_scc_vector.py
+++ b/loki/transformations/single_column/tests/test_scc_vector.py
@@ -632,16 +632,16 @@ def test_scc_vector_section_trim_simple(frontend, horizontal, trim_vector_sectio
 
         if trim_vector_sections:
             assert assign not in loop.body
-            assert assign in routine.body.body
+            assert assign in routine.body
 
             assert comment not in loop.body
-            assert comment in routine.body.body
+            assert comment in routine.body
         else:
             assert assign in loop.body
-            assert assign not in routine.body.body
+            assert assign not in routine.body
 
             assert comment in loop.body
-            assert comment not in routine.body.body
+            assert comment not in routine.body
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -689,10 +689,10 @@ def test_scc_vector_section_trim_nested(frontend, horizontal, trim_vector_sectio
 
     if trim_vector_sections:
         assert cond not in loop.body
-        assert cond in routine.body.body
+        assert cond in routine.body
     else:
         assert cond in loop.body
-        assert cond not in routine.body.body
+        assert cond not in routine.body
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -745,7 +745,7 @@ def test_scc_vector_section_trim_complex(
     loop = FindNodes(ir.Loop).visit(routine.body)[0]
 
     assert cond in loop.body
-    assert cond not in routine.body.body
+    assert cond not in routine.body
     if trim_vector_sections:
         assert assign not in loop.body
         assert(len(FindNodes(ir.Assignment).visit(loop.body)) == 3)

--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -207,9 +207,9 @@ end module some_mod
     )
 
     # ...and full substitution
-    assert fgen(routine.body.body[0]).lower() == 'my_obj%a = my_obj%my_add(my_obj%a(1:my_obj%m, 1:my_obj%n), 1.)'
+    assert fgen(routine.body[0]).lower() == 'my_obj%a = my_obj%my_add(my_obj%a(1:my_obj%m, 1:my_obj%n), 1.)'
     routine.body = SubstituteExpressions(expr_map).visit(routine.body)
-    assert fgen(routine.body.body[0]) == 'obj%a = obj%my_add(obj%a(1:obj%m, 1:obj%n), 1.)'
+    assert fgen(routine.body[0]) == 'obj%a = obj%my_add(obj%a(1:obj%m, 1:obj%n), 1.)'
 
 @pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Argument mismatch for "min"')]))
 def test_transform_utilites_replace_intrinsics(frontend):
@@ -656,7 +656,7 @@ end module test_get_local_arrays_mod
     assert len(local_arrs) == 2
     assert all(l == 'local(i)' for l in local_arrs)
 
-    local_arrs = get_local_arrays(routine, routine.body.body[-1:], unique=False)
+    local_arrs = get_local_arrays(routine, routine.body[-1:], unique=False)
     assert len(local_arrs) == 1
     assert local_arrs[0] == 'local(i)'
 

--- a/loki/types/tests/test_derived_types.py
+++ b/loki/types/tests/test_derived_types.py
@@ -1267,7 +1267,7 @@ end subroutine driver
     driver = Subroutine.from_source(fcode_driver, frontend=frontend, definitions=[module], xmods=[tmp_path])
 
     other_routine = module['other_routine']
-    call = other_routine.body.body[0]
+    call = other_routine.body[0]
     assert isinstance(call, ir.CallStatement)
     assert isinstance(call.name.type.dtype, ProcedureType)
     assert call.name.parent and isinstance(call.name.parent.type.dtype, DerivedType)


### PR DESCRIPTION
## Summary
- add direct sequence-style access for `ir.Section` and `ir.Associate`, including iteration, indexing, containment, and `Section.index(...)`
- preserve existing helper and transformer behavior by treating iterable IR block nodes as atomic in generic utilities such as `as_tuple` and `is_iterable`
- adopt the new API across transformation code and tests by replacing many `routine.body.body` / `routine.spec.body` access patterns with direct `Section` access

## Why
Issue #106 asked for less awkward access to IR block nodes without having to repeatedly reach into `.body`. This change makes the most common block-like nodes easier to work with while avoiding the broader compatibility problems that come from making all `InternalNode` subclasses generically iterable.

## What Changed
- `ir.Section`
  - supports direct iteration, indexing, containment, length, and `index(...)`
- `ir.Associate`
  - inherits the same direct sequence-style access as a scoped block node
  - retains truthy node semantics for scope-sensitive code paths
- `loki.tools.util`
  - keeps iterable IR block nodes atomic for helper logic that distinguishes nodes from replacement sequences
- tests
  - add regression coverage for `Section` and `Associate` sequence behavior
  - add transformer compatibility coverage to ensure iterable block nodes are still treated as atomic replacements
  - update transformation and test code to use direct section accessors

## Validation
Ran:

```bash
. ./loki-activate
python -m pytest   loki/ir/tests/test_ir_nodes.py   loki/ir/tests/test_transformer.py   loki/transformations/single_column/tests/test_scc_vector.py   loki/transformations/tests/test_utilities.py   loki/transformations/data_offload/tests/test_offload_deepcopy.py   loki/tests/test_subroutine.py   loki/tests/test_sourcefile.py   loki/batch/tests/test_transformation.py   loki/backend/tests/test_fgen.py   loki/types/tests/test_derived_types.py   loki/expression/tests/test_expression.py::test_stmt_func_heuristic[fp]   loki/frontend/tests/test_frontends.py::test_associates[fp]   loki/ir/tests/test_scoped_nodes.py::test_scoped_node_get_symbols[fp]   loki/ir/tests/test_scoped_nodes.py::test_scoped_node_parse_expr[fp]   loki/ir/tests/test_visitor.py::test_attach_scopes_associates[fp]   loki/transformations/sanitise/tests/test_associates.py
```

Results:
- focused IR / transformation cleanup suite: `374 passed, 8 skipped, 10 xfailed`
- associate/scoping validation suite: `68 passed, 16 skipped`
- transformer suite after final associate cleanup: `36 passed`