### PR TITLE
Improve ASSOCIATE handling

### DIFF
--- a/loki/backend/pygen.py
+++ b/loki/backend/pygen.py
@@ -14,6 +14,7 @@ from loki.expression import symbols as sym, LokiStringifyMapper
 from loki.types import BasicType, DerivedType, SymbolAttributes
 
 
+
 __all__ = ['pygen', 'PyCodegen', 'PyCodeMapper']
 
 
@@ -299,6 +300,15 @@ class PyCodegen(Stringifier):
         Format the section's body.
         """
         return self.visit(o.body, **kwargs)
+
+    def visit_Associate(self, o, **kwargs):
+        """
+        Resolve ASSOCIATE mappings and emit only the resolved body.
+        """
+        from loki.transformations.sanitise.associates import ResolveAssociatesTransformer
+
+        body = ResolveAssociatesTransformer().visit(o)
+        return self.visit(body, **kwargs)
 
     def visit_CallStatement(self, o, **kwargs):
         """

--- a/loki/backend/tests/test_pygen.py
+++ b/loki/backend/tests/test_pygen.py
@@ -194,7 +194,31 @@ end subroutine pygen_arguments
 
 # TODO: implement and test transpilation of derived types
 
-# TODO: implement and test transpilation of associates
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_pygen_associate(frontend):
+    """
+    Test Python code generation of ASSOCIATE blocks without prior sanitisation.
+    """
+
+    fcode = """
+subroutine pygen_associate(a, b, c)
+  use iso_fortran_env, only: real64
+  implicit none
+
+  real(kind=real64), intent(in) :: a, b
+  real(kind=real64), intent(out) :: c
+
+  associate (x => a, y => b)
+    c = x + y
+  end associate
+end subroutine pygen_associate
+"""
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    pycode = pygen(routine)
+    assert 'associate (' not in pycode.lower()
+    assert 'c = a + b' in pycode.lower()
 
 # TODO: implement and test transpilation of modules
 

--- a/loki/cli/loki_transform.py
+++ b/loki/cli/loki_transform.py
@@ -21,6 +21,7 @@ from loki.batch import Scheduler, SchedulerConfig, ProcessingStrategy
 from loki.cli.common import cli, frontend_options, scheduler_options
 
 from loki.transformations.build_system import FileWriteTransformation
+from loki.transformations.sanitise import AssociatesTransformation
 
 
 @cli.command()
@@ -36,11 +37,13 @@ from loki.transformations.build_system import FileWriteTransformation
               help='Generate and display the subroutine callgraph.')
 @click.option('--root', type=click.Path(), default=None,
               help='Root path to which all paths are relative to.')
+@click.option('--ass-wipe', is_flag=True, default=False,
+              help='Remove all ASSOCIATE blocks and resolve their mappings.')
 @click.option('--log-level', '-l', default='info', envvar='LOKI_LOGGING',
               type=click.Choice(['debug', 'detail', 'perf', 'info', 'warning', 'error']),
               help='Log level to output during batch processing')
 def convert(
-        frontend_opts, scheduler_opts, mode, config, plan_file, callgraph, root, log_level
+        frontend_opts, scheduler_opts, mode, config, plan_file, callgraph, root, ass_wipe, log_level
 ):
     """
     Batch-processing mode for Fortran-to-Fortran transformations that
@@ -54,6 +57,20 @@ def convert(
     """
 
     loki_config['log-level'] = log_level
+
+    # Handle simple --ass-wipe mode for ASSOCIATE removal
+    if ass_wipe and not config:
+        info('[Loki] Removing ASSOCIATE blocks from source files')
+        for source_file in scheduler_opts.source:
+            sfile = Sourcefile.from_file(filename=source_file, **frontend_opts.asdict)
+            transformation = AssociatesTransformation(resolve_associates=True)
+            for routine in sfile.all_subroutines:
+                transformation.transform_subroutine(routine)
+            # Write back to original file
+            sfile.write(path=source_file)
+            info(f'  [DONE] {source_file}')
+        info('[Loki] ASS-WIPE request completed')
+        return
 
     if plan_file is not None:
         processing_strategy = ProcessingStrategy.PLAN

--- a/loki/cli/tests/test_loki_transform.py
+++ b/loki/cli/tests/test_loki_transform.py
@@ -11,7 +11,9 @@ import tomli_w
 
 from click.testing import CliRunner
 
+from loki import Sourcefile
 from loki.cli.loki_transform import cli
+from loki.ir import FindNodes, nodes as ir
 from loki.logging import log_levels
 
 
@@ -151,3 +153,125 @@ def test_loki_transform_convert(testdir, config, caplog, tmp_path):
             # Ensure all files have been generated
             fname_mod = fname.replace('.f90', '.idem.f90').replace('.F90', '.idem.F90')
             assert (tmp_path/'build'/fname_mod).exists()
+
+
+def test_loki_transform_ass_wipe(caplog, tmp_path):
+    """Test the CLI invocation of "convert --ass-wipe" on a source file."""
+
+    source_file = tmp_path/'ass_wipe_test.F90'
+    source_file.write_text(
+    """
+subroutine ass_wipe_test(a, b, c)
+  use iso_fortran_env, only: real64
+  implicit none
+  real(kind=real64), intent(in) :: a, b
+  real(kind=real64), intent(out) :: c
+
+  associate (x => a, y => b)
+    c = x + y
+  end associate
+end subroutine ass_wipe_test
+""".strip() + '\n'
+    )
+
+    caplog.clear()
+    with caplog.at_level(log_levels['INFO']):
+        result = CliRunner().invoke(
+            cli, [
+                '--debug', 'convert', '--frontend=fp',
+                f'--source={source_file}', '--ass-wipe',
+            ]
+        )
+
+    assert result.exit_code == 0
+    updated = source_file.read_text().lower()
+    assert 'associate' not in updated
+    assert 'c = a + b' in updated
+
+    logout = ''.join(str(r) for r in caplog.records)
+    assert '[Loki] Removing ASSOCIATE blocks from source files' in logout
+    assert '[Loki] ASS-WIPE request completed' in logout
+
+
+def test_loki_transform_ass_wipe_nested(caplog, tmp_path):
+    """Test "convert --ass-wipe" resolves nested ASSOCIATE blocks."""
+
+    source_file = tmp_path/'ass_wipe_nested_test.F90'
+    source_file.write_text(
+                """
+subroutine ass_wipe_nested_test(a, b, c)
+    use iso_fortran_env, only: real64
+    implicit none
+    real(kind=real64), intent(in) :: a, b
+    real(kind=real64), intent(out) :: c
+
+    associate (x => a + b)
+        associate (y => x * 2.0_real64)
+            c = y
+        end associate
+    end associate
+end subroutine ass_wipe_nested_test
+""".strip() + '\n'
+    )
+
+    caplog.clear()
+    with caplog.at_level(log_levels['INFO']):
+        result = CliRunner().invoke(
+                        cli, [
+                                '--debug', 'convert', '--frontend=fp',
+                                f'--source={source_file}', '--ass-wipe',
+                        ]
+                )
+
+    assert result.exit_code == 0
+    updated = source_file.read_text().lower()
+    assert 'associate' not in updated
+    assert 'c = (a + b)*2.0_real64' in updated
+
+    logout = ''.join(str(r) for r in caplog.records)
+    assert '[Loki] Removing ASSOCIATE blocks from source files' in logout
+    assert '[Loki] ASS-WIPE request completed' in logout
+
+
+def test_loki_transform_ass_wipe_nested_slices(caplog, tmp_path):
+    """Test "convert --ass-wipe" resolves nested ASSOCIATE blocks with array slices."""
+
+    source_file = tmp_path/'ass_wipe_nested_slices_test.F90'
+    source_file.write_text(
+                """
+subroutine ass_wipe_nested_slices_test(n, arr, c)
+    use iso_fortran_env, only: real64
+    implicit none
+    integer, intent(in) :: n
+    real(kind=real64), intent(in) :: arr(n, 2)
+    real(kind=real64), intent(out) :: c(n)
+
+    associate (x => arr(:, 1), y => arr(:, 2))
+        associate (tmp => x + y)
+            c(:) = tmp(:)
+        end associate
+    end associate
+end subroutine ass_wipe_nested_slices_test
+""".strip() + '\n'
+        )
+
+    caplog.clear()
+    with caplog.at_level(log_levels['INFO']):
+        result = CliRunner().invoke(
+                        cli, [
+                                '--debug', 'convert', '--frontend=fp',
+                                f'--source={source_file}', '--ass-wipe',
+                        ]
+                )
+
+    assert result.exit_code == 0
+    updated = source_file.read_text().lower()
+    assert 'associate' not in updated
+
+    sfile = Sourcefile.from_file(source_file, frontend='fp')
+    associates = FindNodes(ir.Associate).visit(sfile.ir)
+    assert len(associates) == 0
+
+    logout = ''.join(str(r) for r in caplog.records)
+    assert '[Loki] Removing ASSOCIATE blocks from source files' in logout
+    assert '[Loki] ASS-WIPE request completed' in logout

--- a/loki/ir/nodes.py
+++ b/loki/ir/nodes.py
@@ -531,7 +531,10 @@ class Associate(ScopedNode, Section, _AssociateBase):  # pylint: disable=too-man
                     _type = _type.clone(shape=shape)
             else:
                 # TODO: Handle data type and shape of complex expressions
-                shape = ExpressionDimensionsMapper()(expr)
+                try:
+                    shape = ExpressionDimensionsMapper()(expr)
+                except ValueError:
+                    shape = None
                 if shape == (sym.IntLiteral(1),):
                     # For a scalar expression, we remove the shape
                     shape = None

--- a/loki/transformations/sanitise/associates.py
+++ b/loki/transformations/sanitise/associates.py
@@ -12,9 +12,11 @@ constructs to unify code structure and make reasoning about Fortran
 code easier.
 """
 
+import re
 from loki.batch import Transformation
 from loki.expression import symbols as sym,  LokiIdentityMapper
-from loki.ir import nodes as ir, Transformer, NestedTransformer
+
+from loki.ir import nodes as ir, Transformer, NestedTransformer, FindNodes
 from loki.logging import warning
 from loki.tools import dict_override
 from loki.types import SymbolTable
@@ -187,6 +189,11 @@ class ResolveAssociateMapper(LokiIdentityMapper):
 
         new = self.map_scalar(expr, *args, **kwargs)
 
+        # If map_scalar returned a general expression (e.g. a Sum/Product),
+        # it has no clone() - return it directly without applying dimensions.
+        if not hasattr(new, 'clone'):
+            return new
+
         # Recurse over array dimensions
         if isinstance(new, sym.Array) and new.dimensions:
             # Resolve unbound range symbols form existing indices
@@ -230,6 +237,86 @@ class ResolveAssociatesTransformer(Transformer):
     def visit_Expression(self, o, **kwargs):
         return ResolveAssociateMapper(start_depth=self.start_depth)(o)
 
+    @staticmethod
+    def _has_top_level_additive_op(s):
+        """True if *s* contains a top-level ``+`` or ``-`` operator."""
+        depth = 0
+        in_str = False
+        str_ch = None
+        for ch in s:
+            if in_str:
+                if ch == str_ch:
+                    in_str = False
+            elif ch in '"\'':
+                in_str = True
+                str_ch = ch
+            elif ch in '([':
+                depth += 1
+            elif ch in ')]':
+                depth -= 1
+            elif ch in '+-' and depth == 0:
+                return True
+        return False
+
+    @staticmethod
+    def _needs_parens_after(text, pos):
+        """True if text at *pos* (skipping spaces) starts with ``*`` or ``/``."""
+        while pos < len(text) and text[pos] == ' ':
+            pos += 1
+        return pos < len(text) and text[pos] in '*/'
+
+    @staticmethod
+    def _string_mask(text):
+        """Return a boolean list: True where ``text[i]`` is inside a string literal."""
+        mask = [False] * len(text)
+        in_str = False
+        str_ch = None
+        i = 0
+        while i < len(text):
+            ch = text[i]
+            if in_str:
+                mask[i] = True
+                if ch == str_ch:
+                    if i + 1 < len(text) and text[i + 1] == str_ch:
+                        i += 1  # Fortran doubled-quote escape
+                        mask[i] = True
+                    else:
+                        in_str = False
+            elif ch in '"\'':
+                mask[i] = True
+                in_str = True
+                str_ch = ch
+            i += 1
+        return mask
+
+    def _resolve_in_intrinsic_text(self, text, associations):
+        """Replace associated names in *text* using *associations* mappings,
+        skipping occurrences inside Fortran string literals."""
+        for sel_expr, name_sym in associations:
+            name = name_sym.basename.lower()
+            sel_str = str(sel_expr)
+            needs_parens = self._has_top_level_additive_op(sel_str)
+            pat = re.compile(r'\b' + re.escape(name) + r'\b', re.IGNORECASE)
+            str_mask = self._string_mask(text)
+            replacements = []
+            for m in pat.finditer(text):
+                if str_mask[m.start()]:
+                    continue  # do not replace inside string literals
+                repl = (f'({sel_str})'
+                        if needs_parens and self._needs_parens_after(text, m.end())
+                        else sel_str)
+                replacements.append((m.start(), m.end(), repl))
+            if replacements:
+                parts = []
+                prev_end = 0
+                for start, end, repl in replacements:
+                    parts.append(text[prev_end:start])
+                    parts.append(repl)
+                    prev_end = end
+                parts.append(text[prev_end:])
+                text = ''.join(parts)
+        return text
+
     def visit_Associate(self, o, **kwargs):
         """
         Replaces an :any:`Associate` node with its transformed body
@@ -244,6 +331,23 @@ class ResolveAssociatesTransformer(Transformer):
 
         if depth <= self.start_depth:
             return o.clone(body=body)
+
+        # Resolve potential remaining ASSOCIATE aliases in intrinsic statement
+        # text (PRINT/READ/WRITE etc.), which are stored as raw text in
+        # ir.Intrinsic nodes and therefore cannot be reached by the expression
+        # mapper above.
+        intrinsics = FindNodes(ir.Intrinsic).visit(body)
+        if intrinsics:
+            intrinsic_map = {
+                node: node.clone(text=self._resolve_in_intrinsic_text(
+                    node.text, o.associations
+                ))
+                for node in intrinsics
+            }
+            intrinsic_map = {k: v for k, v in intrinsic_map.items()
+                             if v.text != k.text}
+            if intrinsic_map:
+                body = Transformer(intrinsic_map).visit(body)
 
         return body
 

--- a/loki/transformations/sanitise/tests/test_associates.py
+++ b/loki/transformations/sanitise/tests/test_associates.py
@@ -61,6 +61,97 @@ end subroutine transform_associates_simple
 @pytest.mark.parametrize('frontend', available_frontends(
     skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
+def test_transform_associates_print_stmt(frontend):
+    """Test association resolver for PRINT statements represented as Intrinsic text."""
+    fcode = """
+subroutine transform_associates_print_stmt(a, b)
+  use iso_fortran_env, only: real64
+  implicit none
+  real(kind=real64), intent(in) :: a, b
+
+  associate (x => a + b)
+    print *, x
+    print *, 'x =', x
+  end associate
+end subroutine transform_associates_print_stmt
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    do_resolve_associates(routine)
+
+    assert len(FindNodes(ir.Associate).visit(routine.body)) == 0
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    assert len(intrinsics) == 2
+    assert intrinsics[0].text.lower() == 'print *, a + b'
+    assert intrinsics[1].text.lower() == "print *, 'x =', a + b"
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
+))
+def test_transform_associates_non_print_intrinsics(frontend):
+    """Test association resolver for non-PRINT intrinsic statements (READ/WRITE)."""
+    fcode = """
+subroutine transform_associates_io_stmt(a, b, c)
+  use iso_fortran_env, only: real64
+  implicit none
+  real(kind=real64), intent(in) :: a
+  real(kind=real64), intent(inout) :: b
+  real(kind=real64), intent(out) :: c
+
+  associate (x => a + b, y => b)
+    write(*,*) x, y
+    read(*,*) y
+    c = x
+  end associate
+end subroutine transform_associates_io_stmt
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    do_resolve_associates(routine)
+
+    assert len(FindNodes(ir.Associate).visit(routine.body)) == 0
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    assert len(intrinsics) == 2
+    assert intrinsics[0].text.lower() == 'write(*, *) a + b, b'
+    assert intrinsics[1].text.lower() == 'read(*, *) b'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
+))
+def test_transform_associates_triply_nested_intrinsics(frontend):
+    """Test resolution of intrinsic statements across triple-nested ASSOCIATE blocks."""
+    fcode = """
+subroutine transform_associates_triply_nested(a, b)
+  use iso_fortran_env, only: real64
+  implicit none
+  real(kind=real64), intent(inout) :: a, b
+
+  associate (x => a)
+    associate (y => x + b)
+      associate (z => y * 2.0_real64)
+        print *, z
+        write(*,*) z, y, x
+      end associate
+    end associate
+  end associate
+end subroutine transform_associates_triply_nested
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    do_resolve_associates(routine)
+
+    assert len(FindNodes(ir.Associate).visit(routine.body)) == 0
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    assert len(intrinsics) == 2
+    assert intrinsics[0].text.lower() == 'print *, (a + b)*2.0_real64'
+    assert intrinsics[1].text.lower() == 'write(*, *) (a + b)*2.0_real64, a + b, a'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
+))
 def test_transform_associates_nested(frontend):
     """
     Test association resolver with deeply nested associates.


### PR DESCRIPTION
The IFS fortran code base makes heavy, structural  use of `ASSOCIATE` statements.
In many subroutines, nested `ASSOCIATE` statements can be found, and some cases of deep nests exist.
This PR improves handling of `ASSOCIATE` removal, in particular by correctly resolving associated variables in calls to intrinsic functions, such as PRINT and WRITE.
Given the prevalence of `ASSOCIATE` usage, this PR also provides an easy-to-use option for resolving associates in a single file. This option can be invoked as follows : `loki-transform.py convert --source nested_example.F90 --ass-wipe`

An example of this is provided below.

cat nested_example.F90 
```
subroutine nested_example()
      implicit none
      type test_type
              real :: realval
      end type
      type nasty_nested_type
              type(test_type) :: this_test_type
      end type
      type(test_type) :: my_test_type
      type(nasty_nested_type) :: my_nasty_type
      real :: local_real
      associate( assoc_real => my_test_type%realval, associated_test_type => my_nasty_type%this_test_type )
      associate( nested_real => associated_test_type%realval )
      local_real = 3.14
      assoc_real = 3.14159
      nested_real = 3.141592654
      local_real = nested_real
      print *,'local and associated reals : ',local_real, assoc_real, nested_real
      write(*,*) 'testing a write as well', nested_real
      end associate
      end associate
end subroutine nested_example
```
The result of launching `loki-transform.py convert --source nested_example.F90 --ass-wipe`
is a correctly modified `nested_example.F90`, along with the following output: 
```
[Loki] Removing ASSOCIATE blocks from source files
  [DONE] nested_toto.F90
[Loki] ASS-WIPE request completed
```