### PR TITLE
Vertical k-caching for SCC pipeline(s) and beyond

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: ecmwf-ifs/dwarf-p-cloudsc
           path: cloudsc
-          ref: develop
+          ref: nams-scc-k-caching
 
       - name: Clone CLOUDSC2 TL AD
         uses: actions/checkout@v4

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -9,20 +9,26 @@
 Collection of dataflow analysis schema routines.
 """
 
+from collections import defaultdict
 from contextlib import contextmanager
 from loki.expression import Array, ProcedureSymbol
+import loki.expression.symbols as sym
+from loki.expression.symbolic import simplify, is_constant, is_minus_prefix, strip_minus_prefix
 from loki.ir.expr_visitors import FindLiterals
 from loki.tools import as_tuple, flatten, OrderedSet
 from loki.types import BasicType
 from loki.ir import (
-    Visitor, Transformer, FindVariables, FindInlineCalls, FindTypedSymbols
+    Visitor, Transformer, FindVariables, FindInlineCalls, FindTypedSymbols,
+    FindNodes, Assignment, Loop
 )
 from loki.subroutine import Subroutine
 from loki.tools.util import CaseInsensitiveDict
 
 __all__ = [
     'dataflow_analysis_attached', 'read_after_write_vars',
-    'loop_carried_dependencies'
+    'loop_carried_dependencies', 'classify_array_access_offsets',
+    'array_loop_carried_dependencies', 'detect_vertical_carry_variables',
+    'classify_multilevel_arrays'
 ]
 
 
@@ -32,6 +38,8 @@ def strip_nested_dimensions(expr):
     nesting depth.
     """
 
+    if not hasattr(expr, 'parent'):
+        return expr
     parent = expr.parent
     if parent:
         parent = strip_nested_dimensions(parent)
@@ -654,3 +662,440 @@ def loop_carried_dependencies(loop):
         The list of variables that potentially have a loop-carried dependency.
     """
     return loop.uses_symbols & loop.defines_symbols
+
+
+def _extract_offset(dim, loop_var):
+    """
+    Extract the integer offset of an array subscript expression relative to
+    a loop variable.
+
+    For example, if ``dim`` is ``JK - 1`` and ``loop_var`` is ``JK``, this
+    returns ``-1``. If ``dim`` is exactly ``JK``, this returns ``0``.
+    If ``dim`` does not involve ``loop_var`` or is non-affine, returns
+    :data:`None`.
+
+    Parameters
+    ----------
+    dim : expression
+        The subscript expression for one dimension of an array access.
+    loop_var : :any:`Scalar` or str
+        The loop induction variable.
+
+    Returns
+    -------
+    int or None
+        The integer offset, or ``None`` if the expression is not an affine
+        function of :data:`loop_var`.
+    """
+    loop_var_name = loop_var.name.lower() if hasattr(loop_var, 'name') else str(loop_var).lower()
+
+    # Check whether loop_var appears in this dimension at all
+    found_vars = FindVariables().visit(dim)
+    if not any(v.name.lower() == loop_var_name for v in found_vars):
+        return None
+
+    # If dim is exactly the loop variable, offset is 0
+    if isinstance(dim, (sym.Scalar, sym.DeferredTypeSymbol)):
+        if dim.name.lower() == loop_var_name:
+            return 0
+        return None
+
+    # Compute dim - loop_var and simplify; if the result is a compile-time
+    # constant, the offset is that constant value.
+    try:
+        diff = simplify(dim - loop_var)
+    except (TypeError, AttributeError):
+        return None
+
+    if isinstance(diff, sym.IntLiteral):
+        return diff.value
+    if isinstance(diff, int):
+        return diff
+    if is_minus_prefix(diff):
+        inner = strip_minus_prefix(diff)
+        if isinstance(inner, sym.IntLiteral):
+            return -inner.value
+        if isinstance(inner, int):
+            return -inner
+    if is_constant(diff):
+        # Try to evaluate numerically as a last resort
+        try:
+            from loki.expression.evaluation import LokiEvaluationMapper
+            val = LokiEvaluationMapper()(diff)
+            if isinstance(val, (int, float)) and val == int(val):
+                return int(val)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    return None
+
+
+def _collect_array_accesses(node, loop_var):
+    """
+    Walk an IR subtree and collect all array accesses, classifying each
+    subscript dimension that involves the loop variable by its integer offset.
+
+    Parameters
+    ----------
+    node : :any:`Node`
+        The IR subtree to walk (e.g., a loop body or an assignment).
+    loop_var : :any:`Scalar` or str
+        The loop induction variable.
+
+    Returns
+    -------
+    list of tuple
+        Each entry is ``(array_name, dim_index, offset, access_type)`` where:
+        - ``array_name`` : str (lowercased)
+        - ``dim_index`` : int (which dimension of the array, 0-based)
+        - ``offset`` : int (the offset relative to ``loop_var``)
+        - ``access_type`` : str, either ``'read'`` or ``'write'``
+    """
+    accesses = []
+    loop_var_name = loop_var.name.lower() if hasattr(loop_var, 'name') else str(loop_var).lower()
+
+    for assign in FindNodes(Assignment).visit(node):
+        # --- LHS: write access ---
+        lhs = assign.lhs
+        if isinstance(lhs, sym.Array) and lhs.dimensions:
+            for dim_idx, dim in enumerate(lhs.dimensions):
+                offset = _extract_offset(dim, loop_var)
+                if offset is not None:
+                    accesses.append((lhs.name.lower(), dim_idx, offset, 'write'))
+
+        # --- RHS: read accesses ---
+        rhs_vars = FindVariables().visit(assign.rhs)
+        for var in rhs_vars:
+            if isinstance(var, sym.Array) and var.dimensions:
+                for dim_idx, dim in enumerate(var.dimensions):
+                    offset = _extract_offset(dim, loop_var)
+                    if offset is not None:
+                        accesses.append((var.name.lower(), dim_idx, offset, 'read'))
+
+        # Also check for read accesses on the LHS (e.g., arr(JK-1) on LHS
+        # means the array is read at the subscript level for other dimensions,
+        # and more importantly, if LHS is arr(JK) but rhs references arr too,
+        # the LHS subscript dimensions are used for the write address)
+        # Additionally, the LHS variable may appear on the RHS (self-update)
+        if isinstance(lhs, sym.Array) and lhs.dimensions:
+            rhs_var_names = {v.name.lower() for v in rhs_vars if isinstance(v, sym.Array)}
+            if lhs.name.lower() in rhs_var_names:
+                # The array is both read and written; reads from RHS are
+                # already captured above, so nothing extra needed
+                pass
+
+    return accesses
+
+
+def classify_array_access_offsets(loop, loop_var=None):
+    """
+    For a given loop, classify all array accesses in the loop body by their
+    subscript offset relative to the loop induction variable.
+
+    This is a subscript-aware analysis that goes beyond the symbol-level
+    :func:`loop_carried_dependencies`. It examines which dimension of each
+    array uses the loop variable and at what offset (e.g., ``JK``, ``JK-1``,
+    ``JK+1``).
+
+    Parameters
+    ----------
+    loop : :any:`Loop`
+        The loop node to analyse.
+    loop_var : expression, optional
+        The loop induction variable. If not given, uses ``loop.variable``.
+
+    Returns
+    -------
+    dict
+        A dict mapping ``(array_name, dim_index)`` to a dict of
+        ``{offset: set_of_access_types}`` where ``access_types`` are
+        ``'read'`` and/or ``'write'``. For example::
+
+            {
+                ('zpfplsx', 2): {0: {'read'}, 1: {'write'}},
+                ('za', 1):      {0: {'read', 'write'}, -1: {'read'}},
+            }
+    """
+    if loop_var is None:
+        loop_var = loop.variable
+
+    accesses = _collect_array_accesses(loop.body, loop_var)
+
+    result = {}
+    for arr_name, dim_idx, offset, access_type in accesses:
+        key = (arr_name, dim_idx)
+        if key not in result:
+            result[key] = {}
+        if offset not in result[key]:
+            result[key][offset] = set()
+        result[key][offset].add(access_type)
+
+    return result
+
+
+def array_loop_carried_dependencies(loop, loop_var=None):
+    """
+    Find arrays that have true loop-carried dependencies based on subscript
+    analysis.
+
+    Unlike :func:`loop_carried_dependencies`, this function examines the
+    actual array subscript offsets relative to the loop induction variable to
+    determine whether different iterations of the loop access overlapping
+    data elements.
+
+    A loop-carried dependency exists when:
+
+    - **Flow (RAW)**: An array is written at offset ``w`` and read at
+      offset ``r`` where ``w != r`` (the read at iteration ``k`` accesses
+      data written at iteration ``k + (r - w)``).
+    - **Anti (WAR)**: An array is read at offset ``r`` and written at
+      offset ``w`` where ``w != r``.
+    - **Output (WAW)**: An array is written at two different offsets.
+
+    The dependency distance is ``r - w`` for flow dependencies.
+
+    Parameters
+    ----------
+    loop : :any:`Loop`
+        The loop node to analyse.
+    loop_var : expression, optional
+        The loop induction variable. If not given, uses ``loop.variable``.
+
+    Returns
+    -------
+    dict
+        A dict mapping ``array_name`` to a list of dependency descriptors.
+        Each descriptor is a dict with keys:
+
+        - ``'type'``: one of ``'flow'`` (RAW), ``'anti'`` (WAR), ``'output'`` (WAW)
+        - ``'dim_index'``: which dimension (0-based) carries the dependency
+        - ``'write_offset'``: integer offset of the write access
+        - ``'read_offset'``: integer offset of the read access (for flow/anti)
+          or second write offset (for output)
+        - ``'distance'``: the dependency distance (positive means the read
+          depends on data from an earlier iteration in an ascending loop)
+
+        Example::
+
+            {
+                'zpfplsx': [
+                    {'type': 'flow', 'dim_index': 2, 'write_offset': 1,
+                     'read_offset': 0, 'distance': -1}
+                ],
+                'za': [
+                    {'type': 'flow', 'dim_index': 1, 'write_offset': 0,
+                     'read_offset': -1, 'distance': -1}
+                ]
+            }
+    """
+    access_map = classify_array_access_offsets(loop, loop_var)
+
+    deps = defaultdict(list)
+
+    for (arr_name, dim_idx), offset_map in access_map.items():
+        write_offsets = [off for off, types in offset_map.items() if 'write' in types]
+        read_offsets = [off for off, types in offset_map.items() if 'read' in types]
+
+        # Flow dependencies (RAW): written at w, read at r, with w != r
+        for w in write_offsets:
+            for r in read_offsets:
+                if w != r:
+                    deps[arr_name].append({
+                        'type': 'flow',
+                        'dim_index': dim_idx,
+                        'write_offset': w,
+                        'read_offset': r,
+                        'distance': r - w
+                    })
+
+        # Anti dependencies (WAR): read at r, written at w, with w != r
+        # (these are distinct from flow deps when considering ordering)
+        # Note: for the same pair (w, r) with w != r, we already have a flow dep.
+        # An anti dep is the reverse direction -- read first, then write.
+        # In a single loop body executed top-to-bottom, both can exist.
+        # We report anti deps only for pairs where there is a read but NOT
+        # a write at the same offset (otherwise it is a self-update, not anti).
+        # Actually, for loop-carried dependency analysis, both flow and anti
+        # matter. The flow deps are already captured above. Anti deps with
+        # different offsets are the same pairs but with reversed roles.
+        # We avoid double-reporting: flow covers (write_off, read_off),
+        # anti would be the same pair interpreted differently.
+        # For clarity, we only report flow and output dependencies here.
+        # The flow dependency direction already captures both RAW and WAR
+        # depending on the sign of the distance.
+
+        # Output dependencies (WAW): written at two different offsets
+        for i, w1 in enumerate(write_offsets):
+            for w2 in write_offsets[i+1:]:
+                deps[arr_name].append({
+                    'type': 'output',
+                    'dim_index': dim_idx,
+                    'write_offset': w1,
+                    'read_offset': w2,
+                    'distance': w2 - w1
+                })
+
+    return dict(deps)
+
+
+def detect_vertical_carry_variables(loop, loop_var=None):
+    """
+    Detect variables that serve as inter-iteration state carriers within
+    a vertical loop.
+
+    This identifies two patterns commonly found in column-based physics
+    parameterizations:
+
+    1. **Scalar carries**: Variables with no vertical dimension (e.g.,
+       1-D horizontal arrays or scalars) that are both read and written
+       within the loop body. These propagate state from one level to the
+       next (e.g., ``ZANEWM1``, ``ZCOVPTOT`` in CLOUDSC).
+
+    2. **Shift registers**: Arrays with a vertical dimension that are
+       written at one offset and read at a different offset of the loop
+       variable (e.g., written at ``JK+1`` and read at ``JK``). This is the
+       sedimentation flux pattern (``ZPFPLSX``).
+
+    Parameters
+    ----------
+    loop : :any:`Loop`
+        The loop node to analyse.
+    loop_var : expression, optional
+        The loop induction variable. If not given, uses ``loop.variable``.
+
+    Returns
+    -------
+    dict
+        A dict with two keys:
+
+        - ``'scalar_carries'``: list of dicts, each with:
+            - ``'name'``: variable name (lowercased)
+        - ``'shift_registers'``: list of dicts, each with:
+            - ``'name'``: array name (lowercased)
+            - ``'dim_index'``: which dimension carries the shift
+            - ``'write_offset'``: integer offset of the write
+            - ``'read_offset'``: integer offset of the read
+            - ``'direction'``: ``'downward'`` if write_offset > read_offset
+              (data flows from top to bottom in an ascending loop),
+              ``'upward'`` otherwise
+    """
+    if loop_var is None:
+        loop_var = loop.variable
+    loop_var_name = loop_var.name.lower() if hasattr(loop_var, 'name') else str(loop_var).lower()
+
+    # --- 1. Scalar carries ---
+    # Find variables (scalars or arrays without the loop variable in
+    # any subscript) that are both read and written.
+    write_names = set()
+    read_names = set()
+
+    for assign in FindNodes(Assignment).visit(loop.body):
+        lhs = assign.lhs
+        # Check if LHS is a variable that does NOT use the loop var
+        # in any of its subscript dimensions (i.e., it's a "horizontal-only"
+        # or scalar variable relative to this loop).
+        if isinstance(lhs, sym.Array) and lhs.dimensions:
+            uses_loop_var = False
+            for dim in lhs.dimensions:
+                found = FindVariables().visit(dim)
+                if any(v.name.lower() == loop_var_name for v in found):
+                    uses_loop_var = True
+                    break
+            if not uses_loop_var:
+                write_names.add(lhs.name.lower())
+        elif isinstance(lhs, (sym.Scalar, sym.DeferredTypeSymbol)):
+            write_names.add(lhs.name.lower())
+
+        # Check RHS for reads of variables without loop-var subscripts
+        for var in FindVariables().visit(assign.rhs):
+            if isinstance(var, sym.Array) and var.dimensions:
+                uses_loop_var = False
+                for dim in var.dimensions:
+                    found = FindVariables().visit(dim)
+                    if any(v.name.lower() == loop_var_name for v in found):
+                        uses_loop_var = True
+                        break
+                if not uses_loop_var:
+                    read_names.add(var.name.lower())
+            elif isinstance(var, (sym.Scalar, sym.DeferredTypeSymbol)):
+                if var.name.lower() != loop_var_name:
+                    read_names.add(var.name.lower())
+
+    scalar_carries = [
+        {'name': name}
+        for name in sorted(write_names & read_names)
+    ]
+
+    # --- 2. Shift registers ---
+    access_map = classify_array_access_offsets(loop, loop_var)
+    shift_registers = []
+
+    for (arr_name, dim_idx), offset_map in access_map.items():
+        write_offsets = [off for off, types in offset_map.items() if 'write' in types]
+        read_offsets = [off for off, types in offset_map.items() if 'read' in types]
+
+        for w in write_offsets:
+            for r in read_offsets:
+                if w != r:
+                    direction = 'downward' if w > r else 'upward'
+                    shift_registers.append({
+                        'name': arr_name,
+                        'dim_index': dim_idx,
+                        'write_offset': w,
+                        'read_offset': r,
+                        'direction': direction
+                    })
+
+    return {
+        'scalar_carries': scalar_carries,
+        'shift_registers': shift_registers
+    }
+
+
+def classify_multilevel_arrays(routine_or_node, loop_var):
+    """
+    Scan all vertical loops in a routine (or IR subtree) and return the set
+    of array names that are accessed at any non-zero offset of the given
+    loop variable.
+
+    This is a routine-wide version of the per-loop
+    :func:`classify_array_access_offsets`.  It collects information from
+    **every** loop whose induction variable matches *loop_var* (by name,
+    case-insensitive).  An array is classified as "multilevel" if, in *any*
+    of those loops, it is accessed at an offset other than ``0`` (e.g.,
+    ``JK-1``, ``JK+1``).
+
+    The result can be used to decide which arrays in a mixed init loop need
+    to remain in a separate (non-fused) loop and which can safely participate
+    in fusion and subsequent demotion.
+
+    Parameters
+    ----------
+    routine_or_node : :any:`Subroutine` or :any:`Node`
+        The routine or IR subtree to scan.  If a :any:`Subroutine`, the
+        routine's body is scanned.
+    loop_var : :any:`Scalar`, str, or :any:`DeferredTypeSymbol`
+        The loop induction variable whose offsets are of interest.
+
+    Returns
+    -------
+    set of str
+        Lowercased array names that have at least one access at a non-zero
+        offset of *loop_var* anywhere in the scanned IR.
+    """
+    loop_var_name = loop_var.name.lower() if hasattr(loop_var, 'name') else str(loop_var).lower()
+
+    # Determine the IR node to walk
+    body = routine_or_node.body if hasattr(routine_or_node, 'body') else routine_or_node
+
+    multilevel = set()
+
+    for loop in FindNodes(Loop).visit(body):
+        if loop.variable.name.lower() != loop_var_name:
+            continue
+        access_map = classify_array_access_offsets(loop, loop.variable)
+        for (arr_name, _dim_idx), offset_map in access_map.items():
+            if any(off != 0 for off in offset_map):
+                multilevel.add(arr_name)
+
+    return multilevel

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -28,7 +28,8 @@ __all__ = [
     'dataflow_analysis_attached', 'read_after_write_vars',
     'loop_carried_dependencies', 'classify_array_access_offsets',
     'array_loop_carried_dependencies', 'detect_loop_carry_variables',
-    'classify_nonzero_offset_arrays'
+    'classify_nonzero_offset_arrays',
+    'extract_offset'
 ]
 
 
@@ -664,7 +665,7 @@ def loop_carried_dependencies(loop):
     return loop.uses_symbols & loop.defines_symbols
 
 
-def _extract_offset(dim, loop_var):
+def extract_offset(dim, loop_var):
     """
     Extract the integer offset of an array subscript expression relative to
     a loop variable.
@@ -758,12 +759,21 @@ def _collect_array_accesses(node, loop_var):
     # captured.  This is intentional: the carry-pattern analysis that
     # consumes these results operates on assignment-level read/write
     # semantics within vertical loops.
+    #
+    # In particular, arrays passed as subroutine call arguments
+    # represent opaque operations whose internal read/write semantics
+    # cannot be determined from the caller side.  Conditional
+    # expressions (e.g. ``IF (arr(JK) > 0)``) are pure reads with no
+    # write counterpart, and loop bounds are similarly read-only
+    # contexts.  Extending this to non-assignment contexts would
+    # require a separate access-type classification strategy and is
+    # not needed for the carry-pattern and stencil-detection use cases.
     for assign in FindNodes(Assignment).visit(node):
         # --- LHS: write access ---
         lhs = assign.lhs
         if isinstance(lhs, sym.Array) and lhs.dimensions:
             for dim_idx, dim in enumerate(lhs.dimensions):
-                offset = _extract_offset(dim, loop_var)
+                offset = extract_offset(dim, loop_var)
                 if offset is not None:
                     accesses.append((lhs.name.lower(), dim_idx, offset, 'write'))
 
@@ -772,7 +782,7 @@ def _collect_array_accesses(node, loop_var):
         for var in rhs_vars:
             if isinstance(var, sym.Array) and var.dimensions:
                 for dim_idx, dim in enumerate(var.dimensions):
-                    offset = _extract_offset(dim, loop_var)
+                    offset = extract_offset(dim, loop_var)
                     if offset is not None:
                         accesses.append((var.name.lower(), dim_idx, offset, 'read'))
 

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -812,8 +812,8 @@ def classify_array_access_offsets(loop, loop_var=None):
         ``'read'`` and/or ``'write'``. For example::
 
             {
-                ('zpfplsx', 2): {0: {'read'}, 1: {'write'}},
-                ('za', 1):      {0: {'read', 'write'}, -1: {'read'}},
+                ('flux', 2): {0: {'read'}, 1: {'write'}},
+                ('temp', 1):  {0: {'read', 'write'}, -1: {'read'}},
             }
     """
     if loop_var is None:
@@ -878,11 +878,11 @@ def array_loop_carried_dependencies(loop, loop_var=None):
         Example::
 
             {
-                'zpfplsx': [
+                'flux': [
                     {'type': 'flow', 'dim_index': 2, 'write_offset': 1,
                      'read_offset': 0, 'distance': -1}
                 ],
-                'za': [
+                'temp': [
                     {'type': 'flow', 'dim_index': 1, 'write_offset': 0,
                      'read_offset': -1, 'distance': -1}
                 ]

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -720,7 +720,7 @@ def _extract_offset(dim, loop_var):
     if is_constant(diff):
         # Try to evaluate numerically as a last resort
         try:
-            from loki.expression.evaluation import LokiEvaluationMapper
+            from loki.expression.evaluation import LokiEvaluationMapper  # pylint: disable=import-outside-toplevel
             val = LokiEvaluationMapper()(diff)
             if isinstance(val, (int, float)) and val == int(val):
                 return int(val)

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -27,8 +27,8 @@ from loki.tools.util import CaseInsensitiveDict
 __all__ = [
     'dataflow_analysis_attached', 'read_after_write_vars',
     'loop_carried_dependencies', 'classify_array_access_offsets',
-    'array_loop_carried_dependencies', 'detect_vertical_carry_variables',
-    'classify_multilevel_arrays'
+    'array_loop_carried_dependencies', 'detect_loop_carry_variables',
+    'classify_nonzero_offset_arrays'
 ]
 
 
@@ -938,23 +938,21 @@ def array_loop_carried_dependencies(loop, loop_var=None):
     return dict(deps)
 
 
-def detect_vertical_carry_variables(loop, loop_var=None):
+def detect_loop_carry_variables(loop, loop_var=None):
     """
     Detect variables that serve as inter-iteration state carriers within
-    a vertical loop.
+    a loop.
 
-    This identifies two patterns commonly found in column-based physics
-    parameterizations:
+    This identifies two patterns commonly found in iterative
+    computations:
 
-    1. **Scalar carries**: Variables with no vertical dimension (e.g.,
-       1-D horizontal arrays or scalars) that are both read and written
-       within the loop body. These propagate state from one level to the
-       next (e.g., ``ZANEWM1``, ``ZCOVPTOT`` in CLOUDSC).
+    1. **Scalar carries**: Variables with no loop-variable dimension (e.g.,
+       1-D arrays or scalars) that are both read and written within the
+       loop body. These propagate state from one iteration to the next.
 
-    2. **Shift registers**: Arrays with a vertical dimension that are
+    2. **Shift registers**: Arrays with a loop-variable dimension that are
        written at one offset and read at a different offset of the loop
-       variable (e.g., written at ``JK+1`` and read at ``JK``). This is the
-       sedimentation flux pattern (``ZPFPLSX``).
+       variable (e.g., written at ``JK+1`` and read at ``JK``).
 
     Parameters
     ----------
@@ -976,7 +974,7 @@ def detect_vertical_carry_variables(loop, loop_var=None):
             - ``'write_offset'``: integer offset of the write
             - ``'read_offset'``: integer offset of the read
             - ``'direction'``: ``'downward'`` if write_offset > read_offset
-              (data flows from top to bottom in an ascending loop),
+              (data flows from lower to higher index in an ascending loop),
               ``'upward'`` otherwise
     """
     if loop_var is None:
@@ -1052,18 +1050,18 @@ def detect_vertical_carry_variables(loop, loop_var=None):
     }
 
 
-def classify_multilevel_arrays(routine_or_node, loop_var):
+def classify_nonzero_offset_arrays(routine_or_node, loop_var):
     """
-    Scan all vertical loops in a routine (or IR subtree) and return the set
-    of array names that are accessed at any non-zero offset of the given
-    loop variable.
+    Scan all loops in a routine (or IR subtree) whose induction variable
+    matches *loop_var* and return the set of array names that are accessed
+    at any non-zero offset of that variable.
 
     This is a routine-wide version of the per-loop
     :func:`classify_array_access_offsets`.  It collects information from
     **every** loop whose induction variable matches *loop_var* (by name,
-    case-insensitive).  An array is classified as "multilevel" if, in *any*
-    of those loops, it is accessed at an offset other than ``0`` (e.g.,
-    ``JK-1``, ``JK+1``).
+    case-insensitive).  An array is classified as "non-zero offset" if,
+    in *any* of those loops, it is accessed at an offset other than ``0``
+    (e.g., ``JK-1``, ``JK+1``).
 
     The result can be used to decide which arrays in a mixed init loop need
     to remain in a separate (non-fused) loop and which can safely participate

--- a/loki/analyse/analyse_dataflow.py
+++ b/loki/analyse/analyse_dataflow.py
@@ -752,8 +752,12 @@ def _collect_array_accesses(node, loop_var):
         - ``access_type`` : str, either ``'read'`` or ``'write'``
     """
     accesses = []
-    loop_var_name = loop_var.name.lower() if hasattr(loop_var, 'name') else str(loop_var).lower()
 
+    # NOTE: Only Assignment nodes are inspected.  Array accesses in
+    # CallStatement arguments or Conditional expressions are not
+    # captured.  This is intentional: the carry-pattern analysis that
+    # consumes these results operates on assignment-level read/write
+    # semantics within vertical loops.
     for assign in FindNodes(Assignment).visit(node):
         # --- LHS: write access ---
         lhs = assign.lhs

--- a/loki/analyse/tests/test_analyse_dataflow.py
+++ b/loki/analyse/tests/test_analyse_dataflow.py
@@ -877,7 +877,7 @@ end subroutine test_no_dep
 def test_array_loop_carried_dependencies_shift_register(frontend):
     """
     Test the shift register pattern: write at JK+1, read at JK.
-    This is the sedimentation flux pattern from CLOUDSC.
+    This is the sedimentation flux pattern common in atmospheric physics kernels.
     """
     fcode = """
 subroutine test_shift_register(flux, source, n)

--- a/loki/analyse/tests/test_analyse_dataflow.py
+++ b/loki/analyse/tests/test_analyse_dataflow.py
@@ -9,7 +9,9 @@ import pytest
 
 from loki import Module, Sourcefile, Subroutine
 from loki.analyse import (
-    dataflow_analysis_attached, read_after_write_vars, loop_carried_dependencies
+    dataflow_analysis_attached, read_after_write_vars, loop_carried_dependencies,
+    classify_array_access_offsets, array_loop_carried_dependencies,
+    detect_vertical_carry_variables, classify_multilevel_arrays
 )
 from loki.analyse.analyse_dataflow import DataflowAnalysisAttacher, DataflowAnalysisDetacher
 from loki.backend import fgen
@@ -747,3 +749,339 @@ end module
     with dataflow_analysis_attached(routine):
         assert routine.body.defines_symbols == {'a%b%c'}
         assert routine.body.uses_symbols == {'d%b%c'}
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_classify_array_access_offsets_simple(frontend):
+    """
+    Test that classify_array_access_offsets correctly identifies
+    subscript offsets for simple JK and JK-1 patterns.
+    """
+    fcode = """
+subroutine test_offsets(n, arr, brr)
+  integer, intent(in) :: n
+  real, dimension(n) :: arr, brr
+  integer :: jk
+
+  do jk = 2, n
+    arr(jk) = brr(jk - 1) + brr(jk)
+  end do
+end subroutine test_offsets
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    access_map = classify_array_access_offsets(loops[0])
+    # arr is written at offset 0
+    assert ('arr', 0) in access_map
+    assert access_map[('arr', 0)] == {0: {'write'}}
+    # brr is read at offsets -1 and 0
+    assert ('brr', 0) in access_map
+    assert access_map[('brr', 0)] == {-1: {'read'}, 0: {'read'}}
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_classify_array_access_offsets_write_plus_one(frontend):
+    """
+    Test that write at JK+1 is detected correctly (sedimentation pattern).
+    """
+    fcode = """
+subroutine test_write_plus_one(n, flux, source)
+  integer, intent(in) :: n
+  real, dimension(n+1) :: flux
+  real, dimension(n) :: source
+  integer :: jk
+
+  do jk = 1, n
+    flux(jk + 1) = source(jk) * 0.5
+  end do
+end subroutine test_write_plus_one
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    access_map = classify_array_access_offsets(loops[0])
+    assert ('flux', 0) in access_map
+    assert 1 in access_map[('flux', 0)]
+    assert 'write' in access_map[('flux', 0)][1]
+    assert ('source', 0) in access_map
+    assert access_map[('source', 0)] == {0: {'read'}}
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_array_loop_carried_dependencies_simple_flow(frontend):
+    """
+    Test detection of a simple flow (RAW) loop-carried dependency:
+    data(i) = data(i) + data(i-1)
+    """
+    fcode = """
+subroutine test_flow_dep(data, n)
+  integer, intent(in) :: n
+  real, dimension(n) :: data
+  integer :: i
+
+  do i = 2, n
+    data(i) = data(i) + data(i - 1)
+  end do
+end subroutine test_flow_dep
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    deps = array_loop_carried_dependencies(loops[0])
+    assert 'data' in deps
+    # Should find a flow dependency: written at 0, read at -1
+    flow_deps = [d for d in deps['data'] if d['type'] == 'flow']
+    assert len(flow_deps) >= 1
+    found = any(d['write_offset'] == 0 and d['read_offset'] == -1 for d in flow_deps)
+    assert found, f"Expected flow dep (write=0, read=-1), got {flow_deps}"
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_array_loop_carried_dependencies_no_dep(frontend):
+    """
+    Test that arr(i) = arr(i) * 2 (same offset read/write) has NO
+    loop-carried dependency.
+    """
+    fcode = """
+subroutine test_no_dep(arr, n)
+  integer, intent(in) :: n
+  real, dimension(n) :: arr
+  integer :: i
+
+  do i = 1, n
+    arr(i) = arr(i) * 2.0
+  end do
+end subroutine test_no_dep
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    deps = array_loop_carried_dependencies(loops[0])
+    # arr is written and read at offset 0 only -- no cross-offset dependency
+    if 'arr' in deps:
+        # Should have no flow or output deps (both read and write at offset 0)
+        assert all(d['write_offset'] == d['read_offset'] == 0 for d in deps['arr']) is False or \
+               len(deps['arr']) == 0
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_array_loop_carried_dependencies_shift_register(frontend):
+    """
+    Test the shift register pattern: write at JK+1, read at JK.
+    This is the sedimentation flux pattern from CLOUDSC.
+    """
+    fcode = """
+subroutine test_shift_register(flux, source, n)
+  integer, intent(in) :: n
+  real, dimension(n+1) :: flux
+  real, dimension(n) :: source
+  integer :: jk
+
+  do jk = 1, n
+    source(jk) = source(jk) + flux(jk)
+    flux(jk + 1) = source(jk) * 0.5
+  end do
+end subroutine test_shift_register
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    deps = array_loop_carried_dependencies(loops[0])
+    # flux is written at offset +1 and read at offset 0
+    assert 'flux' in deps
+    flow_deps = [d for d in deps['flux'] if d['type'] == 'flow']
+    assert len(flow_deps) >= 1
+    found = any(d['write_offset'] == 1 and d['read_offset'] == 0 for d in flow_deps)
+    assert found, f"Expected flow dep (write=+1, read=0), got {flow_deps}"
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_array_loop_carried_dependencies_multiple(frontend):
+    """
+    Test multiple arrays with different dependency patterns.
+    """
+    fcode = """
+subroutine test_multi_dep(a, b, c, n)
+  integer, intent(in) :: n
+  real, dimension(n) :: a, b, c
+  integer :: i
+
+  do i = 2, n
+    a(i) = a(i - 1) + b(i)
+    c(i) = c(i) * 2.0
+    b(i) = a(i) + 1.0
+  end do
+end subroutine test_multi_dep
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    deps = array_loop_carried_dependencies(loops[0])
+    # a: written at 0, read at -1 => flow dep
+    assert 'a' in deps
+    a_flow = [d for d in deps['a'] if d['type'] == 'flow']
+    assert any(d['write_offset'] == 0 and d['read_offset'] == -1 for d in a_flow)
+    # c: only accessed at offset 0 => no loop-carried dep
+    assert 'c' not in deps or len(deps.get('c', [])) == 0
+    # b: written at 0, read at 0 => no loop-carried dep
+    assert 'b' not in deps or len(deps.get('b', [])) == 0
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_detect_vertical_carry_variables_scalar(frontend):
+    """
+    Test detection of scalar carry variables (1D variables that are
+    both read and written inside a loop over JK).
+    """
+    fcode = """
+subroutine test_carry_vars(nlon, nlev, a, b)
+  integer, intent(in) :: nlon, nlev
+  real, dimension(nlon, nlev) :: a, b
+  real :: carry_val
+  integer :: jk, jl
+
+  carry_val = 0.0
+  do jk = 1, nlev
+    do jl = 1, nlon
+      a(jl, jk) = b(jl, jk) + carry_val
+    end do
+    carry_val = a(1, jk)
+  end do
+end subroutine test_carry_vars
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    # Find the outer JK loop
+    jk_loops = [l for l in loops if l.variable.name.lower() == 'jk']
+    assert len(jk_loops) == 1
+
+    result = detect_vertical_carry_variables(jk_loops[0])
+    scalar_names = {c['name'] for c in result['scalar_carries']}
+    assert 'carry_val' in scalar_names
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_detect_vertical_carry_variables_shift_register(frontend):
+    """
+    Test detection of shift register patterns (array written at JK+1,
+    read at JK).
+    """
+    fcode = """
+subroutine test_shift_detect(n, flux, source)
+  integer, intent(in) :: n
+  real, dimension(n+1) :: flux
+  real, dimension(n) :: source
+  integer :: jk
+
+  do jk = 1, n
+    source(jk) = source(jk) + flux(jk)
+    flux(jk + 1) = source(jk) * 0.5
+  end do
+end subroutine test_shift_detect
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    result = detect_vertical_carry_variables(loops[0])
+    shift_names = {s['name'] for s in result['shift_registers']}
+    assert 'flux' in shift_names
+    # Check direction: write at +1, read at 0 => downward
+    flux_shifts = [s for s in result['shift_registers'] if s['name'] == 'flux']
+    assert any(s['write_offset'] == 1 and s['read_offset'] == 0
+               and s['direction'] == 'downward' for s in flux_shifts)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_classify_multilevel_arrays_basic(frontend):
+    """
+    Test that classify_multilevel_arrays correctly identifies arrays accessed
+    at non-zero offsets across multiple loops in a routine.
+    """
+    fcode = """
+subroutine test_ml_classify(nlon, nz)
+  integer, intent(in) :: nlon, nz
+  real :: za(nlon, nz), zb(nlon, nz), zc(nlon, nz)
+  real :: simple(nlon, nz)
+  integer :: jl, jk
+
+  ! Loop 1: za is written at jk, zb is written at jk
+  do jk = 1, nz
+    do jl = 1, nlon
+      za(jl, jk) = 1.0
+      zb(jl, jk) = 2.0
+      simple(jl, jk) = 3.0
+    end do
+  end do
+
+  ! Loop 2: za is read at jk-1 (makes it multilevel), zc is written at jk+1
+  do jk = 2, nz
+    do jl = 1, nlon
+      zb(jl, jk) = za(jl, jk - 1) + zb(jl, jk)
+      zc(jl, jk + 1) = zb(jl, jk)
+    end do
+  end do
+end subroutine test_ml_classify
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loop_var = routine.variable_map['jk']
+
+    result = classify_multilevel_arrays(routine, loop_var)
+
+    # za has offset -1 in loop 2 => multilevel
+    assert 'za' in result
+    # zc has offset +1 in loop 2 => multilevel
+    assert 'zc' in result
+    # simple is only accessed at offset 0 => NOT multilevel
+    assert 'simple' not in result
+    # zb is only accessed at offset 0 => NOT multilevel (despite being in both loops)
+    assert 'zb' not in result
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_classify_multilevel_arrays_empty(frontend):
+    """
+    Test that classify_multilevel_arrays returns an empty set when all
+    accesses are at offset 0.
+    """
+    fcode = """
+subroutine test_ml_none(nlon, nz)
+  integer, intent(in) :: nlon, nz
+  real :: a(nlon, nz), b(nlon, nz)
+  integer :: jl, jk
+
+  do jk = 1, nz
+    do jl = 1, nlon
+      a(jl, jk) = 1.0
+    end do
+  end do
+
+  do jk = 1, nz
+    do jl = 1, nlon
+      b(jl, jk) = a(jl, jk) + 2.0
+    end do
+  end do
+end subroutine test_ml_none
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loop_var = routine.variable_map['jk']
+
+    result = classify_multilevel_arrays(routine, loop_var)
+    assert len(result) == 0

--- a/loki/analyse/tests/test_analyse_dataflow.py
+++ b/loki/analyse/tests/test_analyse_dataflow.py
@@ -11,7 +11,7 @@ from loki import Module, Sourcefile, Subroutine
 from loki.analyse import (
     dataflow_analysis_attached, read_after_write_vars, loop_carried_dependencies,
     classify_array_access_offsets, array_loop_carried_dependencies,
-    detect_vertical_carry_variables, classify_multilevel_arrays
+    detect_loop_carry_variables, classify_nonzero_offset_arrays
 )
 from loki.analyse.analyse_dataflow import DataflowAnalysisAttacher, DataflowAnalysisDetacher
 from loki.backend import fgen
@@ -941,7 +941,7 @@ end subroutine test_multi_dep
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_detect_vertical_carry_variables_scalar(frontend):
+def test_detect_loop_carry_variables_scalar(frontend):
     """
     Test detection of scalar carry variables (1D variables that are
     both read and written inside a loop over JK).
@@ -969,13 +969,13 @@ end subroutine test_carry_vars
     jk_loops = [l for l in loops if l.variable.name.lower() == 'jk']
     assert len(jk_loops) == 1
 
-    result = detect_vertical_carry_variables(jk_loops[0])
+    result = detect_loop_carry_variables(jk_loops[0])
     scalar_names = {c['name'] for c in result['scalar_carries']}
     assert 'carry_val' in scalar_names
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_detect_vertical_carry_variables_shift_register(frontend):
+def test_detect_loop_carry_variables_shift_register(frontend):
     """
     Test detection of shift register patterns (array written at JK+1,
     read at JK).
@@ -998,7 +998,7 @@ end subroutine test_shift_detect
     loops = FindNodes(ir.Loop).visit(routine.body)
     assert len(loops) == 1
 
-    result = detect_vertical_carry_variables(loops[0])
+    result = detect_loop_carry_variables(loops[0])
     shift_names = {s['name'] for s in result['shift_registers']}
     assert 'flux' in shift_names
     # Check direction: write at +1, read at 0 => downward
@@ -1008,9 +1008,9 @@ end subroutine test_shift_detect
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_classify_multilevel_arrays_basic(frontend):
+def test_classify_nonzero_offset_arrays_basic(frontend):
     """
-    Test that classify_multilevel_arrays correctly identifies arrays accessed
+    Test that classify_nonzero_offset_arrays correctly identifies arrays accessed
     at non-zero offsets across multiple loops in a routine.
     """
     fcode = """
@@ -1042,7 +1042,7 @@ end subroutine test_ml_classify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     loop_var = routine.variable_map['jk']
 
-    result = classify_multilevel_arrays(routine, loop_var)
+    result = classify_nonzero_offset_arrays(routine, loop_var)
 
     # za has offset -1 in loop 2 => multilevel
     assert 'za' in result
@@ -1055,9 +1055,9 @@ end subroutine test_ml_classify
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_classify_multilevel_arrays_empty(frontend):
+def test_classify_nonzero_offset_arrays_empty(frontend):
     """
-    Test that classify_multilevel_arrays returns an empty set when all
+    Test that classify_nonzero_offset_arrays returns an empty set when all
     accesses are at offset 0.
     """
     fcode = """
@@ -1083,5 +1083,5 @@ end subroutine test_ml_none
     routine = Subroutine.from_source(fcode, frontend=frontend)
     loop_var = routine.variable_map['jk']
 
-    result = classify_multilevel_arrays(routine, loop_var)
+    result = classify_nonzero_offset_arrays(routine, loop_var)
     assert len(result) == 0

--- a/loki/analyse/tests/test_analyse_dataflow.py
+++ b/loki/analyse/tests/test_analyse_dataflow.py
@@ -866,11 +866,10 @@ end subroutine test_no_dep
     assert len(loops) == 1
 
     deps = array_loop_carried_dependencies(loops[0])
-    # arr is written and read at offset 0 only -- no cross-offset dependency
-    if 'arr' in deps:
-        # Should have no flow or output deps (both read and write at offset 0)
-        assert all(d['write_offset'] == d['read_offset'] == 0 for d in deps['arr']) is False or \
-               len(deps['arr']) == 0
+    # arr is written and read at offset 0 only -- no cross-offset dependency,
+    # so we expect no loop-carried dependencies to be reported for arr.
+    assert 'arr' not in deps or len(deps['arr']) == 0, \
+        f"Expected no loop-carried deps for arr, got {deps.get('arr')}"
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/analyse/tests/test_analyse_dataflow.py
+++ b/loki/analyse/tests/test_analyse_dataflow.py
@@ -940,6 +940,43 @@ end subroutine test_multi_dep
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_array_loop_carried_dependencies_output_waw(frontend):
+    """
+    Test that writing to the same array at two different offsets of
+    the loop variable produces an output (WAW) dependency.
+    """
+    fcode = """
+subroutine test_waw(arr, n)
+  integer, intent(in) :: n
+  real, dimension(n + 1) :: arr
+  integer :: i
+
+  do i = 1, n
+    arr(i) = 1.0
+    arr(i + 1) = 2.0
+  end do
+end subroutine test_waw
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+
+    deps = array_loop_carried_dependencies(loops[0])
+    assert 'arr' in deps
+
+    # Should have an output (WAW) dependency: written at offset 0 and offset +1
+    output_deps = [d for d in deps['arr'] if d['type'] == 'output']
+    assert len(output_deps) >= 1, (
+        f'Expected WAW output dep for arr, got {deps["arr"]}'
+    )
+    assert any(
+        d['write_offset'] == 0 and d['read_offset'] == 1
+        for d in output_deps
+    ), f'Expected WAW dep with offsets 0 and +1, got {output_deps}'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_detect_loop_carry_variables_scalar(frontend):
     """
     Test detection of scalar carry variables (1D variables that are

--- a/loki/ir/expr_visitors.py
+++ b/loki/ir/expr_visitors.py
@@ -29,7 +29,8 @@ __all__ = [
     'ExpressionFinder', 'FindExpressions', 'FindVariables',
     'FindTypedSymbols', 'FindInlineCalls', 'FindLiterals',
     'FindRealLiterals', 'ExpressionTransformer',
-    'SubstituteExpressions', 'SubstituteStringExpressions',
+    'SubstituteExpressions', 'SubstituteExpressionsSkipLHS',
+    'SubstituteStringExpressions',
     'AttachScopes', 'FindLiteralLists'
 ]
 
@@ -343,6 +344,54 @@ class SubstituteExpressions(ExpressionTransformer):
 
     # visit_VariableDeclaration = visit_Import
     visit_ProcedureDeclaration = visit_VariableDeclaration
+
+
+class SubstituteExpressionsSkipLHS(SubstituteExpressions):
+    """
+    A variant of :any:`SubstituteExpressions` that does not apply the
+    expression mapping to the left-hand side of :any:`Assignment` and
+    :any:`ConditionalAssignment` nodes.
+
+    This is useful when the expression map contains entries that also
+    appear on the LHS of assignments and should not be substituted
+    there.  For example, wrapping denominators in a safe ``MAX(x, TINY(...))``
+    expression should only affect the RHS, not turn the LHS into a
+    non-assignable expression.
+
+    Parameters
+    ----------
+    expr_map : dict
+        Expression mapping to apply to the expression tree.
+    invalidate_source : bool, optional
+        By default the :attr:`source` property of nodes is discarded
+        when rebuilding the node, setting this to ``False`` allows to
+        retain that information.
+    """
+
+    def visit_Assignment(self, o, **kwargs):
+        """
+        Visit only the RHS of :any:`Assignment` nodes, leaving the
+        LHS expression unchanged.
+        """
+        new_rhs = self.visit(o.rhs, **kwargs)
+        if new_rhs is o.rhs:
+            return o
+        return self._rebuild(o, (o.lhs, new_rhs))
+
+    def visit_ConditionalAssignment(self, o, **kwargs):
+        """
+        Visit the condition, RHS, and else_rhs of
+        :any:`ConditionalAssignment` nodes, leaving the LHS unchanged.
+        """
+        new_condition = self.visit(o.condition, **kwargs)
+        new_rhs = self.visit(o.rhs, **kwargs)
+        new_else_rhs = (
+            self.visit(o.else_rhs, **kwargs) if o.else_rhs else o.else_rhs
+        )
+        if (new_condition is o.condition and new_rhs is o.rhs
+                and new_else_rhs is o.else_rhs):
+            return o
+        return self._rebuild(o, (new_condition, o.lhs, new_rhs, new_else_rhs))
 
 
 class SubstituteStringExpressions(SubstituteExpressions):

--- a/loki/ir/tests/test_expr_visitors.py
+++ b/loki/ir/tests/test_expr_visitors.py
@@ -546,7 +546,7 @@ end subroutine test_routine
 
     # Replace original assignment with the conditional assignment
     assigns = FindNodes(ir.Assignment).visit(routine.body)
-    from loki.ir import Transformer
+    from loki.ir import Transformer  # pylint: disable=import-outside-toplevel
     routine.body = Transformer({assigns[0]: cond_assign}).visit(routine.body)
 
     # Create an expression map: b -> b + 1

--- a/loki/ir/tests/test_expr_visitors.py
+++ b/loki/ir/tests/test_expr_visitors.py
@@ -12,7 +12,8 @@ from loki.expression import symbols as sym, parse_expr
 from loki.frontend import available_frontends, OMNI, SourceStatus
 from loki.ir import (
     nodes as ir, FindNodes, FindVariables, FindTypedSymbols,
-    SubstituteExpressions, SubstituteStringExpressions,
+    SubstituteExpressions, SubstituteExpressionsSkipLHS,
+    SubstituteStringExpressions,
     FindLiterals, FindRealLiterals
 )
 
@@ -376,3 +377,136 @@ end subroutine test_routine
         assert decls[1].source.status == SourceStatus.INVALID_NODE
         assert decls[2].source.status == SourceStatus.INVALID_NODE
         assert decls[3].source.status == SourceStatus.VALID
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_substitute_expressions_skip_lhs(frontend):
+    """
+    Test that :any:`SubstituteExpressionsSkipLHS` applies substitutions
+    only to the RHS of assignments, leaving the LHS unchanged, while
+    still substituting in non-assignment nodes such as loop bounds and
+    call arguments.
+    """
+
+    fcode = """
+subroutine test_routine(n, a, b)
+  implicit none
+  integer, intent(in) :: n
+  real(kind=8), intent(inout) :: a, b(n)
+  real(kind=8) :: c(n)
+  integer :: i
+
+  do i=1, n
+    a = a + b(i)
+    c(i) = b(i) + a
+  end do
+
+  call another_routine(n, a, c(:))
+end subroutine test_routine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    a = routine.variable_map['a']
+    n = routine.variable_map['n']
+    new_a = parse_expr('a + 1', scope=routine)
+    new_n = sym.Sum((n, sym.Product((-1, sym.Literal(1)))))
+    expr_map = {a: new_a, n: new_n}
+
+    # Apply substitution skipping LHS
+    routine.body = SubstituteExpressionsSkipLHS(expr_map).visit(routine.body)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    # First assignment: a = a + b(i)
+    # LHS 'a' must remain 'a', not become 'a + 1'
+    assert assigns[0].lhs == 'a'
+    assert assigns[0].rhs == 'a + 1 + b(i)'
+
+    # Second assignment: c(i) = b(i) + a
+    # LHS 'c(i)' must remain 'c(i)', RHS 'a' becomes 'a + 1'
+    assert assigns[1].lhs == 'c(i)' and assigns[1].rhs == 'b(i) + a + 1'
+
+    # Loop bounds should still be substituted (n -> n-1)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert loops[0].bounds == '1:n - 1'
+
+    # Call arguments should still be substituted
+    calls = FindNodes(ir.CallStatement).visit(routine.body)
+    assert calls[0].arguments == ('n - 1', 'a + 1', 'c(:)')
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_substitute_expressions_skip_lhs_array(frontend):
+    """
+    Test that :any:`SubstituteExpressionsSkipLHS` leaves the entire
+    LHS of an assignment unchanged, including array subscripts.
+
+    This verifies that when ``x(i)`` appears in the expression map
+    (e.g. ``x(i) -> MAX(x(i), TINY(1.0))``), the LHS ``x(i)``
+    is not modified while the RHS is.
+    """
+
+    fcode = """
+subroutine test_routine(n, x, y)
+  implicit none
+  integer, intent(in) :: n
+  real(kind=8), intent(inout) :: x(n), y(n)
+  integer :: i
+
+  do i=1, n
+    x(i) = 1.0 / x(i) + y(i)
+  end do
+end subroutine test_routine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    x_i = assigns[0].lhs  # x(i) as it appears on the LHS
+
+    # Map x(i) to a wrapped expression (simulating safe-denominator logic)
+    wrapped = parse_expr('max(x(i), tiny(1.0))', scope=routine)
+    expr_map = {x_i: wrapped}
+
+    routine.body = SubstituteExpressionsSkipLHS(expr_map).visit(routine.body)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    # LHS must remain x(i), NOT MAX(x(i), TINY(1.0))
+    assert str(assigns[0].lhs).lower() == 'x(i)'
+
+    # RHS should have the substitution applied
+    rhs_str = str(assigns[0].rhs).lower()
+    assert 'max' in rhs_str
+    assert 'tiny' in rhs_str
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_substitute_expressions_skip_lhs_noop(frontend):
+    """
+    Test that :any:`SubstituteExpressionsSkipLHS` preserves assignment
+    nodes when the expression map has no matching entries.
+    """
+
+    fcode = """
+subroutine test_routine(a, b)
+  implicit none
+  real(kind=8), intent(inout) :: a, b
+
+  a = a + b
+end subroutine test_routine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    assigns_before = FindNodes(ir.Assignment).visit(routine.body)
+    orig_lhs = str(assigns_before[0].lhs)
+    orig_rhs = str(assigns_before[0].rhs)
+
+    # Map with a variable that does not appear in the routine
+    expr_map = {sym.Variable(name='zzz_nonexistent'): sym.Literal(42)}
+    routine.body = SubstituteExpressionsSkipLHS(expr_map).visit(routine.body)
+
+    assigns_after = FindNodes(ir.Assignment).visit(routine.body)
+    assert len(assigns_after) == 1
+    # The assignment should be unchanged
+    assert str(assigns_after[0].lhs) == orig_lhs
+    assert str(assigns_after[0].rhs) == orig_rhs

--- a/loki/ir/tests/test_expr_visitors.py
+++ b/loki/ir/tests/test_expr_visitors.py
@@ -510,3 +510,67 @@ end subroutine test_routine
     # The assignment should be unchanged
     assert str(assigns_after[0].lhs) == orig_lhs
     assert str(assigns_after[0].rhs) == orig_rhs
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_substitute_expressions_skip_lhs_conditional_assignment(frontend):
+    """
+    Test that :any:`SubstituteExpressionsSkipLHS` applies substitutions
+    to the condition, RHS, and else_rhs of a :any:`ConditionalAssignment`,
+    but leaves the LHS unchanged.
+
+    ConditionalAssignment represents C-style ternary assignments
+    (``lhs = cond ? rhs : else_rhs``).  It is not a Fortran construct,
+    so we build one manually from IR nodes.
+    """
+    fcode = """
+subroutine test_routine(a, b, c)
+  implicit none
+  real(kind=8), intent(inout) :: a, b, c
+  a = b + c
+end subroutine test_routine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    a = routine.variable_map['a']
+    b = routine.variable_map['b']
+    c = routine.variable_map['c']
+
+    # Build a ConditionalAssignment: a = (b > 0) ? b + c : c
+    cond_assign = ir.ConditionalAssignment(
+        condition=sym.Comparison(operator='>', left=b, right=sym.Literal(0)),
+        lhs=a,
+        rhs=sym.Sum((b, c)),
+        else_rhs=c
+    )
+
+    # Replace original assignment with the conditional assignment
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    from loki.ir import Transformer
+    routine.body = Transformer({assigns[0]: cond_assign}).visit(routine.body)
+
+    # Create an expression map: b -> b + 1
+    new_b = parse_expr('b + 1', scope=routine)
+    expr_map = {b: new_b}
+
+    # Apply substitution skipping LHS
+    routine.body = SubstituteExpressionsSkipLHS(expr_map).visit(routine.body)
+
+    # Find the ConditionalAssignment in the transformed body
+    cond_assigns = FindNodes(ir.ConditionalAssignment).visit(routine.body)
+    assert len(cond_assigns) == 1
+    ca = cond_assigns[0]
+
+    # LHS must remain 'a', NOT be substituted
+    assert str(ca.lhs).lower() == 'a'
+
+    # Condition should have b substituted: (b+1 > 0)
+    cond_str = str(ca.condition).lower()
+    assert 'b + 1' in cond_str or 'b+1' in cond_str
+
+    # RHS should have b substituted: b+1 + c
+    rhs_str = str(ca.rhs).lower()
+    assert 'b + 1' in rhs_str or 'b+1' in rhs_str
+
+    # else_rhs should remain 'c' (b does not appear in else_rhs)
+    assert str(ca.else_rhs).lower() == 'c'

--- a/loki/transformations/single_column/__init__.py
+++ b/loki/transformations/single_column/__init__.py
@@ -15,3 +15,4 @@ from loki.transformations.single_column.scc import * # noqa
 from loki.transformations.single_column.scc_cuf import * # noqa
 from loki.transformations.single_column.scc_low_level import * # noqa
 from loki.transformations.single_column.vertical import * # noqa
+from loki.transformations.single_column.vertical_kcaching import * # noqa

--- a/loki/transformations/single_column/scc.py
+++ b/loki/transformations/single_column/scc.py
@@ -16,6 +16,7 @@ from loki.transformations.temporaries import (
         EcstackPoolAllocatorTransformation
 )
 
+from loki.transformations.single_column.vertical_kcaching import SCCVerticalKCaching
 from loki.transformations.single_column.base import SCCBaseTransformation
 from loki.transformations.single_column.annotate import SCCAnnotateTransformation
 from loki.transformations.single_column.demote import SCCDemoteTransformation
@@ -35,7 +36,7 @@ __all__ = [
     'SCCStackFtrPtrPipeline', 'SCCVStackFtrPtrPipeline', 'SCCSStackFtrPtrPipeline',
     'SCCStackDirectIdxPipeline', 'SCCVStackDirectIdxPipeline', 'SCCSStackDirectIdxPipeline',
     'SCCRawStackPipeline', 'SCCVRawStackPipeline', 'SCCSRawStackPipeline',
-    'SCCSEcStackPipeline'
+    'SCCSEcStackPipeline', 'SCCSStackKCachingPipeline'
 ]
 
 
@@ -337,6 +338,59 @@ check_bounds : bool, optional
 
 # alias for backwards compability
 SCCStackPipeline = SCCVStackPipeline
+
+SCCSStackKCachingPipeline = partial(
+    Pipeline, classes=(
+        SCCVerticalKCaching,
+        SCCBaseTransformation,
+        SCCDevectorTransformation,
+        SCCDemoteTransformation,
+        SCCSeqRevectorTransformation,
+        RemoveUnusedVarTransformation,
+        SCCAnnotateTransformation,
+        TemporariesPoolAllocatorTransformation,
+        PragmaModelTransformation
+    )
+)
+"""
+SCC-style k-caching transformation with sequential kernels.
+
+This pipeline uses :any:`SCCVerticalKCaching` to fuse all vertical
+loops into a single ``DO JK = 1, KLEV+1`` loop with IF guards,
+convert multi-level array dependencies to scalar carry variables
+(``_vc``/``_next``), and demote KLEV-dimensioned temporaries to
+scalars.  The standard SCC sequential kernel pipeline with
+pool-allocator stack management is then applied to the resulting
+kernel.
+
+For details of the kernel and driver-side transformations, please
+refer to :any:`SCCSStackPipeline`.  The key addition is the
+:any:`SCCVerticalKCaching` pass that precedes all other
+transformations to perform vertical loop fusion and k-caching.
+
+Parameters
+----------
+horizontal : :any:`Dimension`
+    :any:`Dimension` object describing the variable conventions used in code
+    to define the horizontal data dimension and iteration space.
+vertical : :any:`Dimension`
+    :any:`Dimension` object describing the variable conventions used in code
+    to define the vertical data dimension and iteration space.
+block_dim : :any:`Dimension`
+    Optional ``Dimension`` object to define the blocking dimension
+    to use for hoisted column arrays if hoisting is enabled.
+directive : string or None
+    Directives flavour to use for parallelism annotations; either
+    ``'openacc'``, ``'omp-gpu'`` or ``None``.
+trim_vector_sections : bool
+    Flag to trigger trimming of extracted vector sections to remove
+    nodes that are not assignments involving vector parallel arrays.
+demote_local_arrays : bool
+    Flag to trigger local array demotion to scalar variables where possible
+check_bounds : bool, optional
+    Insert bounds-checks in the kernel to make sure the allocated
+    stack size is not exceeded (default: `True`)
+"""
 
 SCCSStackPipeline = partial(
     Pipeline, classes=(

--- a/loki/transformations/single_column/tests/conftest.py
+++ b/loki/transformations/single_column/tests/conftest.py
@@ -1,0 +1,24 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Shared test helpers for vertical loop transformation tests.
+"""
+
+from loki.ir import FindNodes, Loop
+
+
+def _count_jk_loops(routine):
+    """Count all DO JK=... loops in the routine."""
+    return sum(1 for l in FindNodes(Loop).visit(routine.body)
+               if l.variable.name.lower() == 'jk')
+
+
+def _find_jk_loops(routine):
+    """Return all DO JK=... loops in the routine, in source order."""
+    return [l for l in FindNodes(Loop).visit(routine.body)
+            if l.variable.name.lower() == 'jk']

--- a/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
+++ b/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
@@ -11,18 +11,14 @@ Tests for :mod:`loki.transformations.single_column.vertical_kcaching`.
 
 import re
 import pytest
-from pathlib import Path
 
-from loki import Subroutine, Dimension, Sourcefile
+from loki import Subroutine, Dimension
 from loki.frontend import available_frontends
 from loki.ir import FindNodes, Assignment, Conditional
 from loki.backend import fgen
 
 from loki.transformations.single_column.vertical_kcaching import (
     SCCVerticalKCaching,
-)
-from loki.transformations.single_column.vertical_utils import (
-    _collect_vertical_loops,
 )
 from loki.transformations.single_column.tests.conftest import (
     _count_jk_loops, _find_jk_loops,
@@ -43,53 +39,6 @@ def fixture_horizontal():
 @pytest.fixture(scope='module', name='vertical')
 def fixture_vertical():
     return Dimension(name='vertical', size='nz', index='jk', aliases=('nlev',))
-
-
-@pytest.fixture(scope='module', name='cloudsc_vertical')
-def fixture_cloudsc_vertical():
-    """Vertical dimension matching the dwarf cloudsc kernel."""
-    return Dimension(name='vertical', size='KLEV', index='JK')
-
-
-@pytest.fixture(scope='module', name='cloudsc_horizontal')
-def fixture_cloudsc_horizontal():
-    """Horizontal dimension matching the dwarf cloudsc kernel."""
-    return Dimension(
-        name='horizontal', size='KLON', index='JL',
-        bounds=('KIDIA', 'KFDIA'), aliases=('NPROMA',)
-    )
-
-
-# --------------------------------------------------------------------------
-# Helpers
-# --------------------------------------------------------------------------
-
-
-def _get_cloudsc_path():
-    """
-    Locate the dwarf cloudsc.F90 kernel file.
-
-    Search order:
-    1. Relative to this file's location (traversing up to the workspace root)
-    2. Environment variable CLOUDSC_SRC_DIR
-    """
-    # Walk up from this file to find the workspace root
-    workspace = Path(__file__).resolve()
-    for _ in range(10):
-        workspace = workspace.parent
-        candidate = (workspace / 'source' / 'dwarf-p-cloudsc' /
-                     'src' / 'cloudsc_loki' / 'cloudsc.F90')
-        if candidate.exists():
-            return candidate
-
-    import os
-    env_dir = os.environ.get('CLOUDSC_SRC_DIR')
-    if env_dir:
-        candidate = Path(env_dir) / 'cloudsc.F90'
-        if candidate.exists():
-            return candidate
-
-    return None
 
 
 # --------------------------------------------------------------------------
@@ -491,92 +440,107 @@ def test_kcaching_balanced_fortran(frontend, horizontal, vertical):
 
 
 # --------------------------------------------------------------------------
-# Integration test: cloudsc.F90 (the dwarf kernel)
+# Test: stencil pattern carry conversion
 # --------------------------------------------------------------------------
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_kcaching_cloudsc_integration(frontend, cloudsc_horizontal,
-                                       cloudsc_vertical):
+def test_kcaching_stencil_pattern(frontend, horizontal, vertical):
     """
-    Full integration test: apply SCCVerticalKCaching to the dwarf
-    cloudsc.F90 kernel and verify structural properties.
+    Stencil pattern: a local array written in one loop, then read at
+    JK and JK-1 (but not written) in a second loop.  The backward
+    offset read should be converted to a carry variable with an
+    OOB-guarded init statement.
     """
-    cloudsc_path = _get_cloudsc_path()
-    if cloudsc_path is None:
-        pytest.skip('cloudsc.F90 not found')
+    fcode = """
+  SUBROUTINE test_stencil(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: za(nlon, nz)
+    INTEGER :: jl, jk
 
-    source = Sourcefile.from_file(str(cloudsc_path), frontend=frontend)
-    routine = source['CLOUDSC']
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        za(jl, jk) = pt(jl, jk)
+      END DO
+    END DO
 
-    # Before: should have multiple JK loops
-    loops_before = _count_jk_loops(routine)
-    assert loops_before > 1, (
-        f'Expected multiple JK loops before transformation, got {loops_before}'
-    )
+    DO jk = 2, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = za(jl, jk) - za(jl, jk - 1)
+      END DO
+    END DO
+  END SUBROUTINE test_stencil
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
 
-    trafo = SCCVerticalKCaching(
-        horizontal=cloudsc_horizontal,
-        vertical=cloudsc_vertical
-    )
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
     trafo.process_kernel(routine)
 
-    # After: should have exactly 1 top-level JK loop.
-    # FindNodes recurses, so inner JK loops inside the merged body
-    # also show up.  Use _collect_vertical_loops which finds only
-    # top-level vertical loops.
-    top_vloops = _collect_vertical_loops(routine.body, cloudsc_vertical.index)
-    assert len(top_vloops) == 1, (
-        f'Expected 1 top-level JK loop after transformation, got {len(top_vloops)}'
-    )
-
-    # Carry variables should exist
+    # Stencil carry variable should exist
     var_names = [v.name.lower() for v in routine.variables]
-    all_vc = [n for n in var_names if n.endswith('_vc')]
-    all_next = [n for n in var_names if n.endswith('_next')]
-    assert len(all_vc) > 0, 'Expected carry (_vc) variables'
+    assert 'za_vc' in var_names
 
-    # After carry conversion and auto-interchange of secondary loops,
-    # all KLEV-dimensioned locals should have been demoted to scalars
-    # (or replaced by carry variables).  No KLEV-dimensioned locals
-    # should remain.
-    arg_names = {v.name.lower() for v in routine.arguments}
-    klev_locals = []
-    for var in routine.variables:
-        vname = var.name.lower()
-        if vname in arg_names:
-            continue
-        shape = getattr(var.type, 'shape', None) or getattr(var, 'shape', None)
-        if not shape:
-            continue
-        for s in shape:
-            s_str = str(s).strip().lower()
-            if s_str == 'klev' or s_str.replace(' ', '').startswith('klev+'):
-                klev_locals.append(vname)
-                break
+    # Should have merged to 1 loop
+    assert _count_jk_loops(routine) == 1
 
-    # With auto-interchange, all KLEV locals should be demoted
-    assert len(klev_locals) == 0, (
-        f'Expected no remaining KLEV locals, got {sorted(klev_locals)}'
-    )
+    # The stencil init should contain an OOB guard (IF ... > 1)
+    # which appears before the merged loop.
+    code = fgen(routine).lower()
+    assert '> 1' in code or '>= 2' in code or '.gt. 1' in code
 
-    # Verify IF guards exist in the merged loop.
-    # The merged loop is the top-level JK loop (not nested inside a species
-    # loop).  Find it by picking the JK loop with the most conditionals.
-    jk_loops = _find_jk_loops(routine)
-    merged_loop = max(jk_loops,
-                      key=lambda l: len(FindNodes(Conditional).visit(l.body)))
-    conds = FindNodes(Conditional).visit(merged_loop.body)
-    assert len(conds) >= 10, (
-        f'Expected at least 10 IF guards in merged loop, got {len(conds)}'
-    )
+    # Balanced DO/END DO
+    do_count = len(re.findall(r'^\s*DO\s', fgen(routine), re.MULTILINE))
+    enddo_count = len(re.findall(r'^\s*END\s+DO', fgen(routine), re.MULTILINE))
+    assert do_count == enddo_count
 
-    # Verify balanced DO/END DO
-    code = fgen(routine)
-    do_count = len(re.findall(r'^\s*DO\s', code, re.MULTILINE))
-    enddo_count = len(re.findall(r'^\s*END\s+DO', code, re.MULTILINE))
-    assert do_count == enddo_count, (
-        f'Unbalanced DO/END DO: {do_count} vs {enddo_count}'
-    )
+
+# --------------------------------------------------------------------------
+# Test: B_readback with INTENT(OUT) argument (writeback insertion)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_argument_writeback(frontend, horizontal, vertical):
+    """
+    Pattern B_readback on an INTENT(OUT) *argument* array.  After carry
+    conversion the original output array is never written to — all
+    writes go through the _next carry variable.  The transformation
+    must insert a write-back statement before the rotate so that the
+    output array is populated correctly.
+    """
+    fcode = """
+  SUBROUTINE test_arg_wb(nlon, nz, psrc, pflux)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: psrc(nlon, nz)
+    REAL, INTENT(OUT)   :: pflux(nlon, nz + 1)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pflux(jl, jk + 1) = pflux(jl, jk) + psrc(jl, jk)
+        ! readback at jk+1 to produce a B_readback pattern
+        psrc(jl, jk) = pflux(jl, jk + 1) * 0.5
+      END DO
+    END DO
+  END SUBROUTINE test_arg_wb
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # B_readback carry variables should exist
+    var_names = [v.name.lower() for v in routine.variables]
+    assert 'pflux_vc' in var_names
+    assert 'pflux_next' in var_names
+
+    # The write-back statement should reference the original array
+    # and the _next carry variable
+    code = fgen(routine).lower()
+    assert 'pflux_next' in code
+    # pflux should still be written to (via write-back)
+    assert 'pflux(' in code or 'pflux =' in code
 
     # No self-assignment no-ops
     assigns = FindNodes(Assignment).visit(routine.body)
@@ -584,5 +548,56 @@ def test_kcaching_cloudsc_integration(frontend, cloudsc_horizontal,
         lhs_str = fgen(a.lhs).strip().lower()
         rhs_str = fgen(a.rhs).strip().lower()
         assert lhs_str != rhs_str, (
-            f'Self-assignment no-op: {fgen(a)}'
+            f'Self-assignment no-op should have been removed: {fgen(a)}'
         )
+
+
+# --------------------------------------------------------------------------
+# Test: B_simple pattern carry conversion
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_pattern_b_simple(frontend, horizontal, vertical):
+    """
+    Pattern B_simple: write at JK+1, read at JK (offset 0), but NO
+    readback at JK+1 within the same iteration.  Should produce a
+    single carry variable (_vc) and NO _next variable.
+    """
+    fcode = """
+  SUBROUTINE test_b_simple(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: za(nlon, nz + 1)
+    INTEGER :: jl, jk
+
+    ! First loop: write at JK+1, read at JK -- B_simple pattern
+    ! (no readback at JK+1 in the same iteration)
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        za(jl, jk + 1) = za(jl, jk) + pt(jl, jk)
+      END DO
+    END DO
+
+    ! Second loop references za so the first loop is not dead
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = za(jl, jk) + pt(jl, jk)
+      END DO
+    END DO
+  END SUBROUTINE test_b_simple
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    var_names = [v.name.lower() for v in routine.variables]
+
+    # B_simple creates only _vc, not _next
+    assert 'za_vc' in var_names
+    assert 'za_next' not in var_names
+
+    # Should have merged to 1 loop
+    assert _count_jk_loops(routine) == 1

--- a/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
+++ b/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
@@ -87,8 +87,7 @@ def test_kcaching_basic_merge(frontend, horizontal, vertical):
     if temp_var is not None:
         shape = getattr(temp_var.type, 'shape', None) or ()
         for s in shape:
-            s_str = str(s).strip().lower()
-            assert s_str != 'nz', 'temp should have nz dimension demoted'
+            assert s != 'nz', 'temp should have nz dimension demoted'
 
 
 # --------------------------------------------------------------------------
@@ -600,4 +599,637 @@ def test_kcaching_pattern_b_simple(frontend, horizontal, vertical):
     assert 'za_next' not in var_names
 
     # Should have merged to 1 loop
+    assert _count_jk_loops(routine) == 1
+
+
+# --------------------------------------------------------------------------
+# Test: init-expression substitution uses horizontal bounds, not bare ':'
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_init_subst_horizontal_bounds(frontend, horizontal, vertical):
+    """
+    When Phase 1d substitutes an init expression for an outside-loop
+    reference, scalar horizontal loop variables (e.g. ``jl``) must be
+    replaced by the horizontal bounds range (``start:end``) rather
+    than a bare ``:``.
+
+    A bare ``:`` is not recognised by the SCC pipeline's
+    ``resolve_vector_dimension`` and persists into the devectorisation
+    stage, where it causes a rank mismatch (vector expression assigned
+    to a scalar carry variable).
+
+    Using ``start:end`` allows ``resolve_vector_dimension`` to resolve
+    the range to ``jl`` and the devector pass then removes it cleanly.
+    """
+    fcode = """
+  SUBROUTINE test_init_bounds(nlon, nz, start, end, pa, pcoeff, pout)
+    INTEGER, INTENT(IN) :: nlon, nz, start, end
+    REAL, INTENT(IN)    :: pa(nlon, nz), pcoeff(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: za(nlon, nz)
+    INTEGER :: jl, jk
+
+    ! First loop: initialise za from argument arrays
+    DO jk = 1, nz
+      DO jl = start, end
+        za(jl, jk) = pa(jl, jk) + pcoeff(jl, jk)
+      END DO
+    END DO
+
+    ! Second loop: uses za(jl, jk) and za(jl, jk-1) => carry dependency
+    DO jk = 2, nz
+      DO jl = start, end
+        pout(jl, jk) = za(jl, jk) - za(jl, jk - 1)
+      END DO
+    END DO
+  END SUBROUTINE test_init_bounds
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    code = fgen(routine)
+
+    # The carry init for za_vc should use bounded range (start:end),
+    # NOT a bare ':'.  Check that the init expression references
+    # 'start:end' (the horizontal bounds from the Dimension object).
+    # Pattern: za_vc = pa(start:end, ...) + pcoeff(start:end, ...)
+    assert 'za_vc' in code.lower()
+
+    # Find the init assignment for za_vc
+    assigns = FindNodes(Assignment).visit(routine.body)
+    init_assigns = [a for a in assigns
+                    if fgen(a.lhs).strip().lower().startswith('za_vc')
+                    and 'pa' in fgen(a.rhs).lower()]
+
+    assert len(init_assigns) >= 1, (
+        "Expected at least one za_vc init assignment, found none"
+    )
+    init_rhs = fgen(init_assigns[0].rhs).lower()
+
+    # Must contain bounded range 'start:end', NOT bare ':'
+    assert 'start:end' in init_rhs, (
+        f"Expected 'start:end' in init RHS but got: {init_rhs}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Test 4a: auto-interchange (non-vertical outer loop wrapping vertical)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_auto_interchange(frontend, horizontal, vertical):
+    """
+    Phase 1a: a non-vertical loop (DO JM) wrapping a vertical loop
+    (DO JK) should be auto-interchanged so that the vertical loop
+    becomes outermost, making it visible for merging.
+    """
+    fcode = """
+  SUBROUTINE test_interchange(nlon, nz, nclv, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz, nclv
+    REAL, INTENT(IN)    :: pt(nlon, nz, nclv)
+    REAL, INTENT(OUT)   :: pout(nlon, nz, nclv)
+    INTEGER :: jl, jk, jm
+
+    DO jm = 1, nclv
+      DO jk = 1, nz
+        DO jl = 1, nlon
+          pout(jl, jk, jm) = pt(jl, jk, jm) * 2.0
+        END DO
+      END DO
+    END DO
+  END SUBROUTINE test_interchange
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # After interchange, JK should be the outermost loop
+    code = fgen(routine)
+    # The generated code should show JK as outermost, JM as inner
+    loops = _find_jk_loops(routine)
+    assert len(loops) == 1
+    # JM loop should be nested inside JK
+    from loki.ir import FindNodes, Loop
+    inner_loops = FindNodes(Loop).visit(loops[0].body)
+    jm_loops = [l for l in inner_loops if l.variable.name.lower() == 'jm']
+    assert len(jm_loops) == 1
+
+
+# --------------------------------------------------------------------------
+# Test 4b: carry-aware dead loop (zeroing loop for carry-registered array)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_carry_aware_dead_loop(frontend, horizontal, vertical):
+    """
+    Phase 1c-post: a zeroing loop for an array that becomes a carry
+    variable should be eliminated — the carry init supersedes it.
+    """
+    fcode = """
+  SUBROUTINE test_carry_dead(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: cumul(nlon, nz)
+    INTEGER :: jl, jk
+
+    ! Zeroing loop for cumul
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        cumul(jl, jk) = 0.0
+      END DO
+    END DO
+
+    ! Carry loop
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        IF (jk == 1) THEN
+          cumul(jl, jk) = 0.0
+        ELSE
+          cumul(jl, jk) = cumul(jl, jk - 1)
+        END IF
+        cumul(jl, jk) = cumul(jl, jk) + pt(jl, jk)
+      END DO
+    END DO
+
+    ! Consumer loop
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = cumul(jl, jk)
+      END DO
+    END DO
+  END SUBROUTINE test_carry_dead
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 3
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # The zeroing loop should be dead (cumul is now carry) and removed
+    # Result should be 1 merged loop
+    assert _count_jk_loops(routine) == 1
+
+    # Carry variable should exist
+    var_names = [v.name.lower() for v in routine.variables]
+    assert 'cumul_vc' in var_names
+
+
+# --------------------------------------------------------------------------
+# Test 4c: stencil carry (read-only A(JK-1) on local array)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_stencil_carry(frontend, horizontal, vertical):
+    """
+    Stencil pattern: local array written in loop 1, read at JK and
+    JK-1 in loop 2.  The backward-offset read should become a carry
+    variable with a guarded init.
+    """
+    fcode = """
+  SUBROUTINE test_stencil_carry(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: za(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        za(jl, jk) = pt(jl, jk) * 3.0
+      END DO
+    END DO
+
+    DO jk = 2, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = za(jl, jk) + za(jl, jk - 1)
+      END DO
+    END DO
+  END SUBROUTINE test_stencil_carry
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Should merge to 1 loop
+    assert _count_jk_loops(routine) == 1
+
+    # za_vc carry should exist
+    var_names = [v.name.lower() for v in routine.variables]
+    assert 'za_vc' in var_names
+
+    # Balanced DO/END DO
+    code = fgen(routine)
+    do_count = len(re.findall(r'^\s*DO\s', code, re.MULTILINE))
+    enddo_count = len(re.findall(r'^\s*END\s+DO', code, re.MULTILINE))
+    assert do_count == enddo_count
+
+
+# --------------------------------------------------------------------------
+# Test 4d: cross-loop carry substitution
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_cross_loop_carry(frontend, horizontal, vertical):
+    """
+    Two loops where loop B reads an array written by loop A at offset
+    JK-1.  Cross-loop carry substitution should replace the array
+    reference with the carry variable.
+    """
+    fcode = """
+  SUBROUTINE test_cross_carry(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: flux(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        flux(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+
+    DO jk = 2, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = flux(jl, jk) - flux(jl, jk - 1)
+      END DO
+    END DO
+  END SUBROUTINE test_cross_carry
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Should merge to 1 loop
+    assert _count_jk_loops(routine) == 1
+
+    # flux_vc carry should exist for cross-loop substitution
+    var_names = [v.name.lower() for v in routine.variables]
+    assert 'flux_vc' in var_names
+
+
+# --------------------------------------------------------------------------
+# Test 4e: argument writeback with multi-dim (NCLV extra dim)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_argument_writeback_multidim(frontend, horizontal, vertical):
+    """
+    INTENT(INOUT) argument with an extra dimension (NCLV) beyond
+    horizontal and vertical.  Writeback should use ':' for the extra
+    dim and bounded range for the horizontal dim.
+    """
+    fcode = """
+  SUBROUTINE test_arg_wb_multi(nlon, nz, nclv, start, end, pflux)
+    INTEGER, INTENT(IN)    :: nlon, nz, nclv, start, end
+    REAL, INTENT(INOUT)    :: pflux(nlon, nz + 1, nclv)
+    REAL :: psrc(nlon, nz, nclv)
+    INTEGER :: jl, jk, jm
+
+    DO jk = 1, nz
+      DO jl = start, end
+        DO jm = 1, nclv
+          pflux(jl, jk + 1, jm) = pflux(jl, jk, jm) + psrc(jl, jk, jm)
+        END DO
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = start, end
+        DO jm = 1, nclv
+          psrc(jl, jk, jm) = pflux(jl, jk, jm) * 0.5
+        END DO
+      END DO
+    END DO
+  END SUBROUTINE test_arg_wb_multi
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Should merge to 1 loop
+    assert _count_jk_loops(routine) == 1
+
+    # pflux carry should exist
+    var_names = [v.name.lower() for v in routine.variables]
+    assert 'pflux_vc' in var_names
+
+    # Writeback should reference pflux with subscripts
+    code = fgen(routine).lower()
+    assert 'pflux(' in code
+
+
+# --------------------------------------------------------------------------
+# Test 4f: self-assignment removal
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_self_assignment_removal(frontend, horizontal, vertical):
+    """
+    After carry conversion, self-assignments like ``x_vc = x_vc``
+    should be cleaned up from ALL merged loops, not just the first.
+    """
+    fcode = """
+  SUBROUTINE test_self_assign(nlon, nz, pt, pout, pout2)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz), pout2(nlon, nz)
+    REAL :: a(nlon, nz), b(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        a(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = a(jl, jk) + 1.0
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        b(jl, jk) = pt(jl, jk) * 3.0
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout2(jl, jk) = b(jl, jk) + 2.0
+      END DO
+    END DO
+  END SUBROUTINE test_self_assign
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 4
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # All 4 loops should merge to 1
+    assert _count_jk_loops(routine) == 1
+
+    # No self-assignments should remain
+    assigns = FindNodes(Assignment).visit(routine.body)
+    for a in assigns:
+        lhs_str = fgen(a.lhs).strip().lower()
+        rhs_str = fgen(a.rhs).strip().lower()
+        assert lhs_str != rhs_str, (
+            f'Self-assignment should have been removed: {fgen(a)}'
+        )
+
+
+# --------------------------------------------------------------------------
+# Test 4g: init-subst mismatch (trailing subscripts differ)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_init_subst_mismatch(frontend, horizontal, vertical):
+    """
+    Multi-dim array where the outside-loop reference has different
+    trailing subscripts than the in-loop reference.  The init
+    substitution should NOT be applied (mismatch), but the
+    transformation should still succeed without errors.
+    """
+    fcode = """
+  SUBROUTINE test_init_mismatch(nlon, nz, nclv, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz, nclv
+    REAL, INTENT(IN)    :: pt(nlon, nz, nclv)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: za(nlon, nz, nclv)
+    INTEGER :: jl, jk, jm
+
+    ! Init za for all species
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        DO jm = 1, nclv
+          za(jl, jk, jm) = pt(jl, jk, jm)
+        END DO
+      END DO
+    END DO
+
+    ! Use only first species with stencil pattern
+    DO jk = 2, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = za(jl, jk, 1) - za(jl, jk - 1, 1)
+      END DO
+    END DO
+  END SUBROUTINE test_init_mismatch
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Should not crash; should still produce a valid result
+    # The loops may or may not merge (depends on whether za gets a carry)
+    code = fgen(routine)
+    # Balanced DO/END DO
+    do_count = len(re.findall(r'^\s*DO\s', code, re.MULTILINE))
+    enddo_count = len(re.findall(r'^\s*END\s+DO', code, re.MULTILINE))
+    assert do_count == enddo_count
+
+
+# --------------------------------------------------------------------------
+# Test 4h: merge loops with NZ and NZ+1 bounds (KLEV+N)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_klev_plus_n_bounds(frontend, horizontal, vertical):
+    """
+    Two loops with NZ and NZ+1 upper bounds should merge into one
+    loop with upper bound NZ+1 and appropriate IF guards.
+    """
+    fcode = """
+  SUBROUTINE test_klev_plus_n(nlon, nz, pt, pout, pout2)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL, INTENT(OUT)   :: pout2(nlon, nz + 1)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+
+    DO jk = 1, nz + 1
+      DO jl = 1, nlon
+        pout2(jl, jk) = REAL(jk)
+      END DO
+    END DO
+  END SUBROUTINE test_klev_plus_n
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Should merge to 1 loop
+    assert _count_jk_loops(routine) == 1
+
+    # Should have IF guards
+    loops = _find_jk_loops(routine)
+    conds = FindNodes(Conditional).visit(loops[0].body)
+    assert len(conds) >= 1
+
+    # The merged loop upper bound should be NZ + 1
+    assert loops[0].bounds.children[1] == 'nz + 1'
+
+
+# --------------------------------------------------------------------------
+# Test 5a: backward loop (DO JK = NZ, 1, -1) + forward loop
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_backward_loop(frontend, horizontal, vertical):
+    """
+    A backward loop (DO JK = NZ, 1, -1) should be correctly handled
+    and merged with a forward loop via IF guards.
+    """
+    fcode = """
+  SUBROUTINE test_backward(nlon, nz, pt, pout, pout2)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL, INTENT(OUT)   :: pout2(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+
+    DO jk = nz, 1, -1
+      DO jl = 1, nlon
+        pout2(jl, jk) = pt(jl, jk) * 3.0
+      END DO
+    END DO
+  END SUBROUTINE test_backward
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Backward loops cannot be merged with forward loops;
+    # they should remain separate
+    assert _count_jk_loops(routine) >= 1
+
+    # Balanced DO/END DO
+    code = fgen(routine)
+    do_count = len(re.findall(r'^\s*DO\s', code, re.MULTILINE))
+    enddo_count = len(re.findall(r'^\s*END\s+DO', code, re.MULTILINE))
+    assert do_count == enddo_count
+
+
+# --------------------------------------------------------------------------
+# Test 5b: conditional else body with vertical loop
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_conditional_else_body(frontend, horizontal, vertical):
+    """
+    A vertical loop inside an IF-THEN block, with scalar code in the
+    ELSE block, followed by another vertical loop.  The loops should
+    merge correctly.
+    """
+    fcode = """
+  SUBROUTINE test_cond_else(nlon, nz, flag, pt, pout, pout2)
+    INTEGER, INTENT(IN) :: nlon, nz
+    LOGICAL, INTENT(IN) :: flag
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL, INTENT(OUT)   :: pout2(nlon, nz)
+    INTEGER :: jl, jk
+
+    IF (flag) THEN
+      DO jk = 1, nz
+        DO jl = 1, nlon
+          pout(jl, jk) = pt(jl, jk)
+        END DO
+      END DO
+    ELSE
+      pout2(1, 1) = 0.0
+    END IF
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout2(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+  END SUBROUTINE test_cond_else
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Should not crash; code should be balanced
+    code = fgen(routine)
+    do_count = len(re.findall(r'^\s*DO\s', code, re.MULTILINE))
+    enddo_count = len(re.findall(r'^\s*END\s+DO', code, re.MULTILINE))
+    assert do_count == enddo_count
+
+
+# --------------------------------------------------------------------------
+# Test 5c: apply_to allowlist filtering
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_apply_to_filter(frontend, horizontal, vertical):
+    """
+    Verify that apply_to allowlist works: matching routine is
+    transformed, non-matching routine is not.
+    """
+    fcode = """
+  SUBROUTINE allowed_routine(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: temp(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        temp(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = temp(jl, jk) + 1.0
+      END DO
+    END DO
+  END SUBROUTINE allowed_routine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(
+        horizontal=horizontal, vertical=vertical,
+        apply_to=['allowed_routine']
+    )
+    trafo.transform_subroutine(routine, role='kernel')
+
+    # Should have been transformed (matching apply_to)
     assert _count_jk_loops(routine) == 1

--- a/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
+++ b/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
@@ -1,0 +1,592 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Tests for :mod:`loki.transformations.single_column.vertical_kcaching`.
+"""
+
+import re
+import pytest
+from pathlib import Path
+
+from loki import Subroutine, Dimension, Sourcefile
+from loki.frontend import available_frontends
+from loki.ir import FindNodes, Assignment, Conditional
+from loki.backend import fgen
+
+from loki.transformations.single_column.vertical_kcaching import (
+    SCCVerticalKCaching,
+)
+from loki.transformations.single_column.vertical_complete import (
+    _collect_vertical_loops,
+)
+from loki.transformations.single_column.tests.conftest import (
+    _count_jk_loops, _find_jk_loops,
+)
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+@pytest.fixture(scope='module', name='horizontal')
+def fixture_horizontal():
+    return Dimension(
+        name='horizontal', size='nlon', index='jl',
+        bounds=('start', 'end'), aliases=('nproma',)
+    )
+
+@pytest.fixture(scope='module', name='vertical')
+def fixture_vertical():
+    return Dimension(name='vertical', size='nz', index='jk', aliases=('nlev',))
+
+
+@pytest.fixture(scope='module', name='cloudsc_vertical')
+def fixture_cloudsc_vertical():
+    """Vertical dimension matching the dwarf cloudsc kernel."""
+    return Dimension(name='vertical', size='KLEV', index='JK')
+
+
+@pytest.fixture(scope='module', name='cloudsc_horizontal')
+def fixture_cloudsc_horizontal():
+    """Horizontal dimension matching the dwarf cloudsc kernel."""
+    return Dimension(
+        name='horizontal', size='KLON', index='JL',
+        bounds=('KIDIA', 'KFDIA'), aliases=('NPROMA',)
+    )
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _get_cloudsc_path():
+    """
+    Locate the dwarf cloudsc.F90 kernel file.
+
+    Search order:
+    1. Relative to this file's location (traversing up to the workspace root)
+    2. Environment variable CLOUDSC_SRC_DIR
+    """
+    # Walk up from this file to find the workspace root
+    workspace = Path(__file__).resolve()
+    for _ in range(10):
+        workspace = workspace.parent
+        candidate = (workspace / 'source' / 'dwarf-p-cloudsc' /
+                     'src' / 'cloudsc_loki' / 'cloudsc.F90')
+        if candidate.exists():
+            return candidate
+
+    import os
+    env_dir = os.environ.get('CLOUDSC_SRC_DIR')
+    if env_dir:
+        candidate = Path(env_dir) / 'cloudsc.F90'
+        if candidate.exists():
+            return candidate
+
+    return None
+
+
+# --------------------------------------------------------------------------
+# Test: basic two-loop merge with carries
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_basic_merge(frontend, horizontal, vertical):
+    """
+    Two vertical loops with a forward dependency should be merged
+    into one loop.  The local array should be demoted.
+    """
+    fcode = """
+  SUBROUTINE test_basic(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: temp(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        temp(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = temp(jl, jk) + 1.0
+      END DO
+    END DO
+  END SUBROUTINE test_basic
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Should have merged to 1 loop
+    assert _count_jk_loops(routine) == 1
+
+    # temp should be demoted (no KLEV dimension remaining)
+    var_map = {v.name.lower(): v for v in routine.variables}
+    temp_var = var_map.get('temp')
+    if temp_var is not None:
+        shape = getattr(temp_var.type, 'shape', None) or ()
+        for s in shape:
+            s_str = str(s).strip().lower()
+            assert s_str != 'nz', 'temp should have nz dimension demoted'
+
+
+# --------------------------------------------------------------------------
+# Test: cumulative sum (Pattern A) carry
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_cumsum(frontend, horizontal, vertical):
+    """
+    Pattern A: cumulative sum with IF(JK==1) init.
+    After transformation, should have single loop with carry variable.
+    """
+    fcode = """
+  SUBROUTINE test_cumsum(nlon, nz, delta, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: delta(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: cumul(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        IF (jk == 1) THEN
+          cumul(jl, jk) = 0.0
+        ELSE
+          cumul(jl, jk) = cumul(jl, jk - 1)
+        END IF
+        cumul(jl, jk) = cumul(jl, jk) + delta(jl, jk)
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = cumul(jl, jk)
+      END DO
+    END DO
+  END SUBROUTINE test_cumsum
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Single merged loop
+    assert _count_jk_loops(routine) == 1
+
+    # cumul_vc carry variable should exist
+    var_names = [v.name.lower() for v in routine.variables]
+    assert 'cumul_vc' in var_names
+
+
+# --------------------------------------------------------------------------
+# Test: forward propagation (Pattern B readback)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_pattern_b_readback(frontend, horizontal, vertical):
+    """
+    Pattern B-readback: write at JK+1, read at JK+1 in same iteration.
+    Should produce two carry variables: _vc and _next.
+    """
+    fcode = """
+  SUBROUTINE test_readback(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: flux(nlon, nz + 1)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        flux(jl, jk + 1) = flux(jl, jk) + pt(jl, jk)
+        pout(jl, jk) = flux(jl, jk + 1) * 0.5
+      END DO
+    END DO
+  END SUBROUTINE test_readback
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    var_names = [v.name.lower() for v in routine.variables]
+    assert 'flux_vc' in var_names
+    assert 'flux_next' in var_names
+
+
+# --------------------------------------------------------------------------
+# Test: dead loop elimination
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_dead_loop_removal(frontend, horizontal, vertical):
+    """
+    A loop that only writes to a local never read elsewhere should be
+    removed before merging.
+    """
+    fcode = """
+  SUBROUTINE test_dead(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: zdead(nlon)
+    INTEGER :: jl, jk
+
+    ! Dead loop
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        zdead(jl) = pt(jl, jk)
+      END DO
+    END DO
+
+    ! Live loop
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+  END SUBROUTINE test_dead
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # Dead loop removed, only live loop remains (merged into 1)
+    assert _count_jk_loops(routine) == 1
+
+
+# --------------------------------------------------------------------------
+# Test: different bounds merge with IF guards
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_different_bounds(frontend, horizontal, vertical):
+    """
+    Two loops with different bounds should merge into one loop with
+    IF guards.
+    """
+    fcode = """
+  SUBROUTINE test_diffbounds(nlon, nz, pt, pout, pout2)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL, INTENT(OUT)   :: pout2(nlon, nz + 1)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+
+    DO jk = 1, nz + 1
+      DO jl = 1, nlon
+        pout2(jl, jk) = 1.0
+      END DO
+    END DO
+  END SUBROUTINE test_diffbounds
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    assert _count_jk_loops(routine) == 1
+
+    # Should have IF guards in the merged loop
+    loops = _find_jk_loops(routine)
+    conds = FindNodes(Conditional).visit(loops[0].body)
+    assert len(conds) >= 2
+
+
+# --------------------------------------------------------------------------
+# Test: zero-init removal
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_zero_init_removal(frontend, horizontal, vertical):
+    """
+    Whole-array zero-init for a local array with no other outside-loop
+    references should be removed.
+    """
+    fcode = """
+  SUBROUTINE test_zeroinit(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: arr(nlon, nz)
+    INTEGER :: jl, jk
+
+    arr(:, :) = 0.0
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        arr(jl, jk) = pt(jl, jk) * 2.0
+        pout(jl, jk) = arr(jl, jk)
+      END DO
+    END DO
+  END SUBROUTINE test_zeroinit
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    # After transformation, the arr(:,:) = 0.0 should be gone
+    code = fgen(routine).lower()
+    # Check no whole-array zero init remains
+    assert 'arr(:, :) = 0.0' not in code
+
+
+# --------------------------------------------------------------------------
+# Test: self-assignment removal (Phase 4a)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_no_self_assignments(frontend, horizontal, vertical):
+    """
+    After full transformation, no self-assignment no-ops should remain.
+    """
+    fcode = """
+  SUBROUTINE test_noop(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: temp(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        temp(jl, jk) = pt(jl, jk) * 2.0
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = temp(jl, jk) + 1.0
+      END DO
+    END DO
+  END SUBROUTINE test_noop
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    assigns = FindNodes(Assignment).visit(routine.body)
+    for a in assigns:
+        lhs_str = fgen(a.lhs).strip().lower()
+        rhs_str = fgen(a.rhs).strip().lower()
+        assert lhs_str != rhs_str, (
+            f'Self-assignment no-op should have been removed: {fgen(a)}'
+        )
+
+
+# --------------------------------------------------------------------------
+# Test: apply_to filtering
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_apply_to(frontend, horizontal, vertical):
+    """
+    When apply_to is set, the transformation should only process
+    routines in the list.
+    """
+    fcode = """
+  SUBROUTINE ignored_routine(nlon, nz)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL :: a(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        a(jl, jk) = 1.0
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        a(jl, jk) = 2.0
+      END DO
+    END DO
+  END SUBROUTINE ignored_routine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    assert _count_jk_loops(routine) == 2
+
+    trafo = SCCVerticalKCaching(
+        horizontal=horizontal, vertical=vertical,
+        apply_to=['some_other_routine']
+    )
+    trafo.transform_subroutine(routine, role='kernel')
+
+    # Should NOT have been transformed
+    assert _count_jk_loops(routine) == 2
+
+
+# --------------------------------------------------------------------------
+# Test: balanced DO/END DO in generated code
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_balanced_fortran(frontend, horizontal, vertical):
+    """
+    Generated Fortran should have balanced DO/END DO counts.
+    """
+    fcode = """
+  SUBROUTINE test_balanced(nlon, nz, pt, pout)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN)    :: pt(nlon, nz)
+    REAL, INTENT(OUT)   :: pout(nlon, nz)
+    REAL :: a(nlon, nz), b(nlon, nz)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        a(jl, jk) = pt(jl, jk)
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        b(jl, jk) = a(jl, jk) + 1.0
+      END DO
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        pout(jl, jk) = b(jl, jk)
+      END DO
+    END DO
+  END SUBROUTINE test_balanced
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    trafo = SCCVerticalKCaching(horizontal=horizontal, vertical=vertical)
+    trafo.process_kernel(routine)
+
+    code = fgen(routine)
+    do_count = len(re.findall(r'^\s*DO\s', code, re.MULTILINE))
+    enddo_count = len(re.findall(r'^\s*END\s+DO', code, re.MULTILINE))
+    assert do_count == enddo_count, (
+        f'Unbalanced DO/END DO: {do_count} vs {enddo_count}'
+    )
+
+
+# --------------------------------------------------------------------------
+# Integration test: cloudsc.F90 (the dwarf kernel)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_kcaching_cloudsc_integration(frontend, cloudsc_horizontal,
+                                       cloudsc_vertical):
+    """
+    Full integration test: apply SCCVerticalKCaching to the dwarf
+    cloudsc.F90 kernel and verify structural properties.
+    """
+    cloudsc_path = _get_cloudsc_path()
+    if cloudsc_path is None:
+        pytest.skip('cloudsc.F90 not found')
+
+    source = Sourcefile.from_file(str(cloudsc_path), frontend=frontend)
+    routine = source['CLOUDSC']
+
+    # Before: should have multiple JK loops
+    loops_before = _count_jk_loops(routine)
+    assert loops_before > 1, (
+        f'Expected multiple JK loops before transformation, got {loops_before}'
+    )
+
+    trafo = SCCVerticalKCaching(
+        horizontal=cloudsc_horizontal,
+        vertical=cloudsc_vertical
+    )
+    trafo.process_kernel(routine)
+
+    # After: should have exactly 1 top-level JK loop.
+    # FindNodes recurses, so inner JK loops inside the merged body
+    # also show up.  Use _collect_vertical_loops which finds only
+    # top-level vertical loops.
+    top_vloops = _collect_vertical_loops(routine.body, cloudsc_vertical.index)
+    assert len(top_vloops) == 1, (
+        f'Expected 1 top-level JK loop after transformation, got {len(top_vloops)}'
+    )
+
+    # Carry variables should exist
+    var_names = [v.name.lower() for v in routine.variables]
+    all_vc = [n for n in var_names if n.endswith('_vc')]
+    all_next = [n for n in var_names if n.endswith('_next')]
+    assert len(all_vc) > 0, 'Expected carry (_vc) variables'
+
+    # The remaining KLEV-dimensioned locals should be only 3D arrays
+    # with a species (NCLV) dimension that have computed-index subscripts
+    # (e.g. JC(JCC)) preventing demotion.  All pure 2D (KLON,KLEV) temps
+    # should have been demoted to scalars.
+    # With auto-interchange of JM/JK loops, the 3D arrays (zqx, zqx0,
+    # zpfplsx, zlneg, zqxn2d) are also demoted because their JK loops
+    # are now inside the merged loop.  No KLEV-dimensioned locals should
+    # remain.
+    arg_names = {v.name.lower() for v in routine.arguments}
+    klev_locals = []
+    for var in routine.variables:
+        vname = var.name.lower()
+        if vname in arg_names:
+            continue
+        shape = getattr(var.type, 'shape', None) or getattr(var, 'shape', None)
+        if not shape:
+            continue
+        for s in shape:
+            s_str = str(s).strip().lower()
+            if s_str == 'klev' or s_str.replace(' ', '').startswith('klev+'):
+                klev_locals.append(vname)
+                break
+
+    # With auto-interchange, all KLEV locals should be demoted
+    assert len(klev_locals) == 0, (
+        f'Expected no remaining KLEV locals, got {sorted(klev_locals)}'
+    )
+
+    # Verify IF guards exist in the merged loop.
+    # The merged loop is the top-level JK loop (not nested inside a species
+    # loop).  Find it by picking the JK loop with the most conditionals.
+    jk_loops = _find_jk_loops(routine)
+    merged_loop = max(jk_loops,
+                      key=lambda l: len(FindNodes(Conditional).visit(l.body)))
+    conds = FindNodes(Conditional).visit(merged_loop.body)
+    assert len(conds) >= 10, (
+        f'Expected at least 10 IF guards in merged loop, got {len(conds)}'
+    )
+
+    # Verify balanced DO/END DO
+    code = fgen(routine)
+    do_count = len(re.findall(r'^\s*DO\s', code, re.MULTILINE))
+    enddo_count = len(re.findall(r'^\s*END\s+DO', code, re.MULTILINE))
+    assert do_count == enddo_count, (
+        f'Unbalanced DO/END DO: {do_count} vs {enddo_count}'
+    )
+
+    # No self-assignment no-ops
+    assigns = FindNodes(Assignment).visit(routine.body)
+    for a in assigns:
+        lhs_str = fgen(a.lhs).strip().lower()
+        rhs_str = fgen(a.rhs).strip().lower()
+        assert lhs_str != rhs_str, (
+            f'Self-assignment no-op: {fgen(a)}'
+        )

--- a/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
+++ b/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
@@ -21,7 +21,7 @@ from loki.backend import fgen
 from loki.transformations.single_column.vertical_kcaching import (
     SCCVerticalKCaching,
 )
-from loki.transformations.single_column.vertical_complete import (
+from loki.transformations.single_column.vertical_utils import (
     _collect_vertical_loops,
 )
 from loki.transformations.single_column.tests.conftest import (

--- a/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
+++ b/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
@@ -535,14 +535,10 @@ def test_kcaching_cloudsc_integration(frontend, cloudsc_horizontal,
     all_next = [n for n in var_names if n.endswith('_next')]
     assert len(all_vc) > 0, 'Expected carry (_vc) variables'
 
-    # The remaining KLEV-dimensioned locals should be only 3D arrays
-    # with a species (NCLV) dimension that have computed-index subscripts
-    # (e.g. JC(JCC)) preventing demotion.  All pure 2D (KLON,KLEV) temps
-    # should have been demoted to scalars.
-    # With auto-interchange of JM/JK loops, the 3D arrays (zqx, zqx0,
-    # zpfplsx, zlneg, zqxn2d) are also demoted because their JK loops
-    # are now inside the merged loop.  No KLEV-dimensioned locals should
-    # remain.
+    # After carry conversion and auto-interchange of secondary loops,
+    # all KLEV-dimensioned locals should have been demoted to scalars
+    # (or replaced by carry variables).  No KLEV-dimensioned locals
+    # should remain.
     arg_names = {v.name.lower() for v in routine.arguments}
     klev_locals = []
     for var in routine.variables:

--- a/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
+++ b/loki/transformations/single_column/tests/test_scc_vertical_kcaching.py
@@ -14,7 +14,7 @@ import pytest
 
 from loki import Subroutine, Dimension
 from loki.frontend import available_frontends
-from loki.ir import FindNodes, Assignment, Conditional
+from loki.ir import FindNodes, Assignment, Conditional, Loop
 from loki.backend import fgen
 
 from loki.transformations.single_column.vertical_kcaching import (
@@ -709,12 +709,10 @@ def test_kcaching_auto_interchange(frontend, horizontal, vertical):
     trafo.process_kernel(routine)
 
     # After interchange, JK should be the outermost loop
-    code = fgen(routine)
     # The generated code should show JK as outermost, JM as inner
     loops = _find_jk_loops(routine)
     assert len(loops) == 1
     # JM loop should be nested inside JK
-    from loki.ir import FindNodes, Loop
     inner_loops = FindNodes(Loop).visit(loops[0].body)
     jm_loops = [l for l in inner_loops if l.variable.name.lower() == 'jm']
     assert len(jm_loops) == 1

--- a/loki/transformations/single_column/tests/test_vertical_utils.py
+++ b/loki/transformations/single_column/tests/test_vertical_utils.py
@@ -14,7 +14,7 @@ import pytest
 from loki import Subroutine
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends
-from loki.ir import FindNodes, Loop, Conditional
+from loki.ir import FindNodes, Loop, Conditional, Assignment
 from loki.backend import fgen
 
 from loki.types import BasicType, SymbolAttributes
@@ -26,10 +26,14 @@ from loki.transformations.single_column.vertical_utils import (
     _loop_upper_bound_expr,
     _loop_upper_bound_str,
     _collect_vertical_loops,
+    _collect_call_arg_names,
+    _collect_refs_outside_loops,
+    _collect_outside_refs_for_array,
     _build_bounds_guard,
     _find_demotable_arrays,
     _make_zero_literal,
     _merge_vertical_loops,
+    _remove_self_assignments,
 )
 
 
@@ -608,3 +612,224 @@ class TestMakeZeroLiteral:
         result = _make_zero_literal(stype)
         assert isinstance(result, sym.FloatLiteral)
         assert fgen(result) == '0.0'
+
+
+# --------------------------------------------------------------------------
+# _collect_call_arg_names
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_collect_call_arg_names(frontend):
+    """
+    _collect_call_arg_names should return lowercase names of all
+    variables passed as positional or keyword arguments to calls.
+    """
+    fcode = """
+  SUBROUTINE test_callargs(nlon, nz, a, b, c, d)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL :: a(nlon), b(nlon), c(nlon), d(nlon)
+    REAL :: local_var
+    INTEGER :: jl
+
+    local_var = 1.0
+    CALL foo(a, b, key=c)
+    DO jl = 1, nlon
+      d(jl) = local_var
+    END DO
+  END SUBROUTINE test_callargs
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    result = _collect_call_arg_names(routine)
+
+    # Positional and keyword args should be collected
+    assert 'a' in result
+    assert 'b' in result
+    assert 'c' in result
+
+    # Variables not passed to any call should be absent
+    assert 'local_var' not in result
+    assert 'd' not in result
+
+
+# --------------------------------------------------------------------------
+# _collect_refs_outside_loops — visit_Loop on non-skipped loops
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_collect_refs_outside_loops_loop_bounds(frontend):
+    """
+    _RefCollector.visit_Loop should collect variable references from
+    the bounds of non-skipped loops (e.g. DO JM = 1, NCLV).
+    """
+    fcode = """
+  SUBROUTINE test_ref_loop(nlon, nz, nclv, a)
+    INTEGER, INTENT(IN) :: nlon, nz, nclv
+    REAL :: a(nlon, nz, nclv)
+    INTEGER :: jl, jk, jm
+
+    DO jm = 1, nclv
+      a(1, 1, jm) = 0.0
+    END DO
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        a(jl, jk, 1) = 1.0
+      END DO
+    END DO
+  END SUBROUTINE test_ref_loop
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    # The JK loop is in the skip set; the JM loop is not
+    jk_loops = [l for l in FindNodes(Loop).visit(routine.body)
+                if l.variable.name.lower() == 'jk']
+    assert len(jk_loops) == 1
+    loop_nodes = set(jk_loops)
+
+    result = _collect_refs_outside_loops(routine.body, loop_nodes)
+
+    # JM loop bounds should be collected (visit_Loop recurses)
+    assert 'jm' in result
+    assert 'nclv' in result
+    # Array referenced in non-skipped loop body
+    assert 'a' in result
+    # JL only appears inside the skipped JK loop
+    assert 'jl' not in result
+
+
+# --------------------------------------------------------------------------
+# _collect_outside_refs_for_array — visit_Conditional (condition check)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_collect_outside_refs_for_array_conditional(frontend):
+    """
+    _ArrayRefCollector.visit_Conditional should detect array references
+    in a conditional's condition expression, not only in its body.
+    """
+    fcode = """
+  SUBROUTINE test_arrref_cond(nlon, nz, arr, out)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(IN) :: arr(nlon)
+    REAL, INTENT(OUT) :: out(nlon, nz)
+    INTEGER :: jl, jk
+
+    IF (arr(1) > 0.0) THEN
+      out(1, 1) = 1.0
+    END IF
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        out(jl, jk) = arr(jl)
+      END DO
+    END DO
+  END SUBROUTINE test_arrref_cond
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    jk_loops = [l for l in FindNodes(Loop).visit(routine.body)
+                if l.variable.name.lower() == 'jk']
+    assert len(jk_loops) == 1
+
+    result = _collect_outside_refs_for_array(
+        routine.body, set(jk_loops), 'arr'
+    )
+
+    # The IF condition references 'arr', so a Conditional should be collected
+    assert len(result) >= 1
+    assert any(isinstance(node, Conditional) for node in result)
+
+
+# --------------------------------------------------------------------------
+# _merge_vertical_loops — Both KLEV+N, compare N values
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_merge_vertical_loops_both_klev_plus_n(frontend):
+    """
+    When two loops both have KLEV+N upper bounds with different N values,
+    the merged loop should take the larger N as its upper bound.
+    """
+    fcode = """
+  SUBROUTINE test_klev_n(nlon, nz, a, b)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL, INTENT(OUT) :: a(nlon, nz + 1), b(nlon, nz + 2)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz + 1
+      DO jl = 1, nlon
+        a(jl, jk) = 1.0
+      END DO
+    END DO
+
+    DO jk = 1, nz + 2
+      DO jl = 1, nlon
+        b(jl, jk) = 2.0
+      END DO
+    END DO
+  END SUBROUTINE test_klev_n
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    vloops = _collect_vertical_loops(routine.body, 'jk')
+    assert len(vloops) == 2
+
+    merged = _merge_vertical_loops(routine, 'jk', 'nz')
+
+    # Should produce a single merged loop
+    jk_loops = [l for l in FindNodes(Loop).visit(routine.body)
+                if l.variable.name.lower() == 'jk']
+    assert len(jk_loops) == 1
+
+    # The upper bound should be NZ + 2 (the larger N)
+    assert merged.bounds.children[1] == 'nz + 2'
+
+    # Should have IF guards
+    conds = FindNodes(Conditional).visit(merged.body)
+    assert len(conds) >= 2
+
+
+# --------------------------------------------------------------------------
+# _remove_self_assignments — to_remove branch (actual removals)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_remove_self_assignments_with_removals(frontend):
+    """
+    _remove_self_assignments should detect and remove self-assignment
+    no-ops (x = x) from inside vertical loops and return the count.
+    """
+
+    fcode = """
+  SUBROUTINE test_selfassign(nlon, nz)
+    INTEGER, INTENT(IN) :: nlon, nz
+    REAL :: x(nlon)
+    INTEGER :: jl, jk
+
+    DO jk = 1, nz
+      DO jl = 1, nlon
+        x(jl) = x(jl)
+        x(jl) = 1.0
+      END DO
+    END DO
+  END SUBROUTINE test_selfassign
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    jk_loops = [l for l in FindNodes(Loop).visit(routine.body)
+                if l.variable.name.lower() == 'jk']
+    assert len(jk_loops) == 1
+
+    n_removed = _remove_self_assignments(routine, jk_loops[0])
+    assert n_removed == 1
+
+    # After removal, no self-assignments should remain
+    assigns = FindNodes(Assignment).visit(routine.body)
+    for a in assigns:
+        lhs_str = fgen(a.lhs).strip().lower()
+        rhs_str = fgen(a.rhs).strip().lower()
+        assert lhs_str != rhs_str, (
+            f'Self-assignment should have been removed: {fgen(a)}'
+        )
+
+    # The real assignment x(jl) = 1.0 should survive
+    assert any(fgen(a.rhs).strip() == '1.0' for a in assigns)

--- a/loki/transformations/single_column/tests/test_vertical_utils.py
+++ b/loki/transformations/single_column/tests/test_vertical_utils.py
@@ -196,9 +196,14 @@ class TestBuildBoundsGuard:
         upper = sym.Variable(name='KLEV')
         guard = _build_bounds_guard(jk, lower, upper)
         assert isinstance(guard, sym.LogicalAnd)
-        guard_str = str(guard).lower()
-        assert '>=' in guard_str
-        assert '<=' in guard_str
+        # Check structural properties of the guard: (JK >= 1) .AND. (JK <= KLEV)
+        left, right = guard.children
+        assert left.operator == '>='
+        assert left.left == 'jk'
+        assert left.right == 1
+        assert right.operator == '<='
+        assert right.left == 'jk'
+        assert right.right == 'klev'
 
 
 # --------------------------------------------------------------------------
@@ -228,7 +233,7 @@ def test_loop_upper_bound(frontend):
 
     expr = _loop_upper_bound_expr(loops[0])
     assert expr is not None
-    assert str(expr).strip().lower() == 'klev'
+    assert expr == 'klev'
 
     s = _loop_upper_bound_str(loops[0])
     assert s == 'klev'
@@ -470,9 +475,7 @@ def test_merge_vertical_loops_different_bounds(frontend):
     assert merged is not None
 
     # The merged loop upper bound should be KLEV + 1
-    upper_str = str(merged.bounds.children[1]).strip().lower()
-    assert 'klev' in upper_str
-    assert '1' in upper_str
+    assert merged.bounds.children[1] == 'klev + 1'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/single_column/tests/test_vertical_utils.py
+++ b/loki/transformations/single_column/tests/test_vertical_utils.py
@@ -17,6 +17,7 @@ from loki.frontend import available_frontends
 from loki.ir import FindNodes, Loop, Conditional
 from loki.backend import fgen
 
+from loki.types import BasicType, SymbolAttributes
 from loki.transformations.single_column.vertical_utils import (
     _is_klev_plus_n,
     _extract_plus_n,
@@ -27,6 +28,7 @@ from loki.transformations.single_column.vertical_utils import (
     _collect_vertical_loops,
     _build_bounds_guard,
     _find_demotable_arrays,
+    _make_zero_literal,
     _merge_vertical_loops,
 )
 
@@ -538,3 +540,68 @@ def test_merge_vertical_loops_cond_else_body(frontend):
     code = fgen(routine).lower()
     assert 'else' in code
     assert 'b = 0.0' in code or 'b = 0' in code
+
+
+# --------------------------------------------------------------------------
+# _make_zero_literal
+# --------------------------------------------------------------------------
+
+
+class TestMakeZeroLiteral:
+    """Tests for the _make_zero_literal helper."""
+
+    def test_integer_type(self):
+        """INTEGER type should produce IntLiteral(0)."""
+        stype = SymbolAttributes(BasicType.INTEGER)
+        result = _make_zero_literal(stype)
+        assert isinstance(result, sym.IntLiteral)
+        assert result.value == 0
+
+    def test_logical_type(self):
+        """LOGICAL type should produce LogicLiteral('.FALSE.')."""
+        stype = SymbolAttributes(BasicType.LOGICAL)
+        result = _make_zero_literal(stype)
+        assert isinstance(result, sym.LogicLiteral)
+        assert fgen(result).upper() == '.FALSE.'
+
+    def test_real_with_named_kind(self):
+        """REAL with a named kind (e.g. JPRB) should keep the kind."""
+        kind_var = sym.Variable(name='JPRB')
+        stype = SymbolAttributes(BasicType.REAL, kind=kind_var)
+        result = _make_zero_literal(stype)
+        assert isinstance(result, sym.FloatLiteral)
+        assert result.kind is kind_var
+        assert fgen(result) == '0.0_JPRB'
+
+    def test_real_with_inline_call_kind(self):
+        """REAL with an InlineCall kind (OMNI-resolved) should omit the kind.
+
+        When the OMNI frontend resolves ``JPRB`` to
+        ``selected_real_kind(13, 300)``, the kind is an :any:`InlineCall`.
+        The literal must not embed it (``0.0_selected_real_kind(...)`` is
+        invalid Fortran).
+        """
+        call_kind = sym.InlineCall(
+            function=sym.ProcedureSymbol(name='selected_real_kind'),
+            parameters=(sym.IntLiteral(13), sym.IntLiteral(300)),
+        )
+        stype = SymbolAttributes(BasicType.REAL, kind=call_kind)
+        result = _make_zero_literal(stype)
+        assert isinstance(result, sym.FloatLiteral)
+        assert result.kind is None
+        assert fgen(result) == '0.0'
+
+    def test_real_without_kind(self):
+        """REAL without an explicit kind should produce a plain 0.0."""
+        stype = SymbolAttributes(BasicType.REAL)
+        result = _make_zero_literal(stype)
+        assert isinstance(result, sym.FloatLiteral)
+        assert result.kind is None
+        assert fgen(result) == '0.0'
+
+    def test_deferred_type(self):
+        """DEFERRED dtype should fall through to the REAL branch."""
+        stype = SymbolAttributes(BasicType.DEFERRED)
+        result = _make_zero_literal(stype)
+        assert isinstance(result, sym.FloatLiteral)
+        assert fgen(result) == '0.0'

--- a/loki/transformations/single_column/tests/test_vertical_utils.py
+++ b/loki/transformations/single_column/tests/test_vertical_utils.py
@@ -1,0 +1,497 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Tests for :mod:`loki.transformations.single_column.vertical_utils`.
+"""
+
+import pytest
+
+from loki import Subroutine, Dimension
+from loki.expression import symbols as sym
+from loki.frontend import available_frontends
+from loki.ir import FindNodes, Loop, Assignment, Conditional
+from loki.backend import fgen
+
+from loki.transformations.single_column.vertical_utils import (
+    _is_klev_plus_n,
+    _extract_plus_n,
+    _is_jk_eq_1,
+    _is_zero_literal,
+    _loop_upper_bound_expr,
+    _loop_upper_bound_str,
+    _collect_vertical_loops,
+    _build_bounds_guard,
+    _find_demotable_arrays,
+    _merge_vertical_loops,
+)
+
+
+# --------------------------------------------------------------------------
+# _is_klev_plus_n
+# --------------------------------------------------------------------------
+
+
+class TestIsKlevPlusN:
+    """Tests for the _is_klev_plus_n helper."""
+
+    def test_expression_klev_plus_1(self):
+        """KLEV + 1 should return True."""
+        klev = sym.Variable(name='klev')
+        expr = sym.Sum((klev, sym.IntLiteral(1)))
+        assert _is_klev_plus_n(expr, 'klev') is True
+
+    def test_expression_klev_plus_3(self):
+        """KLEV + 3 should return True."""
+        klev = sym.Variable(name='KLEV')
+        expr = sym.Sum((klev, sym.IntLiteral(3)))
+        assert _is_klev_plus_n(expr, 'klev') is True
+
+    def test_expression_plain_klev(self):
+        """Plain KLEV (no +N) should return False."""
+        klev = sym.Variable(name='klev')
+        assert _is_klev_plus_n(klev, 'klev') is False
+
+    def test_expression_different_var(self):
+        """NFOO + 1 should return False when vertical_size is klev."""
+        nfoo = sym.Variable(name='nfoo')
+        expr = sym.Sum((nfoo, sym.IntLiteral(1)))
+        assert _is_klev_plus_n(expr, 'klev') is False
+
+    def test_string_klev_plus_1(self):
+        """String fallback: 'klev+1' should return True."""
+        assert _is_klev_plus_n('klev+1', 'klev') is True
+
+    def test_string_plain_klev(self):
+        """String fallback: 'klev' should return False."""
+        assert _is_klev_plus_n('klev', 'klev') is False
+
+    def test_none_returns_false(self):
+        """None should return False."""
+        assert _is_klev_plus_n(None, 'klev') is False
+
+
+# --------------------------------------------------------------------------
+# _extract_plus_n
+# --------------------------------------------------------------------------
+
+
+class TestExtractPlusN:
+    """Tests for the _extract_plus_n helper."""
+
+    def test_expression_klev_plus_1(self):
+        klev = sym.Variable(name='klev')
+        expr = sym.Sum((klev, sym.IntLiteral(1)))
+        assert _extract_plus_n(expr, 'klev') == 1
+
+    def test_expression_klev_plus_5(self):
+        klev = sym.Variable(name='KLEV')
+        expr = sym.Sum((klev, sym.IntLiteral(5)))
+        assert _extract_plus_n(expr, 'KLEV') == 5
+
+    def test_expression_plain_klev(self):
+        klev = sym.Variable(name='klev')
+        assert _extract_plus_n(klev, 'klev') == 0
+
+    def test_string_klev_plus_2(self):
+        assert _extract_plus_n('klev+2', 'klev') == 2
+
+    def test_string_plain_klev(self):
+        assert _extract_plus_n('klev', 'klev') == 0
+
+
+# --------------------------------------------------------------------------
+# _is_jk_eq_1
+# --------------------------------------------------------------------------
+
+
+class TestIsJkEq1:
+    """Tests for the _is_jk_eq_1 helper."""
+
+    def test_jk_eq_1(self):
+        """JK == 1 should return True."""
+        jk = sym.Variable(name='JK')
+        expr = sym.Comparison(operator='==', left=jk, right=sym.IntLiteral(1))
+        assert _is_jk_eq_1(expr, 'jk') is True
+
+    def test_1_eq_jk(self):
+        """1 == JK should return True (commutative)."""
+        jk = sym.Variable(name='JK')
+        expr = sym.Comparison(operator='==', left=sym.IntLiteral(1), right=jk)
+        assert _is_jk_eq_1(expr, 'jk') is True
+
+    def test_jk_eq_2(self):
+        """JK == 2 should return False."""
+        jk = sym.Variable(name='JK')
+        expr = sym.Comparison(operator='==', left=jk, right=sym.IntLiteral(2))
+        assert _is_jk_eq_1(expr, 'jk') is False
+
+    def test_jk_gt_1(self):
+        """JK > 1 should return False (wrong operator)."""
+        jk = sym.Variable(name='JK')
+        expr = sym.Comparison(operator='>', left=jk, right=sym.IntLiteral(1))
+        assert _is_jk_eq_1(expr, 'jk') is False
+
+    def test_different_var(self):
+        """JM == 1 should return False when loop_var is JK."""
+        jm = sym.Variable(name='JM')
+        expr = sym.Comparison(operator='==', left=jm, right=sym.IntLiteral(1))
+        assert _is_jk_eq_1(expr, 'jk') is False
+
+    def test_case_insensitive(self):
+        """jk == 1 with loop_var 'JK' should return True."""
+        jk = sym.Variable(name='jk')
+        expr = sym.Comparison(operator='==', left=jk, right=sym.IntLiteral(1))
+        assert _is_jk_eq_1(expr, 'JK') is True
+
+
+# --------------------------------------------------------------------------
+# _is_zero_literal
+# --------------------------------------------------------------------------
+
+
+class TestIsZeroLiteral:
+    """Tests for the _is_zero_literal helper."""
+
+    def test_int_zero(self):
+        assert _is_zero_literal(sym.IntLiteral(0)) is True
+
+    def test_int_nonzero(self):
+        assert _is_zero_literal(sym.IntLiteral(1)) is False
+
+    def test_float_zero(self):
+        assert _is_zero_literal(sym.FloatLiteral(0.0)) is True
+
+    def test_float_nonzero(self):
+        assert _is_zero_literal(sym.FloatLiteral(1.5)) is False
+
+    def test_float_zero_string(self):
+        """FloatLiteral stores value as string."""
+        assert _is_zero_literal(sym.FloatLiteral('0.0')) is True
+
+    def test_variable_returns_false(self):
+        """A variable is not a zero literal."""
+        v = sym.Variable(name='x')
+        assert _is_zero_literal(v) is False
+
+
+# --------------------------------------------------------------------------
+# _build_bounds_guard
+# --------------------------------------------------------------------------
+
+
+class TestBuildBoundsGuard:
+    """Tests for _build_bounds_guard."""
+
+    def test_basic_guard(self):
+        """Should produce JK >= lower .AND. JK <= upper."""
+        jk = sym.Variable(name='JK')
+        lower = sym.IntLiteral(1)
+        upper = sym.Variable(name='KLEV')
+        guard = _build_bounds_guard(jk, lower, upper)
+        assert isinstance(guard, sym.LogicalAnd)
+        guard_str = str(guard).lower()
+        assert '>=' in guard_str
+        assert '<=' in guard_str
+
+
+# --------------------------------------------------------------------------
+# _loop_upper_bound_expr / _loop_upper_bound_str (via parsed Fortran)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_loop_upper_bound(frontend):
+    """_loop_upper_bound_expr/str should return the upper bound of a loop."""
+    fcode = """
+    subroutine test_upper(klev)
+      implicit none
+      integer, intent(in) :: klev
+      integer :: jk
+      real :: x
+
+      do jk = 1, klev
+        x = real(jk)
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = [l for l in FindNodes(Loop).visit(routine.body)
+             if l.variable.name.lower() == 'jk']
+    assert len(loops) == 1
+
+    expr = _loop_upper_bound_expr(loops[0])
+    assert expr is not None
+    assert str(expr).strip().lower() == 'klev'
+
+    s = _loop_upper_bound_str(loops[0])
+    assert s == 'klev'
+
+
+# --------------------------------------------------------------------------
+# _collect_vertical_loops (via parsed Fortran)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_collect_vertical_loops_basic(frontend):
+    """Should find top-level JK loops in source order."""
+    fcode = """
+    subroutine test_collect(klev)
+      implicit none
+      integer, intent(in) :: klev
+      integer :: jk
+      real :: a, b
+
+      do jk = 1, klev
+        a = real(jk)
+      end do
+
+      b = 0.0
+
+      do jk = 1, klev
+        b = b + real(jk)
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    result = _collect_vertical_loops(routine.body, 'jk')
+    assert len(result) == 2
+    # Each entry is (loop, cond_wrapper)
+    for loop, cond in result:
+        assert isinstance(loop, Loop)
+        assert loop.variable.name.lower() == 'jk'
+        assert cond is None
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_collect_vertical_loops_conditional_wrapper(frontend):
+    """JK loop inside a Conditional should be returned with the wrapper."""
+    fcode = """
+    subroutine test_collect_cond(klev, flag)
+      implicit none
+      integer, intent(in) :: klev
+      logical, intent(in) :: flag
+      integer :: jk
+      real :: a
+
+      if (flag) then
+        do jk = 1, klev
+          a = real(jk)
+        end do
+      end if
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    result = _collect_vertical_loops(routine.body, 'jk')
+    assert len(result) == 1
+    loop, cond = result[0]
+    assert isinstance(loop, Loop)
+    assert cond is not None
+    assert isinstance(cond, Conditional)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_collect_vertical_loops_skips_non_jk(frontend):
+    """A non-JK loop should not be returned."""
+    fcode = """
+    subroutine test_non_jk(n)
+      implicit none
+      integer, intent(in) :: n
+      integer :: i
+      real :: a
+
+      do i = 1, n
+        a = real(i)
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    result = _collect_vertical_loops(routine.body, 'jk')
+    assert len(result) == 0
+
+
+# --------------------------------------------------------------------------
+# _find_demotable_arrays (via parsed Fortran)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_find_demotable_simple(frontend):
+    """A local KLEV array accessed only at offset 0 inside a JK loop
+    should be demotable."""
+    fcode = """
+    subroutine test_demote(nlon, klev, result_out)
+      implicit none
+      integer, intent(in) :: nlon, klev
+      real, intent(out) :: result_out(nlon, klev)
+      integer :: jl, jk
+      real :: tmp(nlon, klev)
+
+      do jk = 1, klev
+        do jl = 1, nlon
+          tmp(jl, jk) = real(jk)
+          result_out(jl, jk) = tmp(jl, jk) * 2.0
+        end do
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = [l for l in FindNodes(Loop).visit(routine.body)
+             if l.variable.name.lower() == 'jk']
+    assert len(loops) == 1
+
+    demotable = _find_demotable_arrays(routine, 'jk', 'klev', loops[0])
+    assert 'tmp' in demotable
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_find_demotable_argument_not_demoted(frontend):
+    """An argument array should never be demotable."""
+    fcode = """
+    subroutine test_no_demote(nlon, klev, arr)
+      implicit none
+      integer, intent(in) :: nlon, klev
+      real, intent(inout) :: arr(nlon, klev)
+      integer :: jl, jk
+
+      do jk = 1, klev
+        do jl = 1, nlon
+          arr(jl, jk) = arr(jl, jk) + 1.0
+        end do
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = [l for l in FindNodes(Loop).visit(routine.body)
+             if l.variable.name.lower() == 'jk']
+    demotable = _find_demotable_arrays(routine, 'jk', 'klev', loops[0])
+    assert 'arr' not in demotable
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_find_demotable_nonzero_offset_excluded(frontend):
+    """A local array accessed at JK-1 should NOT be demotable."""
+    fcode = """
+    subroutine test_no_demote_offset(nlon, klev, out)
+      implicit none
+      integer, intent(in) :: nlon, klev
+      real, intent(out) :: out(nlon, klev)
+      integer :: jl, jk
+      real :: tmp(nlon, klev)
+
+      do jk = 1, klev
+        do jl = 1, nlon
+          tmp(jl, jk) = real(jk)
+        end do
+      end do
+
+      do jk = 2, klev
+        do jl = 1, nlon
+          out(jl, jk) = tmp(jl, jk - 1)
+        end do
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    loops = [l for l in FindNodes(Loop).visit(routine.body)
+             if l.variable.name.lower() == 'jk']
+    demotable = _find_demotable_arrays(routine, 'jk', 'klev', loops[0])
+    assert 'tmp' not in demotable
+
+
+# --------------------------------------------------------------------------
+# _merge_vertical_loops (via parsed Fortran)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_merge_vertical_loops_basic(frontend):
+    """Two JK loops should merge into one with IF guards."""
+    fcode = """
+    subroutine test_merge(klev)
+      implicit none
+      integer, intent(in) :: klev
+      integer :: jk
+      real :: a, b
+
+      do jk = 1, klev
+        a = real(jk)
+      end do
+
+      do jk = 1, klev
+        b = real(jk) * 2.0
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    # Before: 2 JK loops
+    loops_before = [l for l in FindNodes(Loop).visit(routine.body)
+                    if l.variable.name.lower() == 'jk']
+    assert len(loops_before) == 2
+
+    merged = _merge_vertical_loops(routine, 'jk', 'klev')
+    assert merged is not None
+
+    # After: 1 JK loop
+    loops_after = [l for l in FindNodes(Loop).visit(routine.body)
+                   if l.variable.name.lower() == 'jk']
+    assert len(loops_after) == 1
+
+    # The merged loop should contain IF guards
+    conds = FindNodes(Conditional).visit(loops_after[0].body)
+    assert len(conds) >= 2
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_merge_vertical_loops_different_bounds(frontend):
+    """Merging loops with KLEV and KLEV+1 bounds should use KLEV+1."""
+    fcode = """
+    subroutine test_merge_bounds(klev)
+      implicit none
+      integer, intent(in) :: klev
+      integer :: jk
+      real :: a, b
+
+      do jk = 1, klev
+        a = real(jk)
+      end do
+
+      do jk = 1, klev + 1
+        b = real(jk)
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    merged = _merge_vertical_loops(routine, 'jk', 'klev')
+    assert merged is not None
+
+    # The merged loop upper bound should be KLEV + 1
+    upper_str = str(merged.bounds.children[1]).strip().lower()
+    assert 'klev' in upper_str
+    assert '1' in upper_str
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_merge_no_loops(frontend):
+    """If there are no JK loops, merge should return None."""
+    fcode = """
+    subroutine test_no_loops(n)
+      implicit none
+      integer, intent(in) :: n
+      integer :: i
+      real :: a
+
+      do i = 1, n
+        a = real(i)
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    result = _merge_vertical_loops(routine, 'jk', 'klev')
+    assert result is None

--- a/loki/transformations/single_column/tests/test_vertical_utils.py
+++ b/loki/transformations/single_column/tests/test_vertical_utils.py
@@ -15,6 +15,7 @@ from loki import Subroutine
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends
 from loki.ir import FindNodes, Loop, Conditional
+from loki.backend import fgen
 
 from loki.transformations.single_column.vertical_utils import (
     _is_klev_plus_n,
@@ -494,3 +495,50 @@ def test_merge_no_loops(frontend):
     routine = Subroutine.from_source(fcode, frontend=frontend)
     result = _merge_vertical_loops(routine, 'jk', 'klev')
     assert result is None
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_merge_vertical_loops_cond_else_body(frontend):
+    """A JK loop wrapped in IF/ELSE should preserve the else branch
+    after merging."""
+    fcode = """
+    subroutine test_merge_cond_else(klev, flag)
+      implicit none
+      integer, intent(in) :: klev
+      logical, intent(in) :: flag
+      integer :: jk
+      real :: a, b
+
+      if (flag) then
+        do jk = 1, klev
+          a = real(jk)
+        end do
+      else
+        b = 0.0
+      end if
+
+      do jk = 1, klev
+        b = real(jk) * 2.0
+      end do
+    end subroutine
+    """
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    # Before: 2 JK loops (one wrapped in IF/ELSE)
+    loops_before = [l for l in FindNodes(Loop).visit(routine.body)
+                    if l.variable.name.lower() == 'jk']
+    assert len(loops_before) == 2
+
+    merged = _merge_vertical_loops(routine, 'jk', 'klev')
+    assert merged is not None
+
+    # After: 1 JK loop
+    loops_after = [l for l in FindNodes(Loop).visit(routine.body)
+                   if l.variable.name.lower() == 'jk']
+    assert len(loops_after) == 1
+
+    # The merged loop body should contain a conditional with an
+    # else branch that preserves the original ``b = 0.0`` statement.
+    code = fgen(routine).lower()
+    assert 'else' in code
+    assert 'b = 0.0' in code or 'b = 0' in code

--- a/loki/transformations/single_column/tests/test_vertical_utils.py
+++ b/loki/transformations/single_column/tests/test_vertical_utils.py
@@ -11,11 +11,10 @@ Tests for :mod:`loki.transformations.single_column.vertical_utils`.
 
 import pytest
 
-from loki import Subroutine, Dimension
+from loki import Subroutine
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends
-from loki.ir import FindNodes, Loop, Assignment, Conditional
-from loki.backend import fgen
+from loki.ir import FindNodes, Loop, Conditional
 
 from loki.transformations.single_column.vertical_utils import (
     _is_klev_plus_n,

--- a/loki/transformations/single_column/tests/test_vertical_utils.py
+++ b/loki/transformations/single_column/tests/test_vertical_utils.py
@@ -345,7 +345,7 @@ def test_find_demotable_simple(frontend):
              if l.variable.name.lower() == 'jk']
     assert len(loops) == 1
 
-    demotable = _find_demotable_arrays(routine, 'jk', 'klev', loops[0])
+    demotable = _find_demotable_arrays(routine, 'jk', 'klev')
     assert 'tmp' in demotable
 
 
@@ -367,9 +367,7 @@ def test_find_demotable_argument_not_demoted(frontend):
     end subroutine
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    loops = [l for l in FindNodes(Loop).visit(routine.body)
-             if l.variable.name.lower() == 'jk']
-    demotable = _find_demotable_arrays(routine, 'jk', 'klev', loops[0])
+    demotable = _find_demotable_arrays(routine, 'jk', 'klev')
     assert 'arr' not in demotable
 
 
@@ -398,9 +396,7 @@ def test_find_demotable_nonzero_offset_excluded(frontend):
     end subroutine
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    loops = [l for l in FindNodes(Loop).visit(routine.body)
-             if l.variable.name.lower() == 'jk']
-    demotable = _find_demotable_arrays(routine, 'jk', 'klev', loops[0])
+    demotable = _find_demotable_arrays(routine, 'jk', 'klev')
     assert 'tmp' not in demotable
 
 

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -9,7 +9,7 @@
 K-caching vertical-loop merge transformation for SCC pipelines.
 
 :class:`SCCVerticalKCaching` fuses **all** vertical loops in a routine
-into a single ``DO JK = 1, KLEV+1`` loop with IF guards, converts
+into a single ``DO JK = 1, KLEV+N`` loop with IF guards, converts
 multi-level array dependencies to scalar carry variables (two-scalar
 ``_vc``/``_next`` approach with explicit rotate), demotes KLEV-
 dimensioned temporaries to scalars, and performs cross-loop carry
@@ -21,19 +21,19 @@ The transformation operates in the following phases:
     1a. Loop interchange to expose vertical loops as outermost.
     1b. Dead-loop elimination.
     1c. Comprehensive carry conversion in *all* vertical loops.
+    1c-post. Carry-aware dead-loop elimination (zeroing loops for
+        arrays now served by carry variables).
     1d. Init-expression substitution for outside-loop reads.
     1e. Whole-array zero-init removal.
 
-**Phase 2 — Merge**
-    Merge all remaining vertical loops into a single
-    ``DO JK = 1, <max_upper>`` loop.  Each original loop body is
-    wrapped in ``IF (JK >= lower .AND. JK <= upper)`` guards.
-
-**Phase 2b — Cross-loop carry substitution**
-    Replace remaining raw array references in the merged loop body
-    with carry variables created in Phase 1c.  This resolves forward
-    read-only accesses that span multiple original loops and enables
-    further demotion.
+**Phase 2 — Merge & cross-loop fixup**
+    2.  Merge all remaining vertical loops into a single
+        ``DO JK = 1, <max_upper>`` loop with IF guards.
+    2-post. Hoist carry rotates to the end of the merged loop body.
+    2b. Cross-loop carry substitution (replace raw array references
+        with carry variables from other original loops).
+    2c. Argument write-backs for INTENT(OUT/INOUT) arrays converted
+        to B-readback carry patterns.
 
 **Phase 3 — Demotion**
     Demote all local arrays whose vertical dimension became
@@ -43,6 +43,9 @@ The transformation operates in the following phases:
     4a. Remove self-assignment no-ops.
     4b. Remove declarations of demoted local arrays that have zero
         remaining executable references.
+
+See the :class:`SCCVerticalKCaching` class docstring for a detailed
+description of each phase.
 """
 
 from loki.batch import Transformation
@@ -238,8 +241,9 @@ def _auto_interchange_vertical_loops(routine, vertical_index):
             )
             loop_map[outer_loop] = new_outer
 
-    # TODO: Consider extracting loop interchange into a reusable utility
-    # (e.g. ``do_loop_interchange``) if other transformations need it.
+    # NOTE: Pragma-based interchange is handled by do_loop_interchange()
+    # in Phase 1a.  This function covers the heuristic (automatic) case
+    # for loop nests without explicit interchange pragmas.
     if loop_map:
         routine.body = Transformer(loop_map).visit(routine.body)
     return len(loop_map)
@@ -247,26 +251,168 @@ def _auto_interchange_vertical_loops(routine, vertical_index):
 
 class SCCVerticalKCaching(Transformation):
     """
-    Full k-caching vertical-loop merge transformation.
+    K-caching vertical-loop merge transformation for SCC pipelines.
 
-    Merges **all** vertical loops in a routine into a single
-    vertical loop with IF guards, converts array
-    dependencies to scalar carry variables (``_vc``/``_next``),
-    performs cross-loop carry substitution, and demotes all eligible
-    local arrays.
+    This transformation fuses all vertical (``DO JK``) loops in a Fortran
+    kernel routine into a single loop, converts inter-level array
+    dependencies to scalar carry variables, and demotes KLEV-dimensioned
+    temporaries — dramatically reducing GPU memory traffic and register
+    pressure.
 
-    This is designed as a general-purpose transformation that works
-    on any kernel with proper-dimensioned vertical loops.
+    Overview
+    --------
+
+    Given a kernel with *N* vertical loops that operate on shared local
+    arrays, the transformation:
+
+    1. Merges all *N* loops into a single ``DO JK = 1, <max_upper>``
+       loop with ``IF (JK >= lower .AND. JK <= upper)`` guards.
+    2. Converts array accesses at neighbouring levels (``X(JK-1)``,
+       ``X(JK+1)``) to scalar carry variables (``x_vc``, ``x_next``)
+       that are rotated at the end of each iteration.
+    3. Demotes local arrays whose vertical dimension became level-local
+       (i.e., only accessed at offset 0) from 2-D/3-D to 1-D/2-D.
+
+    After transformation, the fused loop body reads and writes scalars
+    instead of indexing into large arrays, enabling the GPU compiler
+    to map carries to registers.
+
+    Phases in detail
+    ----------------
+
+    **Phase 1a — Loop interchange**
+
+    Exposes vertical loops hidden inside non-vertical outer loops.
+    For example, ``DO JM = 1, NCLV`` / ``DO JK = 1, KLEV`` is
+    interchanged to ``DO JK`` / ``DO JM`` so that the vertical loop
+    becomes outermost and visible to the merge pass.
+
+    Uses :func:`do_loop_interchange` (pragma-driven) followed by
+    :func:`_auto_interchange_vertical_loops` (heuristic: interchange
+    when the outer loop body contains *only* the inner vertical loop
+    plus pragmas/comments).
+
+    **Phase 1b — Dead-loop elimination**
+
+    Removes vertical loops whose written outputs are never read
+    elsewhere in the routine.  Delegates to
+    :func:`_find_dead_loops_all`.
+
+    **Phase 1c — Carry conversion**
+
+    The core of the transformation.  Scans every vertical loop for
+    four array access patterns and converts them to scalar carry
+    variables:
+
+    * **Pattern A** (cumulative sum): ``X(JK) = X(JK-1) + delta``
+      with an ``IF (JK==1)`` init.  One carry: ``x_vc``.
+    * **Pattern B-simple** (forward propagation): writes at ``JK+1``,
+      reads at ``JK``, no readback at ``JK+1`` in the same iteration.
+      One carry: ``x_vc``.
+    * **Pattern B-readback** (forward propagation with readback):
+      writes at ``JK+1``, reads at both ``JK`` and ``JK+1`` in the
+      same iteration.  Two carries: ``x_vc`` (incoming level) and
+      ``x_next`` (outgoing level), with an explicit rotate
+      ``x_vc = x_next`` at the end of each iteration.
+    * **Stencil** (read-only backward access): array written in one
+      loop, read at ``JK`` and ``JK-1`` in another loop but never
+      written there.  One carry: ``x_vc``, initialised from the
+      array at ``lower - 1`` before the merged loop.
+
+    Delegates to :func:`_convert_all_carries`.
+
+    **Phase 1c-post — Carry-aware dead-loop elimination**
+
+    After carry conversion, zeroing loops (e.g. ``X(:,:) = 0``) that
+    initialise arrays now served by carry variables become dead.
+    :func:`_find_dead_loops_carry_aware` removes them using the carry
+    registry built in Phase 1c.
+
+    **Phase 1d — Init-expression substitution**
+
+    When a local array is first written inside a vertical loop
+    (``X(JL, JK) = f(args)``) and also referenced outside all loops
+    (e.g. as a carry init), the outside reference is replaced with the
+    RHS expression ``f(args)`` evaluated at the appropriate level.
+    Delegates to :func:`_substitute_init_expressions_all_loops`.
+
+    **Phase 1e — Whole-array zero-init removal**
+
+    Removes ``X(:,:) = 0.0`` statements that are the sole
+    outside-loop reference to a local array, enabling demotion.
+    Delegates to :func:`_remove_whole_array_zero_inits`.
+
+    **Phase 2 — Loop merge**
+
+    All remaining vertical loops are merged into a single
+    ``DO JK = 1, <max_upper>`` loop.  The upper bound is the maximum
+    across all loops (comparing ``KLEV+N`` values when loops have
+    different bounds).  Each original loop body is wrapped in
+    ``IF (JK >= lower .AND. JK <= upper)`` guards.  Delegates to
+    :func:`_merge_vertical_loops`.
+
+    **Phase 2 post-merge — Hoist rotates**
+
+    Carry rotate statements (``x_vc = x_next``) and save statements
+    (``x_vc = X(:, JK)``) are moved to the end of the merged loop
+    body so that all reads of ``x_vc`` within the iteration see the
+    incoming value before the rotate overwrites it.  Delegates to
+    :func:`_hoist_rotates_to_end`.
+
+    **Phase 2b — Cross-loop carry substitution**
+
+    After merge, some loop bodies still reference the original array
+    at offsets served by a carry variable from a *different* original
+    loop.  This phase replaces those remaining array references with
+    the appropriate carry variable (offset 0 → ``x_vc``, offset +1 →
+    ``x_next``, offset -1 → ``x_vc`` for Pattern A / stencil).
+    Delegates to :func:`_cross_loop_carry_substitution`.
+
+    **Phase 2c — Argument write-backs**
+
+    For ``INTENT(OUT)`` or ``INTENT(INOUT)`` argument arrays converted
+    to B-readback carries, inserts ``ARRAY(JL, JK+1) = array_next``
+    before the rotate so that the output array is populated with the
+    correct values.  This must happen *after* Phase 2b to avoid
+    cross-loop substitution turning the write-back into a
+    self-assignment.  Delegates to
+    :func:`_insert_writebacks_for_argument_carries`.
+
+    **Phase 3 — Demotion**
+
+    Local arrays whose vertical dimension is now accessed only at
+    offset 0 (level-local) are demoted: the KLEV dimension is
+    removed from their declaration.  Delegates to
+    :func:`_find_demotable_arrays` and :func:`demote_variables`.
+
+    **Phase 4a — Self-assignment cleanup**
+
+    Removes no-op self-assignments (``x_vc = x_vc``) that arise when
+    carry substitution replaces both sides of a save statement.
+    Delegates to :func:`_remove_self_assignments`.
+
+    **Phase 4b — Dead declaration removal**
+
+    Removes declarations of demoted local arrays that have zero
+    remaining executable references (the original array name is fully
+    replaced by the carry variable).  Delegates to
+    :func:`_remove_dead_carry_originals`.
 
     Parameters
     ----------
     horizontal : :any:`Dimension`, optional
         Dimension object describing the horizontal (index, size, bounds).
+        When provided, horizontal loop variables (e.g. ``JL``) in carry
+        init, save, and write-back statements are replaced with bounded
+        ranges (e.g. ``KIDIA:KFDIA``) so that the downstream SCC
+        pipeline's ``resolve_vector_dimension`` pass can resolve them
+        correctly.  Without this, bare ``:`` ranges would persist and
+        cause rank mismatches during devectorisation.
     vertical : :any:`Dimension`
-        Dimension object describing the vertical (index, size, bounds).
+        Dimension object describing the vertical (index, size).
     apply_to : list of str, optional
-        Routine names to apply to (lowercase).  If not provided,
-        apply to all kernel routines.
+        Routine names to apply to (case-insensitive).  If not provided,
+        the transformation is applied to all kernel routines.
     """
 
     def __init__(self, horizontal=None, vertical=None, apply_to=None):

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -211,6 +211,12 @@ def _auto_interchange_vertical_loops(routine, vertical_index):
             # and bounds between the two loop levels.
             # Collect any pragmas/comments from the outer loop body
             # (e.g., !DIR$ IVDEP) and attach them to the new inner loop.
+            # TODO: Pragmas/comments between the outer loop header and
+            # the inner loop are currently placed inside the new inner
+            # loop body.  For directive-style pragmas that annotate the
+            # *following* loop, this may change which loop they apply to
+            # after interchange.  Consider keeping them as siblings
+            # before the new inner loop in the outer loop body instead.
             non_loop_items = tuple(
                 n for n in outer_loop.body
                 if isinstance(n, (ir.Comment, ir.Pragma))
@@ -330,8 +336,7 @@ class SCCVerticalKCaching(Transformation):
 
         for loop, _cond in all_vloops:
             new_loop, init_stmts, conversions = _convert_all_carries(
-                routine, loop, vertical_size,
-                horizontal_index=horizontal_index
+                routine, loop, vertical_size
             )
             if conversions:
                 routine.body = Transformer(

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -181,7 +181,9 @@ def _auto_interchange_vertical_loops(routine, vertical_index):
     vi_lower = vertical_index.lower()
     loop_map = {}
 
-    # TODO [K-CACHING]: FindNodes(ir.Loop) will give all loops, not only the outermost
+    # NOTE: FindNodes(ir.Loop) visits all loops (not only outermost), but
+    # the filter below (exactly one inner vertical loop, no other executable
+    # code) ensures only genuine two-level nests are interchanged.
     for outer_loop in FindNodes(ir.Loop).visit(routine.body):
         # Skip if this is already a vertical loop
         if outer_loop.variable.name.lower() == vi_lower:
@@ -230,7 +232,8 @@ def _auto_interchange_vertical_loops(routine, vertical_index):
             )
             loop_map[outer_loop] = new_outer
 
-    # TODO [K-CACHING]: loop interchange via utility: `do_loop_interchange`?!
+    # TODO: Consider extracting loop interchange into a reusable utility
+    # (e.g. ``do_loop_interchange``) if other transformations need it.
     if loop_map:
         routine.body = Transformer(loop_map).visit(routine.body)
     return len(loop_map)
@@ -368,7 +371,7 @@ class SCCVerticalKCaching(Transformation):
                 ).visit(routine.body)
 
         # Phase 1c-post: Carry-aware dead-loop elimination.
-        # After carry conversion, some zeroing loops (e.g. ZPFPLSX = 0)
+        # After carry conversion, some zeroing loops (e.g. ``arr = 0``)
         # that were NOT dead before (because other loops still read the
         # original array) become dead because Phase 2b cross-loop carry
         # substitution will replace all remaining reads with carry

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -308,9 +308,6 @@ class SCCVerticalKCaching(Transformation):
         # consulted, so routines using alias names will not be matched.
         vertical_index = self.vertical.index
         vertical_size = str(self.vertical.size)
-        horizontal_index = (
-            self.horizontal.index if self.horizontal is not None else None
-        )
 
         # Phase 1a: Loop interchange (pragma-based + automatic)
         do_loop_interchange(routine)
@@ -336,7 +333,7 @@ class SCCVerticalKCaching(Transformation):
 
         for loop, _cond in all_vloops:
             new_loop, init_stmts, conversions = _convert_all_carries(
-                routine, loop, vertical_size
+                routine, loop, vertical_size, horizontal=self.horizontal
             )
             if conversions:
                 routine.body = Transformer(
@@ -396,7 +393,8 @@ class SCCVerticalKCaching(Transformation):
 
         # Phase 1d: Init-expression substitution
         substituted = _substitute_init_expressions_all_loops(
-            routine, vertical_index, vertical_size
+            routine, vertical_index, vertical_size,
+            horizontal=self.horizontal
         )
         if substituted:
             info('[SCCVerticalKCaching] %s: Phase 1d - substituted '
@@ -457,7 +455,7 @@ class SCCVerticalKCaching(Transformation):
                 merged_loop = all_vloops[0][0]
                 n_wb = _insert_writebacks_for_argument_carries(
                     routine, merged_loop, carry_registry,
-                    horizontal_index=horizontal_index
+                    horizontal=self.horizontal
                 )
                 if n_wb:
                     info('[SCCVerticalKCaching] %s: Phase 2c - '
@@ -482,15 +480,14 @@ class SCCVerticalKCaching(Transformation):
                      ', '.join(demotable))
 
         # Phase 4: Cleanup
-        all_vloops = _collect_vertical_loops(routine.body, vertical_index)
-        if all_vloops:
-            merged_loop = all_vloops[0][0]
 
-            # 4a. Remove self-assignment no-ops
-            n_noops = _remove_self_assignments(routine, merged_loop)
-            if n_noops:
-                info('[SCCVerticalKCaching] %s: Phase 4a - removed '
-                     '%d self-assignment no-op(s)', routine.name, n_noops)
+        # 4a. Remove self-assignment no-ops from all vertical loops.
+        all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+        all_loops = [vloop for vloop, _ in all_vloops]
+        n_noops_total = _remove_self_assignments(routine, all_loops)
+        if n_noops_total:
+            info('[SCCVerticalKCaching] %s: Phase 4a - removed '
+                 '%d self-assignment no-op(s)', routine.name, n_noops_total)
 
         # 4b. Remove dead carry-original declarations
         if carry_registry and demotable:

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -15,9 +15,6 @@ multi-level array dependencies to scalar carry variables (two-scalar
 dimensioned temporaries to scalars, and performs cross-loop carry
 substitution — dramatically reducing GPU memory pressure.
 
-This is the full "k-caching" optimisation that produces code
-structurally equivalent to manually-written SCC-K-CACHING kernels.
-
 The transformation operates in the following phases:
 
 **Phase 1 — Preparation**
@@ -93,7 +90,7 @@ def _find_dead_loops_carry_aware(routine, vertical_index, carry_registry):
        be replaced by carry variables during Phase 2b cross-loop carry
        substitution.
 
-    Without this, zeroing loops like ``ZPFPLSX(JK,JM) = 0.0`` survive
+    Without this, zeroing loops like ``X(JK,JM) = 0.0`` survive
     the merge and zero the carry variable on every iteration, destroying
     inter-level accumulation (e.g. precipitation sedimentation).
 
@@ -184,6 +181,7 @@ def _auto_interchange_vertical_loops(routine, vertical_index):
     vi_lower = vertical_index.lower()
     loop_map = {}
 
+    # TODO [K-CACHING]: FindNodes(ir.Loop) will give all loops, not only the outermost
     for outer_loop in FindNodes(ir.Loop).visit(routine.body):
         # Skip if this is already a vertical loop
         if outer_loop.variable.name.lower() == vi_lower:
@@ -232,6 +230,7 @@ def _auto_interchange_vertical_loops(routine, vertical_index):
             )
             loop_map[outer_loop] = new_outer
 
+    # TODO [K-CACHING]: loop interchange via utility: `do_loop_interchange`?!
     if loop_map:
         routine.body = Transformer(loop_map).visit(routine.body)
     return len(loop_map)
@@ -242,13 +241,13 @@ class SCCVerticalKCaching(Transformation):
     Full k-caching vertical-loop merge transformation.
 
     Merges **all** vertical loops in a routine into a single
-    ``DO JK = 1, KLEV+1`` loop with IF guards, converts array
+    vertical loop with IF guards, converts array
     dependencies to scalar carry variables (``_vc``/``_next``),
     performs cross-loop carry substitution, and demotes all eligible
     local arrays.
 
     This is designed as a general-purpose transformation that works
-    on any kernel with KLEV-dimensioned vertical loops.
+    on any kernel with proper-dimensioned vertical loops.
 
     Parameters
     ----------
@@ -295,6 +294,7 @@ class SCCVerticalKCaching(Transformation):
 
         Phases 1-4 as described in the module docstring.
         """
+        # TODO [K-CACHING]: there are possibly also aliases of index and size
         vertical_index = self.vertical.index
         vertical_size = str(self.vertical.size)
         horizontal_index = (
@@ -402,6 +402,7 @@ class SCCVerticalKCaching(Transformation):
                  'zero-inits for %s', routine.name,
                  ', '.join(sorted(removed)))
 
+        # TODO [K-CACHING]: merge all vertical loops if possible
         # Phase 2: Merge all vertical loops
         merged = _merge_vertical_loops(
             routine, vertical_index, vertical_size

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -465,7 +465,7 @@ class SCCVerticalKCaching(Transformation):
         if all_vloops:
             merged_loop = all_vloops[0][0]
             demotable = _find_demotable_arrays(
-                routine, vertical_index, vertical_size, merged_loop
+                routine, vertical_index, vertical_size
             )
             if demotable:
                 dims_to_demote = (

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -330,7 +330,7 @@ class SCCVerticalKCaching(Transformation):
 
         for loop, _cond in all_vloops:
             new_loop, init_stmts, conversions = _convert_all_carries(
-                routine, loop, vertical_index, vertical_size,
+                routine, loop, vertical_size,
                 horizontal_index=horizontal_index
             )
             if conversions:
@@ -437,7 +437,7 @@ class SCCVerticalKCaching(Transformation):
             if all_vloops:
                 merged_loop = all_vloops[0][0]
                 n_subs = _cross_loop_carry_substitution(
-                    routine, merged_loop, carry_registry, vertical_index
+                    routine, merged_loop, carry_registry
                 )
                 if n_subs:
                     info('[SCCVerticalKCaching] %s: Phase 2b - '
@@ -451,7 +451,7 @@ class SCCVerticalKCaching(Transformation):
             if all_vloops:
                 merged_loop = all_vloops[0][0]
                 n_wb = _insert_writebacks_for_argument_carries(
-                    routine, merged_loop, carry_registry, vertical_index,
+                    routine, merged_loop, carry_registry,
                     horizontal_index=horizontal_index
                 )
                 if n_wb:

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -294,7 +294,9 @@ class SCCVerticalKCaching(Transformation):
 
         Phases 1-4 as described in the module docstring.
         """
-        # TODO [K-CACHING]: there are possibly also aliases of index and size
+        # NOTE: Only the primary index/size names are used here.
+        # Dimension.index_aliases and Dimension.size_aliases are not
+        # consulted, so routines using alias names will not be matched.
         vertical_index = self.vertical.index
         vertical_size = str(self.vertical.size)
         horizontal_index = (
@@ -402,7 +404,6 @@ class SCCVerticalKCaching(Transformation):
                  'zero-inits for %s', routine.name,
                  ', '.join(sorted(removed)))
 
-        # TODO [K-CACHING]: merge all vertical loops if possible
         # Phase 2: Merge all vertical loops
         merged = _merge_vertical_loops(
             routine, vertical_index, vertical_size

--- a/loki/transformations/single_column/vertical_kcaching.py
+++ b/loki/transformations/single_column/vertical_kcaching.py
@@ -1,0 +1,493 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+K-caching vertical-loop merge transformation for SCC pipelines.
+
+:class:`SCCVerticalKCaching` fuses **all** vertical loops in a routine
+into a single ``DO JK = 1, KLEV+1`` loop with IF guards, converts
+multi-level array dependencies to scalar carry variables (two-scalar
+``_vc``/``_next`` approach with explicit rotate), demotes KLEV-
+dimensioned temporaries to scalars, and performs cross-loop carry
+substitution — dramatically reducing GPU memory pressure.
+
+This is the full "k-caching" optimisation that produces code
+structurally equivalent to manually-written SCC-K-CACHING kernels.
+
+The transformation operates in the following phases:
+
+**Phase 1 — Preparation**
+    1a. Loop interchange to expose vertical loops as outermost.
+    1b. Dead-loop elimination.
+    1c. Comprehensive carry conversion in *all* vertical loops.
+    1d. Init-expression substitution for outside-loop reads.
+    1e. Whole-array zero-init removal.
+
+**Phase 2 — Merge**
+    Merge all remaining vertical loops into a single
+    ``DO JK = 1, <max_upper>`` loop.  Each original loop body is
+    wrapped in ``IF (JK >= lower .AND. JK <= upper)`` guards.
+
+**Phase 2b — Cross-loop carry substitution**
+    Replace remaining raw array references in the merged loop body
+    with carry variables created in Phase 1c.  This resolves forward
+    read-only accesses that span multiple original loops and enables
+    further demotion.
+
+**Phase 3 — Demotion**
+    Demote all local arrays whose vertical dimension became
+    level-local after merging.
+
+**Phase 4 — Cleanup**
+    4a. Remove self-assignment no-ops.
+    4b. Remove declarations of demoted local arrays that have zero
+        remaining executable references.
+"""
+
+from loki.batch import Transformation
+from loki.ir import nodes as ir, FindNodes, Transformer
+from loki.logging import info, warning
+from loki.transformations.transform_loop import do_loop_interchange
+from loki.transformations.array_indexing import demote_variables
+
+# Shared utilities for vertical loop transformations
+from loki.transformations.single_column.vertical_utils import (
+    _collect_vertical_loops,
+    _find_demotable_arrays,
+    _any_read_outside_node,
+    _find_dead_loops_all,
+    _convert_all_carries,
+    _substitute_init_expressions_all_loops,
+    _remove_whole_array_zero_inits,
+    _merge_vertical_loops,
+    _hoist_rotates_to_end,
+    _cross_loop_carry_substitution,
+    _insert_writebacks_for_argument_carries,
+    _remove_self_assignments,
+    _remove_dead_carry_originals,
+    _is_zero_literal,
+)
+
+__all__ = ['SCCVerticalKCaching']
+
+
+# ---------------------------------------------------------------------------
+# Carry-aware dead-loop elimination
+# ---------------------------------------------------------------------------
+
+def _find_dead_loops_carry_aware(routine, vertical_index, carry_registry):
+    """
+    Identify vertical loops whose written outputs will be dead after
+    cross-loop carry substitution in Phase 2b.
+
+    This is a carry-aware variant of :func:`_find_dead_loops_all`.
+    A loop is considered dead if **every** variable it writes satisfies
+    at least one of:
+
+    1. It is never read anywhere else in the routine (truly dead).
+    2. It is in the *carry_registry*, meaning all remaining reads will
+       be replaced by carry variables during Phase 2b cross-loop carry
+       substitution.
+
+    Without this, zeroing loops like ``ZPFPLSX(JK,JM) = 0.0`` survive
+    the merge and zero the carry variable on every iteration, destroying
+    inter-level accumulation (e.g. precipitation sedimentation).
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    vertical_index : str
+    carry_registry : dict
+        Mapping of lowercase array names to carry info dicts.
+
+    Returns
+    -------
+    list
+        Top-level IR nodes (Loop or Conditional wrappers) that are dead.
+    """
+    all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+    dead = []
+
+    arg_names = {v.name.lower() for v in routine.arguments}
+    carry_names = set(carry_registry.keys())  # already lowercase
+
+    for loop, cond_wrapper in all_vloops:
+        written_names = set()
+        for assign in FindNodes(ir.Assignment).visit(loop.body):
+            written_names.add(assign.lhs.name.lower())
+
+        if not written_names:
+            continue
+
+        # Writing to a routine argument is never dead
+        if written_names & arg_names:
+            continue
+
+        # Partition written names: carry-registered vs non-carry
+        non_carry_written = written_names - carry_names
+
+        exclude_node = cond_wrapper if cond_wrapper is not None else loop
+
+        # For non-carry names, check if they are read outside
+        if non_carry_written:
+            if _any_read_outside_node(routine.body, exclude_node,
+                                       non_carry_written):
+                continue
+
+        # For carry-registered names: they will be handled by Phase 2b
+        # cross-loop carry substitution, so we treat them as "will be
+        # dead" — but ONLY if the loop body is a pure zeroing/init loop.
+        # We verify this by checking that every assignment in the loop
+        # to a carry-registered array has a literal zero RHS.
+        carry_written = written_names & carry_names
+        if carry_written:
+            is_pure_init = True
+            for assign in FindNodes(ir.Assignment).visit(loop.body):
+                arr_lower = assign.lhs.name.lower()
+                if arr_lower in carry_names:
+                    # Check if RHS is a literal zero (0, 0.0, 0.0_JPRB, etc.)
+                    rhs = assign.rhs
+                    if _is_zero_literal(rhs):
+                        continue
+                    # Not a pure zero init — keep the loop
+                    is_pure_init = False
+                    break
+            if not is_pure_init:
+                continue
+
+        dead.append(exclude_node)
+
+    return dead
+
+
+def _auto_interchange_vertical_loops(routine, vertical_index):
+    """
+    Automatically interchange loop nests where a non-vertical loop
+    (e.g. ``DO JM = 1, NCLV-1``) is the outermost loop and the
+    vertical loop (``DO JK = 1, KLEV``) is immediately nested inside.
+
+    After interchange the vertical loop becomes outermost, making it
+    visible to ``_collect_vertical_loops`` and eligible for merging.
+
+    The interchange is safe when the outer loop's body consists solely
+    of the inner vertical loop (possibly preceded/followed only by
+    pragmas or comments), because that means there is no code between
+    the outer loop header and the inner loop that depends on the outer
+    loop variable in a way that would be violated by reordering.
+
+    Returns the number of interchanges performed.
+    """
+    vi_lower = vertical_index.lower()
+    loop_map = {}
+
+    for outer_loop in FindNodes(ir.Loop).visit(routine.body):
+        # Skip if this is already a vertical loop
+        if outer_loop.variable.name.lower() == vi_lower:
+            continue
+
+        # Find the immediate inner loop(s) — skip pragmas/comments
+        inner_loops = [n for n in outer_loop.body
+                       if isinstance(n, ir.Loop)]
+        non_loop_exec = [n for n in outer_loop.body
+                         if not isinstance(n, (ir.Loop, ir.Comment,
+                                               ir.Pragma))]
+
+        # Only interchange if:
+        # 1. There is exactly one inner loop
+        # 2. That inner loop IS a vertical loop
+        # 3. There is no executable code between outer and inner
+        #    (only pragmas/comments are allowed)
+        if (len(inner_loops) == 1 and
+                inner_loops[0].variable.name.lower() == vi_lower and
+                len(non_loop_exec) == 0):
+            inner_loop = inner_loops[0]
+
+            # Build interchanged nest: JK outer, JM inner
+            # The inner loop body stays the same, just swap variables
+            # and bounds between the two loop levels.
+            # Collect any pragmas/comments from the outer loop body
+            # (e.g., !DIR$ IVDEP) and attach them to the new inner loop.
+            non_loop_items = tuple(
+                n for n in outer_loop.body
+                if isinstance(n, (ir.Comment, ir.Pragma))
+            )
+
+            new_inner = inner_loop.clone(
+                variable=outer_loop.variable,
+                bounds=outer_loop.bounds,
+                pragma=inner_loop.pragma,
+                pragma_post=inner_loop.pragma_post,
+                body=non_loop_items + inner_loop.body,
+            )
+            new_outer = outer_loop.clone(
+                variable=inner_loop.variable,
+                bounds=inner_loop.bounds,
+                body=(new_inner,),
+                pragma=outer_loop.pragma,
+                pragma_post=outer_loop.pragma_post,
+            )
+            loop_map[outer_loop] = new_outer
+
+    if loop_map:
+        routine.body = Transformer(loop_map).visit(routine.body)
+    return len(loop_map)
+
+
+class SCCVerticalKCaching(Transformation):
+    """
+    Full k-caching vertical-loop merge transformation.
+
+    Merges **all** vertical loops in a routine into a single
+    ``DO JK = 1, KLEV+1`` loop with IF guards, converts array
+    dependencies to scalar carry variables (``_vc``/``_next``),
+    performs cross-loop carry substitution, and demotes all eligible
+    local arrays.
+
+    This is designed as a general-purpose transformation that works
+    on any kernel with KLEV-dimensioned vertical loops.
+
+    Parameters
+    ----------
+    horizontal : :any:`Dimension`, optional
+        Dimension object describing the horizontal (index, size, bounds).
+    vertical : :any:`Dimension`
+        Dimension object describing the vertical (index, size, bounds).
+    apply_to : list of str, optional
+        Routine names to apply to (lowercase).  If not provided,
+        apply to all kernel routines.
+    """
+
+    def __init__(self, horizontal=None, vertical=None, apply_to=None):
+        self.horizontal = horizontal
+        self.vertical = vertical
+        self.apply_to = apply_to or ()
+
+        if self.vertical is None:
+            info('[SCCVerticalKCaching] is not applied as the '
+                 'vertical dimension is not defined!')
+
+    # ------------------------------------------------------------------
+    # Dispatch
+    # ------------------------------------------------------------------
+
+    def transform_subroutine(self, routine, **kwargs):
+        """Dispatch to :meth:`process_kernel` for kernel-role routines."""
+        if self.vertical is None:
+            return
+        role = kwargs.get('role', 'kernel')
+        if role == 'kernel':
+            if self.apply_to and routine.name.lower() not in \
+                    [n.lower() for n in self.apply_to]:
+                return
+            self.process_kernel(routine)
+
+    # ------------------------------------------------------------------
+    # Main orchestrator
+    # ------------------------------------------------------------------
+
+    def process_kernel(self, routine):
+        """
+        Orchestrate the k-caching transformation.
+
+        Phases 1-4 as described in the module docstring.
+        """
+        vertical_index = self.vertical.index
+        vertical_size = str(self.vertical.size)
+        horizontal_index = (
+            self.horizontal.index if self.horizontal is not None else None
+        )
+
+        # Phase 1a: Loop interchange (pragma-based + automatic)
+        do_loop_interchange(routine)
+        n_auto = _auto_interchange_vertical_loops(routine, vertical_index)
+        if n_auto:
+            info('[SCCVerticalKCaching] %s: Phase 1a - auto-interchanged '
+                 '%d loop nest(s) to expose vertical loops', routine.name,
+                 n_auto)
+
+        # Phase 1b: Dead-loop elimination
+        dead_loops = _find_dead_loops_all(routine, vertical_index)
+        if dead_loops:
+            node_map = {node: None for node in dead_loops}
+            routine.body = Transformer(node_map).visit(routine.body)
+            info('[SCCVerticalKCaching] %s: Phase 1b - removed '
+                 '%d dead loop(s)', routine.name, len(dead_loops))
+
+        # Phase 1c: Carry conversion in ALL vertical loops
+        all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+        all_carry_init_stmts = []
+        total_conversions = 0
+        carry_registry = {}
+
+        for loop, _cond in all_vloops:
+            new_loop, init_stmts, conversions = _convert_all_carries(
+                routine, loop, vertical_index, vertical_size,
+                horizontal_index=horizontal_index
+            )
+            if conversions:
+                routine.body = Transformer(
+                    {loop: new_loop}).visit(routine.body)
+                all_carry_init_stmts.extend(init_stmts)
+                total_conversions += len(conversions)
+                for conv in conversions:
+                    info('[SCCVerticalKCaching] %s:   %s -> %s '
+                         '(pattern %s)', routine.name, conv['array'],
+                         conv['carry'], conv['pattern'])
+                    arr_lower = conv['array'].lower()
+                    if arr_lower not in carry_registry:
+                        carry_registry[arr_lower] = {
+                            'carry': conv['carry'],
+                            'pattern': conv['pattern'],
+                            'next': conv.get('next'),
+                            'dim_index': conv['dim_index'],
+                        }
+
+        if total_conversions:
+            info('[SCCVerticalKCaching] %s: Phase 1c - converted '
+                 '%d carries', routine.name, total_conversions)
+
+        # Place carry init statements before the first vertical loop
+        if all_carry_init_stmts:
+            all_vloops = _collect_vertical_loops(
+                routine.body, vertical_index)
+            if all_vloops:
+                first_loop = all_vloops[0][0]
+                first_node = (all_vloops[0][1]
+                              if all_vloops[0][1] is not None
+                              else first_loop)
+                init_section = ir.Section(
+                    body=tuple(all_carry_init_stmts))
+                routine.body = Transformer(
+                    {first_node: (init_section, first_node)}
+                ).visit(routine.body)
+
+        # Phase 1c-post: Carry-aware dead-loop elimination.
+        # After carry conversion, some zeroing loops (e.g. ZPFPLSX = 0)
+        # that were NOT dead before (because other loops still read the
+        # original array) become dead because Phase 2b cross-loop carry
+        # substitution will replace all remaining reads with carry
+        # variables.  We detect these proactively using the carry
+        # registry so they don't get merged and zero the carry variable
+        # on every JK iteration.
+        if carry_registry:
+            dead_loops_post = _find_dead_loops_carry_aware(
+                routine, vertical_index, carry_registry
+            )
+            if dead_loops_post:
+                node_map = {node: None for node in dead_loops_post}
+                routine.body = Transformer(node_map).visit(routine.body)
+                info('[SCCVerticalKCaching] %s: Phase 1c-post - removed '
+                     '%d dead loop(s) after carry conversion (carry-aware)',
+                     routine.name, len(dead_loops_post))
+
+        # Phase 1d: Init-expression substitution
+        substituted = _substitute_init_expressions_all_loops(
+            routine, vertical_index, vertical_size
+        )
+        if substituted:
+            info('[SCCVerticalKCaching] %s: Phase 1d - substituted '
+                 'init expressions for %s', routine.name,
+                 ', '.join(sorted(substituted)))
+
+        # Phase 1e: Remove whole-array zero-inits
+        removed = _remove_whole_array_zero_inits(
+            routine, vertical_index, vertical_size
+        )
+        if removed:
+            info('[SCCVerticalKCaching] %s: Phase 1e - removed '
+                 'zero-inits for %s', routine.name,
+                 ', '.join(sorted(removed)))
+
+        # Phase 2: Merge all vertical loops
+        merged = _merge_vertical_loops(
+            routine, vertical_index, vertical_size
+        )
+        if merged is None:
+            warning('[SCCVerticalKCaching] %s: no vertical loops to '
+                    'merge', routine.name)
+            return
+
+        # Phase 2 post-merge: Hoist carry rotates to end of merged loop
+        if carry_registry:
+            all_vloops = _collect_vertical_loops(
+                routine.body, vertical_index)
+            if all_vloops:
+                merged_loop = all_vloops[0][0]
+                n_hoisted = _hoist_rotates_to_end(
+                    routine, merged_loop, carry_registry
+                )
+                if n_hoisted:
+                    info('[SCCVerticalKCaching] %s: Phase 2 post-merge '
+                         '- hoisted %d rotate/save(s)', routine.name,
+                         n_hoisted)
+
+        # Phase 2b: Cross-loop carry substitution (always enabled)
+        if carry_registry:
+            all_vloops = _collect_vertical_loops(
+                routine.body, vertical_index)
+            if all_vloops:
+                merged_loop = all_vloops[0][0]
+                n_subs = _cross_loop_carry_substitution(
+                    routine, merged_loop, carry_registry, vertical_index
+                )
+                if n_subs:
+                    info('[SCCVerticalKCaching] %s: Phase 2b - '
+                         'cross-loop carry substitution: %d replacement(s)',
+                         routine.name, n_subs)
+
+        # Phase 2c: Insert write-back statements for argument arrays
+        if carry_registry:
+            all_vloops = _collect_vertical_loops(
+                routine.body, vertical_index)
+            if all_vloops:
+                merged_loop = all_vloops[0][0]
+                n_wb = _insert_writebacks_for_argument_carries(
+                    routine, merged_loop, carry_registry, vertical_index,
+                    horizontal_index=horizontal_index
+                )
+                if n_wb:
+                    info('[SCCVerticalKCaching] %s: Phase 2c - '
+                         'inserted %d write-back(s) for argument arrays',
+                         routine.name, n_wb)
+
+        # Phase 3: Demotion
+        demotable = []
+        all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+        if all_vloops:
+            merged_loop = all_vloops[0][0]
+            demotable = _find_demotable_arrays(
+                routine, vertical_index, vertical_size, merged_loop
+            )
+            if demotable:
+                dims_to_demote = (
+                    self.vertical.size_expressions +
+                    (f"{self.vertical.size}+1",))
+                demote_variables(routine, demotable, dims_to_demote)
+                info('[SCCVerticalKCaching] %s: Phase 3 - demoted '
+                     '%d array(s): %s', routine.name, len(demotable),
+                     ', '.join(demotable))
+
+        # Phase 4: Cleanup
+        all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+        if all_vloops:
+            merged_loop = all_vloops[0][0]
+
+            # 4a. Remove self-assignment no-ops
+            n_noops = _remove_self_assignments(routine, merged_loop)
+            if n_noops:
+                info('[SCCVerticalKCaching] %s: Phase 4a - removed '
+                     '%d self-assignment no-op(s)', routine.name, n_noops)
+
+        # 4b. Remove dead carry-original declarations
+        if carry_registry and demotable:
+            dead = _remove_dead_carry_originals(
+                routine, carry_registry, demotable
+            )
+            if dead:
+                info('[SCCVerticalKCaching] %s: Phase 4b - removed '
+                     '%d dead variable(s): %s', routine.name,
+                     len(dead), ', '.join(dead))

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -10,7 +10,51 @@
 """
 Shared utility functions for vertical loop transformations.
 
-This module collects helper functions for vertical loop transformations.
+This module provides the building blocks used by
+:class:`~loki.transformations.single_column.vertical_kcaching.SCCVerticalKCaching`
+to merge vertical loops, convert array dependencies to scalar carry
+variables, and demote KLEV-dimensioned temporaries.
+
+The utilities are grouped as follows:
+
+**Loop inspection**
+    :func:`_collect_vertical_loops`, :func:`_loop_upper_bound_expr`,
+    :func:`_loop_upper_bound_str`, :func:`_loop_is_backward`,
+    :func:`_loop_effective_bounds`, :func:`_is_klev_plus_n`,
+    :func:`_extract_plus_n`.
+
+**Carry conversion** (Phase 1c)
+    :func:`_convert_all_carries`, :func:`_build_carry_expr_entries`,
+    :func:`_build_save_assignment`.
+
+**Init-expression substitution** (Phase 1d)
+    :func:`_substitute_init_expressions_all_loops`,
+    :func:`_build_init_subst_map`, :func:`_apply_subst_outside_loops`.
+
+**Dead-loop / zero-init elimination** (Phases 1b, 1e)
+    :func:`_find_dead_loops_all`, :func:`_remove_whole_array_zero_inits`,
+    :func:`_find_zero_inits_outside_loops`.
+
+**Loop merging** (Phase 2)
+    :func:`_merge_vertical_loops`, :func:`_build_bounds_guard`,
+    :func:`_relocate_interloop_code`.
+
+**Post-merge fixup** (Phases 2b, 2c)
+    :func:`_cross_loop_carry_substitution`,
+    :func:`_insert_writebacks_for_argument_carries`,
+    :func:`_hoist_rotates_to_end`.
+
+**Demotion helpers** (Phase 3)
+    :func:`_find_demotable_arrays`, :func:`_collect_call_arg_names`,
+    :func:`_collect_refs_outside_loops`.
+
+**Cleanup** (Phase 4)
+    :func:`_remove_self_assignments`, :func:`_remove_dead_carry_originals`.
+
+**Shared infrastructure**
+    :class:`_SkipNodesVisitor`, :class:`_EarlyTermination`,
+    :func:`_make_zero_literal`, :func:`_is_zero_literal`,
+    :func:`_is_jk_eq_1`, :func:`_collect_loop_node_set`.
 """
 
 from collections import defaultdict, OrderedDict
@@ -86,41 +130,6 @@ class _SkipNodesVisitor(Visitor):
 
     def visit_Loop(self, o, **kwargs):
         self.visit(o.body, **kwargs)
-
-
-def _walk_outside(body, skip_nodes, callback):
-    """
-    Walk *body* recursively, skipping any node in *skip_nodes*.
-
-    For each non-skipped, non-container leaf node, calls
-    ``callback(node)``.  Recurses into :any:`Section`, :any:`Associate`,
-    :any:`Conditional` (body + else_body), and :any:`Loop` containers.
-
-    Parameters
-    ----------
-    body : tuple, list, or node with ``.body``
-        The IR nodes to walk.
-    skip_nodes : set
-        Nodes to skip entirely (e.g. vertical loops).
-    callback : callable(node) -> bool or None
-        Called for each leaf node.  If it returns ``True`` the walk
-        stops early and ``_walk_outside`` returns ``True``.
-    """
-
-    class _Walker(_SkipNodesVisitor):
-        def __init__(self, skip_nodes, callback):
-            super().__init__(skip_nodes)
-            self.callback = callback
-
-        def visit_Node(self, o, **kwargs):
-            if self.callback(o):
-                raise _EarlyTermination()
-
-    try:
-        _Walker(skip_nodes, callback).visit(body)
-        return False
-    except _EarlyTermination:
-        return True
 
 
 def _collect_call_arg_names(routine):
@@ -508,8 +517,40 @@ def _substitute_jk_in_expr(expr, jk_var, replacement):
 def _build_init_subst_map(body, loop_nodes, init_map, local_2d,
                            expr_map, substituted, horizontal=None):
     """
-    Walk *body* and for any Array reference to an init-mapped array
-    that appears outside all JK loops, add a substitution entry.
+    Walk *body* and for any :any:`Array` reference to an init-mapped
+    array that appears outside all vertical loops, add a substitution
+    entry to *expr_map*.
+
+    The substitution replaces the outside-loop array reference with
+    the RHS expression of the first in-loop assignment to that array,
+    evaluated at the appropriate level index.
+
+    Non-vertical subscripts (e.g. ``JL``) in the substitution expression
+    are replaced with the appropriate range:
+
+    * Horizontal loop variables matching ``horizontal.index`` are
+      replaced with ``horizontal.bounds`` (e.g. ``KIDIA:KFDIA``).
+    * Other scalar subscripts are replaced with bare ``:``
+      (:any:`RangeIndex`).
+
+    Parameters
+    ----------
+    body : :any:`Section` or tuple
+        The routine body to walk.
+    loop_nodes : set
+        IR nodes to skip (the vertical loops).
+    init_map : dict
+        ``{array_name_lower: Assignment}`` — the first in-loop write.
+    local_2d : dict
+        ``{array_name_lower: {'klev_dim_idx': int, ...}}`` — info about
+        each local array with a KLEV dimension.
+    expr_map : dict
+        Accumulator for ``{old_expr: new_expr}`` substitution entries.
+    substituted : set
+        Accumulator for lowercase array names that were substituted.
+    horizontal : :any:`Dimension`, optional
+        When provided, horizontal loop variables in substitution
+        expressions use bounded ranges from ``horizontal.bounds``.
     """
 
     class _InitSubstBuilder(_SkipNodesVisitor):
@@ -971,6 +1012,11 @@ def _convert_all_carries(routine, loop, vertical_size,
     vertical_size : str
     carry_suffix : str
     next_suffix : str
+    horizontal : :any:`Dimension`, optional
+        When provided, horizontal loop variables in carry init, save,
+        and rotate statements are replaced with bounded ranges from
+        ``horizontal.bounds`` so that the SCC pipeline's
+        ``resolve_vector_dimension`` can resolve them.
 
     Returns
     -------
@@ -1397,21 +1443,28 @@ def _convert_all_carries(routine, loop, vertical_size,
 def _substitute_init_expressions_all_loops(routine, vertical_index,
                                             vertical_size, horizontal=None):
     """
-    Like the ``_substitute_init_expressions`` variant in
-    ``vertical_complete`` but searches *all* vertical loops (not just
-    a designated main loop) for init assignments.
+    For each local 2-D+ array with a KLEV dimension, find the first
+    ``X(JL, JK) = f(args)`` assignment (in source order across all
+    vertical loops) and substitute outside-loop references to that
+    array with the RHS expression evaluated at the appropriate level.
 
-    .. note::
+    This is the all-loops variant of ``_substitute_init_expressions``
+    from ``vertical_complete``: it searches *all* vertical loops for
+    init assignments rather than only a designated main loop.
 
-       A future improvement could unify this with the
-       ``_substitute_init_expressions`` function by adding an
-       optional ``main_loop_only`` parameter.
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    vertical_index : str
+    vertical_size : str
+    horizontal : :any:`Dimension`, optional
+        Forwarded to :func:`_build_init_subst_map` to replace
+        horizontal loop variables with bounded ranges.
 
-    For each local 2-D+ array with a KLEV dimension, the first
-    ``X(JL, JK) = f(args)`` assignment found (in source order across
-    all vertical loops) is used to substitute outside-loop reads.
-
-    Returns a set of lowercase array names that were substituted.
+    Returns
+    -------
+    set of str
+        Lowercase array names that were substituted.
     """
     vertical_index_lower = vertical_index.lower()
     vertical_size_lower = vertical_size.lower()
@@ -2270,6 +2323,10 @@ def _insert_writebacks_for_argument_carries(routine, merged_loop,
     carry_registry : dict
         ``{array_name_lower: {'carry': str, 'pattern': str,
         'next': str or None, 'dim_index': int}}``
+    horizontal : :any:`Dimension`, optional
+        When provided, the horizontal dimension in write-back array
+        subscripts uses bounded ranges from ``horizontal.bounds``
+        instead of bare ``:``.
 
     Returns
     -------

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -22,14 +22,32 @@ from loki.ir import (
 )
 from loki.logging import info, warning
 from loki.tools import as_tuple, CaseInsensitiveDict
+from loki.types import BasicType
 from loki.expression.symbolic import simplify
 from loki.analyse.analyse_dataflow import (
     classify_array_access_offsets, array_loop_carried_dependencies,
-    _extract_offset,
+    extract_offset,
 )
 
 
 __all__ = []
+
+
+def _make_zero_literal(orig_type):
+    """
+    Return a type-appropriate zero literal for carry variable initialisation.
+
+    Returns :any:`IntLiteral` for INTEGER arrays, :any:`LogicLiteral`
+    for LOGICAL arrays, and :any:`FloatLiteral` (with the original kind)
+    for REAL and all other types.
+    """
+    dtype = getattr(orig_type, 'dtype', None)
+    if dtype == BasicType.INTEGER:
+        return sym.IntLiteral(0)
+    if dtype == BasicType.LOGICAL:
+        return sym.LogicLiteral('.FALSE.')
+    # Default: REAL (or COMPLEX, DEFERRED, etc.)
+    return sym.FloatLiteral(0.0, kind=orig_type.kind)
 
 
 def _loop_upper_bound_expr(loop):
@@ -683,7 +701,7 @@ def _build_carry_expr_entries(all_vars, arr_name, dim_idx, loop_var,
             continue
         if dim_idx >= len(v.dimensions):
             continue
-        offset = _extract_offset(v.dimensions[dim_idx], loop_var)
+        offset = extract_offset(v.dimensions[dim_idx], loop_var)
         if offset is None:
             continue
 
@@ -757,7 +775,6 @@ def _build_save_assignment(orig_decl, carry_decl, orig_shape, dim_idx,
 
 
 def _convert_all_carries(routine, loop, vertical_size,
-                         horizontal_index=None,
                          carry_suffix='_vc', next_suffix='_next'):
     """
     Convert all carry and stencil patterns in *loop* to scalar carry
@@ -806,12 +823,6 @@ def _convert_all_carries(routine, loop, vertical_size,
     loop : :any:`Loop`
         The vertical loop to transform.
     vertical_size : str
-    horizontal_index : str, optional
-        Name of the horizontal loop variable (e.g. ``'JL'``).  Used to
-        distinguish the horizontal subscript from other loop indices
-        (like ``JM``) in multi-dimensional arrays.  Non-horizontal loop
-        indices are replaced with ``':'`` in init and rotate statements
-        (which are placed outside their enclosing loops).
     carry_suffix : str
     next_suffix : str
 
@@ -1025,43 +1036,26 @@ def _convert_all_carries(routine, loop, vertical_size,
             ) if carry_shape else None
 
         # range dims for init/rotate (out-of-loop context)
-        # Non-horizontal loop variables (e.g. JM) are invalid outside
-        # their enclosing loop, so replace them with ':' (RangeIndex).
-        # The horizontal index (e.g. JL) is kept as-is because the SCC
-        # pipeline converts it to a scalar parameter.
-        _horiz_lower = horizontal_index.lower() if horizontal_index else None
-
-        def _is_horizontal_var(expr):
-            """Check if expr is the horizontal index variable."""
-            if _horiz_lower and isinstance(expr, sym.Scalar):
-                return expr.name.lower() == _horiz_lower
-            return False
+        # All non-vertical dimensions (including the horizontal index)
+        # are replaced with ':' (RangeIndex) so that init, save, and
+        # rotate statements use array-section notation.  This makes the
+        # transformation independent of whether SCCDevector has already
+        # converted the horizontal loop variable to a scalar parameter.
 
         def _init_rotate_dims():
-            """Dims for init/rotate statements placed outside inner loops."""
-            if actual_non_vert_dims is None:
-                return tuple(
-                    sym.RangeIndex((None, None, None))
-                    for _ in carry_shape
-                ) if carry_shape else None
-            result = []
-            for d in actual_non_vert_dims:
-                if _is_horizontal_var(d):
-                    result.append(d)  # keep JL
-                else:
-                    result.append(sym.RangeIndex((None, None, None)))
-            return tuple(result) if result else None
+            """Dims for init/rotate statements (all non-vertical dims become ':')."""
+            return tuple(
+                sym.RangeIndex((None, None, None))
+                for _ in carry_shape
+            ) if carry_shape else None
 
         def _out_of_loop_dim(dim_expr):
             """Sanitize a single dim expr for out-of-loop (init/save/rotate) context.
 
-            Keeps the horizontal index as-is, replaces other loop
-            variables with ':' (RangeIndex).
+            Replaces all scalar loop variables (including the horizontal
+            index) with ':' (RangeIndex).  Integer literals and other
+            non-variable expressions are kept as-is.
             """
-            if _is_horizontal_var(dim_expr):
-                return dim_expr
-            # If it's a scalar variable that isn't the horizontal index,
-            # it's probably a loop variable (like JM) — replace with ':'
             if isinstance(dim_expr, sym.Scalar) and not isinstance(dim_expr, sym.IntLiteral):
                 return sym.RangeIndex((None, None, None))
             return dim_expr
@@ -1082,10 +1076,9 @@ def _convert_all_carries(routine, loop, vertical_size,
                 else:
                     if actual_non_vert_dims is not None and nv_idx < len(actual_non_vert_dims):
                         dim_expr = actual_non_vert_dims[nv_idx]
-                        # For init (outside loops), replace non-horizontal
-                        # loop variables with ':'
-                        if not _is_horizontal_var(dim_expr):
-                            dim_expr = sym.RangeIndex((None, None, None))
+                        # For init (outside loops), replace all loop
+                        # variables (including horizontal) with ':'
+                        dim_expr = _out_of_loop_dim(dim_expr)
                     else:
                         dim_expr = sym.RangeIndex((None, None, None))
                     init_orig_dims.append(dim_expr)
@@ -1102,7 +1095,7 @@ def _convert_all_carries(routine, loop, vertical_size,
             zero_lhs = carry_decl.clone(
                 dimensions=tuple(init_carry_dims) if init_carry_dims else None
             )
-            zero_rhs = sym.FloatLiteral(0.0, kind=orig_decl.type.kind)
+            zero_rhs = _make_zero_literal(orig_decl.type)
             zero_assign = ir.Assignment(lhs=zero_lhs, rhs=zero_rhs)
 
             guard_cond = sym.Comparison(
@@ -1117,7 +1110,7 @@ def _convert_all_carries(routine, loop, vertical_size,
             # Init: carry = 0.0
             init_dims = _init_rotate_dims()
             init_lhs = carry_decl.clone(dimensions=init_dims)
-            init_rhs = sym.FloatLiteral(0.0, kind=orig_decl.type.kind)
+            init_rhs = _make_zero_literal(orig_decl.type)
             init_stmts.append(ir.Assignment(lhs=init_lhs, rhs=init_rhs))
 
         # --- Build expression substitution map ---
@@ -1760,6 +1753,13 @@ def _merge_vertical_loops(routine, vertical_index, vertical_size):
     merged_body = []
 
     for loop, cond_wrapper in all_vloops:
+        # TODO: If the same Conditional wrapper contains vertical loops
+        # in both its IF and ELSE branches, only the first-encountered
+        # branch's loop is correctly merged.  The second loop (from the
+        # other branch) may be lost because _collect_vertical_loops
+        # returns the same wrapper reference for both, and the
+        # replacement logic only operates on cond_wrapper.body.  This
+        # edge case does not occur in the IFS/cloudsc kernels.
         body = loop.body
         lower_expr = loop.bounds.children[0]
         upper_expr = loop.bounds.children[1]
@@ -2051,7 +2051,7 @@ def _cross_loop_carry_substitution(routine, merged_loop, carry_registry):
         if dim_idx >= len(v.dimensions):
             continue
 
-        offset = _extract_offset(v.dimensions[dim_idx], loop_var)
+        offset = extract_offset(v.dimensions[dim_idx], loop_var)
         if offset is None:
             continue
 
@@ -2178,10 +2178,9 @@ def _insert_writebacks_for_argument_carries(routine, merged_loop,
         # Build write-back: ARRAY(JL, JK+1) = array_next
         # For the vertical dimension, use JK+1.
         # For the horizontal dimension, use the horizontal index variable
-        # (e.g. JL) so that SCCBase's resolve_vector_dimension and
-        # SCCDevector handle it correctly.  A bare ':' would NOT be
-        # converted by resolve_vector_dimension and would remain as
-        # array-section notation, writing to all horizontal indices.
+        # (e.g. JL) on BOTH LHS and RHS to keep ranks consistent.
+        # Using ':' (RangeIndex) on one side and a scalar on the other
+        # would produce a rank mismatch in the generated Fortran.
         wb_orig_dims = []
         wb_next_dims = []
         nv_idx = 0
@@ -2193,21 +2192,11 @@ def _insert_writebacks_for_argument_carries(routine, merged_loop,
             else:
                 next_shape = next_decl.type.shape if next_decl.type.shape else ()
                 if horiz_var is not None:
-                    # Use the horizontal index variable (e.g. JL).
-                    # This is correct because the write-back is inside
-                    # the merged JK loop which is itself inside the
-                    # DO JL = KIDIA, KFDIA horizontal loop.
-                    # SCCDevector will later strip that loop and make JL
-                    # a scalar parameter.
+                    # Use the horizontal index variable (e.g. JL) on
+                    # both LHS and RHS for rank-consistent indexing.
                     wb_orig_dims.append(horiz_var)
-                    # Don't add horizontal dim to the RHS next variable:
-                    # the _next carry var has the same KLON dimension
-                    # but SCCDemote will demote it.  For now, keep ':'
-                    # on the RHS if next_shape has this dimension.
                     if nv_idx < len(next_shape):
-                        wb_next_dims.append(
-                            sym.RangeIndex((None, None, None))
-                        )
+                        wb_next_dims.append(horiz_var)
                 elif nv_idx < len(next_shape):
                     wb_next_dims.append(
                         sym.RangeIndex((None, None, None))

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -40,6 +40,12 @@ def _make_zero_literal(orig_type):
     Returns :any:`IntLiteral` for INTEGER arrays, :any:`LogicLiteral`
     for LOGICAL arrays, and :any:`FloatLiteral` (with the original kind)
     for REAL and all other types.
+
+    When the kind is an :any:`InlineCall` (e.g. ``selected_real_kind(13, 300)``
+    as produced by the OMNI frontend), it is omitted from the literal because
+    Fortran requires kind parameters in literals to be named constants or
+    integer literals.  A plain ``0.0`` is safe here since Fortran performs
+    implicit type conversion in assignment context.
     """
     dtype = getattr(orig_type, 'dtype', None)
     if dtype == BasicType.INTEGER:
@@ -47,7 +53,10 @@ def _make_zero_literal(orig_type):
     if dtype == BasicType.LOGICAL:
         return sym.LogicLiteral('.FALSE.')
     # Default: REAL (or COMPLEX, DEFERRED, etc.)
-    return sym.FloatLiteral(0.0, kind=orig_type.kind)
+    kind = orig_type.kind
+    if isinstance(kind, sym.InlineCall):
+        return sym.FloatLiteral(0.0)
+    return sym.FloatLiteral(0.0, kind=kind)
 
 
 def _loop_upper_bound_expr(loop):

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -17,7 +17,7 @@ from collections import defaultdict, OrderedDict
 
 from loki.expression import symbols as sym
 from loki.ir import (
-    nodes as ir, FindNodes, Transformer, FindVariables,
+    nodes as ir, FindNodes, Visitor, Transformer, FindVariables,
     SubstituteExpressions, SubstituteExpressionsSkipLHS
 )
 from loki.logging import info, warning
@@ -31,6 +31,113 @@ from loki.analyse.analyse_dataflow import (
 
 
 __all__ = []
+
+
+class _EarlyTermination(Exception):
+    """Raised to short-circuit a Visitor walk."""
+
+
+class _SkipNodesVisitor(Visitor):
+    """
+    Base :any:`Visitor` that skips specific node instances and recurses
+    into transparent container nodes (:any:`Section`, :any:`Associate`,
+    :any:`Conditional`, :any:`Loop`).
+
+    Subclasses override ``visit_Node`` (or type-specific ``visit_*``
+    methods) to process leaf / non-container nodes.  The default
+    ``visit_Node`` does nothing.
+    """
+
+    def __init__(self, skip_nodes=None):
+        super().__init__()
+        self.skip_nodes = skip_nodes or set()
+
+    # -- tuple / list: filter out skipped nodes before dispatching ------
+
+    def visit_tuple(self, o, **kwargs):
+        for c in o:
+            if c not in self.skip_nodes:
+                self.visit(c, **kwargs)
+
+    visit_list = visit_tuple
+
+    # -- expressions / unknown objects: nothing to do -------------------
+
+    def visit_object(self, o, **kwargs):
+        pass
+
+    # -- default leaf: subclasses override this -------------------------
+
+    def visit_Node(self, o, **kwargs):
+        pass
+
+    # -- transparent containers: recurse --------------------------------
+
+    def visit_Section(self, o, **kwargs):
+        self.visit(o.body, **kwargs)
+
+    def visit_Associate(self, o, **kwargs):
+        self.visit(o.body, **kwargs)
+
+    def visit_Conditional(self, o, **kwargs):
+        self.visit(o.body, **kwargs)
+        if o.else_body:
+            self.visit(o.else_body, **kwargs)
+
+    def visit_Loop(self, o, **kwargs):
+        self.visit(o.body, **kwargs)
+
+
+def _walk_outside(body, skip_nodes, callback):
+    """
+    Walk *body* recursively, skipping any node in *skip_nodes*.
+
+    For each non-skipped, non-container leaf node, calls
+    ``callback(node)``.  Recurses into :any:`Section`, :any:`Associate`,
+    :any:`Conditional` (body + else_body), and :any:`Loop` containers.
+
+    Parameters
+    ----------
+    body : tuple, list, or node with ``.body``
+        The IR nodes to walk.
+    skip_nodes : set
+        Nodes to skip entirely (e.g. vertical loops).
+    callback : callable(node) -> bool or None
+        Called for each leaf node.  If it returns ``True`` the walk
+        stops early and ``_walk_outside`` returns ``True``.
+    """
+
+    class _Walker(_SkipNodesVisitor):
+        def __init__(self, skip_nodes, callback):
+            super().__init__(skip_nodes)
+            self.callback = callback
+
+        def visit_Node(self, o, **kwargs):
+            if self.callback(o):
+                raise _EarlyTermination()
+
+    try:
+        _Walker(skip_nodes, callback).visit(body)
+        return False
+    except _EarlyTermination:
+        return True
+
+
+def _collect_call_arg_names(routine):
+    """
+    Return a set of lowercase variable names that appear as arguments
+    in any :any:`CallStatement` in *routine*.
+    """
+    names = set()
+    for call in FindNodes(ir.CallStatement).visit(routine.body):
+        for arg in call.arguments:
+            for v in FindVariables().visit(arg):
+                names.add(v.name.lower())
+        if call.kwarguments:
+            for _kw, arg in call.kwarguments:
+                for v in FindVariables().visit(arg):
+                    names.add(v.name.lower())
+    return names
 
 
 def _make_zero_literal(orig_type):
@@ -59,15 +166,41 @@ def _make_zero_literal(orig_type):
     return sym.FloatLiteral(0.0, kind=kind)
 
 
-def _loop_upper_bound_expr(loop):
+def _loop_is_backward(loop):
+    """Return ``True`` if *loop* has a negative step."""
+    bounds = loop.bounds
+    if bounds is None or bounds.children is None:
+        return False
+    if len(bounds.children) > 2 and bounds.children[2] is not None:
+        # str() is intentional: step may be a symbolic negation (e.g. Product((-1, x)))
+        # whose rendered form starts with '-'; no reliable node comparison exists.
+        step_str = str(bounds.children[2]).strip()
+        return step_str.startswith('-') or step_str.startswith('-(')
+    return False
+
+
+def _loop_effective_bounds(loop):
     """
-    Return the upper-bound expression of *loop*'s range, or ``None``
-    if bounds are not available.
+    Return ``(lower, upper)`` expressions for *loop*, accounting for
+    backward (negative-step) loops where children[0] > children[1].
     """
     bounds = loop.bounds
     if bounds is None or bounds.children is None:
-        return None
-    return bounds.children[1]
+        return None, None
+    lower, upper = bounds.children[0], bounds.children[1]
+    if _loop_is_backward(loop):
+        lower, upper = upper, lower
+    return lower, upper
+
+
+def _loop_upper_bound_expr(loop):
+    """
+    Return the effective upper-bound expression of *loop*'s range, or
+    ``None`` if bounds are not available.  For backward loops the start
+    expression (children[0]) is returned since it is the larger value.
+    """
+    _lower, upper = _loop_effective_bounds(loop)
+    return upper
 
 
 def _loop_upper_bound_str(loop):
@@ -148,28 +281,65 @@ def _collect_vertical_loops(body, vertical_index):
        an alias (e.g. ``NLEV``) instead of the primary index name, those
        loops will not be collected.
     """
-    vertical_index_lower = vertical_index.lower()
-    result = []
-    nodes = body if isinstance(body, (tuple, list)) else body.body
 
-    for node in nodes:
-        if isinstance(node, ir.Loop):
-            if node.variable.name.lower() == vertical_index_lower:
-                result.append((node, None))
-            # don't recurse into the JK loop body
-        elif isinstance(node, ir.Conditional):
-            # Check for JK loops directly inside the conditional branches
-            for branch_nodes in (node.body, node.else_body or ()):
+    class _VLoopCollector(Visitor):
+        def __init__(self):
+            super().__init__()
+            self.vertical_index_lower = vertical_index.lower()
+            self.result = []
+
+        def visit_tuple(self, o, **kwargs):
+            for c in o:
+                self.visit(c, **kwargs)
+
+        visit_list = visit_tuple
+
+        def visit_object(self, o, **kwargs):
+            pass
+
+        def visit_Node(self, o, **kwargs):
+            pass  # don't recurse into unrecognised node types
+
+        def visit_Loop(self, o, **kwargs):
+            if o.variable.name.lower() == self.vertical_index_lower:
+                self.result.append((o, kwargs.get('wrapper')))
+            # don't recurse into the loop body
+
+        def visit_Conditional(self, o, **kwargs):  # pylint: disable=unused-argument
+            # Only check for JK loops as direct children of conditional
+            # branches (matching original non-recursive behavior).
+            for branch_nodes in (o.body, o.else_body or ()):
                 for child in branch_nodes:
                     if isinstance(child, ir.Loop):
-                        if child.variable.name.lower() == vertical_index_lower:
-                            result.append((child, node))
-        elif isinstance(node, (ir.Section, ir.Associate)):
-            # Recurse into transparent container nodes
-            result.extend(_collect_vertical_loops(node, vertical_index))
-        elif isinstance(node, ir.Comment):
-            pass  # skip
-    return result
+                        if child.variable.name.lower() == self.vertical_index_lower:
+                            self.result.append((child, o))
+
+        def visit_Section(self, o, **kwargs):
+            self.visit(o.body, **kwargs)
+
+        def visit_Associate(self, o, **kwargs):
+            self.visit(o.body, **kwargs)
+
+        def visit_Comment(self, o, **kwargs):
+            pass
+
+    collector = _VLoopCollector()
+    collector.visit(body)
+    return collector.result
+
+
+def _collect_loop_node_set(all_vloops):
+    """
+    Build a set of IR nodes (loops and their conditional wrappers) from the
+    list returned by :func:`_collect_vertical_loops`.  This set is used by
+    several helpers to skip over vertical-loop bodies when walking the IR.
+    """
+    loop_nodes = set()
+    for loop, cond_wrapper in all_vloops:
+        loop_nodes.add(loop)
+        if cond_wrapper is not None:
+            loop_nodes.add(cond_wrapper)
+    return loop_nodes
 
 
 def _is_jk_eq_1(expr, loop_var_name):
@@ -264,63 +434,45 @@ def _any_read_outside_node(body, exclude_node, written_names):
     assignment, in a conditional expression, in a call argument, or
     in any context other than the bare LHS of an assignment.
     """
-    nodes = body if isinstance(body, (tuple, list)) else body.body
-    for node in nodes:
-        if node is exclude_node:
-            continue
-        # Recurse into transparent containers
-        if isinstance(node, (ir.Section, ir.Associate)):
-            if _any_read_outside_node(node.body, exclude_node,
-                                       written_names):
-                return True
-            continue
-        # For assignments, check RHS + LHS subscripts (but not the
-        # LHS variable name itself)
-        if isinstance(node, ir.Assignment):
+
+    class _ReadChecker(_SkipNodesVisitor):
+        def __init__(self, exclude_node, written_names):
+            skip = {exclude_node} if exclude_node else set()
+            super().__init__(skip)
+            self.written_names = written_names
+
+        def _check(self, vars_iter):
+            for var in vars_iter:
+                if var.name.lower() in self.written_names:
+                    raise _EarlyTermination()
+
+        def visit_Assignment(self, o, **kwargs):  # pylint: disable=unused-argument
             # RHS reads
-            rhs_vars = FindVariables().visit(node.rhs)
-            for var in rhs_vars:
-                if var.name.lower() in written_names:
-                    return True
+            self._check(FindVariables().visit(o.rhs))
             # LHS subscript reads (e.g. A(ZTRPAUS) would be a read)
-            lhs = node.lhs
+            lhs = o.lhs
             if hasattr(lhs, 'dimensions') and lhs.dimensions:
                 for dim in lhs.dimensions:
-                    dim_vars = FindVariables().visit(dim)
-                    for var in dim_vars:
-                        if var.name.lower() in written_names:
-                            return True
-            continue
-        # For conditionals, check condition + branches
-        if isinstance(node, ir.Conditional):
-            cond_vars = FindVariables().visit(node.condition)
-            for var in cond_vars:
-                if var.name.lower() in written_names:
-                    return True
-            if _any_read_outside_node(node.body, exclude_node,
-                                       written_names):
-                return True
-            if node.else_body:
-                if _any_read_outside_node(node.else_body, exclude_node,
-                                           written_names):
-                    return True
-            continue
-        # For loops (non-JK), check bounds + body
-        if isinstance(node, ir.Loop):
-            bounds_vars = FindVariables().visit(node.bounds)
-            for var in bounds_vars:
-                if var.name.lower() in written_names:
-                    return True
-            if _any_read_outside_node(node.body, exclude_node,
-                                       written_names):
-                return True
-            continue
-        # For everything else, any reference counts as a read
-        all_vars = FindVariables().visit(node)
-        for var in all_vars:
-            if var.name.lower() in written_names:
-                return True
-    return False
+                    self._check(FindVariables().visit(dim))
+
+        def visit_Conditional(self, o, **kwargs):
+            self._check(FindVariables().visit(o.condition))
+            self.visit(o.body, **kwargs)
+            if o.else_body:
+                self.visit(o.else_body, **kwargs)
+
+        def visit_Loop(self, o, **kwargs):
+            self._check(FindVariables().visit(o.bounds))
+            self.visit(o.body, **kwargs)
+
+        def visit_Node(self, o, **kwargs):
+            self._check(FindVariables().visit(o))
+
+    try:
+        _ReadChecker(exclude_node, written_names).visit(body)
+        return False
+    except _EarlyTermination:
+        return True
 
 
 def _substitute_jk_in_expr(expr, jk_var, replacement):
@@ -354,84 +506,90 @@ def _substitute_jk_in_expr(expr, jk_var, replacement):
 
 
 def _build_init_subst_map(body, loop_nodes, init_map, local_2d,
-                           vertical_index_lower, expr_map, substituted):
+                           expr_map, substituted, horizontal=None):
     """
     Walk *body* and for any Array reference to an init-mapped array
     that appears outside all JK loops, add a substitution entry.
     """
-    nodes = body if isinstance(body, (tuple, list)) else body.body
 
-    for node in nodes:
-        if node in loop_nodes:
-            continue
-        if isinstance(node, (ir.Section, ir.Associate)):
-            _build_init_subst_map(node.body, loop_nodes, init_map,
-                                  local_2d, vertical_index_lower,
-                                  expr_map, substituted)
-            continue
-        if isinstance(node, ir.Conditional):
-            _build_init_subst_map(node.body, loop_nodes, init_map,
-                                  local_2d, vertical_index_lower,
-                                  expr_map, substituted)
-            if node.else_body:
-                _build_init_subst_map(node.else_body, loop_nodes,
-                                      init_map, local_2d,
-                                      vertical_index_lower,
-                                      expr_map, substituted)
-            continue
-        # Recurse into non-vertical Loop nodes (e.g. DO JM loops) so
-        # that inner vertical loops in loop_nodes are properly skipped.
-        if isinstance(node, ir.Loop):
-            _build_init_subst_map(node.body, loop_nodes, init_map,
-                                  local_2d, vertical_index_lower,
-                                  expr_map, substituted)
-            continue
+    class _InitSubstBuilder(_SkipNodesVisitor):
+        def __init__(self):
+            super().__init__(loop_nodes)
 
-        # Check Array references in this node
-        all_vars = FindVariables().visit(node)
-        for var in all_vars:
-            var_lower = var.name.lower()
-            if var_lower not in init_map:
-                continue
-            if not hasattr(var, 'dimensions') or not var.dimensions:
-                continue
-
-            init_assign = init_map[var_lower]
-            info_entry = local_2d[var_lower]
-            klev_dim = info_entry['klev_dim_idx']
-            if klev_dim >= len(var.dimensions):
-                continue
-            level_idx = var.dimensions[klev_dim]
-
-            # Verify non-vertical subscripts match between the
-            # reference and the init expression (e.g. reject
-            # ZQX(:,:,JM) when init was for ZQX(:,:,NCLDQV)).
-            # Range subscripts (`:`) are considered compatible with
-            # any scalar subscript (e.g. `:` matches `JL`).
-            init_dims = init_assign.lhs.dimensions
-            if len(var.dimensions) == len(init_dims):
-                mismatch = False
-                for di, (ref_d, init_d) in enumerate(
-                        zip(var.dimensions, init_dims)):
-                    if di == klev_dim:
-                        continue  # vertical dim — allowed to differ
-                    # Range subscripts are compatible with anything
-                    if isinstance(ref_d, sym.RangeIndex):
-                        continue
-                    if isinstance(init_d, sym.RangeIndex):
-                        continue
-                    if str(ref_d).strip().lower() != str(init_d).strip().lower():
-                        mismatch = True
-                        break
-                if mismatch:
+        def visit_Node(self, o, **kwargs):
+            all_vars = FindVariables().visit(o)
+            for var in all_vars:
+                var_lower = var.name.lower()
+                if var_lower not in init_map:
+                    continue
+                if not hasattr(var, 'dimensions') or not var.dimensions:
                     continue
 
-            # Build RHS with JK replaced by the level index
-            jk_var = init_assign.lhs.dimensions[klev_dim]
-            rhs_substituted = _substitute_jk_in_expr(
-                init_assign.rhs, jk_var, level_idx)
-            expr_map[var] = rhs_substituted
-            substituted.add(var_lower)
+                init_assign = init_map[var_lower]
+                info_entry = local_2d[var_lower]
+                klev_dim = info_entry['klev_dim_idx']
+                if klev_dim >= len(var.dimensions):
+                    continue
+                level_idx = var.dimensions[klev_dim]
+
+                # Verify non-vertical subscripts match between the
+                # reference and the init expression (e.g. reject
+                # ZQX(:,:,JM) when init was for ZQX(:,:,NCLDQV)).
+                # Range subscripts (`:`) are considered compatible with
+                # any scalar subscript (e.g. `:` matches `JL`).
+                init_dims = init_assign.lhs.dimensions
+                if len(var.dimensions) == len(init_dims):
+                    mismatch = False
+                    for di, (ref_d, init_d) in enumerate(
+                            zip(var.dimensions, init_dims)):
+                        if di == klev_dim:
+                            continue  # vertical dim — allowed to differ
+                        if isinstance(ref_d, sym.RangeIndex):
+                            continue
+                        if isinstance(init_d, sym.RangeIndex):
+                            continue
+                        if ref_d != init_d:
+                            mismatch = True
+                            break
+                    if mismatch:
+                        continue
+
+                # Build RHS with JK replaced by the level index
+                jk_var = init_assign.lhs.dimensions[klev_dim]
+                rhs_substituted = _substitute_jk_in_expr(
+                    init_assign.rhs, jk_var, level_idx)
+
+                # If the target reference uses ':' (RangeIndex) for a
+                # dimension where the init expression used a scalar loop
+                # variable (e.g. JL), replace that loop variable with a
+                # range in the substituted RHS to avoid out-of-scope refs.
+                # When the horizontal Dimension is available we use its
+                # bounds (e.g. ``KIDIA:KFDIA``) so that the SCC pipeline's
+                # ``resolve_vector_dimension`` can later resolve the range
+                # to the scalar index.  Without a horizontal Dimension we
+                # fall back to an unbounded ``:`` (sufficient for idem).
+                init_dims = init_assign.lhs.dimensions
+                if len(var.dimensions) == len(init_dims):
+                    if horizontal is not None:
+                        _lower = sym.Variable(name=horizontal.bounds[0], scope=None)
+                        _upper = sym.Variable(name=horizontal.bounds[1], scope=None)
+                        range_idx = sym.RangeIndex((_lower, _upper, None))
+                    else:
+                        range_idx = sym.RangeIndex((None, None, None))
+                    for di, (ref_d, init_d) in enumerate(
+                            zip(var.dimensions, init_dims)):
+                        if di == klev_dim:
+                            continue
+                        if (isinstance(ref_d, sym.RangeIndex)
+                                and isinstance(init_d, (sym.Scalar, sym.DeferredTypeSymbol))
+                                and not isinstance(init_d, sym.IntLiteral)):
+                            rhs_substituted = _substitute_jk_in_expr(
+                                rhs_substituted, init_d, range_idx)
+
+                expr_map[var] = rhs_substituted
+                substituted.add(var_lower)
+
+    _InitSubstBuilder().visit(body)
 
 
 def _apply_subst_outside_loops(routine, loop_nodes, expr_map):
@@ -461,45 +619,35 @@ def _collect_refs_outside_loops(body, loop_nodes):
     Collect all variable names referenced outside any node in
     *loop_nodes*.  Returns a set of lowercase variable names.
     """
-    refs = set()
-    nodes = body if isinstance(body, (tuple, list)) else body.body
 
-    for node in nodes:
-        if node in loop_nodes:
-            continue
-        if isinstance(node, (ir.Section, ir.Associate)):
-            refs.update(
-                _collect_refs_outside_loops(node.body, loop_nodes))
-            continue
-        if isinstance(node, ir.Conditional):
-            if node in loop_nodes:
-                continue
-            for var in FindVariables().visit(node.condition):
-                refs.add(var.name.lower())
-            refs.update(
-                _collect_refs_outside_loops(node.body, loop_nodes))
-            if node.else_body:
-                refs.update(
-                    _collect_refs_outside_loops(
-                        node.else_body, loop_nodes))
-            continue
-        # Recurse into non-vertical Loop nodes (e.g. DO JM) so that
-        # inner vertical loops in loop_nodes are properly skipped.
-        if isinstance(node, ir.Loop):
-            for var in FindVariables().visit(node.variable):
-                refs.add(var.name.lower())
-            for bound in (node.bounds.lower, node.bounds.upper,
-                          node.bounds.step):
+    class _RefCollector(_SkipNodesVisitor):
+        def __init__(self):
+            super().__init__(loop_nodes)
+            self.refs = set()
+
+        def _add_vars(self, expr):
+            for var in FindVariables().visit(expr):
+                self.refs.add(var.name.lower())
+
+        def visit_Conditional(self, o, **kwargs):
+            self._add_vars(o.condition)
+            self.visit(o.body, **kwargs)
+            if o.else_body:
+                self.visit(o.else_body, **kwargs)
+
+        def visit_Loop(self, o, **kwargs):
+            self._add_vars(o.variable)
+            for bound in (o.bounds.lower, o.bounds.upper, o.bounds.step):
                 if bound is not None:
-                    for var in FindVariables().visit(bound):
-                        refs.add(var.name.lower())
-            refs.update(
-                _collect_refs_outside_loops(node.body, loop_nodes))
-            continue
-        for var in FindVariables().visit(node):
-            refs.add(var.name.lower())
+                    self._add_vars(bound)
+            self.visit(o.body, **kwargs)
 
-    return refs
+        def visit_Node(self, o, **kwargs):
+            self._add_vars(o)
+
+    collector = _RefCollector()
+    collector.visit(body)
+    return collector.refs
 
 
 def _find_demotable_arrays(routine, vertical_index, vertical_size):
@@ -534,15 +682,7 @@ def _find_demotable_arrays(routine, vertical_index, vertical_size):
     arg_names = {v.name.lower() for v in routine.arguments}
 
     # Variables passed to calls (not safe to demote)
-    call_arg_names = set()
-    for call in FindNodes(ir.CallStatement).visit(routine.body):
-        for arg in call.arguments:
-            for v in FindVariables().visit(arg):
-                call_arg_names.add(v.name.lower())
-        if call.kwarguments:
-            for _kw, arg in call.kwarguments:
-                for v in FindVariables().visit(arg):
-                    call_arg_names.add(v.name.lower())
+    call_arg_names = _collect_call_arg_names(routine)
 
     # Find all local arrays with KLEV dimension
     candidates = {}
@@ -569,11 +709,7 @@ def _find_demotable_arrays(routine, vertical_index, vertical_size):
 
     # Collect all vertical loops
     all_vloops = _collect_vertical_loops(routine.body, vertical_index)
-    loop_nodes = set()
-    for loop, cond_wrapper in all_vloops:
-        loop_nodes.add(loop)
-        if cond_wrapper is not None:
-            loop_nodes.add(cond_wrapper)
+    loop_nodes = _collect_loop_node_set(all_vloops)
 
     # Check that no candidate is accessed outside vertical loops
     outside_refs = _collect_refs_outside_loops(routine.body, loop_nodes)
@@ -784,7 +920,8 @@ def _build_save_assignment(orig_decl, carry_decl, orig_shape, dim_idx,
 
 
 def _convert_all_carries(routine, loop, vertical_size,
-                         carry_suffix='_vc', next_suffix='_next'):
+                         carry_suffix='_vc', next_suffix='_next',
+                         horizontal=None):
     """
     Convert all carry and stencil patterns in *loop* to scalar carry
     variables, making the loop body level-local.
@@ -854,15 +991,7 @@ def _convert_all_carries(routine, loop, vertical_size,
 
     # Arguments and call-args (stencil conversion applies only to locals)
     arg_names = {v.name.lower() for v in routine.arguments}
-    call_arg_names = set()
-    for call in FindNodes(ir.CallStatement).visit(routine.body):
-        for arg in call.arguments:
-            for v in FindVariables().visit(arg):
-                call_arg_names.add(v.name.lower())
-        if call.kwarguments:
-            for _kw, arg in call.kwarguments:
-                for v in FindVariables().visit(arg):
-                    call_arg_names.add(v.name.lower())
+    call_arg_names = _collect_call_arg_names(routine)
 
     var_map_ci = CaseInsensitiveDict(
         {v.name: v for v in routine.variables}
@@ -1035,14 +1164,29 @@ def _convert_all_carries(routine, loop, vertical_size,
         # --- Helper closures (called within the same loop iteration) ---
         # pylint: disable=cell-var-from-loop
 
+        # Build the range index for out-of-loop (init/save/rotate) context.
+        # When horizontal bounds are available, use them (e.g. KIDIA:KFDIA)
+        # so that resolve_vector_dimension can later resolve the range to
+        # the horizontal index variable.  Fall back to bare ':' otherwise.
+        if horizontal is not None:
+            _h_lower = sym.Variable(name=horizontal.bounds[0], scope=None)
+            _h_upper = sym.Variable(name=horizontal.bounds[1], scope=None)
+            _ool_range = sym.RangeIndex((_h_lower, _h_upper, None))
+        else:
+            _ool_range = sym.RangeIndex((None, None, None))
+
         # range dims for carry (in-body context)
         def _carry_range_dims():
             if actual_non_vert_dims is not None:
                 return actual_non_vert_dims
+            if not carry_shape:
+                return None
+            if len(carry_shape) == 1 and horizontal is not None:
+                return (_ool_range,)
             return tuple(
                 sym.RangeIndex((None, None, None))
                 for _ in carry_shape
-            ) if carry_shape else None
+            )
 
         # range dims for init/rotate (out-of-loop context)
         # All non-vertical dimensions (including the horizontal index)
@@ -1052,20 +1196,36 @@ def _convert_all_carries(routine, loop, vertical_size,
         # converted the horizontal loop variable to a scalar parameter.
 
         def _init_rotate_dims():
-            """Dims for init/rotate statements (all non-vertical dims become ':')."""
+            """Dims for init/rotate statements (all non-vertical dims become ranges).
+
+            Uses bounded range (``KIDIA:KFDIA``) for carry variables with
+            exactly one non-vertical dimension (assumed horizontal).
+            For multi-dimensional carries (e.g. ``(nlon, NCLV)``), bare
+            ``:`` is used because we cannot reliably identify which
+            dimension is horizontal from shape alone.
+            """
+            if not carry_shape:
+                return None
+            if len(carry_shape) == 1 and horizontal is not None:
+                return (_ool_range,)
             return tuple(
                 sym.RangeIndex((None, None, None))
                 for _ in carry_shape
-            ) if carry_shape else None
+            )
 
         def _out_of_loop_dim(dim_expr):
             """Sanitize a single dim expr for out-of-loop (init/save/rotate) context.
 
-            Replaces all scalar loop variables (including the horizontal
-            index) with ':' (RangeIndex).  Integer literals and other
-            non-variable expressions are kept as-is.
+            Replaces scalar loop variables with a range index.  When the
+            variable matches the horizontal index (e.g. ``JL``), a bounded
+            range (``KIDIA:KFDIA``) is used; other scalar variables get a
+            bare ``:``.  Integer literals and non-variable expressions are
+            kept as-is.
             """
             if isinstance(dim_expr, sym.Scalar) and not isinstance(dim_expr, sym.IntLiteral):
+                if (horizontal is not None
+                        and dim_expr == horizontal.index):
+                    return _ool_range
                 return sym.RangeIndex((None, None, None))
             return dim_expr
 
@@ -1235,7 +1395,7 @@ def _convert_all_carries(routine, loop, vertical_size,
 
 
 def _substitute_init_expressions_all_loops(routine, vertical_index,
-                                            vertical_size):
+                                            vertical_size, horizontal=None):
     """
     Like the ``_substitute_init_expressions`` variant in
     ``vertical_complete`` but searches *all* vertical loops (not just
@@ -1319,17 +1479,13 @@ def _substitute_init_expressions_all_loops(routine, vertical_index,
         return set()
 
     # Identify all vertical loop nodes (to exclude from substitution)
-    loop_nodes = set()
-    for loop, cond_wrapper in all_vloops:
-        loop_nodes.add(loop)
-        if cond_wrapper is not None:
-            loop_nodes.add(cond_wrapper)
+    loop_nodes = _collect_loop_node_set(all_vloops)
 
     # Build expression substitution map for outside-loop reads
     expr_map = {}
     substituted = set()
     _build_init_subst_map(routine.body, loop_nodes, init_map, local_kd,
-                          vertical_index_lower, expr_map, substituted)
+                          expr_map, substituted, horizontal)
 
     if expr_map:
         _apply_subst_outside_loops(routine, loop_nodes, expr_map)
@@ -1371,48 +1527,29 @@ def _find_zero_inits_outside_loops(body, loop_nodes, klev_locals,
     Walk *body* outside loop nodes and find whole-array zero-init
     assignments to vertical locals.
     """
-    nodes = body if isinstance(body, (tuple, list)) else body.body
 
-    for node in nodes:
-        if node in loop_nodes:
-            continue
-        if isinstance(node, (ir.Section, ir.Associate)):
-            _find_zero_inits_outside_loops(
-                node.body, loop_nodes, klev_locals, zero_init_map
-            )
-            continue
-        if isinstance(node, ir.Conditional):
-            _find_zero_inits_outside_loops(
-                node.body, loop_nodes, klev_locals, zero_init_map
-            )
-            if node.else_body:
-                _find_zero_inits_outside_loops(
-                    node.else_body, loop_nodes, klev_locals, zero_init_map
-                )
-            continue
+    class _ZeroInitFinder(_SkipNodesVisitor):
+        def __init__(self):
+            super().__init__(loop_nodes)
 
-        if not isinstance(node, ir.Assignment):
-            continue
+        # Don't recurse into Loop bodies (only Section/Associate/Conditional)
+        def visit_Loop(self, o, **kwargs):
+            pass
 
-        lhs = node.lhs
-        lhs_name = lhs.name.lower()
-        if lhs_name not in klev_locals:
-            continue
+        def visit_Assignment(self, o, **kwargs):  # pylint: disable=unused-argument
+            lhs = o.lhs
+            lhs_name = lhs.name.lower()
+            if lhs_name not in klev_locals:
+                return
+            dims = getattr(lhs, 'dimensions', None)
+            if not dims:
+                return
+            if not all(isinstance(d, sym.RangeIndex) for d in dims):
+                return
+            if _is_zero_literal(o.rhs):
+                zero_init_map[lhs_name] = o
 
-        # Check: LHS must use all-range-index dimensions
-        dims = getattr(lhs, 'dimensions', None)
-        if not dims:
-            continue
-        all_range = all(
-            isinstance(d, sym.RangeIndex) for d in dims
-        )
-        if not all_range:
-            continue
-
-        # Check: RHS must be a zero literal
-        rhs = node.rhs
-        if _is_zero_literal(rhs):
-            zero_init_map[lhs_name] = node
+    _ZeroInitFinder().visit(body)
 
 
 def _collect_outside_refs_for_array(body, loop_nodes, arr_name,
@@ -1423,40 +1560,38 @@ def _collect_outside_refs_for_array(body, loop_nodes, arr_name,
 
     Returns a list of nodes.
     """
-    refs = []
-    nodes = body if isinstance(body, (tuple, list)) else body.body
 
-    for node in nodes:
-        if node in loop_nodes:
-            continue
-        if node is exclude_node:
-            continue
-        if isinstance(node, (ir.Section, ir.Associate)):
-            refs.extend(_collect_outside_refs_for_array(
-                node.body, loop_nodes, arr_name, exclude_node
-            ))
-            continue
-        if isinstance(node, ir.Conditional):
-            # Check condition
-            for var in FindVariables().visit(node.condition):
+    class _ArrayRefCollector(_SkipNodesVisitor):
+        def __init__(self):
+            skip = set(loop_nodes)
+            if exclude_node is not None:
+                skip.add(exclude_node)
+            super().__init__(skip)
+            self.refs = []
+
+        # Don't recurse into Loop bodies
+        def visit_Loop(self, o, **kwargs):
+            pass
+
+        def visit_Conditional(self, o, **kwargs):
+            # Check condition for references
+            for var in FindVariables().visit(o.condition):
                 if var.name.lower() == arr_name:
-                    refs.append(node)
+                    self.refs.append(o)
                     break
-            refs.extend(_collect_outside_refs_for_array(
-                node.body, loop_nodes, arr_name, exclude_node
-            ))
-            if node.else_body:
-                refs.extend(_collect_outside_refs_for_array(
-                    node.else_body, loop_nodes, arr_name, exclude_node
-                ))
-            continue
-        # Check if this node references the array
-        for var in FindVariables().visit(node):
-            if var.name.lower() == arr_name:
-                refs.append(node)
-                break
+            self.visit(o.body, **kwargs)
+            if o.else_body:
+                self.visit(o.else_body, **kwargs)
 
-    return refs
+        def visit_Node(self, o, **kwargs):
+            for var in FindVariables().visit(o):
+                if var.name.lower() == arr_name:
+                    self.refs.append(o)
+                    break
+
+    collector = _ArrayRefCollector()
+    collector.visit(body)
+    return collector.refs
 
 
 def _remove_whole_array_zero_inits(routine, vertical_index, vertical_size):
@@ -1483,15 +1618,7 @@ def _remove_whole_array_zero_inits(routine, vertical_index, vertical_size):
     arg_names = {v.name.lower() for v in routine.arguments}
 
     # Variables passed to calls
-    call_arg_names = set()
-    for call in FindNodes(ir.CallStatement).visit(routine.body):
-        for arg in call.arguments:
-            for v in FindVariables().visit(arg):
-                call_arg_names.add(v.name.lower())
-        if call.kwarguments:
-            for _kw, arg in call.kwarguments:
-                for v in FindVariables().visit(arg):
-                    call_arg_names.add(v.name.lower())
+    call_arg_names = _collect_call_arg_names(routine)
 
     # Find local KLEV arrays
     klev_locals = {}
@@ -1515,11 +1642,7 @@ def _remove_whole_array_zero_inits(routine, vertical_index, vertical_size):
 
     # Collect all vertical loop nodes
     all_vloops = _collect_vertical_loops(routine.body, vertical_index)
-    loop_nodes = set()
-    for loop, cond_wrapper in all_vloops:
-        loop_nodes.add(loop)
-        if cond_wrapper is not None:
-            loop_nodes.add(cond_wrapper)
+    loop_nodes = _collect_loop_node_set(all_vloops)
 
     # Find whole-array zero-init assignments outside loops
     # Pattern: LHS has all-range-index dimensions, RHS is 0 or 0.0
@@ -1581,7 +1704,7 @@ def _extract_plus_n(upper_expr, vertical_size):
         if isinstance(diff, int):
             return diff
         # Check if it's exactly KLEV (diff == 0 symbolically)
-        if diff is not None and str(diff).strip() == '0':
+        if diff is not None and diff == 0:
             return 0
         # Expression-level check didn't resolve; fall through to string
 
@@ -1621,9 +1744,9 @@ def _relocate_interloop_code(body, top_nodes, merged_loop):
     * Any non-loop statements that sit **between** consecutive vertical-
       loop top-nodes are moved to just **before** the merged loop.
 
-    The function recurses into transparent container nodes
-    (:any:`Section`, :any:`Associate`) because the vertical loops may
-    live inside such containers.
+    The function uses a :any:`Visitor` to recurse into transparent
+    container nodes (:any:`Section`, :any:`Associate`) until it finds
+    the level that directly contains the *top_nodes*.
 
     Parameters
     ----------
@@ -1638,59 +1761,56 @@ def _relocate_interloop_code(body, top_nodes, merged_loop):
     -------
     Rebuilt *body* with the same type as the input.
     """
-    if isinstance(body, (tuple, list)):
-        nodes = body
-        wrap = tuple
-    else:
-        nodes = body.body
-        wrap = None  # will wrap at the end
 
-    # Check if any top_nodes live directly in this node list
-    has_top_nodes = any(n in top_nodes for n in nodes)
+    class _Relocator(Visitor):
+        def __init__(self):
+            super().__init__()
+            self.top_nodes = top_nodes
+            self.merged_loop = merged_loop
 
-    if has_top_nodes:
-        # Partition the node list into three regions:
-        # 1. pre-region: everything before the first top-node
-        # 2. loop-region: first top-node through last top-node (inclusive)
-        # 3. post-region: everything after the last top-node
-        first_idx = None
-        last_idx = None
-        for i, n in enumerate(nodes):
-            if n in top_nodes:
-                if first_idx is None:
-                    first_idx = i
-                last_idx = i
+        def visit_object(self, o, **kwargs):
+            return o
 
-        pre = list(nodes[:first_idx])
-        post = list(nodes[last_idx + 1:])
+        def visit_Node(self, o, **kwargs):
+            return o  # leaf nodes pass through unchanged
 
-        # From the loop-region, collect inter-loop statements
-        # (nodes that are NOT top-nodes) and move them before
-        # the merged loop
-        interloop = []
-        for i in range(first_idx, last_idx + 1):
-            n = nodes[i]
-            if n not in top_nodes:
-                interloop.append(n)
+        def visit_tuple(self, o, **kwargs):
+            has_top = any(n in self.top_nodes for n in o)
+            if has_top:
+                # Find first/last top-node indices
+                first_idx = last_idx = None
+                for i, n in enumerate(o):
+                    if n in self.top_nodes:
+                        if first_idx is None:
+                            first_idx = i
+                        last_idx = i
+                pre = o[:first_idx]
+                post = o[last_idx + 1:]
+                # Collect inter-loop statements (non-top-nodes in the
+                # loop region) and place them before the merged loop
+                interloop = tuple(
+                    n for i, n in enumerate(o)
+                    if first_idx <= i <= last_idx and n not in self.top_nodes
+                )
+                return pre + interloop + (self.merged_loop,) + post
+            # Recurse into children to find the level with top_nodes
+            return tuple(self.visit(n, **kwargs) for n in o)
 
-        new_nodes = pre + interloop + [merged_loop] + post
-        result = tuple(new_nodes)
-    else:
-        # Recurse into container nodes to find the level that
-        # contains the top-nodes
-        new_nodes = []
-        for n in nodes:
-            if isinstance(n, (ir.Section, ir.Associate)):
-                new_n = _relocate_interloop_code(n, top_nodes, merged_loop)
-                new_nodes.append(new_n)
-            else:
-                new_nodes.append(n)
-        result = tuple(new_nodes)
+        visit_list = visit_tuple
 
-    if wrap is not None:
-        return result
-    # Reconstruct the container node
-    return body.clone(body=result)
+        def visit_Section(self, o, **kwargs):
+            new_body = self.visit(o.body, **kwargs)
+            if new_body is o.body:
+                return o
+            return o.clone(body=new_body)
+
+        def visit_Associate(self, o, **kwargs):
+            new_body = self.visit(o.body, **kwargs)
+            if new_body is o.body:
+                return o
+            return o.clone(body=new_body)
+
+    return _Relocator().visit(body)
 
 
 def _merge_vertical_loops(routine, vertical_index, vertical_size):
@@ -1770,8 +1890,7 @@ def _merge_vertical_loops(routine, vertical_index, vertical_size):
         # replacement logic only operates on cond_wrapper.body.  This
         # edge case does not occur in the IFS/cloudsc kernels.
         body = loop.body
-        lower_expr = loop.bounds.children[0]
-        upper_expr = loop.bounds.children[1]
+        lower_expr, upper_expr = _loop_effective_bounds(loop)
 
         # Build IF guard condition: JK >= lower .AND. JK <= upper
         guard_cond = _build_bounds_guard(loop_var, lower_expr, upper_expr)
@@ -1835,7 +1954,7 @@ def _merge_vertical_loops(routine, vertical_index, vertical_size):
     return merged_loop
 
 
-def _collect_rotates_from_node(node, rotate_keys, save_names,
+def _collect_rotates_from_node(node, rotate_keys, save_names,  # pylint: disable=unused-argument
                                enclosing_guard_cond, remove_map, hoisted):
     """
     Recursively walk an IR node tree to find carry rotate/save
@@ -1853,44 +1972,50 @@ def _collect_rotates_from_node(node, rotate_keys, save_names,
     hoisted : list
         Updated in-place: ``(guard_condition, assignment)`` pairs.
     """
-    if isinstance(node, ir.Conditional):
-        # This is a guarded block — recurse into body with this guard
-        guard_cond = node.condition
-        for child in node.body:
-            _collect_rotates_from_node(
-                child, rotate_keys, save_names,
-                guard_cond, remove_map, hoisted
-            )
-        # Also check nested conditionals in else_body
-        for child in node.else_body:
-            _collect_rotates_from_node(
-                child, rotate_keys, save_names,
-                enclosing_guard_cond, remove_map, hoisted
-            )
-    elif isinstance(node, ir.Section):
-        for child in node.body:
-            _collect_rotates_from_node(
-                child, rotate_keys, save_names,
-                enclosing_guard_cond, remove_map, hoisted
-            )
-    elif isinstance(node, ir.Assignment):
-        lhs_name = node.lhs.name.lower() if hasattr(node.lhs, 'name') else ''
-        rhs_name = node.rhs.name.lower() if hasattr(node.rhs, 'name') else ''
 
-        # Check for B_readback rotate: _vc = _next
-        if (lhs_name, rhs_name) in rotate_keys:
-            remove_map[node] = None
-            hoisted.append((enclosing_guard_cond, node))
+    class _RotateCollector(Visitor):
+        def visit_tuple(self, o, **kwargs):
+            for c in o:
+                self.visit(c, **kwargs)
 
-        # Check for Pattern A / stencil save: the save is typically the
-        # LAST assignment to _vc in the loop body.  We identify it by
-        # LHS being a carry variable AND the RHS NOT being a _next
-        # variable and NOT being part of the computation (i.e., the
-        # RHS is a simple variable, not a complex expression with _vc).
-        # Actually, we should NOT hoist Pattern A saves because they
-        # set _vc to the CURRENT level value, which is needed by
-        # cross-loop reads at offset 0 within the same iteration.
-        # Only hoist B_readback rotates.
+        visit_list = visit_tuple
+
+        def visit_object(self, o, **kwargs):
+            pass
+
+        def visit_Node(self, o, **kwargs):
+            pass
+
+        def visit_Section(self, o, **kwargs):
+            self.visit(o.body, **kwargs)
+
+        def visit_Conditional(self, o, **kwargs):
+            # Recurse into body with this conditional's guard
+            guard_cond = o.condition
+            self.visit(o.body, guard_cond=guard_cond)
+            # Also check nested conditionals in else_body
+            self.visit(o.else_body, **kwargs)
+
+        def visit_Assignment(self, o, guard_cond=None, **kwargs):  # pylint: disable=unused-argument
+            lhs_name = o.lhs.name.lower() if hasattr(o.lhs, 'name') else ''
+            rhs_name = o.rhs.name.lower() if hasattr(o.rhs, 'name') else ''
+
+            # Check for B_readback rotate: _vc = _next
+            if (lhs_name, rhs_name) in rotate_keys:
+                remove_map[o] = None
+                hoisted.append((guard_cond, o))
+
+            # Check for Pattern A / stencil save: the save is typically the
+            # LAST assignment to _vc in the loop body.  We identify it by
+            # LHS being a carry variable AND the RHS NOT being a _next
+            # variable and NOT being part of the computation (i.e., the
+            # RHS is a simple variable, not a complex expression with _vc).
+            # Actually, we should NOT hoist Pattern A saves because they
+            # set _vc to the CURRENT level value, which is needed by
+            # cross-loop reads at offset 0 within the same iteration.
+            # Only hoist B_readback rotates.
+
+    _RotateCollector().visit(node, guard_cond=enclosing_guard_cond)
 
 
 def _hoist_rotates_to_end(routine, merged_loop, carry_registry):
@@ -1974,6 +2099,7 @@ def _hoist_rotates_to_end(routine, merged_loop, carry_registry):
     # rotates under the same guard.
     guard_groups = OrderedDict()
     for guard_cond, assign in hoisted:
+        # str() is intentional: used as a hashable grouping key for guard conditions
         key = str(guard_cond) if guard_cond is not None else '__no_guard__'
         if key not in guard_groups:
             guard_groups[key] = (guard_cond, [])
@@ -2114,7 +2240,7 @@ def _cross_loop_carry_substitution(routine, merged_loop, carry_registry):
 
 def _insert_writebacks_for_argument_carries(routine, merged_loop,
                                              carry_registry,
-                                             horizontal_index=None):
+                                             horizontal=None):
     """
     Insert write-back statements for INTENT(OUT) argument arrays that
     were converted to B_readback carry patterns.
@@ -2144,9 +2270,6 @@ def _insert_writebacks_for_argument_carries(routine, merged_loop,
     carry_registry : dict
         ``{array_name_lower: {'carry': str, 'pattern': str,
         'next': str or None, 'dim_index': int}}``
-    horizontal_index : str, optional
-        Name of the horizontal loop variable (e.g. ``'JL'``).  Used to
-        construct correct array subscripts for write-back statements.
 
     Returns
     -------
@@ -2158,11 +2281,6 @@ def _insert_writebacks_for_argument_carries(routine, merged_loop,
         {v.name: v for v in routine.variables}
     )
     arg_names = {v.name.lower() for v in routine.arguments}
-
-    # Get the horizontal index variable object if available
-    horiz_var = None
-    if horizontal_index:
-        horiz_var = var_map.get(horizontal_index)
 
     # Collect B_readback entries for argument arrays
     writebacks = []
@@ -2200,23 +2318,23 @@ def _insert_writebacks_for_argument_carries(routine, merged_loop,
                 )
             else:
                 next_shape = next_decl.type.shape if next_decl.type.shape else ()
-                if horiz_var is not None:
-                    # Use the horizontal index variable (e.g. JL) on
-                    # both LHS and RHS for rank-consistent indexing.
-                    wb_orig_dims.append(horiz_var)
-                    if nv_idx < len(next_shape):
-                        wb_next_dims.append(horiz_var)
-                elif nv_idx < len(next_shape):
-                    wb_next_dims.append(
-                        sym.RangeIndex((None, None, None))
-                    )
-                    wb_orig_dims.append(
-                        sym.RangeIndex((None, None, None))
-                    )
+                # Use a range for non-vertical dimensions in write-backs.
+                # The write-back sits outside any horizontal (DO JL) loop,
+                # so scalar JL would be out-of-scope.  For dimensions that
+                # match the horizontal size, use bounded range (KIDIA:KFDIA)
+                # so that resolve_vector_dimension can resolve it.
+                # Other non-vertical dims use bare ':'.
+                _is_horiz = (horizontal is not None
+                             and _s == horizontal.size)
+                if _is_horiz:
+                    _lower = sym.Variable(name=horizontal.bounds[0], scope=None)
+                    _upper = sym.Variable(name=horizontal.bounds[1], scope=None)
+                    range_dim = sym.RangeIndex((_lower, _upper, None))
                 else:
-                    wb_orig_dims.append(
-                        sym.RangeIndex((None, None, None))
-                    )
+                    range_dim = sym.RangeIndex((None, None, None))
+                wb_orig_dims.append(range_dim)
+                if nv_idx < len(next_shape):
+                    wb_next_dims.append(range_dim)
                 nv_idx += 1
 
         wb_lhs = orig_decl.clone(dimensions=tuple(wb_orig_dims))
@@ -2269,8 +2387,9 @@ def _remove_self_assignments(routine, merged_loop):
     Parameters
     ----------
     routine : :any:`Subroutine`
-    merged_loop : :any:`Loop`
-        The single merged vertical loop.
+    merged_loop : :any:`Loop` or list of :any:`Loop`
+        The vertical loop(s) to clean up.  When a list is given every
+        loop is processed in a single tree-rebuild pass.
 
     Returns
     -------
@@ -2279,20 +2398,28 @@ def _remove_self_assignments(routine, merged_loop):
     """
     from loki.backend import fgen  # pylint: disable=import-outside-toplevel
 
-    to_remove = {}
-    for assign in FindNodes(ir.Assignment).visit(merged_loop.body):
-        lhs_str = fgen(assign.lhs).strip().lower()
-        rhs_str = fgen(assign.rhs).strip().lower()
-        if lhs_str == rhs_str:
-            to_remove[assign] = None  # Transformer convention: map to None = delete
+    loops = merged_loop if isinstance(merged_loop, (list, tuple)) else [merged_loop]
 
-    if not to_remove:
+    # Collect self-assignments across all target loops
+    loop_map = {}   # old_loop -> new_loop (only for loops with removals)
+    n_total = 0
+    for loop in loops:
+        to_remove = {}
+        for assign in FindNodes(ir.Assignment).visit(loop.body):
+            lhs_str = fgen(assign.lhs).strip().lower()
+            rhs_str = fgen(assign.rhs).strip().lower()
+            if lhs_str == rhs_str:
+                to_remove[assign] = None
+        if to_remove:
+            new_body = Transformer(to_remove).visit(loop.body)
+            loop_map[loop] = loop.clone(body=new_body)
+            n_total += len(to_remove)
+
+    if not loop_map:
         return 0
 
-    new_body = Transformer(to_remove).visit(merged_loop.body)
-    new_loop = merged_loop.clone(body=new_body)
-    routine.body = Transformer({merged_loop: new_loop}).visit(routine.body)
-    return len(to_remove)
+    routine.body = Transformer(loop_map).visit(routine.body)
+    return n_total
 
 
 def _remove_dead_carry_originals(routine, carry_registry, demoted_names):

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -5,6 +5,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+# pylint: disable=too-many-lines
+
 """
 Shared utility functions for vertical loop transformations.
 
@@ -473,8 +475,7 @@ def _collect_refs_outside_loops(body, loop_nodes):
     return refs
 
 
-def _find_demotable_arrays(routine, vertical_index, vertical_size,
-                            main_loop):
+def _find_demotable_arrays(routine, vertical_index, vertical_size):
     """
     Identify local arrays with a vertical dimension that can be safely
     demoted after loop absorption.
@@ -495,7 +496,6 @@ def _find_demotable_arrays(routine, vertical_index, vertical_size,
     routine : :any:`Subroutine`
     vertical_index : str
     vertical_size : str
-    main_loop : :any:`Loop`
 
     Returns
     -------
@@ -1012,7 +1012,10 @@ def _convert_all_carries(routine, loop, vertical_size,
                 actual_non_vert_dims = _candidate
                 break
 
-        # --- Helper: range dims for carry (in-body context) ---
+        # --- Helper closures (called within the same loop iteration) ---
+        # pylint: disable=cell-var-from-loop
+
+        # range dims for carry (in-body context)
         def _carry_range_dims():
             if actual_non_vert_dims is not None:
                 return actual_non_vert_dims
@@ -1021,7 +1024,7 @@ def _convert_all_carries(routine, loop, vertical_size,
                 for _ in carry_shape
             ) if carry_shape else None
 
-        # --- Helper: range dims for init/rotate (out-of-loop context) ---
+        # range dims for init/rotate (out-of-loop context)
         # Non-horizontal loop variables (e.g. JM) are invalid outside
         # their enclosing loop, so replace them with ':' (RangeIndex).
         # The horizontal index (e.g. JL) is kept as-is because the SCC
@@ -1062,6 +1065,8 @@ def _convert_all_carries(routine, loop, vertical_size,
             if isinstance(dim_expr, sym.Scalar) and not isinstance(dim_expr, sym.IntLiteral):
                 return sym.RangeIndex((None, None, None))
             return dim_expr
+
+        # pylint: enable=cell-var-from-loop
 
         # --- Init statement ---
         if pattern == 'stencil':
@@ -1867,7 +1872,6 @@ def _collect_rotates_from_node(node, rotate_keys, save_names,
         if (lhs_name, rhs_name) in rotate_keys:
             remove_map[node] = None
             hoisted.append((enclosing_guard_cond, node))
-            return
 
         # Check for Pattern A / stencil save: the save is typically the
         # LAST assignment to _vc in the loop body.  We identify it by
@@ -2275,7 +2279,7 @@ def _remove_self_assignments(routine, merged_loop):
     int
         Number of self-assignments removed.
     """
-    from loki.backend import fgen
+    from loki.backend import fgen  # pylint: disable=import-outside-toplevel
 
     to_remove = {}
     for assign in FindNodes(ir.Assignment).visit(merged_loop.body):

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -111,8 +111,14 @@ def _collect_vertical_loops(body, vertical_index):
     Loops nested inside ``Conditional`` wrappers are returned as
     ``(loop, conditional_wrapper)`` pairs; top-level loops are returned
     as ``(loop, None)`` pairs.
+
+    .. note::
+
+       This function matches the induction variable by name only and
+       does not consult ``Dimension.index_aliases``.  If a routine uses
+       an alias (e.g. ``NLEV``) instead of the primary index name, those
+       loops will not be collected.
     """
-    # TODO [K-CACHING]: index aliases could exist
     vertical_index_lower = vertical_index.lower()
     result = []
     nodes = body if isinstance(body, (tuple, list)) else body.body
@@ -196,14 +202,13 @@ def _mark_jk1_conditionals(loop, arr_name, dim_idx, cond_to_remove,
             # Check if the ELSE branch contains assignments to our carry array
             # at JK with RHS being ARRAY(JK-1)
             else_body = cond.else_body or ()
-            # TODO [K-CACHING]: rename has_our_array to has_array in this function
-            has_our_array = False
+            has_array = False
             for stmt in FindNodes(ir.Assignment).visit(else_body):
                 if isinstance(stmt.lhs, sym.Array) and stmt.lhs.name.lower() == arr_name.lower():
-                    has_our_array = True
+                    has_array = True
                     break
 
-            if has_our_array:
+            if has_array:
                 # The ELSE branch assignments like X(JK) = X(JK-1) are already
                 # handled by the expr_map (X(JK-1) → carry). But we need to
                 # replace the entire IF/ELSE block with just the ELSE branch
@@ -301,8 +306,7 @@ def _substitute_jk_in_expr(expr, jk_var, replacement):
     vmap = {}
     all_vars = FindVariables().visit(expr)
     for var in all_vars:
-        # TODO [K-CACHING]: if it is a sym.Array there is no need to check for `hasattr(var, 'dimensions')`
-        if isinstance(var, sym.Array) and hasattr(var, 'dimensions') and var.dimensions:
+        if isinstance(var, sym.Array) and var.dimensions:
             new_dims = tuple(
                 replacement
                 if (isinstance(d, (sym.Scalar, sym.DeferredTypeSymbol))
@@ -478,17 +482,14 @@ def _find_demotable_arrays(routine, vertical_index, vertical_size,
 
     An array is demotable if:
 
-    .. note::
-
-       It is not safe to demote if a variable is used in multiple
-       vertical loops that could not be fused.  This check is not yet
-       implemented.
-
     1. It is a local variable (not an argument, not imported).
     2. It has ``vertical_size`` (or ``vertical_size + 1``) in its shape.
     3. It is NOT accessed outside all vertical loops in the routine.
     4. Within every vertical loop, every access uses offset 0.
     5. It is NOT passed as an argument to any subroutine/function call.
+    6. It is NOT referenced in more than one vertical loop (otherwise
+       data written in one loop and read in another would be lost after
+       demotion).
 
     Parameters
     ----------
@@ -555,6 +556,25 @@ def _find_demotable_arrays(routine, vertical_index, vertical_size,
     if not safe:
         return []
 
+    # Exclude arrays referenced in more than one vertical loop.
+    # After demotion the vertical dimension is removed, so data written
+    # in one loop and read in another would be lost.
+    if len(all_vloops) > 1:
+        arr_loop_count = defaultdict(int)
+        for loop, _cond in all_vloops:
+            loop_vars = {v.name.lower() for v in FindVariables().visit(loop.body)}
+            for cand in safe:
+                if cand in loop_vars:
+                    arr_loop_count[cand] += 1
+        multi_loop = {name for name, count in arr_loop_count.items() if count > 1}
+        if multi_loop:
+            info('[_find_demotable_arrays] Excluding %s: used in multiple '
+                 'vertical loops', ', '.join(sorted(multi_loop)))
+            safe -= multi_loop
+
+    if not safe:
+        return []
+
     # Check that within each vertical loop, every access is at offset 0
     for loop, _cond in all_vloops:
         access_map = classify_array_access_offsets(
@@ -613,18 +633,140 @@ def _find_dead_loops_all(routine, vertical_index):
     return dead
 
 
+def _build_carry_expr_entries(all_vars, arr_name, dim_idx, loop_var,
+                              target_offsets, carry_decl,
+                              alt_carry_decl=None, alt_offsets=None):
+    """
+    Build expression-substitution map entries that replace array
+    accesses at specific loop-variable offsets with a carry variable.
+
+    Parameters
+    ----------
+    all_vars : iterable of expression
+        Result of ``FindVariables(unique=False).visit(loop.body)``.
+    arr_name : str
+        Name of the original array.
+    dim_idx : int
+        Index of the vertical dimension in the array's subscript list.
+    loop_var : expression
+        Loop induction variable (e.g. ``JK``).
+    target_offsets : set or callable
+        Either a set of integer offsets whose references should be
+        rewritten to *carry_decl*, or a callable
+        ``(offset) -> bool``.
+    carry_decl : expression
+        The carry variable to substitute in.
+    alt_carry_decl : expression, optional
+        A second carry variable (e.g. ``_next``) used for a second
+        group of offsets.
+    alt_offsets : set or callable, optional
+        Offsets whose references should be rewritten to
+        *alt_carry_decl* instead of *carry_decl*.
+
+    Returns
+    -------
+    dict
+        Mapping ``{old_expr: new_expr}`` suitable for merging into an
+        ``expr_map`` passed to ``SubstituteExpressions``.
+    """
+    arr_lower = arr_name.lower()
+    entries = {}
+
+    def _match(offset, target):
+        if callable(target):
+            return target(offset)
+        return offset in target
+
+    for v in all_vars:
+        if not isinstance(v, sym.Array) or not v.dimensions:
+            continue
+        if v.name.lower() != arr_lower:
+            continue
+        if dim_idx >= len(v.dimensions):
+            continue
+        offset = _extract_offset(v.dimensions[dim_idx], loop_var)
+        if offset is None:
+            continue
+
+        new_dims = tuple(
+            d for i, d in enumerate(v.dimensions) if i != dim_idx
+        )
+
+        if alt_carry_decl is not None and alt_offsets is not None and _match(offset, alt_offsets):
+            entries[v] = alt_carry_decl.clone(
+                dimensions=new_dims if new_dims else None
+            )
+        elif _match(offset, target_offsets):
+            entries[v] = carry_decl.clone(
+                dimensions=new_dims if new_dims else None
+            )
+
+    return entries
+
+
+def _build_save_assignment(orig_decl, carry_decl, orig_shape, dim_idx,
+                           save_index_expr, actual_non_vert_dims,
+                           out_of_loop_dim_fn):
+    """
+    Build an assignment ``carry = X(..., <save_index>, ...)`` that
+    captures the current iteration's value for use in the next.
+
+    Parameters
+    ----------
+    orig_decl : expression
+        The original array declaration (with full shape).
+    carry_decl : expression
+        The carry variable declaration.
+    orig_shape : tuple
+        Shape of the original array.
+    dim_idx : int
+        Index of the vertical dimension.
+    save_index_expr : expression
+        The index expression for the vertical dimension in the save
+        statement (e.g. ``loop_var`` or ``Sum((loop_var, IntLiteral(1)))``).
+    actual_non_vert_dims : tuple or None
+        Actual non-vertical dimension expressions from the loop body.
+    out_of_loop_dim_fn : callable
+        ``(dim_expr) -> dim_expr`` that sanitises dimension
+        expressions for out-of-loop context (replaces non-horizontal
+        loop variables with ``':'``).
+
+    Returns
+    -------
+    :any:`Assignment`
+    """
+    save_orig_dims = []
+    save_carry_dims = []
+    nv_idx = 0
+    for i, _s in enumerate(orig_shape):
+        if i == dim_idx:
+            save_orig_dims.append(save_index_expr)
+        else:
+            if (actual_non_vert_dims is not None
+                    and nv_idx < len(actual_non_vert_dims)):
+                dim_expr = out_of_loop_dim_fn(actual_non_vert_dims[nv_idx])
+            else:
+                dim_expr = sym.RangeIndex((None, None, None))
+            save_orig_dims.append(dim_expr)
+            save_carry_dims.append(dim_expr)
+            nv_idx += 1
+    save_rhs = orig_decl.clone(dimensions=tuple(save_orig_dims))
+    save_lhs = carry_decl.clone(
+        dimensions=tuple(save_carry_dims) if save_carry_dims else None
+    )
+    return ir.Assignment(lhs=save_lhs, rhs=save_rhs)
+
+
 def _convert_all_carries(routine, loop, vertical_index, vertical_size,
                          horizontal_index=None,
                          carry_suffix='_vc', next_suffix='_next'):
     """
-    .. note::
-
-       This function is long and would benefit from extracting
-       pattern-specific logic (A, B_simple, B_readback, stencil)
-       into dedicated helper or nested functions.
-
     Convert all carry and stencil patterns in *loop* to scalar carry
     variables, making the loop body level-local.
+
+    Shared logic for building expression substitution entries and save
+    assignments is delegated to :func:`_build_carry_expr_entries` and
+    :func:`_build_save_assignment`.
 
     Four patterns are recognised:
 
@@ -980,43 +1122,18 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
 
         if pattern == 'A':
             # Replace reads at JK-1 with carry
-            for v in all_vars:
-                if not isinstance(v, sym.Array) or not v.dimensions:
-                    continue
-                if v.name.lower() != arr_name.lower():
-                    continue
-                if dim_idx >= len(v.dimensions):
-                    continue
-                offset = _extract_offset(v.dimensions[dim_idx], loop_var)
-                if offset == -1:
-                    new_dims = tuple(
-                        d for i, d in enumerate(v.dimensions)
-                        if i != dim_idx
-                    )
-                    expr_map[v] = carry_decl.clone(
-                        dimensions=new_dims if new_dims else None
-                    )
+            expr_map.update(_build_carry_expr_entries(
+                all_vars, arr_name, dim_idx, loop_var,
+                target_offsets={-1}, carry_decl=carry_decl
+            ))
 
             # Save: carry = X(JL, JK) at end of body
-            save_orig_dims = []
-            save_carry_dims = []
-            nv_idx = 0
-            for i, _s in enumerate(orig_shape):
-                if i == dim_idx:
-                    save_orig_dims.append(loop_var)
-                else:
-                    if actual_non_vert_dims is not None and nv_idx < len(actual_non_vert_dims):
-                        dim_expr = _out_of_loop_dim(actual_non_vert_dims[nv_idx])
-                    else:
-                        dim_expr = sym.RangeIndex((None, None, None))
-                    save_orig_dims.append(dim_expr)
-                    save_carry_dims.append(dim_expr)
-                    nv_idx += 1
-            save_rhs = orig_decl.clone(dimensions=tuple(save_orig_dims))
-            save_lhs = carry_decl.clone(
-                dimensions=tuple(save_carry_dims) if save_carry_dims else None
-            )
-            save_stmts.append(ir.Assignment(lhs=save_lhs, rhs=save_rhs))
+            save_stmts.append(_build_save_assignment(
+                orig_decl, carry_decl, orig_shape, dim_idx,
+                save_index_expr=loop_var,
+                actual_non_vert_dims=actual_non_vert_dims,
+                out_of_loop_dim_fn=_out_of_loop_dim
+            ))
 
             # Remove IF(JK==1) conditionals
             _mark_jk1_conditionals(loop, arr_name, dim_idx,
@@ -1024,71 +1141,27 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
 
         elif pattern == 'B_simple':
             # Replace reads at JK (offset 0) with carry
-            for v in all_vars:
-                if not isinstance(v, sym.Array) or not v.dimensions:
-                    continue
-                if v.name.lower() != arr_name.lower():
-                    continue
-                if dim_idx >= len(v.dimensions):
-                    continue
-                offset = _extract_offset(v.dimensions[dim_idx], loop_var)
-                if offset == 0:
-                    new_dims = tuple(
-                        d for i, d in enumerate(v.dimensions)
-                        if i != dim_idx
-                    )
-                    expr_map[v] = carry_decl.clone(
-                        dimensions=new_dims if new_dims else None
-                    )
+            expr_map.update(_build_carry_expr_entries(
+                all_vars, arr_name, dim_idx, loop_var,
+                target_offsets={0}, carry_decl=carry_decl
+            ))
 
             # Save: carry = X(JL, JK+1) at end of body
-            save_orig_dims = []
-            save_carry_dims = []
-            nv_idx = 0
-            for i, _s in enumerate(orig_shape):
-                if i == dim_idx:
-                    save_orig_dims.append(
-                        sym.Sum((loop_var, sym.IntLiteral(1)))
-                    )
-                else:
-                    if actual_non_vert_dims is not None and nv_idx < len(actual_non_vert_dims):
-                        dim_expr = _out_of_loop_dim(actual_non_vert_dims[nv_idx])
-                    else:
-                        dim_expr = sym.RangeIndex((None, None, None))
-                    save_orig_dims.append(dim_expr)
-                    save_carry_dims.append(dim_expr)
-                    nv_idx += 1
-            save_rhs = orig_decl.clone(dimensions=tuple(save_orig_dims))
-            save_lhs = carry_decl.clone(
-                dimensions=tuple(save_carry_dims) if save_carry_dims else None
-            )
-            save_stmts.append(ir.Assignment(lhs=save_lhs, rhs=save_rhs))
+            save_stmts.append(_build_save_assignment(
+                orig_decl, carry_decl, orig_shape, dim_idx,
+                save_index_expr=sym.Sum((loop_var, sym.IntLiteral(1))),
+                actual_non_vert_dims=actual_non_vert_dims,
+                out_of_loop_dim_fn=_out_of_loop_dim
+            ))
 
         elif pattern == 'B_readback':
             # Two carries: _vc for reads at offset 0, _next for
             # write at +1 and reads at +1
-            for v in all_vars:
-                if not isinstance(v, sym.Array) or not v.dimensions:
-                    continue
-                if v.name.lower() != arr_name.lower():
-                    continue
-                if dim_idx >= len(v.dimensions):
-                    continue
-                offset = _extract_offset(v.dimensions[dim_idx], loop_var)
-                if offset is None:
-                    continue
-                new_dims = tuple(
-                    d for i, d in enumerate(v.dimensions)
-                    if i != dim_idx
-                )
-                if offset == 0:
-                    expr_map[v] = carry_decl.clone(
-                        dimensions=new_dims if new_dims else None
-                    )
-                elif offset == 1:
-                    expr_map[v] = next_decl.clone(
-                        dimensions=new_dims if new_dims else None
-                    )
+            expr_map.update(_build_carry_expr_entries(
+                all_vars, arr_name, dim_idx, loop_var,
+                target_offsets={0}, carry_decl=carry_decl,
+                alt_carry_decl=next_decl, alt_offsets={1}
+            ))
 
             # Rotate: carry = next at end of body
             rot_lhs = carry_decl.clone(dimensions=_init_rotate_dims())
@@ -1105,43 +1178,18 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
 
         elif pattern == 'stencil':
             # Replace reads at negative offsets with carry
-            for v in all_vars:
-                if not isinstance(v, sym.Array) or not v.dimensions:
-                    continue
-                if v.name.lower() != arr_name.lower():
-                    continue
-                if dim_idx >= len(v.dimensions):
-                    continue
-                offset = _extract_offset(v.dimensions[dim_idx], loop_var)
-                if offset is not None and offset < 0:
-                    new_dims = tuple(
-                        d for i, d in enumerate(v.dimensions)
-                        if i != dim_idx
-                    )
-                    expr_map[v] = carry_decl.clone(
-                        dimensions=new_dims if new_dims else None
-                    )
+            expr_map.update(_build_carry_expr_entries(
+                all_vars, arr_name, dim_idx, loop_var,
+                target_offsets=lambda off: off < 0, carry_decl=carry_decl
+            ))
 
             # Save: carry = X(JL, JK) at end of body
-            save_orig_dims = []
-            save_carry_dims = []
-            nv_idx = 0
-            for i, _s in enumerate(orig_shape):
-                if i == dim_idx:
-                    save_orig_dims.append(loop_var)
-                else:
-                    if actual_non_vert_dims is not None and nv_idx < len(actual_non_vert_dims):
-                        dim_expr = _out_of_loop_dim(actual_non_vert_dims[nv_idx])
-                    else:
-                        dim_expr = sym.RangeIndex((None, None, None))
-                    save_orig_dims.append(dim_expr)
-                    save_carry_dims.append(dim_expr)
-                    nv_idx += 1
-            save_rhs = orig_decl.clone(dimensions=tuple(save_orig_dims))
-            save_lhs = carry_decl.clone(
-                dimensions=tuple(save_carry_dims) if save_carry_dims else None
-            )
-            save_stmts.append(ir.Assignment(lhs=save_lhs, rhs=save_rhs))
+            save_stmts.append(_build_save_assignment(
+                orig_decl, carry_decl, orig_shape, dim_idx,
+                save_index_expr=loop_var,
+                actual_non_vert_dims=actual_non_vert_dims,
+                out_of_loop_dim_fn=_out_of_loop_dim
+            ))
 
         # Record conversion
         conv_entry = {

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -163,8 +163,7 @@ def _is_jk_eq_1(expr, loop_var_name):
     return False
 
 
-def _mark_jk1_conditionals(loop, arr_name, dim_idx, cond_to_remove,
-                            carry_decl, expr_map):
+def _mark_jk1_conditionals(loop, arr_name, cond_to_remove):
     """
     For Pattern A carries, find ``IF (JK == 1)`` conditionals in the loop
     body that initialise the carry array and mark them for removal.
@@ -757,7 +756,7 @@ def _build_save_assignment(orig_decl, carry_decl, orig_shape, dim_idx,
     return ir.Assignment(lhs=save_lhs, rhs=save_rhs)
 
 
-def _convert_all_carries(routine, loop, vertical_index, vertical_size,
+def _convert_all_carries(routine, loop, vertical_size,
                          horizontal_index=None,
                          carry_suffix='_vc', next_suffix='_next'):
     """
@@ -806,7 +805,6 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
     routine : :any:`Subroutine`
     loop : :any:`Loop`
         The vertical loop to transform.
-    vertical_index : str
     vertical_size : str
     horizontal_index : str, optional
         Name of the horizontal loop variable (e.g. ``'JL'``).  Used to
@@ -1136,8 +1134,7 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
             ))
 
             # Remove IF(JK==1) conditionals
-            _mark_jk1_conditionals(loop, arr_name, dim_idx,
-                                   cond_to_remove, carry_decl, expr_map)
+            _mark_jk1_conditionals(loop, arr_name, cond_to_remove)
 
         elif pattern == 'B_simple':
             # Replace reads at JK (offset 0) with carry
@@ -1772,12 +1769,24 @@ def _merge_vertical_loops(routine, vertical_index, vertical_size):
         )
 
         if cond_wrapper is not None:
-            # Nest inside the original conditional
-            nested = ir.Conditional(
-                condition=cond_wrapper.condition,
-                body=(guarded,),
-                else_body=()
-            )
+            # Nest inside the original conditional, preserving its
+            # else_body if present.  If the wrapper has a non-trivial
+            # else branch we keep it intact and only replace the loop
+            # in the body branch with the guarded version.
+            if cond_wrapper.else_body:
+                # Preserve the original conditional structure: replace
+                # the loop inside the body branch, keep else_body.
+                new_body = tuple(
+                    guarded if stmt is loop else stmt
+                    for stmt in cond_wrapper.body
+                )
+                nested = cond_wrapper.clone(body=new_body)
+            else:
+                nested = ir.Conditional(
+                    condition=cond_wrapper.condition,
+                    body=(guarded,),
+                    else_body=()
+                )
             merged_body.append(nested)
         else:
             merged_body.append(guarded)
@@ -1981,8 +1990,7 @@ def _hoist_rotates_to_end(routine, merged_loop, carry_registry):
     return len(remove_map)
 
 
-def _cross_loop_carry_substitution(routine, merged_loop, carry_registry,
-                                    vertical_index):
+def _cross_loop_carry_substitution(routine, merged_loop, carry_registry):
     """
     Replace remaining raw array references in the merged loop body with
     the carry variables created in Phase 1c.
@@ -1995,7 +2003,7 @@ def _cross_loop_carry_substitution(routine, merged_loop, carry_registry,
 
     Substitution rules by offset:
 
-    * **offset 0** → ``<array>_vc``  (all patterns)
+    * **offset 0** → ``<array>_vc``  (all patterns except ``A`` and ``stencil``)
     * **offset +1** → ``<array>_next``  (B_readback only)
     * **offset -1** → ``<array>_vc``  (Pattern A / stencil)
 
@@ -2007,7 +2015,6 @@ def _cross_loop_carry_substitution(routine, merged_loop, carry_registry,
     carry_registry : dict
         ``{array_name_lower: {'carry': str, 'pattern': str,
         'next': str or None, 'dim_index': int}}``
-    vertical_index : str
 
     Returns
     -------
@@ -2093,7 +2100,7 @@ def _cross_loop_carry_substitution(routine, merged_loop, carry_registry,
 
 
 def _insert_writebacks_for_argument_carries(routine, merged_loop,
-                                             carry_registry, vertical_index,
+                                             carry_registry,
                                              horizontal_index=None):
     """
     Insert write-back statements for INTENT(OUT) argument arrays that
@@ -2124,7 +2131,6 @@ def _insert_writebacks_for_argument_carries(routine, merged_loop,
     carry_registry : dict
         ``{array_name_lower: {'carry': str, 'pattern': str,
         'next': str or None, 'dim_index': int}}``
-    vertical_index : str
     horizontal_index : str, optional
         Name of the horizontal loop variable (e.g. ``'JL'``).  Used to
         construct correct array subscripts for write-back statements.

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -1,0 +1,2214 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Shared utility functions for vertical loop transformations.
+
+This module collects helper functions used by both
+:mod:`vertical_complete` and :mod:`vertical_merge` to avoid
+code duplication and circular imports.
+"""
+
+from collections import defaultdict, OrderedDict
+
+from loki.expression import symbols as sym
+from loki.ir import (
+    nodes as ir, FindNodes, Transformer, FindVariables,
+    SubstituteExpressions, SubstituteExpressionsSkipLHS
+)
+from loki.logging import info, warning
+from loki.tools import as_tuple, CaseInsensitiveDict
+from loki.analyse.analyse_dataflow import (
+    classify_array_access_offsets, array_loop_carried_dependencies,
+    _extract_offset,
+)
+
+
+__all__ = []
+
+
+# ---------------------------------------------------------------------------
+# Functions from vertical_complete.py
+# ---------------------------------------------------------------------------
+
+def _loop_upper_bound_str(loop):
+    """
+    Return the upper-bound of *loop*'s range as a normalised
+    lowercase string, e.g. ``'klev'``, ``'klev + 1'``.
+    """
+    bounds = loop.bounds
+    if bounds is None or bounds.children is None:
+        return ''
+    upper = bounds.children[1]
+    return str(upper).strip().lower()
+
+
+def _is_klev_plus_n(upper_str, vertical_size):
+    """
+    Return ``True`` if *upper_str* represents the vertical size plus a
+    positive integer, e.g. ``'klev + 1'``.
+
+    Parameters
+    ----------
+    upper_str : str
+        Normalised lowercase upper bound string.
+    vertical_size : str
+        Normalised lowercase vertical size, e.g. ``'klev'``.
+    """
+    vs = vertical_size.lower()
+    us = upper_str.replace(' ', '')
+    # Match patterns like "klev+1", "klev+2", etc.
+    if us.startswith(vs + '+'):
+        suffix = us[len(vs) + 1:]
+        try:
+            n = int(suffix)
+            return n >= 1
+        except ValueError:
+            return False
+    return False
+
+
+def _collect_vertical_loops(body, vertical_index):
+    """
+    Walk *body* (a :any:`Section`, :any:`Associate`, or tuple of nodes)
+    and return all :any:`Loop` nodes whose variable is *vertical_index*,
+    preserving source order.
+
+    The walk recurses into transparent container nodes (:any:`Section`,
+    :any:`Associate`) but NOT into loop or conditional bodies — only
+    the outermost JK loop at each position is returned.
+
+    Loops nested inside ``Conditional`` wrappers are returned as
+    ``(loop, conditional_wrapper)`` pairs; top-level loops are returned
+    as ``(loop, None)`` pairs.
+    """
+    vertical_index_lower = vertical_index.lower()
+    result = []
+    nodes = body if isinstance(body, (tuple, list)) else body.body
+
+    for node in nodes:
+        if isinstance(node, ir.Loop):
+            if node.variable.name.lower() == vertical_index_lower:
+                result.append((node, None))
+            # don't recurse into the JK loop body
+        elif isinstance(node, ir.Conditional):
+            # Check for JK loops directly inside the conditional branches
+            for branch_nodes in (node.body, node.else_body or ()):
+                for child in branch_nodes:
+                    if isinstance(child, ir.Loop):
+                        if child.variable.name.lower() == vertical_index_lower:
+                            result.append((child, node))
+        elif isinstance(node, (ir.Section, ir.Associate)):
+            # Recurse into transparent container nodes
+            result.extend(_collect_vertical_loops(node, vertical_index))
+        elif isinstance(node, ir.Comment):
+            pass  # skip
+    return result
+
+
+def _is_jk_eq_1(expr, loop_var_name):
+    """
+    Return True if *expr* represents ``JK == 1`` or ``1 == JK``.
+    """
+    if isinstance(expr, sym.Comparison):
+        if expr.operator == '==':
+            left_str = str(expr.left).strip().lower()
+            right_str = str(expr.right).strip().lower()
+            if ((left_str == loop_var_name and right_str == '1') or
+                    (right_str == loop_var_name and left_str == '1')):
+                return True
+    return False
+
+
+def _mark_jk1_conditionals(loop, arr_name, dim_idx, cond_to_remove,
+                            carry_decl, expr_map):
+    """
+    For Pattern A carries, find ``IF (JK == 1)`` conditionals in the loop
+    body that initialise the carry array and mark them for removal.
+
+    The typical pattern is::
+
+        IF (JK==1) THEN
+          X(JL, JK) = 0.0
+          Y(JL, JK) = 0.0
+        ELSE
+          X(JL, JK) = X(JL, JK-1)
+          Y(JL, JK) = Y(JL, JK-1)
+        END IF
+
+    The entire conditional is replaced by load-from-carry assignments::
+
+        X(JL, JK) = z_x_vc(JL)
+        Y(JL, JK) = z_y_vc(JL)
+
+    which are already handled by the expression map for the ELSE branch.
+    The IF branch (init to 0) is now unnecessary because the carry
+    variable is initialised to 0 before the loop.
+    """
+    loop_var = loop.variable
+    loop_var_name = loop_var.name.lower()
+
+    for node in loop.body if isinstance(loop.body, tuple) else (loop.body,):
+        # Walk into inner loops (e.g. DO JL) to find conditionals
+        for cond in FindNodes(ir.Conditional).visit(node):
+            # Check if condition is JK == 1 (or 1 == JK)
+            condition = cond.condition
+            if not _is_jk_eq_1(condition, loop_var_name):
+                continue
+
+            # Check if the ELSE branch contains assignments to our carry array
+            # at JK with RHS being ARRAY(JK-1)
+            else_body = cond.else_body or ()
+            has_our_array = False
+            for stmt in FindNodes(ir.Assignment).visit(else_body):
+                if isinstance(stmt.lhs, sym.Array) and stmt.lhs.name.lower() == arr_name.lower():
+                    has_our_array = True
+                    break
+
+            if has_our_array:
+                # The ELSE branch assignments like X(JK) = X(JK-1) are already
+                # handled by the expr_map (X(JK-1) → carry). But we need to
+                # replace the entire IF/ELSE block with just the ELSE branch
+                # assignments (after substitution), because the IF branch
+                # (X(JK) = 0) is no longer needed (carry is pre-initialised).
+                #
+                # We'll mark the conditional for replacement with the ELSE
+                # branch body (which will be substituted by the expr_map
+                # pass that runs first).
+                replacement = list(else_body)
+                cond_to_remove.append((cond, replacement))
+                break  # Only one JK==1 conditional per carry array
+
+
+def _any_read_outside_node(body, exclude_node, written_names):
+    """
+    Return ``True`` if any variable in *written_names* is **read**
+    (not just written) in any node of *body* other than *exclude_node*.
+
+    Recurses into transparent container nodes (:any:`Section`,
+    :any:`Associate`) so that the exclude works correctly when loops
+    are nested inside such containers.
+
+    A variable is considered "read" if it appears on the RHS of an
+    assignment, in a conditional expression, in a call argument, or
+    in any context other than the bare LHS of an assignment.
+    """
+    nodes = body if isinstance(body, (tuple, list)) else body.body
+    for node in nodes:
+        if node is exclude_node:
+            continue
+        # Recurse into transparent containers
+        if isinstance(node, (ir.Section, ir.Associate)):
+            if _any_read_outside_node(node.body, exclude_node,
+                                       written_names):
+                return True
+            continue
+        # For assignments, check RHS + LHS subscripts (but not the
+        # LHS variable name itself)
+        if isinstance(node, ir.Assignment):
+            # RHS reads
+            rhs_vars = FindVariables().visit(node.rhs)
+            for var in rhs_vars:
+                if var.name.lower() in written_names:
+                    return True
+            # LHS subscript reads (e.g. A(ZTRPAUS) would be a read)
+            lhs = node.lhs
+            if hasattr(lhs, 'dimensions') and lhs.dimensions:
+                for dim in lhs.dimensions:
+                    dim_vars = FindVariables().visit(dim)
+                    for var in dim_vars:
+                        if var.name.lower() in written_names:
+                            return True
+            continue
+        # For conditionals, check condition + branches
+        if isinstance(node, ir.Conditional):
+            cond_vars = FindVariables().visit(node.condition)
+            for var in cond_vars:
+                if var.name.lower() in written_names:
+                    return True
+            if _any_read_outside_node(node.body, exclude_node,
+                                       written_names):
+                return True
+            if node.else_body:
+                if _any_read_outside_node(node.else_body, exclude_node,
+                                           written_names):
+                    return True
+            continue
+        # For loops (non-JK), check bounds + body
+        if isinstance(node, ir.Loop):
+            bounds_vars = FindVariables().visit(node.bounds)
+            for var in bounds_vars:
+                if var.name.lower() in written_names:
+                    return True
+            if _any_read_outside_node(node.body, exclude_node,
+                                       written_names):
+                return True
+            continue
+        # For everything else, any reference counts as a read
+        all_vars = FindVariables().visit(node)
+        for var in all_vars:
+            if var.name.lower() in written_names:
+                return True
+    return False
+
+
+def _substitute_jk_in_expr(expr, jk_var, replacement):
+    """
+    Replace all occurrences of *jk_var* in *expr* with *replacement*.
+
+    Handles both scalar references (``JK``) and array subscripts
+    containing the loop variable (``A(JL, JK)`` → ``A(JL, NJKT3)``).
+    """
+    jk_lower = jk_var.name.lower()
+    vmap = {}
+    all_vars = FindVariables().visit(expr)
+    for var in all_vars:
+        if isinstance(var, sym.Array) and hasattr(var, 'dimensions') and var.dimensions:
+            new_dims = tuple(
+                replacement
+                if (isinstance(d, (sym.Scalar, sym.DeferredTypeSymbol))
+                    and d.name.lower() == jk_lower)
+                else d
+                for d in var.dimensions
+            )
+            if new_dims != var.dimensions:
+                vmap[var] = var.clone(dimensions=new_dims)
+        elif isinstance(var, (sym.Scalar, sym.DeferredTypeSymbol)):
+            if var.name.lower() == jk_lower:
+                vmap[var] = replacement
+
+    if vmap:
+        return SubstituteExpressions(vmap).visit(expr)
+    return expr
+
+
+def _build_init_subst_map(body, loop_nodes, init_map, local_2d,
+                           vertical_index_lower, expr_map, substituted):
+    """
+    Walk *body* and for any Array reference to an init-mapped array
+    that appears outside all JK loops, add a substitution entry.
+    """
+    nodes = body if isinstance(body, (tuple, list)) else body.body
+
+    for node in nodes:
+        if node in loop_nodes:
+            continue
+        if isinstance(node, (ir.Section, ir.Associate)):
+            _build_init_subst_map(node.body, loop_nodes, init_map,
+                                  local_2d, vertical_index_lower,
+                                  expr_map, substituted)
+            continue
+        if isinstance(node, ir.Conditional):
+            _build_init_subst_map(node.body, loop_nodes, init_map,
+                                  local_2d, vertical_index_lower,
+                                  expr_map, substituted)
+            if node.else_body:
+                _build_init_subst_map(node.else_body, loop_nodes,
+                                      init_map, local_2d,
+                                      vertical_index_lower,
+                                      expr_map, substituted)
+            continue
+        # Recurse into non-vertical Loop nodes (e.g. DO JM loops) so
+        # that inner vertical loops in loop_nodes are properly skipped.
+        if isinstance(node, ir.Loop):
+            _build_init_subst_map(node.body, loop_nodes, init_map,
+                                  local_2d, vertical_index_lower,
+                                  expr_map, substituted)
+            continue
+
+        # Check Array references in this node
+        all_vars = FindVariables().visit(node)
+        for var in all_vars:
+            var_lower = var.name.lower()
+            if var_lower not in init_map:
+                continue
+            if not hasattr(var, 'dimensions') or not var.dimensions:
+                continue
+
+            init_assign = init_map[var_lower]
+            info_entry = local_2d[var_lower]
+            klev_dim = info_entry['klev_dim_idx']
+            if klev_dim >= len(var.dimensions):
+                continue
+            level_idx = var.dimensions[klev_dim]
+
+            # Verify non-vertical subscripts match between the
+            # reference and the init expression (e.g. reject
+            # ZQX(:,:,JM) when init was for ZQX(:,:,NCLDQV)).
+            # Range subscripts (`:`) are considered compatible with
+            # any scalar subscript (e.g. `:` matches `JL`).
+            init_dims = init_assign.lhs.dimensions
+            if len(var.dimensions) == len(init_dims):
+                mismatch = False
+                for di, (ref_d, init_d) in enumerate(
+                        zip(var.dimensions, init_dims)):
+                    if di == klev_dim:
+                        continue  # vertical dim — allowed to differ
+                    # Range subscripts are compatible with anything
+                    if isinstance(ref_d, sym.RangeIndex):
+                        continue
+                    if isinstance(init_d, sym.RangeIndex):
+                        continue
+                    if str(ref_d).strip().lower() != str(init_d).strip().lower():
+                        mismatch = True
+                        break
+                if mismatch:
+                    continue
+
+            # Build RHS with JK replaced by the level index
+            jk_var = init_assign.lhs.dimensions[klev_dim]
+            rhs_substituted = _substitute_jk_in_expr(
+                init_assign.rhs, jk_var, level_idx)
+            expr_map[var] = rhs_substituted
+            substituted.add(var_lower)
+
+
+def _apply_subst_outside_loops(routine, loop_nodes, expr_map):
+    """
+    Apply *expr_map* substitutions only to top-level nodes outside
+    vertical loops.
+    """
+    nodes = routine.body.body if hasattr(routine.body, 'body') else routine.body
+    new_body = []
+    changed = False
+
+    for node in nodes:
+        if node in loop_nodes:
+            new_body.append(node)
+            continue
+        new_node = SubstituteExpressionsSkipLHS(expr_map).visit(node)
+        new_body.append(new_node)
+        if new_node is not node:
+            changed = True
+
+    if changed:
+        routine.body = routine.body.clone(body=tuple(new_body))
+
+
+def _collect_refs_outside_loops(body, loop_nodes):
+    """
+    Collect all variable names referenced outside any node in
+    *loop_nodes*.  Returns a set of lowercase variable names.
+    """
+    refs = set()
+    nodes = body if isinstance(body, (tuple, list)) else body.body
+
+    for node in nodes:
+        if node in loop_nodes:
+            continue
+        if isinstance(node, (ir.Section, ir.Associate)):
+            refs.update(
+                _collect_refs_outside_loops(node.body, loop_nodes))
+            continue
+        if isinstance(node, ir.Conditional):
+            if node in loop_nodes:
+                continue
+            for var in FindVariables().visit(node.condition):
+                refs.add(var.name.lower())
+            refs.update(
+                _collect_refs_outside_loops(node.body, loop_nodes))
+            if node.else_body:
+                refs.update(
+                    _collect_refs_outside_loops(
+                        node.else_body, loop_nodes))
+            continue
+        # Recurse into non-vertical Loop nodes (e.g. DO JM) so that
+        # inner vertical loops in loop_nodes are properly skipped.
+        if isinstance(node, ir.Loop):
+            for var in FindVariables().visit(node.variable):
+                refs.add(var.name.lower())
+            for bound in (node.bounds.lower, node.bounds.upper,
+                          node.bounds.step):
+                if bound is not None:
+                    for var in FindVariables().visit(bound):
+                        refs.add(var.name.lower())
+            refs.update(
+                _collect_refs_outside_loops(node.body, loop_nodes))
+            continue
+        for var in FindVariables().visit(node):
+            refs.add(var.name.lower())
+
+    return refs
+
+
+def _find_demotable_arrays(routine, vertical_index, vertical_size,
+                            main_loop):
+    """
+    Identify local arrays with a vertical dimension that can be safely
+    demoted after loop absorption.
+
+    An array is demotable if:
+
+    1. It is a local variable (not an argument, not imported).
+    2. It has ``vertical_size`` (or ``vertical_size + 1``) in its shape.
+    3. It is NOT accessed outside all vertical loops in the routine.
+    4. Within every vertical loop, every access uses offset 0.
+    5. It is NOT passed as an argument to any subroutine/function call.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    vertical_index : str
+    vertical_size : str
+    main_loop : :any:`Loop`
+
+    Returns
+    -------
+    list of str
+        Lowercase names of arrays that are safe to demote.
+    """
+    vertical_size_lower = vertical_size.lower()
+
+    arg_names = {v.name.lower() for v in routine.arguments}
+
+    # Variables passed to calls (not safe to demote)
+    call_arg_names = set()
+    for call in FindNodes(ir.CallStatement).visit(routine.body):
+        for arg in call.arguments:
+            for v in FindVariables().visit(arg):
+                call_arg_names.add(v.name.lower())
+        if call.kwarguments:
+            for _kw, arg in call.kwarguments:
+                for v in FindVariables().visit(arg):
+                    call_arg_names.add(v.name.lower())
+
+    # Find all local arrays with KLEV dimension
+    candidates = {}
+    for var in routine.variables:
+        vname = var.name.lower()
+        if vname in arg_names:
+            continue
+        shape = (getattr(var.type, 'shape', None)
+                 or getattr(var, 'shape', None))
+        if not shape:
+            continue
+        has_klev = False
+        for s in shape:
+            s_str = str(s).strip().lower()
+            if (s_str == vertical_size_lower or
+                    s_str.replace(' ', '').startswith(
+                        vertical_size_lower + '+')):
+                has_klev = True
+                break
+        if has_klev and vname not in call_arg_names:
+            candidates[vname] = var
+
+    if not candidates:
+        return []
+
+    # Collect all vertical loops
+    all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+    loop_nodes = set()
+    for loop, cond_wrapper in all_vloops:
+        loop_nodes.add(loop)
+        if cond_wrapper is not None:
+            loop_nodes.add(cond_wrapper)
+
+    # Check that no candidate is accessed outside vertical loops
+    outside_refs = _collect_refs_outside_loops(routine.body, loop_nodes)
+    safe = set(candidates.keys()) - outside_refs
+
+    if not safe:
+        return []
+
+    # Check that within each vertical loop, every access is at offset 0
+    for loop, _cond in all_vloops:
+        access_map = classify_array_access_offsets(
+            loop, loop_var=loop.variable)
+        for (arr_name, _dim_idx), offset_map in access_map.items():
+            arr_lower = arr_name.lower()
+            if arr_lower not in safe:
+                continue
+            for offset in offset_map:
+                if offset != 0:
+                    safe.discard(arr_lower)
+
+    return sorted(safe)
+
+
+# ---------------------------------------------------------------------------
+# Functions from vertical_merge.py
+# ---------------------------------------------------------------------------
+
+def _find_dead_loops_all(routine, vertical_index):
+    """
+    Identify vertical loops whose written outputs are never read by
+    any other code in the routine.
+
+    Unlike :func:`vertical_complete._find_dead_loops`, this version
+    does **not** exclude any loop — every vertical loop is a candidate.
+
+    Returns a list of top-level IR nodes (Loop or Conditional wrappers)
+    that are dead and can be safely removed.
+    """
+    all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+    dead = []
+
+    arg_names = {v.name.lower() for v in routine.arguments}
+
+    for loop, cond_wrapper in all_vloops:
+        written_names = set()
+        for assign in FindNodes(ir.Assignment).visit(loop.body):
+            written_names.add(assign.lhs.name.lower())
+
+        if not written_names:
+            continue
+
+        # Writing to a routine argument is never dead
+        if written_names & arg_names:
+            continue
+
+        exclude_node = cond_wrapper if cond_wrapper is not None else loop
+
+        if not _any_read_outside_node(routine.body, exclude_node,
+                                       written_names):
+            dead.append(exclude_node)
+
+    return dead
+
+
+def _convert_all_carries(routine, loop, vertical_index, vertical_size,
+                         horizontal_index=None,
+                         carry_suffix='_vc', next_suffix='_next'):
+    """
+    Convert all carry and stencil patterns in *loop* to scalar carry
+    variables, making the loop body level-local.
+
+    Four patterns are recognised:
+
+    **Pattern A** — cumulative sum (read at JK-1, write at JK)::
+
+        IF (JK==1) THEN; X(JL,JK) = 0; ELSE; X(JL,JK) = X(JL,JK-1); END IF
+        X(JL,JK) = X(JL,JK) + delta
+
+    Converted with 1 carry: ``x_vc``.
+
+    **Pattern B-simple** — forward propagation, no readback
+    (read at JK, write at JK+1, no reads at JK+1)::
+
+        X(JL,JK+1) = f(X(JL,JK))
+
+    Converted with 1 carry: ``x_vc``.
+
+    **Pattern B-readback** — forward propagation with same-iteration
+    readback (read at JK, write at JK+1, AND reads at JK+1)::
+
+        X(JL,JK+1) = f(X(JL,JK))
+        Y = g(X(JL,JK+1))
+
+    Converted with 2 carries: ``x_vc`` (incoming) + ``x_next``
+    (outgoing).  A rotate ``x_vc = x_next`` is appended.
+
+    **Stencil** — read-only backward access (read at JK-1, never
+    written in the loop, local array only)::
+
+        Y = f(X(JL,JK-1))
+
+    Converted with 1 carry: ``x_vc``.  Init: ``x_vc = X(:, lower-1)``.
+    Save: ``x_vc = X(:, JK)`` at end of loop body.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    loop : :any:`Loop`
+        The vertical loop to transform.
+    vertical_index : str
+    vertical_size : str
+    horizontal_index : str, optional
+        Name of the horizontal loop variable (e.g. ``'JL'``).  Used to
+        distinguish the horizontal subscript from other loop indices
+        (like ``JM``) in multi-dimensional arrays.  Non-horizontal loop
+        indices are replaced with ``':'`` in init and rotate statements
+        (which are placed outside their enclosing loops).
+    carry_suffix : str
+    next_suffix : str
+
+    Returns
+    -------
+    tuple
+        ``(new_loop, init_stmts, conversions)``
+    """
+    vertical_size_lower = vertical_size.lower()
+    loop_var = loop.variable
+
+    # --- Classify accesses and dependencies ---
+    access_map = classify_array_access_offsets(loop, loop_var=loop_var)
+    deps = array_loop_carried_dependencies(loop, loop_var=loop_var)
+
+    # Build per-array access summary: {arr_lower: {(arr_name, dim_idx): offset_map}}
+    arr_dim_map = defaultdict(lambda: defaultdict(dict))
+    for (arr_name, dim_idx), offset_map in access_map.items():
+        arr_dim_map[arr_name.lower()][(arr_name, dim_idx)] = offset_map
+
+    # Arguments and call-args (stencil conversion applies only to locals)
+    arg_names = {v.name.lower() for v in routine.arguments}
+    call_arg_names = set()
+    for call in FindNodes(ir.CallStatement).visit(routine.body):
+        for arg in call.arguments:
+            for v in FindVariables().visit(arg):
+                call_arg_names.add(v.name.lower())
+        if call.kwarguments:
+            for _kw, arg in call.kwarguments:
+                for v in FindVariables().visit(arg):
+                    call_arg_names.add(v.name.lower())
+
+    var_map_ci = CaseInsensitiveDict(
+        {v.name: v for v in routine.variables}
+    )
+
+    # --- Collect carry specs ---
+    #
+    # Each spec: (arr_name, dim_idx, pattern, carry_names_dict)
+    #   pattern: 'A', 'B_simple', 'B_readback', 'stencil'
+    #   carry_names_dict: {'vc': name} or {'vc': name, 'next': name}
+    carry_specs = []
+    seen = set()
+
+    # 1) Detect flow dependencies (Pattern A and B)
+    for arr_name, dep_list in deps.items():
+        for dep in dep_list:
+            if dep['type'] != 'flow':
+                continue
+            dim_idx = dep['dim_index']
+            key = (arr_name.lower(), dim_idx)
+            if key in seen:
+                continue
+
+            w_off = dep['write_offset']
+            r_off = dep['read_offset']
+
+            if w_off == 0 and r_off == -1:
+                # Pattern A
+                carry_specs.append((arr_name, dim_idx, 'A', {}))
+                seen.add(key)
+            elif w_off == 1 and r_off == 0:
+                # Pattern B — check for readback at +1
+                has_readback = False
+                for (an, di), omap in access_map.items():
+                    if an.lower() == arr_name.lower() and di == dim_idx:
+                        if 1 in omap and 'read' in omap[1]:
+                            has_readback = True
+                            break
+                if has_readback:
+                    carry_specs.append((arr_name, dim_idx, 'B_readback', {}))
+                else:
+                    carry_specs.append((arr_name, dim_idx, 'B_simple', {}))
+                seen.add(key)
+
+    # 2) Detect stencil patterns (read at non-zero offset, no write at any offset)
+    for arr_lower, dim_entries in arr_dim_map.items():
+        # Stencils only for locals
+        if arr_lower in arg_names or arr_lower in call_arg_names:
+            continue
+        orig_decl = var_map_ci.get(arr_lower)
+        if orig_decl is None:
+            continue
+        shape = orig_decl.type.shape if orig_decl.type.shape else ()
+        if not shape:
+            continue
+
+        for (arr_name, dim_idx), offset_map in dim_entries.items():
+            key = (arr_lower, dim_idx)
+            if key in seen:
+                continue
+            # Check dimension is vertical
+            if dim_idx >= len(shape):
+                continue
+            s_str = str(shape[dim_idx]).strip().lower()
+            if not (s_str == vertical_size_lower or
+                    s_str.replace(' ', '').startswith(
+                        vertical_size_lower + '+')):
+                continue
+
+            # Stencil only for *backward* offsets (negative).
+            # Forward (+1) reads in read-only arrays cannot be converted
+            # to a simple carry (would require look-ahead).
+            negative = [off for off in offset_map if off < 0]
+            if not negative:
+                continue
+
+            # Must be read-only at ALL offsets in this dimension
+            has_write = False
+            for off, atypes in offset_map.items():
+                if 'write' in atypes:
+                    has_write = True
+                    break
+            if has_write:
+                continue
+
+            carry_specs.append((arr_name, dim_idx, 'stencil', {}))
+            seen.add(key)
+
+    if not carry_specs:
+        return loop, [], []
+
+    # --- Build carry variables, expr maps, init/save statements ---
+
+    expr_map = {}
+    init_stmts = []
+    save_stmts = []
+    rotate_stmts = []
+    cond_to_remove = []
+    conversions = []
+
+    for arr_name, dim_idx, pattern, _ in carry_specs:
+        orig_decl = var_map_ci.get(arr_name)
+        if orig_decl is None:
+            warning('[convert_all_carries] Array %r not found — skipping',
+                    arr_name)
+            continue
+
+        orig_shape = orig_decl.type.shape if orig_decl.type.shape else ()
+        if not orig_shape or dim_idx >= len(orig_shape):
+            warning('[convert_all_carries] Cannot determine shape for '
+                    '%r dim %d — skipping', arr_name, dim_idx)
+            continue
+
+        # --- Create carry variable(s) ---
+        carry_shape = tuple(
+            s for i, s in enumerate(orig_shape) if i != dim_idx
+        )
+        carry_type = orig_decl.type.clone(
+            shape=carry_shape if carry_shape else None,
+            intent=None
+        )
+
+        carry_name = arr_name.lower() + carry_suffix
+        carry_var = sym.Variable(
+            name=carry_name, type=carry_type,
+            dimensions=carry_shape if carry_shape else None,
+            scope=routine
+        )
+        if carry_name.lower() not in CaseInsensitiveDict(
+            {v.name: v for v in routine.variables}
+        ):
+            routine.variables += as_tuple(carry_var)
+        carry_decl = routine.variable_map.get(carry_name, carry_var)
+
+        # For B_readback, also create the 'next' variable
+        next_decl = None
+        if pattern == 'B_readback':
+            next_name = arr_name.lower() + next_suffix
+            next_var = sym.Variable(
+                name=next_name, type=carry_type,
+                dimensions=carry_shape if carry_shape else None,
+                scope=routine
+            )
+            if next_name.lower() not in CaseInsensitiveDict(
+                {v.name: v for v in routine.variables}
+            ):
+                routine.variables += as_tuple(next_var)
+            next_decl = routine.variable_map.get(next_name, next_var)
+
+        # --- Extract actual non-vertical subscripts from loop body ---
+        # Scan loop body for the first reference to this array and capture
+        # the non-vertical dimension expressions (e.g. JL).  These are used
+        # instead of bare ':' (RangeIndex) in init/save/rotate statements
+        # so that downstream SCCDevector/SCCDemote produce valid Fortran.
+        _body_vars = FindVariables(unique=False).visit(loop.body)
+        actual_non_vert_dims = None
+        for _bv in _body_vars:
+            if not isinstance(_bv, sym.Array) or not _bv.dimensions:
+                continue
+            if _bv.name.lower() != arr_name.lower():
+                continue
+            if dim_idx >= len(_bv.dimensions):
+                continue
+            _candidate = tuple(
+                d for i, d in enumerate(_bv.dimensions) if i != dim_idx
+            )
+            if _candidate:
+                actual_non_vert_dims = _candidate
+                break
+
+        # --- Helper: range dims for carry (in-body context) ---
+        def _carry_range_dims():
+            if actual_non_vert_dims is not None:
+                return actual_non_vert_dims
+            return tuple(
+                sym.RangeIndex((None, None, None))
+                for _ in carry_shape
+            ) if carry_shape else None
+
+        # --- Helper: range dims for init/rotate (out-of-loop context) ---
+        # Non-horizontal loop variables (e.g. JM) are invalid outside
+        # their enclosing loop, so replace them with ':' (RangeIndex).
+        # The horizontal index (e.g. JL) is kept as-is because the SCC
+        # pipeline converts it to a scalar parameter.
+        _horiz_lower = horizontal_index.lower() if horizontal_index else None
+
+        def _is_horizontal_var(expr):
+            """Check if expr is the horizontal index variable."""
+            if _horiz_lower and isinstance(expr, sym.Scalar):
+                return expr.name.lower() == _horiz_lower
+            return False
+
+        def _init_rotate_dims():
+            """Dims for init/rotate statements placed outside inner loops."""
+            if actual_non_vert_dims is None:
+                return tuple(
+                    sym.RangeIndex((None, None, None))
+                    for _ in carry_shape
+                ) if carry_shape else None
+            result = []
+            for d in actual_non_vert_dims:
+                if _is_horizontal_var(d):
+                    result.append(d)  # keep JL
+                else:
+                    result.append(sym.RangeIndex((None, None, None)))
+            return tuple(result) if result else None
+
+        def _out_of_loop_dim(dim_expr):
+            """Sanitize a single dim expr for out-of-loop (init/save/rotate) context.
+
+            Keeps the horizontal index as-is, replaces other loop
+            variables with ':' (RangeIndex).
+            """
+            if _is_horizontal_var(dim_expr):
+                return dim_expr
+            # If it's a scalar variable that isn't the horizontal index,
+            # it's probably a loop variable (like JM) — replace with ':'
+            if isinstance(dim_expr, sym.Scalar) and not isinstance(dim_expr, sym.IntLiteral):
+                return sym.RangeIndex((None, None, None))
+            return dim_expr
+
+        # --- Init statement ---
+        if pattern == 'stencil':
+            # Init: carry = X(:, lower-1, :)  (guarded against OOB)
+            lower_expr = loop.bounds.children[0]
+            init_idx = sym.Sum((lower_expr, sym.IntLiteral(-1)))
+            init_orig_dims = []
+            init_carry_dims = []
+            nv_idx = 0
+            for i, _s in enumerate(orig_shape):
+                if i == dim_idx:
+                    init_orig_dims.append(init_idx)
+                else:
+                    if actual_non_vert_dims is not None and nv_idx < len(actual_non_vert_dims):
+                        dim_expr = actual_non_vert_dims[nv_idx]
+                        # For init (outside loops), replace non-horizontal
+                        # loop variables with ':'
+                        if not _is_horizontal_var(dim_expr):
+                            dim_expr = sym.RangeIndex((None, None, None))
+                    else:
+                        dim_expr = sym.RangeIndex((None, None, None))
+                    init_orig_dims.append(dim_expr)
+                    init_carry_dims.append(dim_expr)
+                    nv_idx += 1
+            stencil_rhs = orig_decl.clone(dimensions=tuple(init_orig_dims))
+            stencil_lhs = carry_decl.clone(
+                dimensions=tuple(init_carry_dims) if init_carry_dims else None
+            )
+            stencil_assign = ir.Assignment(lhs=stencil_lhs, rhs=stencil_rhs)
+
+            # Guard against OOB: if lower == 1, X(:, 0) is invalid.
+            # Wrap in: IF (lower > 1) THEN carry = X(:,lower-1) ELSE carry = 0 END IF
+            zero_lhs = carry_decl.clone(
+                dimensions=tuple(init_carry_dims) if init_carry_dims else None
+            )
+            zero_rhs = sym.FloatLiteral(0.0, kind=orig_decl.type.kind)
+            zero_assign = ir.Assignment(lhs=zero_lhs, rhs=zero_rhs)
+
+            guard_cond = sym.Comparison(
+                operator='>', left=lower_expr, right=sym.IntLiteral(1)
+            )
+            init_stmts.append(ir.Conditional(
+                condition=guard_cond,
+                body=(stencil_assign,),
+                else_body=(zero_assign,),
+            ))
+        else:
+            # Init: carry = 0.0
+            init_dims = _init_rotate_dims()
+            init_lhs = carry_decl.clone(dimensions=init_dims)
+            init_rhs = sym.FloatLiteral(0.0, kind=orig_decl.type.kind)
+            init_stmts.append(ir.Assignment(lhs=init_lhs, rhs=init_rhs))
+
+        # --- Build expression substitution map ---
+        all_vars = FindVariables(unique=False).visit(loop.body)
+
+        if pattern == 'A':
+            # Replace reads at JK-1 with carry
+            for v in all_vars:
+                if not isinstance(v, sym.Array) or not v.dimensions:
+                    continue
+                if v.name.lower() != arr_name.lower():
+                    continue
+                if dim_idx >= len(v.dimensions):
+                    continue
+                offset = _extract_offset(v.dimensions[dim_idx], loop_var)
+                if offset == -1:
+                    new_dims = tuple(
+                        d for i, d in enumerate(v.dimensions)
+                        if i != dim_idx
+                    )
+                    expr_map[v] = carry_decl.clone(
+                        dimensions=new_dims if new_dims else None
+                    )
+
+            # Save: carry = X(JL, JK) at end of body
+            save_orig_dims = []
+            save_carry_dims = []
+            nv_idx = 0
+            for i, _s in enumerate(orig_shape):
+                if i == dim_idx:
+                    save_orig_dims.append(loop_var)
+                else:
+                    if actual_non_vert_dims is not None and nv_idx < len(actual_non_vert_dims):
+                        dim_expr = _out_of_loop_dim(actual_non_vert_dims[nv_idx])
+                    else:
+                        dim_expr = sym.RangeIndex((None, None, None))
+                    save_orig_dims.append(dim_expr)
+                    save_carry_dims.append(dim_expr)
+                    nv_idx += 1
+            save_rhs = orig_decl.clone(dimensions=tuple(save_orig_dims))
+            save_lhs = carry_decl.clone(
+                dimensions=tuple(save_carry_dims) if save_carry_dims else None
+            )
+            save_stmts.append(ir.Assignment(lhs=save_lhs, rhs=save_rhs))
+
+            # Remove IF(JK==1) conditionals
+            _mark_jk1_conditionals(loop, arr_name, dim_idx,
+                                   cond_to_remove, carry_decl, expr_map)
+
+        elif pattern == 'B_simple':
+            # Replace reads at JK (offset 0) with carry
+            for v in all_vars:
+                if not isinstance(v, sym.Array) or not v.dimensions:
+                    continue
+                if v.name.lower() != arr_name.lower():
+                    continue
+                if dim_idx >= len(v.dimensions):
+                    continue
+                offset = _extract_offset(v.dimensions[dim_idx], loop_var)
+                if offset == 0:
+                    new_dims = tuple(
+                        d for i, d in enumerate(v.dimensions)
+                        if i != dim_idx
+                    )
+                    expr_map[v] = carry_decl.clone(
+                        dimensions=new_dims if new_dims else None
+                    )
+
+            # Save: carry = X(JL, JK+1) at end of body
+            save_orig_dims = []
+            save_carry_dims = []
+            nv_idx = 0
+            for i, _s in enumerate(orig_shape):
+                if i == dim_idx:
+                    save_orig_dims.append(
+                        sym.Sum((loop_var, sym.IntLiteral(1)))
+                    )
+                else:
+                    if actual_non_vert_dims is not None and nv_idx < len(actual_non_vert_dims):
+                        dim_expr = _out_of_loop_dim(actual_non_vert_dims[nv_idx])
+                    else:
+                        dim_expr = sym.RangeIndex((None, None, None))
+                    save_orig_dims.append(dim_expr)
+                    save_carry_dims.append(dim_expr)
+                    nv_idx += 1
+            save_rhs = orig_decl.clone(dimensions=tuple(save_orig_dims))
+            save_lhs = carry_decl.clone(
+                dimensions=tuple(save_carry_dims) if save_carry_dims else None
+            )
+            save_stmts.append(ir.Assignment(lhs=save_lhs, rhs=save_rhs))
+
+        elif pattern == 'B_readback':
+            # Two carries: _vc for reads at offset 0, _next for
+            # write at +1 and reads at +1
+            for v in all_vars:
+                if not isinstance(v, sym.Array) or not v.dimensions:
+                    continue
+                if v.name.lower() != arr_name.lower():
+                    continue
+                if dim_idx >= len(v.dimensions):
+                    continue
+                offset = _extract_offset(v.dimensions[dim_idx], loop_var)
+                if offset is None:
+                    continue
+                new_dims = tuple(
+                    d for i, d in enumerate(v.dimensions)
+                    if i != dim_idx
+                )
+                if offset == 0:
+                    expr_map[v] = carry_decl.clone(
+                        dimensions=new_dims if new_dims else None
+                    )
+                elif offset == 1:
+                    expr_map[v] = next_decl.clone(
+                        dimensions=new_dims if new_dims else None
+                    )
+
+            # Rotate: carry = next at end of body
+            rot_lhs = carry_decl.clone(dimensions=_init_rotate_dims())
+            rot_rhs = next_decl.clone(dimensions=_init_rotate_dims())
+            rotate_stmts.append(ir.Assignment(lhs=rot_lhs, rhs=rot_rhs))
+
+            # NOTE: Write-back for argument arrays (populating the original
+            # output array from _next) is handled separately in
+            # _insert_writebacks_for_argument_carries(), which runs AFTER
+            # Phase 2b cross-loop carry substitution.  Generating write-backs
+            # here would cause Phase 2b's SubstituteExpressions to turn them
+            # into self-assignments (e.g. pfsqlf_next = pfsqlf_next) that
+            # Phase 4a then removes.
+
+        elif pattern == 'stencil':
+            # Replace reads at negative offsets with carry
+            for v in all_vars:
+                if not isinstance(v, sym.Array) or not v.dimensions:
+                    continue
+                if v.name.lower() != arr_name.lower():
+                    continue
+                if dim_idx >= len(v.dimensions):
+                    continue
+                offset = _extract_offset(v.dimensions[dim_idx], loop_var)
+                if offset is not None and offset < 0:
+                    new_dims = tuple(
+                        d for i, d in enumerate(v.dimensions)
+                        if i != dim_idx
+                    )
+                    expr_map[v] = carry_decl.clone(
+                        dimensions=new_dims if new_dims else None
+                    )
+
+            # Save: carry = X(JL, JK) at end of body
+            save_orig_dims = []
+            save_carry_dims = []
+            nv_idx = 0
+            for i, _s in enumerate(orig_shape):
+                if i == dim_idx:
+                    save_orig_dims.append(loop_var)
+                else:
+                    if actual_non_vert_dims is not None and nv_idx < len(actual_non_vert_dims):
+                        dim_expr = _out_of_loop_dim(actual_non_vert_dims[nv_idx])
+                    else:
+                        dim_expr = sym.RangeIndex((None, None, None))
+                    save_orig_dims.append(dim_expr)
+                    save_carry_dims.append(dim_expr)
+                    nv_idx += 1
+            save_rhs = orig_decl.clone(dimensions=tuple(save_orig_dims))
+            save_lhs = carry_decl.clone(
+                dimensions=tuple(save_carry_dims) if save_carry_dims else None
+            )
+            save_stmts.append(ir.Assignment(lhs=save_lhs, rhs=save_rhs))
+
+        # Record conversion
+        conv_entry = {
+            'array': arr_name,
+            'carry': carry_name,
+            'pattern': pattern,
+            'dim_index': dim_idx,
+        }
+        if next_decl is not None:
+            conv_entry['next'] = next_decl.name
+        conversions.append(conv_entry)
+        info('[vertical_utils] %s → %s (pattern %s)',
+             arr_name, carry_name, pattern)
+
+    if not expr_map and not cond_to_remove:
+        return loop, [], []
+
+    # --- Apply transformations to loop body ---
+
+    # 1) Remove IF(JK==1) conditionals (Pattern A)
+    new_body = loop.body
+    if cond_to_remove:
+        cond_map = {}
+        for cond, replacement_stmts in cond_to_remove:
+            cond_map[cond] = (
+                tuple(replacement_stmts) if replacement_stmts else None
+            )
+        new_body = Transformer(cond_map).visit(new_body)
+
+    # 2) Apply expression substitution
+    new_body = SubstituteExpressions(expr_map).visit(new_body)
+
+    # 3) Append save + writeback + rotate statements
+    body_tuple = as_tuple(new_body)
+    body_tuple = body_tuple + tuple(save_stmts) + tuple(rotate_stmts)
+
+    new_loop = loop.clone(body=body_tuple)
+    return new_loop, init_stmts, conversions
+
+
+def _substitute_init_expressions_all_loops(routine, vertical_index,
+                                            vertical_size):
+    """
+    Like :func:`vertical_complete._substitute_init_expressions` but
+    searches *all* vertical loops (not just the main loop) for init
+    assignments.
+
+    For each local 2-D+ array with a KLEV dimension, the first
+    ``X(JL, JK) = f(args)`` assignment found (in source order across
+    all vertical loops) is used to substitute outside-loop reads.
+
+    Returns a set of lowercase array names that were substituted.
+    """
+    vertical_index_lower = vertical_index.lower()
+    vertical_size_lower = vertical_size.lower()
+
+    arg_names = {v.name.lower() for v in routine.arguments}
+
+    # Find local arrays with a KLEV dimension
+    local_kd = {}
+    for var in routine.variables:
+        if var.name.lower() in arg_names:
+            continue
+        shape = getattr(var.type, 'shape', None) or getattr(var, 'shape', None)
+        if not shape:
+            continue
+        for idx, s in enumerate(shape):
+            s_str = str(s).strip().lower()
+            if (s_str == vertical_size_lower or
+                    s_str.replace(' ', '').startswith(
+                        vertical_size_lower + '+')):
+                local_kd[var.name.lower()] = {
+                    'var': var, 'klev_dim_idx': idx, 'shape': shape}
+                break
+
+    if not local_kd:
+        return set()
+
+    # Scan ALL vertical loops for init assignments
+    all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+    init_map = {}  # array_name_lower -> Assignment node
+
+    for loop, _cond in all_vloops:
+        for assign in FindNodes(ir.Assignment).visit(loop.body):
+            lhs = assign.lhs
+            lhs_name = lhs.name.lower()
+            if lhs_name not in local_kd:
+                continue
+            if lhs_name in init_map:
+                continue  # Only use the first assignment
+
+            dims = getattr(lhs, 'dimensions', None)
+            if not dims:
+                continue
+            info_entry = local_kd[lhs_name]
+            klev_dim = info_entry['klev_dim_idx']
+            if klev_dim >= len(dims):
+                continue
+            jk_sub = dims[klev_dim]
+            if not (isinstance(jk_sub, (sym.Scalar, sym.DeferredTypeSymbol))
+                    and jk_sub.name.lower() == vertical_index_lower):
+                continue
+
+            # RHS must not reference other KLEV locals
+            rhs_vars = FindVariables().visit(assign.rhs)
+            rhs_uses_local = False
+            for rv in rhs_vars:
+                rv_lower = rv.name.lower()
+                if rv_lower == lhs_name:
+                    continue
+                if rv_lower in local_kd and rv_lower not in arg_names:
+                    rhs_uses_local = True
+                    break
+            if rhs_uses_local:
+                continue
+
+            init_map[lhs_name] = assign
+
+    if not init_map:
+        return set()
+
+    # Identify all vertical loop nodes (to exclude from substitution)
+    loop_nodes = set()
+    for loop, cond_wrapper in all_vloops:
+        loop_nodes.add(loop)
+        if cond_wrapper is not None:
+            loop_nodes.add(cond_wrapper)
+
+    # Build expression substitution map for outside-loop reads
+    expr_map = {}
+    substituted = set()
+    _build_init_subst_map(routine.body, loop_nodes, init_map, local_kd,
+                          vertical_index_lower, expr_map, substituted)
+
+    if expr_map:
+        _apply_subst_outside_loops(routine, loop_nodes, expr_map)
+
+    return substituted
+
+
+def _is_zero_literal(expr):
+    """Return True if *expr* is a zero literal (int or float).
+
+    Loki stores FloatLiteral.value as a **string** (e.g. ``'0.0'``)
+    to preserve precision, so we must convert before comparing.
+    """
+    if isinstance(expr, sym.IntLiteral):
+        return expr.value == 0
+    if isinstance(expr, sym.FloatLiteral):
+        try:
+            return float(expr.value) == 0.0
+        except (ValueError, TypeError):
+            return False
+    # Handle IntrinsicLiteral (Loki's catch-all for complex/BOZ constants)
+    if isinstance(expr, sym.IntrinsicLiteral):
+        try:
+            return float(expr.value) == 0.0
+        except (ValueError, TypeError):
+            return False
+    # Generic fallback for any node with a value attribute
+    if hasattr(expr, 'value'):
+        try:
+            return float(expr.value) == 0.0
+        except (ValueError, TypeError):
+            pass
+    return False
+
+
+def _find_zero_inits_outside_loops(body, loop_nodes, klev_locals,
+                                    zero_init_map):
+    """
+    Walk *body* outside loop nodes and find whole-array zero-init
+    assignments to KLEV locals.
+    """
+    nodes = body if isinstance(body, (tuple, list)) else body.body
+
+    for node in nodes:
+        if node in loop_nodes:
+            continue
+        if isinstance(node, (ir.Section, ir.Associate)):
+            _find_zero_inits_outside_loops(
+                node.body, loop_nodes, klev_locals, zero_init_map
+            )
+            continue
+        if isinstance(node, ir.Conditional):
+            _find_zero_inits_outside_loops(
+                node.body, loop_nodes, klev_locals, zero_init_map
+            )
+            if node.else_body:
+                _find_zero_inits_outside_loops(
+                    node.else_body, loop_nodes, klev_locals, zero_init_map
+                )
+            continue
+
+        if not isinstance(node, ir.Assignment):
+            continue
+
+        lhs = node.lhs
+        lhs_name = lhs.name.lower()
+        if lhs_name not in klev_locals:
+            continue
+
+        # Check: LHS must use all-range-index dimensions
+        dims = getattr(lhs, 'dimensions', None)
+        if not dims:
+            continue
+        all_range = all(
+            isinstance(d, sym.RangeIndex) for d in dims
+        )
+        if not all_range:
+            continue
+
+        # Check: RHS must be a zero literal
+        rhs = node.rhs
+        if _is_zero_literal(rhs):
+            zero_init_map[lhs_name] = node
+
+
+def _collect_outside_refs_for_array(body, loop_nodes, arr_name,
+                                     exclude_node=None):
+    """
+    Collect all IR nodes outside loop_nodes that reference *arr_name*
+    (case-insensitive), excluding *exclude_node* if given.
+
+    Returns a list of nodes.
+    """
+    refs = []
+    nodes = body if isinstance(body, (tuple, list)) else body.body
+
+    for node in nodes:
+        if node in loop_nodes:
+            continue
+        if node is exclude_node:
+            continue
+        if isinstance(node, (ir.Section, ir.Associate)):
+            refs.extend(_collect_outside_refs_for_array(
+                node.body, loop_nodes, arr_name, exclude_node
+            ))
+            continue
+        if isinstance(node, ir.Conditional):
+            # Check condition
+            for var in FindVariables().visit(node.condition):
+                if var.name.lower() == arr_name:
+                    refs.append(node)
+                    break
+            refs.extend(_collect_outside_refs_for_array(
+                node.body, loop_nodes, arr_name, exclude_node
+            ))
+            if node.else_body:
+                refs.extend(_collect_outside_refs_for_array(
+                    node.else_body, loop_nodes, arr_name, exclude_node
+                ))
+            continue
+        # Check if this node references the array
+        for var in FindVariables().visit(node):
+            if var.name.lower() == arr_name:
+                refs.append(node)
+                break
+
+    return refs
+
+
+def _remove_whole_array_zero_inits(routine, vertical_index, vertical_size):
+    """
+    Remove whole-array zero-initialisation statements (e.g.
+    ``X(:,:,:) = 0.0``) that sit outside all vertical loops, for local
+    arrays that would become demotable if the init were removed.
+
+    An init is removed only if it is the **sole** outside-loop reference
+    to that array.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    vertical_index : str
+    vertical_size : str
+
+    Returns
+    -------
+    list of str
+        Lowercase names of arrays whose inits were removed.
+    """
+    vertical_size_lower = vertical_size.lower()
+    arg_names = {v.name.lower() for v in routine.arguments}
+
+    # Variables passed to calls
+    call_arg_names = set()
+    for call in FindNodes(ir.CallStatement).visit(routine.body):
+        for arg in call.arguments:
+            for v in FindVariables().visit(arg):
+                call_arg_names.add(v.name.lower())
+        if call.kwarguments:
+            for _kw, arg in call.kwarguments:
+                for v in FindVariables().visit(arg):
+                    call_arg_names.add(v.name.lower())
+
+    # Find local KLEV arrays
+    klev_locals = {}
+    for var in routine.variables:
+        vname = var.name.lower()
+        if vname in arg_names or vname in call_arg_names:
+            continue
+        shape = getattr(var.type, 'shape', None) or getattr(var, 'shape', None)
+        if not shape:
+            continue
+        has_klev = False
+        for s in shape:
+            s_str = str(s).strip().lower()
+            if (s_str == vertical_size_lower or
+                    s_str.replace(' ', '').startswith(
+                        vertical_size_lower + '+')):
+                has_klev = True
+                break
+        if has_klev:
+            klev_locals[vname] = var
+
+    if not klev_locals:
+        return []
+
+    # Collect all vertical loop nodes
+    all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+    loop_nodes = set()
+    for loop, cond_wrapper in all_vloops:
+        loop_nodes.add(loop)
+        if cond_wrapper is not None:
+            loop_nodes.add(cond_wrapper)
+
+    # Find whole-array zero-init assignments outside loops
+    # Pattern: LHS has all-range-index dimensions, RHS is 0 or 0.0
+    zero_init_map = {}  # arr_name_lower -> Assignment node
+    _find_zero_inits_outside_loops(
+        routine.body, loop_nodes, klev_locals, zero_init_map
+    )
+
+    if not zero_init_map:
+        return []
+
+    # For each candidate, check if removing the init eliminates ALL
+    # outside-loop references
+    removable = []
+    for arr_name, init_node in zero_init_map.items():
+        # Collect all outside-loop refs to this array, excluding the init
+        outside_refs = _collect_outside_refs_for_array(
+            routine.body, loop_nodes, arr_name, exclude_node=init_node
+        )
+        if not outside_refs:
+            removable.append((arr_name, init_node))
+
+    if not removable:
+        return []
+
+    # Remove the init assignments
+    node_map = {node: None for _, node in removable}
+    routine.body = Transformer(node_map).visit(routine.body)
+
+    removed = [name for name, _ in removable]
+    return removed
+
+
+def _extract_plus_n(upper_str, vertical_size_lower):
+    """Extract N from a 'klev+N' string. Returns 0 for plain 'klev'."""
+    us = upper_str.replace(' ', '')
+    vs = vertical_size_lower
+    if us.startswith(vs + '+'):
+        try:
+            return int(us[len(vs) + 1:])
+        except ValueError:
+            return 0
+    return 0
+
+
+def _build_bounds_guard(loop_var, lower_expr, upper_expr):
+    """
+    Build ``JK >= lower .AND. JK <= upper`` as a Loki expression.
+    """
+    ge_cond = sym.Comparison(
+        operator='>=', left=loop_var, right=lower_expr
+    )
+    le_cond = sym.Comparison(
+        operator='<=', left=loop_var, right=upper_expr
+    )
+    return sym.LogicalAnd((ge_cond, le_cond))
+
+
+def _relocate_interloop_code(body, top_nodes, merged_loop):
+    """
+    Rebuild *body* so that:
+
+    * The first vertical-loop top-node is replaced by the *merged_loop*.
+    * All subsequent vertical-loop top-nodes are removed.
+    * Any non-loop statements that sit **between** consecutive vertical-
+      loop top-nodes are moved to just **before** the merged loop.
+
+    The function recurses into transparent container nodes
+    (:any:`Section`, :any:`Associate`) because the vertical loops may
+    live inside such containers.
+
+    Parameters
+    ----------
+    body : :any:`Section`, :any:`Associate`, or tuple of nodes
+    top_nodes : set
+        Set of IR nodes (Loop or Conditional wrappers) that correspond
+        to the original vertical loops.
+    merged_loop : :any:`Loop`
+        The single merged loop to substitute.
+
+    Returns
+    -------
+    Rebuilt *body* with the same type as the input.
+    """
+    if isinstance(body, (tuple, list)):
+        nodes = body
+        wrap = tuple
+    else:
+        nodes = body.body
+        wrap = None  # will wrap at the end
+
+    # Check if any top_nodes live directly in this node list
+    has_top_nodes = any(n in top_nodes for n in nodes)
+
+    if has_top_nodes:
+        # Partition the node list into three regions:
+        # 1. pre-region: everything before the first top-node
+        # 2. loop-region: first top-node through last top-node (inclusive)
+        # 3. post-region: everything after the last top-node
+        first_idx = None
+        last_idx = None
+        for i, n in enumerate(nodes):
+            if n in top_nodes:
+                if first_idx is None:
+                    first_idx = i
+                last_idx = i
+
+        pre = list(nodes[:first_idx])
+        post = list(nodes[last_idx + 1:])
+
+        # From the loop-region, collect inter-loop statements
+        # (nodes that are NOT top-nodes) and move them before
+        # the merged loop
+        interloop = []
+        for i in range(first_idx, last_idx + 1):
+            n = nodes[i]
+            if n not in top_nodes:
+                interloop.append(n)
+
+        new_nodes = pre + interloop + [merged_loop] + post
+        result = tuple(new_nodes)
+    else:
+        # Recurse into container nodes to find the level that
+        # contains the top-nodes
+        new_nodes = []
+        for n in nodes:
+            if isinstance(n, (ir.Section, ir.Associate)):
+                new_n = _relocate_interloop_code(n, top_nodes, merged_loop)
+                new_nodes.append(new_n)
+            else:
+                new_nodes.append(n)
+        result = tuple(new_nodes)
+
+    if wrap is not None:
+        return result
+    # Reconstruct the container node
+    return body.clone(body=result)
+
+
+def _merge_vertical_loops(routine, vertical_index, vertical_size):
+    """
+    Merge all vertical loops into a single ``DO JK = 1, <max_upper>``
+    loop with IF guards for each original loop's bounds.
+
+    Each loop body is wrapped in::
+
+        IF (JK >= lower .AND. JK <= upper) THEN
+            body
+        END IF
+
+    Conditional-wrapped loops get nested guards::
+
+        IF (condition) THEN
+            IF (JK >= lower .AND. JK <= upper) THEN
+                body
+            END IF
+        END IF
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    vertical_index : str
+    vertical_size : str
+
+    Returns
+    -------
+    :any:`Loop` or None
+        The merged loop, or ``None`` if no vertical loops were found.
+    """
+    all_vloops = _collect_vertical_loops(routine.body, vertical_index)
+    if not all_vloops:
+        return None
+
+    # Determine the merged upper bound: the maximum across all loops
+    vertical_size_lower = vertical_size.lower()
+    max_upper = None
+    max_upper_str = ''
+
+    for loop, _cond in all_vloops:
+        upper_str = _loop_upper_bound_str(loop)
+        upper_expr = loop.bounds.children[1]
+
+        if max_upper is None:
+            max_upper = upper_expr
+            max_upper_str = upper_str
+        elif _is_klev_plus_n(upper_str, vertical_size_lower):
+            # This is KLEV+N — use it if larger than current max
+            if not _is_klev_plus_n(max_upper_str, vertical_size_lower):
+                max_upper = upper_expr
+                max_upper_str = upper_str
+            else:
+                # Both are KLEV+N — compare N values
+                # Extract N from both
+                n_current = _extract_plus_n(max_upper_str, vertical_size_lower)
+                n_new = _extract_plus_n(upper_str, vertical_size_lower)
+                if n_new > n_current:
+                    max_upper = upper_expr
+                    max_upper_str = upper_str
+        elif upper_str == vertical_size_lower:
+            if max_upper_str != vertical_size_lower and \
+               not _is_klev_plus_n(max_upper_str, vertical_size_lower):
+                max_upper = upper_expr
+                max_upper_str = upper_str
+
+    # Use the first loop's variable for the merged loop
+    loop_var = all_vloops[0][0].variable
+
+    # Build the merged loop body: guarded bodies in source order
+    merged_body = []
+
+    for loop, cond_wrapper in all_vloops:
+        body = loop.body
+        lower_expr = loop.bounds.children[0]
+        upper_expr = loop.bounds.children[1]
+
+        # Build IF guard condition: JK >= lower .AND. JK <= upper
+        guard_cond = _build_bounds_guard(loop_var, lower_expr, upper_expr)
+
+        guarded = ir.Conditional(
+            condition=guard_cond,
+            body=(ir.Section(body=as_tuple(body)),),
+            else_body=()
+        )
+
+        if cond_wrapper is not None:
+            # Nest inside the original conditional
+            nested = ir.Conditional(
+                condition=cond_wrapper.condition,
+                body=(guarded,),
+                else_body=()
+            )
+            merged_body.append(nested)
+        else:
+            merged_body.append(guarded)
+
+    # Build the merged loop
+    one = sym.IntLiteral(1)
+    merged_bounds = sym.LoopRange((one, max_upper))
+    merged_loop = ir.Loop(
+        variable=loop_var.clone(),
+        bounds=merged_bounds,
+        body=tuple(merged_body)
+    )
+
+    # Build the set of top-level IR nodes for all vertical loops
+    top_nodes = set()
+    for loop, cond_wrapper in all_vloops:
+        top_nodes.add(cond_wrapper if cond_wrapper is not None else loop)
+
+    # Relocate inter-loop code: move statements that sit between
+    # consecutive vertical loops to just before the merged loop.
+    # This prevents scalar resets (e.g. ZCOVPTOT = 0.0) from ending
+    # up after the merged loop when the loops they were sandwiched
+    # between are merged together.
+    routine.body = _relocate_interloop_code(
+        routine.body, top_nodes, merged_loop
+    )
+
+    n_loops = len(all_vloops)
+    info('[vertical_utils] Merged %d vertical loops into 1 '
+         '(DO JK = 1, %s)', n_loops, max_upper_str)
+
+    return merged_loop
+
+
+def _collect_rotates_from_node(node, rotate_keys, save_names,
+                               enclosing_guard_cond, remove_map, hoisted):
+    """
+    Recursively walk an IR node tree to find carry rotate/save
+    assignments and collect them for hoisting.
+
+    Parameters
+    ----------
+    node : IR node
+    rotate_keys : set of (vc_lower, next_lower) tuples
+    save_names : set of vc_lower names
+    enclosing_guard_cond : expression or None
+        The IF condition of the enclosing guard block.
+    remove_map : dict
+        Updated in-place: ``{assignment: None}`` for nodes to remove.
+    hoisted : list
+        Updated in-place: ``(guard_condition, assignment)`` pairs.
+    """
+    if isinstance(node, ir.Conditional):
+        # This is a guarded block — recurse into body with this guard
+        guard_cond = node.condition
+        for child in node.body:
+            _collect_rotates_from_node(
+                child, rotate_keys, save_names,
+                guard_cond, remove_map, hoisted
+            )
+        # Also check nested conditionals in else_body
+        for child in node.else_body:
+            _collect_rotates_from_node(
+                child, rotate_keys, save_names,
+                enclosing_guard_cond, remove_map, hoisted
+            )
+    elif isinstance(node, ir.Section):
+        for child in node.body:
+            _collect_rotates_from_node(
+                child, rotate_keys, save_names,
+                enclosing_guard_cond, remove_map, hoisted
+            )
+    elif isinstance(node, ir.Assignment):
+        lhs_name = node.lhs.name.lower() if hasattr(node.lhs, 'name') else ''
+        rhs_name = node.rhs.name.lower() if hasattr(node.rhs, 'name') else ''
+
+        # Check for B_readback rotate: _vc = _next
+        if (lhs_name, rhs_name) in rotate_keys:
+            remove_map[node] = None
+            hoisted.append((enclosing_guard_cond, node))
+            return
+
+        # Check for Pattern A / stencil save: the save is typically the
+        # LAST assignment to _vc in the loop body.  We identify it by
+        # LHS being a carry variable AND the RHS NOT being a _next
+        # variable and NOT being part of the computation (i.e., the
+        # RHS is a simple variable, not a complex expression with _vc).
+        # Actually, we should NOT hoist Pattern A saves because they
+        # set _vc to the CURRENT level value, which is needed by
+        # cross-loop reads at offset 0 within the same iteration.
+        # Only hoist B_readback rotates.
+
+
+def _hoist_rotates_to_end(routine, merged_loop, carry_registry):
+    """
+    Move carry rotate and save statements to the very end of the
+    merged loop body, so that all guarded blocks within an iteration
+    see the pre-rotate carry values.
+
+    After merging, guarded blocks from different original loops appear
+    in source order.  A carry rotate like ``zpfplsx_vc = zpfplsx_next``
+    that was at the end of one original loop's body now sits inside a
+    guarded block that may precede another guarded block reading
+    ``zpfplsx_vc``.  If the reader block expects the value at offset 0
+    (current JK), but the rotate has already advanced it, the reader
+    gets the wrong value.
+
+    This function:
+
+    1. Identifies rotate/save assignments by matching carry_registry
+       entries (``_vc = _next`` for B_readback, ``_vc = <expr>`` for
+       Pattern A and stencil).
+    2. Removes them from their current position inside guarded blocks.
+    3. Re-appends them at the end of the merged loop body, inside the
+       same IF guard that surrounded them.
+
+    Only B_readback rotates (``_vc = _next``) and stencil/Pattern-A
+    saves are moved.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    merged_loop : :any:`Loop`
+        The single merged vertical loop (modified in-place via
+        Transformer).
+    carry_registry : dict
+        ``{array_name_lower: {'carry': str, 'pattern': str,
+        'next': str or None, 'dim_index': int}}``
+
+    Returns
+    -------
+    int
+        Number of statements hoisted.
+    """
+    if not carry_registry:
+        return 0
+
+    # Build a set of (carry_name_lower, next_name_lower) pairs for
+    # B_readback rotates, and a set of carry_name_lower for all saves.
+    rotate_keys = set()   # (vc_name_lower, next_name_lower) for B_readback
+    save_names = set()    # vc_name_lower for Pattern A and stencil saves
+    for _arr, entry in carry_registry.items():
+        vc_lower = entry['carry'].lower()
+        if entry['pattern'] == 'B_readback' and entry.get('next'):
+            rotate_keys.add((vc_lower, entry['next'].lower()))
+        # For Pattern A and stencil, the save is _vc = <some_expression>
+        # where the expression is NOT a _next variable.
+        # We identify saves by the LHS being a carry variable.
+        save_names.add(vc_lower)
+
+    # Walk the merged loop body to find rotate/save assignments and
+    # their enclosing IF guards.  We only look at the top-level
+    # children of the merged loop body (which are Conditional guards).
+    remove_map = {}     # assignment node → None (remove)
+    hoisted = []        # (guard_condition, assignment) pairs
+
+    for top_node in merged_loop.body:
+        _collect_rotates_from_node(
+            top_node, rotate_keys, save_names,
+            None, remove_map, hoisted
+        )
+
+    if not remove_map:
+        return 0
+
+    # Remove the rotate/save statements from their original positions
+    # and build the new loop with them appended at the end.
+    new_loop = Transformer(remove_map).visit(merged_loop)
+
+    # Build new guarded blocks at the end of the loop body for the
+    # hoisted statements.  Group by guard condition string to combine
+    # rotates under the same guard.
+    guard_groups = OrderedDict()
+    for guard_cond, assign in hoisted:
+        key = str(guard_cond) if guard_cond is not None else '__no_guard__'
+        if key not in guard_groups:
+            guard_groups[key] = (guard_cond, [])
+        guard_groups[key][1].append(assign)
+
+    appended = []
+    for key, (guard_cond, assigns) in guard_groups.items():
+        if guard_cond is not None:
+            block = ir.Conditional(
+                condition=guard_cond,
+                body=tuple(assigns),
+                else_body=()
+            )
+            appended.append(block)
+        else:
+            appended.extend(assigns)
+
+    # Append the hoisted blocks at the end of the merged loop body
+    new_body = tuple(list(new_loop.body) + appended)
+    final_loop = new_loop.clone(body=new_body)
+
+    # Replace the ORIGINAL merged_loop in the routine body with the
+    # final loop that has rotates removed from guarded blocks and
+    # appended at the end.
+    routine.body = Transformer({merged_loop: final_loop}).visit(routine.body)
+
+    return len(remove_map)
+
+
+def _cross_loop_carry_substitution(routine, merged_loop, carry_registry,
+                                    vertical_index):
+    """
+    Replace remaining raw array references in the merged loop body with
+    the carry variables created in Phase 1c.
+
+    After per-loop carry conversion (Phase 1c) and merge (Phase 2),
+    some loops that were *not* the source of a carry conversion may
+    still reference the original array at offsets that are served by
+    a carry variable from another loop.  This function resolves those
+    cross-loop references.
+
+    Substitution rules by offset:
+
+    * **offset 0** → ``<array>_vc``  (all patterns)
+    * **offset +1** → ``<array>_next``  (B_readback only)
+    * **offset -1** → ``<array>_vc``  (Pattern A / stencil)
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    merged_loop : :any:`Loop`
+        The single merged vertical loop.
+    carry_registry : dict
+        ``{array_name_lower: {'carry': str, 'pattern': str,
+        'next': str or None, 'dim_index': int}}``
+    vertical_index : str
+
+    Returns
+    -------
+    int
+        Number of individual expression substitutions performed.
+    """
+    if not carry_registry:
+        return 0
+
+    loop_var = merged_loop.variable
+    var_map = routine.variable_map
+
+    expr_map = {}
+    all_vars = FindVariables(unique=False).visit(merged_loop.body)
+
+    for v in all_vars:
+        if not isinstance(v, sym.Array) or not v.dimensions:
+            continue
+
+        arr_lower = v.name.lower()
+        if arr_lower not in carry_registry:
+            continue
+
+        entry = carry_registry[arr_lower]
+        dim_idx = entry['dim_index']
+        pattern = entry['pattern']
+        carry_name = entry['carry']
+        next_name = entry.get('next')
+
+        if dim_idx >= len(v.dimensions):
+            continue
+
+        offset = _extract_offset(v.dimensions[dim_idx], loop_var)
+        if offset is None:
+            continue
+
+        # Determine which carry variable to use for this offset
+        target_name = None
+        if offset == 0:
+            # For stencil patterns, _vc holds JK-1 value, NOT JK.
+            # Offset 0 must not be substituted for stencil arrays.
+            #
+            # For Pattern A, _vc also holds JK-1 value (before the
+            # save statement at end of body).  After merging, a
+            # *different* loop's init write (e.g. X(JK) = expr)
+            # runs BEFORE the carrier loop's guarded block.  If
+            # Phase 2b turned that init write into ``x_vc = expr``,
+            # it would overwrite the JK-1 carry value.  Leaving
+            # offset-0 as plain array refs lets Phase 3 demote
+            # them to scalars independently of the carry.
+            if pattern not in ('stencil', 'A'):
+                target_name = carry_name
+        elif offset == 1 and pattern == 'B_readback' and next_name:
+            target_name = next_name
+        elif offset == -1 and pattern in ('A', 'stencil'):
+            target_name = carry_name
+        else:
+            # Offset not served by this carry pattern — leave as-is
+            continue
+
+        target_decl = var_map.get(target_name)
+        if target_decl is None:
+            continue
+
+        # Build replacement: drop the vertical dimension
+        new_dims = tuple(
+            d for i, d in enumerate(v.dimensions) if i != dim_idx
+        )
+        expr_map[v] = target_decl.clone(
+            dimensions=new_dims if new_dims else None
+        )
+
+    if not expr_map:
+        return 0
+
+    # Apply substitutions to the merged loop body
+    new_body = SubstituteExpressions(expr_map).visit(merged_loop.body)
+    new_loop = merged_loop.clone(body=new_body)
+    routine.body = Transformer({merged_loop: new_loop}).visit(routine.body)
+
+    n_subs = len(expr_map)
+    return n_subs
+
+
+def _insert_writebacks_for_argument_carries(routine, merged_loop,
+                                             carry_registry, vertical_index,
+                                             horizontal_index=None):
+    """
+    Insert write-back statements for INTENT(OUT) argument arrays that
+    were converted to B_readback carry patterns.
+
+    After carry conversion (Phase 1c) and cross-loop carry substitution
+    (Phase 2b), the original output arrays (e.g. ``PFSQLF``) are never
+    written to — all writes go to the ``_next`` carry variable.  This
+    function inserts::
+
+        ARRAY(JL, JK + 1) = array_next
+
+    just before the rotate statement ``array_vc = array_next``, so that
+    the output array is populated with the correct values.
+
+    **Why this is done after Phase 2b, not in Phase 1c:**
+
+    Phase 2b uses :func:`SubstituteExpressions` which replaces both LHS
+    and RHS.  If write-backs were generated in Phase 1c, Phase 2b would
+    replace ``PFSQLF(JL, JK+1)`` on the LHS with ``pfsqlf_next``,
+    creating a self-assignment that Phase 4a removes.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    merged_loop : :any:`Loop`
+        The single merged vertical loop.
+    carry_registry : dict
+        ``{array_name_lower: {'carry': str, 'pattern': str,
+        'next': str or None, 'dim_index': int}}``
+    vertical_index : str
+    horizontal_index : str, optional
+        Name of the horizontal loop variable (e.g. ``'JL'``).  Used to
+        construct correct array subscripts for write-back statements.
+
+    Returns
+    -------
+    int
+        Number of write-back statements inserted.
+    """
+    loop_var = merged_loop.variable
+    var_map = CaseInsensitiveDict(
+        {v.name: v for v in routine.variables}
+    )
+    arg_names = {v.name.lower() for v in routine.arguments}
+
+    # Get the horizontal index variable object if available
+    horiz_var = None
+    if horizontal_index:
+        horiz_var = var_map.get(horizontal_index)
+
+    # Collect B_readback entries for argument arrays
+    writebacks = []
+    for arr_lower, entry in carry_registry.items():
+        if entry['pattern'] != 'B_readback':
+            continue
+        if arr_lower not in arg_names:
+            continue
+        next_name = entry.get('next')
+        if not next_name:
+            continue
+
+        orig_decl = var_map.get(arr_lower)
+        next_decl = var_map.get(next_name)
+        carry_decl = var_map.get(entry['carry'])
+        if orig_decl is None or next_decl is None or carry_decl is None:
+            continue
+
+        dim_idx = entry['dim_index']
+        orig_shape = orig_decl.type.shape if orig_decl.type.shape else ()
+
+        # Build write-back: ARRAY(JL, JK+1) = array_next
+        # For the vertical dimension, use JK+1.
+        # For the horizontal dimension, use the horizontal index variable
+        # (e.g. JL) so that SCCBase's resolve_vector_dimension and
+        # SCCDevector handle it correctly.  A bare ':' would NOT be
+        # converted by resolve_vector_dimension and would remain as
+        # array-section notation, writing to all horizontal indices.
+        wb_orig_dims = []
+        wb_next_dims = []
+        nv_idx = 0
+        for i, _s in enumerate(orig_shape):
+            if i == dim_idx:
+                wb_orig_dims.append(
+                    sym.Sum((loop_var, sym.IntLiteral(1)))
+                )
+            else:
+                next_shape = next_decl.type.shape if next_decl.type.shape else ()
+                if horiz_var is not None:
+                    # Use the horizontal index variable (e.g. JL).
+                    # This is correct because the write-back is inside
+                    # the merged JK loop which is itself inside the
+                    # DO JL = KIDIA, KFDIA horizontal loop.
+                    # SCCDevector will later strip that loop and make JL
+                    # a scalar parameter.
+                    wb_orig_dims.append(horiz_var)
+                    # Don't add horizontal dim to the RHS next variable:
+                    # the _next carry var has the same KLON dimension
+                    # but SCCDemote will demote it.  For now, keep ':'
+                    # on the RHS if next_shape has this dimension.
+                    if nv_idx < len(next_shape):
+                        wb_next_dims.append(
+                            sym.RangeIndex((None, None, None))
+                        )
+                elif nv_idx < len(next_shape):
+                    wb_next_dims.append(
+                        sym.RangeIndex((None, None, None))
+                    )
+                    wb_orig_dims.append(
+                        sym.RangeIndex((None, None, None))
+                    )
+                else:
+                    wb_orig_dims.append(
+                        sym.RangeIndex((None, None, None))
+                    )
+                nv_idx += 1
+
+        wb_lhs = orig_decl.clone(dimensions=tuple(wb_orig_dims))
+        wb_rhs = next_decl.clone(
+            dimensions=tuple(wb_next_dims) if wb_next_dims else None
+        )
+        wb_stmt = ir.Assignment(lhs=wb_lhs, rhs=wb_rhs)
+
+        # Find the rotate statement: carry_vc = carry_next
+        # The write-back goes just before it
+        writebacks.append((entry['carry'], next_name, wb_stmt))
+
+    if not writebacks:
+        return 0
+
+    # Find rotate statements in the merged loop and insert write-backs
+    # before them.  We walk the loop body to find assignments where
+    # LHS name matches carry_vc and RHS name matches carry_next.
+    carry_to_wb = {}
+    for carry_name, next_name, wb_stmt in writebacks:
+        carry_to_wb[(carry_name.lower(), next_name.lower())] = wb_stmt
+
+    node_map = {}
+    for assign in FindNodes(ir.Assignment).visit(merged_loop.body):
+        lhs_name = assign.lhs.name.lower() if hasattr(assign.lhs, 'name') else ''
+        rhs_name = assign.rhs.name.lower() if hasattr(assign.rhs, 'name') else ''
+        key = (lhs_name, rhs_name)
+        if key in carry_to_wb:
+            wb = carry_to_wb.pop(key)
+            # Insert write-back before rotate
+            node_map[assign] = (wb, assign)
+
+    if not node_map:
+        return 0
+
+    new_loop = Transformer(node_map).visit(merged_loop)
+    routine.body = Transformer({merged_loop: new_loop}).visit(routine.body)
+
+    return len(node_map)
+
+def _remove_self_assignments(routine, merged_loop):
+    """
+    Remove self-assignment no-ops (``x = x``) from *merged_loop*.
+
+    These arise when carry conversion (Phase 1c) generates a save
+    statement ``x_vc(:) = X(:, JK)`` and a later phase (1d or 2b)
+    substitutes the original array ``X`` with ``x_vc``, turning the
+    save into ``x_vc(:) = x_vc(:)``.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    merged_loop : :any:`Loop`
+        The single merged vertical loop.
+
+    Returns
+    -------
+    int
+        Number of self-assignments removed.
+    """
+    from loki.backend import fgen
+
+    to_remove = {}
+    for assign in FindNodes(ir.Assignment).visit(merged_loop.body):
+        lhs_str = fgen(assign.lhs).strip().lower()
+        rhs_str = fgen(assign.rhs).strip().lower()
+        if lhs_str == rhs_str:
+            to_remove[assign] = None  # Transformer convention: map to None = delete
+
+    if not to_remove:
+        return 0
+
+    new_body = Transformer(to_remove).visit(merged_loop.body)
+    new_loop = merged_loop.clone(body=new_body)
+    routine.body = Transformer({merged_loop: new_loop}).visit(routine.body)
+    return len(to_remove)
+
+
+def _remove_dead_carry_originals(routine, carry_registry, demoted_names):
+    """
+    Remove declarations of demoted local arrays that have zero
+    remaining executable references after carry conversion.
+
+    A variable is removed only if ALL conditions are met:
+
+    1. It is in *carry_registry* (i.e. a carry was created for it).
+    2. Its name (lowercase) is in *demoted_names*.
+    3. It is **not** a subroutine argument.
+    4. It has **zero** references in the routine body (executable code).
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+    carry_registry : dict
+        ``{array_name_lower: {'carry': str, ...}}``
+    demoted_names : list of str
+        Lowercase names of arrays that were demoted in Phase 3.
+
+    Returns
+    -------
+    list of str
+        Lowercase names of variables removed.
+    """
+    arg_names = {v.name.lower() for v in routine.arguments}
+    demoted_set = set(n.lower() for n in demoted_names)
+
+    # Collect all variable references in the routine body
+    all_refs = FindVariables(unique=False).visit(routine.body)
+    ref_names = set(v.name.lower() for v in all_refs)
+
+    removed = []
+    for arr_lower in sorted(carry_registry):
+        if arr_lower not in demoted_set:
+            continue
+        if arr_lower in arg_names:
+            continue
+        if arr_lower in ref_names:
+            continue
+        # No references — safe to remove the declaration
+        removed.append(arr_lower)
+
+    if removed:
+        removed_set = set(removed)
+        routine.variables = tuple(
+            v for v in routine.variables
+            if v.name.lower() not in removed_set
+        )
+
+    return removed

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -8,9 +8,7 @@
 """
 Shared utility functions for vertical loop transformations.
 
-This module collects helper functions used by both
-:mod:`vertical_complete` and :mod:`vertical_merge` to avoid
-code duplication and circular imports.
+This module collects helper functions for vertical loop transformations.
 """
 
 from collections import defaultdict, OrderedDict
@@ -22,6 +20,7 @@ from loki.ir import (
 )
 from loki.logging import info, warning
 from loki.tools import as_tuple, CaseInsensitiveDict
+from loki.expression.symbolic import simplify
 from loki.analyse.analyse_dataflow import (
     classify_array_access_offsets, array_loop_carried_dependencies,
     _extract_offset,
@@ -31,37 +30,64 @@ from loki.analyse.analyse_dataflow import (
 __all__ = []
 
 
-# ---------------------------------------------------------------------------
-# Functions from vertical_complete.py
-# ---------------------------------------------------------------------------
+def _loop_upper_bound_expr(loop):
+    """
+    Return the upper-bound expression of *loop*'s range, or ``None``
+    if bounds are not available.
+    """
+    bounds = loop.bounds
+    if bounds is None or bounds.children is None:
+        return None
+    return bounds.children[1]
+
 
 def _loop_upper_bound_str(loop):
     """
     Return the upper-bound of *loop*'s range as a normalised
     lowercase string, e.g. ``'klev'``, ``'klev + 1'``.
     """
-    bounds = loop.bounds
-    if bounds is None or bounds.children is None:
+    upper = _loop_upper_bound_expr(loop)
+    if upper is None:
         return ''
-    upper = bounds.children[1]
     return str(upper).strip().lower()
 
 
-def _is_klev_plus_n(upper_str, vertical_size):
+def _is_klev_plus_n(upper_expr, vertical_size):
     """
-    Return ``True`` if *upper_str* represents the vertical size plus a
-    positive integer, e.g. ``'klev + 1'``.
+    Return ``True`` if *upper_expr* represents the vertical size plus a
+    positive integer, e.g. ``KLEV + 1``.
 
     Parameters
     ----------
-    upper_str : str
-        Normalised lowercase upper bound string.
-    vertical_size : str
-        Normalised lowercase vertical size, e.g. ``'klev'``.
+    upper_expr : expression or str
+        The upper-bound expression (a Loki expression node) or, for
+        backward compatibility, a normalised lowercase string.
+    vertical_size : str or expression
+        The vertical size variable name (e.g. ``'klev'``) or a Loki
+        expression node.
     """
-    vs = vertical_size.lower()
+    # --- Expression-level path ---
+    if not isinstance(upper_expr, str) and upper_expr is not None:
+        vs_name = (vertical_size.lower() if isinstance(vertical_size, str)
+                   else str(vertical_size).strip().lower())
+        # Build a symbolic representation of the vertical size for subtraction
+        vs_sym = sym.Variable(name=vs_name)
+        try:
+            diff = simplify(upper_expr - vs_sym)
+        except (TypeError, AttributeError):
+            diff = None
+        if isinstance(diff, sym.IntLiteral):
+            return diff.value >= 1
+        if isinstance(diff, int):
+            return diff >= 1
+        # Expression-level check didn't resolve; fall through to string path
+
+    # --- String fallback ---
+    upper_str = (str(upper_expr).strip().lower()
+                 if not isinstance(upper_expr, str) else upper_expr)
+    vs = (vertical_size.lower() if isinstance(vertical_size, str)
+          else str(vertical_size).strip().lower())
     us = upper_str.replace(' ', '')
-    # Match patterns like "klev+1", "klev+2", etc.
     if us.startswith(vs + '+'):
         suffix = us[len(vs) + 1:]
         try:
@@ -86,6 +112,7 @@ def _collect_vertical_loops(body, vertical_index):
     ``(loop, conditional_wrapper)`` pairs; top-level loops are returned
     as ``(loop, None)`` pairs.
     """
+    # TODO [K-CACHING]: index aliases could exist
     vertical_index_lower = vertical_index.lower()
     result = []
     nodes = body if isinstance(body, (tuple, list)) else body.body
@@ -113,14 +140,20 @@ def _collect_vertical_loops(body, vertical_index):
 def _is_jk_eq_1(expr, loop_var_name):
     """
     Return True if *expr* represents ``JK == 1`` or ``1 == JK``.
+
+    Uses expression-level comparison via Loki's ``StrCompareMixin``
+    (case-insensitive ``==``) and ``IntLiteral`` numeric equality.
     """
-    if isinstance(expr, sym.Comparison):
-        if expr.operator == '==':
-            left_str = str(expr.left).strip().lower()
-            right_str = str(expr.right).strip().lower()
-            if ((left_str == loop_var_name and right_str == '1') or
-                    (right_str == loop_var_name and left_str == '1')):
-                return True
+    if isinstance(expr, sym.Comparison) and expr.operator == '==':
+        left, right = expr.left, expr.right
+        # JK == 1
+        if (left == loop_var_name and
+                isinstance(right, sym.IntLiteral) and right.value == 1):
+            return True
+        # 1 == JK
+        if (right == loop_var_name and
+                isinstance(left, sym.IntLiteral) and left.value == 1):
+            return True
     return False
 
 
@@ -163,6 +196,7 @@ def _mark_jk1_conditionals(loop, arr_name, dim_idx, cond_to_remove,
             # Check if the ELSE branch contains assignments to our carry array
             # at JK with RHS being ARRAY(JK-1)
             else_body = cond.else_body or ()
+            # TODO [K-CACHING]: rename has_our_array to has_array in this function
             has_our_array = False
             for stmt in FindNodes(ir.Assignment).visit(else_body):
                 if isinstance(stmt.lhs, sym.Array) and stmt.lhs.name.lower() == arr_name.lower():
@@ -267,6 +301,7 @@ def _substitute_jk_in_expr(expr, jk_var, replacement):
     vmap = {}
     all_vars = FindVariables().visit(expr)
     for var in all_vars:
+        # TODO [K-CACHING]: if it is a sym.Array there is no need to check for `hasattr(var, 'dimensions')`
         if isinstance(var, sym.Array) and hasattr(var, 'dimensions') and var.dimensions:
             new_dims = tuple(
                 replacement
@@ -443,6 +478,12 @@ def _find_demotable_arrays(routine, vertical_index, vertical_size,
 
     An array is demotable if:
 
+    .. note::
+
+       It is not safe to demote if a variable is used in multiple
+       vertical loops that could not be fused.  This check is not yet
+       implemented.
+
     1. It is a local variable (not an argument, not imported).
     2. It has ``vertical_size`` (or ``vertical_size + 1``) in its shape.
     3. It is NOT accessed outside all vertical loops in the routine.
@@ -488,10 +529,9 @@ def _find_demotable_arrays(routine, vertical_index, vertical_size,
             continue
         has_klev = False
         for s in shape:
-            s_str = str(s).strip().lower()
-            if (s_str == vertical_size_lower or
-                    s_str.replace(' ', '').startswith(
-                        vertical_size_lower + '+')):
+            # Use expression-level comparison (StrCompareMixin handles
+            # case-insensitive equality) and _is_klev_plus_n for KLEV+N.
+            if s == vertical_size_lower or _is_klev_plus_n(s, vertical_size_lower):
                 has_klev = True
                 break
         if has_klev and vname not in call_arg_names:
@@ -530,17 +570,19 @@ def _find_demotable_arrays(routine, vertical_index, vertical_size,
     return sorted(safe)
 
 
-# ---------------------------------------------------------------------------
-# Functions from vertical_merge.py
-# ---------------------------------------------------------------------------
-
 def _find_dead_loops_all(routine, vertical_index):
     """
     Identify vertical loops whose written outputs are never read by
     any other code in the routine.
 
-    Unlike :func:`vertical_complete._find_dead_loops`, this version
+    Unlike the variant in ``vertical_complete`` this version
     does **not** exclude any loop — every vertical loop is a candidate.
+
+    .. note::
+
+       A future improvement could add an optional ``exclude_loop``
+       parameter to unify this with the ``_find_dead_loops`` variant
+       that excludes a main loop.
 
     Returns a list of top-level IR nodes (Loop or Conditional wrappers)
     that are dead and can be safely removed.
@@ -575,6 +617,12 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
                          horizontal_index=None,
                          carry_suffix='_vc', next_suffix='_next'):
     """
+    .. note::
+
+       This function is long and would benefit from extracting
+       pattern-specific logic (A, B_simple, B_readback, stencil)
+       into dedicated helper or nested functions.
+
     Convert all carry and stencil patterns in *loop* to scalar carry
     variables, making the loop body level-local.
 
@@ -718,10 +766,9 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
             # Check dimension is vertical
             if dim_idx >= len(shape):
                 continue
-            s_str = str(shape[dim_idx]).strip().lower()
-            if not (s_str == vertical_size_lower or
-                    s_str.replace(' ', '').startswith(
-                        vertical_size_lower + '+')):
+            s = shape[dim_idx]
+            if not (s == vertical_size_lower or
+                    _is_klev_plus_n(s, vertical_size_lower)):
                 continue
 
             # Stencil only for *backward* offsets (negative).
@@ -1138,9 +1185,15 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
 def _substitute_init_expressions_all_loops(routine, vertical_index,
                                             vertical_size):
     """
-    Like :func:`vertical_complete._substitute_init_expressions` but
-    searches *all* vertical loops (not just the main loop) for init
-    assignments.
+    Like the ``_substitute_init_expressions`` variant in
+    ``vertical_complete`` but searches *all* vertical loops (not just
+    a designated main loop) for init assignments.
+
+    .. note::
+
+       A future improvement could unify this with the
+       ``_substitute_init_expressions`` function by adding an
+       optional ``main_loop_only`` parameter.
 
     For each local 2-D+ array with a KLEV dimension, the first
     ``X(JL, JK) = f(args)`` assignment found (in source order across
@@ -1162,10 +1215,7 @@ def _substitute_init_expressions_all_loops(routine, vertical_index,
         if not shape:
             continue
         for idx, s in enumerate(shape):
-            s_str = str(s).strip().lower()
-            if (s_str == vertical_size_lower or
-                    s_str.replace(' ', '').startswith(
-                        vertical_size_lower + '+')):
+            if s == vertical_size_lower or _is_klev_plus_n(s, vertical_size_lower):
                 local_kd[var.name.lower()] = {
                     'var': var, 'klev_dim_idx': idx, 'shape': shape}
                 break
@@ -1267,7 +1317,7 @@ def _find_zero_inits_outside_loops(body, loop_nodes, klev_locals,
                                     zero_init_map):
     """
     Walk *body* outside loop nodes and find whole-array zero-init
-    assignments to KLEV locals.
+    assignments to vertical locals.
     """
     nodes = body if isinstance(body, (tuple, list)) else body.body
 
@@ -1402,10 +1452,7 @@ def _remove_whole_array_zero_inits(routine, vertical_index, vertical_size):
             continue
         has_klev = False
         for s in shape:
-            s_str = str(s).strip().lower()
-            if (s_str == vertical_size_lower or
-                    s_str.replace(' ', '').startswith(
-                        vertical_size_lower + '+')):
+            if s == vertical_size_lower or _is_klev_plus_n(s, vertical_size_lower):
                 has_klev = True
                 break
         if has_klev:
@@ -1454,10 +1501,44 @@ def _remove_whole_array_zero_inits(routine, vertical_index, vertical_size):
     return removed
 
 
-def _extract_plus_n(upper_str, vertical_size_lower):
-    """Extract N from a 'klev+N' string. Returns 0 for plain 'klev'."""
+def _extract_plus_n(upper_expr, vertical_size):
+    """
+    Extract the integer *N* from an expression of the form ``KLEV + N``.
+
+    Returns ``0`` for a plain ``KLEV`` expression.
+
+    Parameters
+    ----------
+    upper_expr : expression or str
+        The upper-bound expression (a Loki expression node) or, for
+        backward compatibility, a normalised lowercase string.
+    vertical_size : str or expression
+        The vertical size (e.g. ``'klev'``).
+    """
+    # --- Expression-level path ---
+    if not isinstance(upper_expr, str) and upper_expr is not None:
+        vs_name = (vertical_size.lower() if isinstance(vertical_size, str)
+                   else str(vertical_size).strip().lower())
+        vs_sym = sym.Variable(name=vs_name)
+        try:
+            diff = simplify(upper_expr - vs_sym)
+        except (TypeError, AttributeError):
+            diff = None
+        if isinstance(diff, sym.IntLiteral):
+            return diff.value
+        if isinstance(diff, int):
+            return diff
+        # Check if it's exactly KLEV (diff == 0 symbolically)
+        if diff is not None and str(diff).strip() == '0':
+            return 0
+        # Expression-level check didn't resolve; fall through to string
+
+    # --- String fallback ---
+    upper_str = (str(upper_expr).strip().lower()
+                 if not isinstance(upper_expr, str) else upper_expr)
+    vs = (vertical_size.lower() if isinstance(vertical_size, str)
+          else str(vertical_size).strip().lower())
     us = upper_str.replace(' ', '')
-    vs = vertical_size_lower
     if us.startswith(vs + '+'):
         try:
             return int(us[len(vs) + 1:])
@@ -1597,33 +1678,30 @@ def _merge_vertical_loops(routine, vertical_index, vertical_size):
     # Determine the merged upper bound: the maximum across all loops
     vertical_size_lower = vertical_size.lower()
     max_upper = None
-    max_upper_str = ''
 
+    # TODO: this should generate a MAX(upper_bound1, upper_bound2, ...) in case there is
+    #  any doubt about which is larger
     for loop, _cond in all_vloops:
-        upper_str = _loop_upper_bound_str(loop)
-        upper_expr = loop.bounds.children[1]
+        upper_expr = _loop_upper_bound_expr(loop)
+        if upper_expr is None:
+            continue
 
         if max_upper is None:
             max_upper = upper_expr
-            max_upper_str = upper_str
-        elif _is_klev_plus_n(upper_str, vertical_size_lower):
+        elif _is_klev_plus_n(upper_expr, vertical_size_lower):
             # This is KLEV+N — use it if larger than current max
-            if not _is_klev_plus_n(max_upper_str, vertical_size_lower):
+            if not _is_klev_plus_n(max_upper, vertical_size_lower):
                 max_upper = upper_expr
-                max_upper_str = upper_str
             else:
                 # Both are KLEV+N — compare N values
-                # Extract N from both
-                n_current = _extract_plus_n(max_upper_str, vertical_size_lower)
-                n_new = _extract_plus_n(upper_str, vertical_size_lower)
+                n_current = _extract_plus_n(max_upper, vertical_size_lower)
+                n_new = _extract_plus_n(upper_expr, vertical_size_lower)
                 if n_new > n_current:
                     max_upper = upper_expr
-                    max_upper_str = upper_str
-        elif upper_str == vertical_size_lower:
-            if max_upper_str != vertical_size_lower and \
-               not _is_klev_plus_n(max_upper_str, vertical_size_lower):
+        elif upper_expr == vertical_size_lower:
+            if max_upper != vertical_size_lower and \
+               not _is_klev_plus_n(max_upper, vertical_size_lower):
                 max_upper = upper_expr
-                max_upper_str = upper_str
 
     # Use the first loop's variable for the merged loop
     loop_var = all_vloops[0][0].variable
@@ -1681,7 +1759,7 @@ def _merge_vertical_loops(routine, vertical_index, vertical_size):
 
     n_loops = len(all_vloops)
     info('[vertical_utils] Merged %d vertical loops into 1 '
-         '(DO JK = 1, %s)', n_loops, max_upper_str)
+         '(DO JK = 1, %s)', n_loops, max_upper)
 
     return merged_loop
 

--- a/loki/transformations/single_column/vertical_utils.py
+++ b/loki/transformations/single_column/vertical_utils.py
@@ -1173,7 +1173,7 @@ def _convert_all_carries(routine, loop, vertical_index, vertical_size,
             # _insert_writebacks_for_argument_carries(), which runs AFTER
             # Phase 2b cross-loop carry substitution.  Generating write-backs
             # here would cause Phase 2b's SubstituteExpressions to turn them
-            # into self-assignments (e.g. pfsqlf_next = pfsqlf_next) that
+            # into self-assignments (e.g. ``arr_next = arr_next``) that
             # Phase 4a then removes.
 
         elif pattern == 'stencil':
@@ -1798,7 +1798,7 @@ def _merge_vertical_loops(routine, vertical_index, vertical_size):
 
     # Relocate inter-loop code: move statements that sit between
     # consecutive vertical loops to just before the merged loop.
-    # This prevents scalar resets (e.g. ZCOVPTOT = 0.0) from ending
+    # This prevents scalar resets (e.g. ``result = 0.0``) from ending
     # up after the merged loop when the loops they were sandwiched
     # between are merged together.
     routine.body = _relocate_interloop_code(
@@ -1878,10 +1878,10 @@ def _hoist_rotates_to_end(routine, merged_loop, carry_registry):
     see the pre-rotate carry values.
 
     After merging, guarded blocks from different original loops appear
-    in source order.  A carry rotate like ``zpfplsx_vc = zpfplsx_next``
+    in source order.  A carry rotate like ``arr_vc = arr_next``
     that was at the end of one original loop's body now sits inside a
     guarded block that may precede another guarded block reading
-    ``zpfplsx_vc``.  If the reader block expects the value at offset 0
+    ``arr_vc``.  If the reader block expects the value at offset 0
     (current JK), but the rotate has already advanced it, the reader
     gets the wrong value.
 

--- a/loki/transformations/temporaries/pool_allocator.py
+++ b/loki/transformations/temporaries/pool_allocator.py
@@ -443,7 +443,18 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             stack_type_bytes = InlineCall(Variable(name='C_SIZEOF'),
                                           parameters=as_tuple(stack_type_bytes))
             stack_size_assign = Assignment(lhs=stack_size_var, rhs=stack_size)
-            body_prepend += [stack_size_assign]
+            # Ensure the stack size is at least 1 to avoid zero-sized allocations,
+            # which cause runtime errors when the stack storage is accessed at index 1
+            # (e.g. LOC(ZSTACK(1, IBL))).
+            stack_size_clamp = Assignment(
+                lhs=stack_size_var,
+                rhs=InlineCall(
+                    function=Variable(name='MAX'),
+                    parameters=(stack_size_var, IntLiteral(1)),
+                    kw_parameters=()
+                )
+            )
+            body_prepend += [stack_size_assign, stack_size_clamp]
             variables_append += [stack_size_var]
 
         if self.stack_storage_name in variable_map:

--- a/loki/transformations/temporaries/tests/test_pool_allocator.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator.py
@@ -5,6 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+# pylint: disable=too-many-lines
 import pytest
 
 from loki.expression.parser import parse_expr
@@ -65,9 +66,15 @@ def check_stack_created_in_driver(
 
     # # Check the stack size
     assignments = FindNodes(Assignment).visit(driver.body)
-    for assignment in assignments:
-        if assignment.lhs == 'istsz':
-            assert simplify(assignment.rhs) == simplify(stack_size)
+    istsz_assigns = [a for a in assignments if a.lhs == 'istsz']
+    assert len(istsz_assigns) >= 1
+    # First assignment is the size computation
+    assert simplify(istsz_assigns[0].rhs) == simplify(stack_size)
+    # When the transformation generates the stack (not pre-existing),
+    # a MAX(..., 1) clamp statement follows to prevent zero-sized allocations
+    if len(istsz_assigns) == 2:
+        assert isinstance(istsz_assigns[1].rhs, InlineCall)
+        assert istsz_assigns[1].rhs.function == 'MAX'
 
     # # Check for stack assignment inside loop
     loops = FindNodes(Loop).visit(driver.body)
@@ -1429,3 +1436,103 @@ end module kernel_mod
 
     # check that array size was imported to the driver
     assert 'n' in driver.imported_symbols
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_pool_allocator_zero_size_allocation(tmp_path, frontend, block_dim, horizontal):
+    """
+    When the kernel has no stack-allocatable temporaries (e.g. all arrays
+    have been demoted to scalars by a prior k-caching transformation), the
+    computed stack size is 0.  A zero-sized ALLOCATE causes a Fortran
+    runtime error when the stack is accessed at index 1
+    (``LOC(ZSTACK(1, IBL))``).
+
+    Verify that the pool allocator inserts a clamp statement
+    ``ISTSZ = MAX(ISTSZ, 1)`` after the size assignment to guarantee a
+    minimum allocation of 1.
+    """
+    fcode_driver = """
+subroutine driver(NLON, NZ, NB, FIELD1)
+    use kernel_mod, only: kernel
+    implicit none
+    INTEGER, PARAMETER :: JPRB = SELECTED_REAL_KIND(13,300)
+    INTEGER, INTENT(IN) :: NLON, NZ, NB
+    real(kind=jprb), intent(inout) :: field1(nlon, nb)
+    integer :: b
+    do b=1,nb
+        call KERNEL(1, nlon, nlon, nz, field1(:,b))
+    end do
+end subroutine driver
+    """.strip()
+    fcode_kernel = """
+module kernel_mod
+    implicit none
+contains
+    subroutine kernel(start, end, klon, klev, field1)
+        implicit none
+        integer, parameter :: jprb = selected_real_kind(13,300)
+        integer, intent(in) :: start, end, klon, klev
+        real(kind=jprb), intent(inout) :: field1(klon)
+        real(kind=jprb) :: scalar_tmp
+        integer :: jl
+
+        do jl=start,end
+            scalar_tmp = field1(jl) * 2.0_jprb
+            field1(jl) = scalar_tmp
+        end do
+    end subroutine kernel
+end module kernel_mod
+    """.strip()
+
+    config = {
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': False,
+            'enable_imports': True,
+        },
+        'routines': {
+            'driver': {'role': 'driver'}
+        }
+    }
+
+    (tmp_path/'driver.F90').write_text(fcode_driver)
+    (tmp_path/'kernel_mod.F90').write_text(fcode_kernel)
+    scheduler = Scheduler(
+        paths=[tmp_path], config=SchedulerConfig.from_dict(config),
+        frontend=frontend, xmods=[tmp_path]
+    )
+
+    transformation = TemporariesPoolAllocatorTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=False,
+        cray_ptr_loc_rhs=False
+    )
+    scheduler.process(transformation=transformation)
+    driver = scheduler['#driver'].ir
+
+    # Stack infrastructure should still be created
+    assert 'istsz' in driver.variables
+    assert 'zstack(:,:)' in driver.variables
+
+    # Find all assignments to ISTSZ
+    assigns = [a for a in FindNodes(Assignment).visit(driver.body)
+                if a.lhs == 'istsz']
+    assert len(assigns) == 2, (
+        f'Expected 2 ISTSZ assignments (size + clamp), got {len(assigns)}'
+    )
+
+    # First assignment: ISTSZ = 0 (no temporaries)
+    assert assigns[0].rhs == 0
+
+    # Second assignment: ISTSZ = MAX(ISTSZ, 1)
+    clamp_rhs = assigns[1].rhs
+    assert isinstance(clamp_rhs, InlineCall)
+    assert clamp_rhs.function == 'MAX'
+    assert clamp_rhs.parameters[0] == 'istsz'
+    assert clamp_rhs.parameters[1] == 1
+
+    # ALLOCATE should reference ISTSZ
+    allocations = FindNodes(Allocation).visit(driver.body)
+    assert len(allocations) == 1
+    assert 'zstack(istsz,nb)' in allocations[0].variables


### PR DESCRIPTION
This pull request introduces several new utilities and tests for dataflow analysis and expression substitution in the codebase, as well as a **new pipeline for vertical loop fusion and k-caching transformations** in the single-column (SCC) transformation suite. The most notable changes are the addition of robust tests for array access and loop-carried dependency analysis, the implementation of a new expression visitor that skips substitutions on assignment LHS, and the integration of a new vertical k-caching pipeline.

**Dataflow Analysis Enhancements and Tests:**

* Added comprehensive tests to `test_analyse_dataflow.py` for new dataflow analysis utilities, including `classify_array_access_offsets`, `array_loop_carried_dependencies`, `detect_loop_carry_variables`, and `classify_nonzero_offset_arrays`, covering various Fortran loop and array access patterns.
* Updated imports in `test_analyse_dataflow.py` to include the new analysis functions.

**Expression Substitution Improvements:**

* Introduced `SubstituteExpressionsSkipLHS`, a subclass of `SubstituteExpressions`, which applies substitutions only to the right-hand side (RHS) of assignments, leaving the left-hand side (LHS) unchanged. This is essential for cases where substitutions should not affect assignment targets.
* Added tests for `SubstituteExpressionsSkipLHS` in `test_expr_visitors.py`, ensuring correct behavior for both scalar and array assignments, and verifying that non-assignment nodes are still substituted.
* Updated import lists in `expr_visitors.py` and `test_expr_visitors.py` to expose `SubstituteExpressionsSkipLHS`. [[1]](diffhunk://#diff-cd38c31e937a1478653d40a9f97adea800fadd922039b18b42b013e9b2b6c4b5L31-R32) [[2]](diffhunk://#diff-3a83b0701afe61df974b47a8494dd958cde74f2e9246c8fce49ace620428463eL15-R16)

**Single-Column Transformation Pipelines:**

* Integrated the new `SCCVerticalKCaching` transformation and exposed it in the SCC module's public API. [[1]](diffhunk://#diff-3019979c0630e1460b5cb11d3131e0cccef8dba9128611a4a0730ff2024c8032R18) [[2]](diffhunk://#diff-3d449f6968adad209ec2b0aaa8ea844e5bf4b0cfc01ad5c3177f3ed56cc0ec3dR19)
* Added a new pipeline, `SCCSStackKCachingPipeline`, which applies vertical loop fusion and k-caching before the standard SCC sequential kernel transformations. This pipeline is now included in the list of available SCC pipelines. [[1]](diffhunk://#diff-3d449f6968adad209ec2b0aaa8ea844e5bf4b0cfc01ad5c3177f3ed56cc0ec3dL38-R39) [[2]](diffhunk://#diff-3d449f6968adad209ec2b0aaa8ea844e5bf4b0cfc01ad5c3177f3ed56cc0ec3dR342-R394)