### PR TITLE
Don't mark loops with constant bounds as sequential

### DIFF
--- a/loki/transformations/single_column/revector.py
+++ b/loki/transformations/single_column/revector.py
@@ -8,7 +8,7 @@
 import re
 
 from loki.batch import Transformation
-from loki.expression import symbols as sym
+from loki.expression import symbols as sym, simplify, is_dimension_constant
 from loki.ir import (
     nodes as ir, FindNodes, Transformer, is_loki_pragma,
     pragmas_attached, pragma_regions_attached
@@ -138,6 +138,18 @@ class BaseRevectorTransformation(Transformation):
                         loops[0]._update(pragma=(pragma,))
                         region._update(pragma=None, pragma_post=None)
 
+    @staticmethod
+    def _has_constant_loop_bounds(loop):
+        """
+        Return ``True`` if all explicitly provided loop bounds and step
+        reduce to compile-time constants.
+        """
+        return all(
+            is_dimension_constant(simplify(bound))
+            for bound in (loop.bounds.start, loop.bounds.stop, loop.bounds.step)
+            if bound is not None
+        )
+
     def mark_seq_loops(self, section):
         """
         Mark interior sequential loops in a thread-parallel section
@@ -145,6 +157,9 @@ class BaseRevectorTransformation(Transformation):
 
         This utility requires loop-pragmas to be attached via
         :any:`pragmas_attached`. It also updates loops in-place.
+
+        Loops whose bounds and step are compile-time constants are left
+        unannotated.
 
         Parameters
         ----------
@@ -155,6 +170,10 @@ class BaseRevectorTransformation(Transformation):
 
             # Skip loops explicitly marked with `!$loki/claw nodep`
             if loop.pragma and any('nodep' in p.content.lower() for p in as_tuple(loop.pragma)):
+                continue
+
+            # Skip loops with compile-time constant iteration spaces
+            if self._has_constant_loop_bounds(loop):
                 continue
 
             # Mark loop as sequential with `!$loki loop seq`

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -857,8 +857,7 @@ def test_scc_outer_loop(frontend, horizontal, blocking):
         assert kernel_loops[0].pragma[0].content == 'loop vector'
         assert kernel_loops[1].variable == 'niter'
         assert kernel_loops[1].bounds == '1:3'
-        assert kernel_loops[1].pragma[0].keyword == 'acc'
-        assert kernel_loops[1].pragma[0].content == 'loop seq'
+        assert kernel_loops[1].pragma is None
         assert kernel_loops[2].variable == 'jl'
         assert kernel_loops[2].bounds == 'start:end'
         assert kernel_loops[2].pragma[0].keyword == 'acc'
@@ -1094,33 +1093,27 @@ def test_scc_multiple_acc_pragmas(frontend, horizontal, blocking, dims_type, tmp
         scc_pipeline.apply(routine, role='driver', targets=['some_kernel',])
 
     pragmas = FindNodes(Pragma).visit(routine.ir)
-    # Note: local_dims%wrk = 0 (wrk is a 100-element array) gets resolved to an
-    # explicit loop, which receives an '!$acc loop seq' pragma, giving 7 pragmas total.
-    assert len(pragmas) == 7
+    assert len(pragmas) == 6
 
     assert pragmas[0].keyword.lower() == 'acc'
     assert pragmas[0].content == 'data present(dims)'
-    assert pragmas[6].content == 'end data'
-    assert pragmas[6].keyword.lower() == 'acc'
+    assert pragmas[5].content == 'end data'
+    assert pragmas[5].keyword.lower() == 'acc'
 
     if data_offload:
-        assert all(p.keyword.lower() == 'acc' for p in pragmas[1:6])
+        assert all(p.keyword.lower() == 'acc' for p in pragmas[1:5])
         assert pragmas[2].content == 'parallel loop gang private(local_dims) vector_length(dims%klon)'
-        assert pragmas[3].keyword.lower() == 'acc'
-        assert pragmas[3].content == 'loop seq'
-        assert pragmas[4].content == 'end parallel loop'
-        assert pragmas[5].content == 'end data'
+        assert pragmas[3].content == 'end parallel loop'
+        assert pragmas[4].content == 'end data'
 
         assert 'data copy(work)' in pragmas[1].content
     else:
         assert pragmas[1].keyword == 'loki'
         assert pragmas[2].keyword.lower() == 'omp'
-        assert pragmas[3].keyword.lower() == 'acc'
-        assert pragmas[3].content == 'loop seq'
-        assert pragmas[4].keyword.lower() == 'omp'
-        assert pragmas[5].keyword == 'loki'
+        assert pragmas[3].keyword.lower() == 'omp'
+        assert pragmas[4].keyword == 'loki'
         assert pragmas[2].content == 'parallel do private(b) shared(work, nproma)'
-        assert pragmas[4].content == 'end parallel do'
+        assert pragmas[3].content == 'end parallel do'
 
     # check that pointer association was correctly identified as a separator node
     routine = source['some_kernel']

--- a/loki/transformations/single_column/tests/test_scc_vector.py
+++ b/loki/transformations/single_column/tests/test_scc_vector.py
@@ -45,6 +45,54 @@ def fixture_blocking():
 
 @pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('revector_trafo', [SCCSeqRevectorTransformation, SCCVecRevectorTransformation])
+def test_scc_revector_mark_seq_loops_constant_bounds(frontend, horizontal, revector_trafo):
+    """
+    Test that loops with compile-time constant bounds are not marked as seq.
+    """
+    fcode = """
+subroutine some_kernel(start, end, nlon, nz, work)
+  implicit none
+  integer, intent(in) :: start, end, nlon, nz
+  real, intent(inout) :: work(nlon, nz)
+  integer :: jl, jk
+
+  do jk = 1, 3
+    do jl = start, end
+      work(jl, jk) = 1.
+    end do
+  end do
+
+  do jk = 2, nz
+    do jl = start, end
+      work(jl, jk) = work(jl, jk-1) + 1.
+    end do
+  end do
+end subroutine some_kernel
+    """
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    transformation = revector_trafo(horizontal=horizontal)
+
+    with pragmas_attached(routine, node_type=ir.Loop):
+        transformation.mark_seq_loops(routine.body)
+
+        loops = FindNodes(ir.Loop).visit(routine.body)
+        constant_loop = next(loop for loop in loops if loop.variable == 'jk' and loop.bounds.start == 1)
+        variable_loop = next(loop for loop in loops if loop.variable == 'jk' and loop.bounds.stop == 'nz')
+        horizontal_loops = [loop for loop in loops if loop.variable == 'jl']
+
+        assert constant_loop.bounds.stop == 3
+        assert constant_loop.pragma is None
+
+        assert variable_loop.bounds.start == 2
+        assert variable_loop.pragma
+        assert is_loki_pragma(variable_loop.pragma, starts_with='loop seq')
+
+        assert all(loop.pragma is None for loop in horizontal_loops)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('revector_trafo', [SCCSeqRevectorTransformation, SCCVecRevectorTransformation])
 @pytest.mark.parametrize('ignore_nested_kernel', [False, True])
 def test_scc_revector_transformation(frontend, horizontal, revector_trafo, ignore_nested_kernel, tmp_path):
     """


### PR DESCRIPTION
The compiler may unroll a loop with constant bounds, which leaves dangling `!$acc loop seq` statements that lead to compiler errors. This PR amends the revector transformations so that loops with constant bounds are not annotated as sequential.