### PR TITLE
Various unused argument removal fixes and improvements

### DIFF
--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -225,10 +225,10 @@ def do_remove_unused_call_args(routine, unused_args_map):
         if call.routine is BasicType.DEFERRED or not unused_args_map.get(call.routine, None):
             continue
 
-        unused_args = [call.arguments[c] for c in unused_args_map[call.routine].values() if c < len(call.arguments)]
+        unused_positions = {c for c in unused_args_map[call.routine].values() if c < len(call.arguments)}
         unused_kwargs = [(kw, arg) for kw, arg in call.kwarguments if kw.lower() in unused_args_map[call.routine]]
 
-        new_args = [arg for arg in call.arguments if not arg in unused_args]
+        new_args = [arg for i, arg in enumerate(call.arguments) if i not in unused_positions]
         new_kwargs = [(kw, arg) for kw, arg in call.kwarguments if not (kw, arg) in unused_kwargs]
 
         call._update(arguments=as_tuple(new_args), kwarguments=as_tuple(new_kwargs))

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -153,16 +153,54 @@ class RemoveCodeTransformation(Transformation):
         if self.remove_unused_args and (item := kwargs['item']):
             # collect unused args from successors
             successors = kwargs['sub_sgraph'].successors(item=item)
-            unused_args_map = {successor.ir: successor.trafo_data.get(self._key, {}).get('unused_args', {})
-                               for successor in successors}
+            unused_args_map = {}
+            for successor in successors:
+                succ_data = successor.trafo_data.get(self._key, {})
+                succ_ir = successor.ir
+                unused_args_map[succ_ir] = succ_data.get(succ_ir.name, {}).get('unused_args', {})
+
+            variable_map = routine.symbol_map
+            used_or_defined_symbols = OrderedSet()
+            if item.config.get('remove_unused_args', True) and kwargs['role'] == 'kernel':
+                # internal procedures are transformed after the parent routine,
+                # so determine their unused args eagerly to update call sites here
+                for child in routine.subroutines:
+                    child_symbol_map = child.symbol_map
+                    child_used_symbols = get_used_or_defined_symbols(child)
+
+                    # Collect symbols used or defined in contained subroutines, whilst ignoring
+                    # those that mask parent symbols
+                    used_or_defined_symbols |= OrderedSet(
+                        variable_map[child_symbol.name_parts[0]].clone(dimensions=None)
+                        for child_symbol in child_used_symbols
+                        if child_symbol.name_parts[0] in variable_map
+                        and child_symbol.name_parts[0] not in child_symbol_map
+                    )
+
+                    child_unused_args, _ = find_unused_dummy_args_and_vars(
+                        child, used_or_defined_symbols=child_used_symbols
+                    )
+                    unused_args_map[child] = child_unused_args
+                    item.trafo_data.setdefault(self._key, {})[child.name] = {'unused_args': child_unused_args}
+
             do_remove_unused_call_args(routine, unused_args_map)
 
             if item.config.get('remove_unused_args', True) and kwargs['role'] == 'kernel':
-                # find unused args
-                unused_args, _ = find_unused_dummy_args_and_vars(routine)
+                # find unused args, which for contained subroutines may already be known
+                item_data = item.trafo_data.get(self._key, {})
+                unused_args = item_data.get(routine.name, {}).get('unused_args', {})
+
+                if not unused_args:
+                    used_or_defined_symbols |= get_used_or_defined_symbols(routine)
+                    unused_args, _ = find_unused_dummy_args_and_vars(
+                        routine, used_or_defined_symbols=used_or_defined_symbols
+                    )
+
+                    # store unused args keyed by routine name to avoid
+                    # internal procedures overwriting the parent's data
+                    item.trafo_data.setdefault(self._key, {})[routine.name] = {'unused_args': unused_args}
+
                 do_remove_unused_dummy_args(routine, unused_args)
-                # store unused args
-                item.trafo_data[self._key] = {'unused_args': unused_args}
 
 
 def do_remove_unused_dummy_args(routine, unused_args):
@@ -251,7 +289,35 @@ def do_remove_unused_call_args(routine, unused_args_map):
         routine.body = SubstituteExpressions(inline_call_map).visit(routine.body)
 
 
-def find_unused_dummy_args_and_vars(routine):
+def get_used_or_defined_symbols(routine):
+    """
+    Collect symbols used or defined in a routine, including array-shape references.
+    """
+    variable_map = routine.symbol_map
+    routine_arg_names = [arg.name.lower() for arg in routine.arguments]
+    with dataflow_analysis_attached(routine):
+        used_or_defined_symbols = routine.body.uses_symbols | routine.body.defines_symbols
+
+        # We search for symbols used to define array sizes of symbols referenced
+        # in the body, as well as local arrays declared in the routine.
+        used_or_defined_array_shapes = [s.shape for s in used_or_defined_symbols if isinstance(s, sym.Array)]
+        local_var_shapes = [
+            var.shape for var in routine.variables
+            if isinstance(var, sym.Array) and var.name.lower() not in routine_arg_names
+        ]
+        used_or_defined_symbols |= FindVariables(unique=True).visit(
+            used_or_defined_array_shapes + local_var_shapes
+        )
+
+        used_or_defined_symbols |= OrderedSet(
+            variable_map.get(v.name_parts[0], v).clone(dimensions=None)
+            for v in used_or_defined_symbols
+        )
+
+    return used_or_defined_symbols
+
+
+def find_unused_dummy_args_and_vars(routine, used_or_defined_symbols=None):
     """
     Utility routine to find all the unused arguments in a :any:`Subroutine`.
 
@@ -259,6 +325,8 @@ def find_unused_dummy_args_and_vars(routine):
     ----------
     routine : :any:`Subroutine`
         A :any:`Subroutine` to search for unused dummy arguments.
+    used_or_defined_symbols : set, optional
+        The set of symbols used or defined in the routine.
 
     Return
     ------
@@ -267,23 +335,15 @@ def find_unused_dummy_args_and_vars(routine):
        routine's argument list.
     """
 
-    variable_map = routine.symbol_map
-    with dataflow_analysis_attached(routine):
-        used_or_defined_symbols = routine.body.uses_symbols | routine.body.defines_symbols
+    if used_or_defined_symbols is None:
+        used_or_defined_symbols = get_used_or_defined_symbols(routine)
 
-        # we search for symbols used to define array sizes
-        used_or_defined_array_shapes = [s.shape for s in used_or_defined_symbols if isinstance(s, sym.Array)]
-        used_or_defined_symbols |= FindVariables(unique=True).visit(used_or_defined_array_shapes)
-
-        used_or_defined_symbols |= OrderedSet(variable_map.get(v.name_parts[0], v).clone(dimensions=None)
-                                              for v in used_or_defined_symbols)
-
-        unused_args = {a.clone(dimensions=None): c for c, a in enumerate(routine.arguments)
-                       if not a.name.lower() in used_or_defined_symbols}
-        routine_arg_names = [arg.name.lower() for arg in routine.arguments]
-        local_vars = [var for var in routine.variables if var.name.lower() not in routine_arg_names]
-        unused_vars = [var.clone(dimensions=None) for var in local_vars
-                if not var.name.lower() in used_or_defined_symbols]
+    unused_args = {a.clone(dimensions=None): c for c, a in enumerate(routine.arguments)
+                   if not a.name.lower() in used_or_defined_symbols}
+    routine_arg_names = [arg.name.lower() for arg in routine.arguments]
+    local_vars = [var for var in routine.variables if var.name.lower() not in routine_arg_names]
+    unused_vars = [var.clone(dimensions=None) for var in local_vars
+            if not var.name.lower() in used_or_defined_symbols]
 
     return unused_args, unused_vars
 

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -11,6 +11,7 @@ section and to perform Dead Code Elimination.
 """
 
 import operator as op
+from itertools import chain
 
 from loki.analyse import dataflow_analysis_attached
 from loki.batch import Transformation
@@ -259,7 +260,8 @@ def do_remove_unused_call_args(routine, unused_args_map):
        utility.
     """
 
-    for call in FindNodes(ir.CallStatement).visit(routine.body):
+    inline_call_map = {}
+    for call in chain(FindNodes(ir.CallStatement).visit(routine.body), FindInlineCalls().visit(routine.body)):
         if call.routine is BasicType.DEFERRED or not unused_args_map.get(call.routine, None):
             continue
 
@@ -269,21 +271,10 @@ def do_remove_unused_call_args(routine, unused_args_map):
         new_args = [arg for i, arg in enumerate(call.arguments) if i not in unused_positions]
         new_kwargs = [(kw, arg) for kw, arg in call.kwarguments if not (kw, arg) in unused_kwargs]
 
-        call._update(arguments=as_tuple(new_args), kwarguments=as_tuple(new_kwargs))
-
-    # Handle inline function calls
-    inline_call_map = {}
-    for call in FindInlineCalls().visit(routine.body):
-        if call.routine is BasicType.DEFERRED or not unused_args_map.get(call.routine, None):
-            continue
-
-        unused_positions = {c for c in unused_args_map[call.routine].values() if c < len(call.arguments)}
-        unused_kwargs = [(kw, arg) for kw, arg in call.kwarguments if kw.lower() in unused_args_map[call.routine]]
-
-        new_args = tuple(arg for i, arg in enumerate(call.arguments) if i not in unused_positions)
-        new_kwargs = {kw: arg for kw, arg in call.kwarguments if not (kw, arg) in unused_kwargs}
-
-        inline_call_map[call] = call.clone(parameters=new_args, kw_parameters=new_kwargs)
+        if isinstance(call, ir.CallStatement):
+            call._update(arguments=as_tuple(new_args), kwarguments=as_tuple(new_kwargs))
+        else:
+            inline_call_map[call] = call.clone(parameters=as_tuple(new_args), kw_parameters=dict(new_kwargs))
 
     if inline_call_map:
         routine.body = SubstituteExpressions(inline_call_map).visit(routine.body)

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -15,7 +15,7 @@ import operator as op
 from loki.analyse import dataflow_analysis_attached
 from loki.batch import Transformation
 from loki.expression import simplify, symbols as sym, symbolic_op
-from loki.ir import nodes as ir, Transformer, FindNodes, FindVariables
+from loki.ir import nodes as ir, Transformer, FindNodes, FindVariables, FindInlineCalls, SubstituteExpressions
 from loki.ir.pragma_utils import (
     is_loki_pragma, pragma_regions_attached, get_pragma_parameters
 )
@@ -208,15 +208,15 @@ def do_remove_unused_vars(routine, unused_vars=None, remove_only_arrays=True):
 def do_remove_unused_call_args(routine, unused_args_map):
     """
     Utility routine to remove unused arguments from all the
-    :any:`CallStatement`s in a given routine.
+    :any:`CallStatement`s and :any:`InlineCall`s in a given routine.
 
     Parameters
     ----------
     routine : :any:`Subroutine`
-        A :any:`Subroutine` whose call statements will be updated.
+        A :any:`Subroutine` whose call statements and inline calls will be updated.
     unused_args_map : dict
-       A dict mapping the :any:`Subroutine` corresponding to the :any:`CallStatement`,
-       accessed via the `any:`CallStatement`.routine property, to its unused arguments.
+       A dict mapping the :any:`Subroutine` corresponding to the :any:`CallStatement`
+       or :any:`InlineCall`, accessed via the ``routine`` property, to its unused arguments.
        The unused arguments must be retrieved using the :any:`find_unused_dummy_args`
        utility.
     """
@@ -232,6 +232,23 @@ def do_remove_unused_call_args(routine, unused_args_map):
         new_kwargs = [(kw, arg) for kw, arg in call.kwarguments if not (kw, arg) in unused_kwargs]
 
         call._update(arguments=as_tuple(new_args), kwarguments=as_tuple(new_kwargs))
+
+    # Handle inline function calls
+    inline_call_map = {}
+    for call in FindInlineCalls().visit(routine.body):
+        if call.routine is BasicType.DEFERRED or not unused_args_map.get(call.routine, None):
+            continue
+
+        unused_positions = {c for c in unused_args_map[call.routine].values() if c < len(call.arguments)}
+        unused_kwargs = [(kw, arg) for kw, arg in call.kwarguments if kw.lower() in unused_args_map[call.routine]]
+
+        new_args = tuple(arg for i, arg in enumerate(call.arguments) if i not in unused_positions)
+        new_kwargs = {kw: arg for kw, arg in call.kwarguments if not (kw, arg) in unused_kwargs}
+
+        inline_call_map[call] = call.clone(parameters=new_args, kw_parameters=new_kwargs)
+
+    if inline_call_map:
+        routine.body = SubstituteExpressions(inline_call_map).visit(routine.body)
 
 
 def find_unused_dummy_args_and_vars(routine):

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -11,7 +11,7 @@ import pytest
 from loki import Subroutine, Module, Sourcefile, gettempdir
 from loki.batch import Scheduler, SchedulerConfig
 from loki.frontend import available_frontends, OMNI
-from loki.ir import nodes as ir, FindNodes
+from loki.ir import nodes as ir, FindNodes, FindInlineCalls
 
 from loki.transformations.remove_code import (
     do_remove_dead_code, do_remove_marked_regions, do_remove_calls,
@@ -156,9 +156,23 @@ subroutine driver(dims, StrUct)
 end subroutine driver
 """
 
+    fcode_inline_module = """
+module inline_mod
+contains
+function inline_func(kst, kend, D, E, F) result(res)
+    implicit none
+    integer, intent(in) :: kst, kend, d, e, f
+    integer :: res
+
+    res = kst + kend + d
+end function inline_func
+end module inline_mod
+"""
+
     fcode_kernel = """
 subroutine kernel(kst, kend, diMs, stRUCt, sTructs, a, b, c, d)
     use types_mod, only : dims_type, some_unused_type
+    use inline_mod, only : inline_func
     implicit none
     integer, intent(in) :: kst, kend
     type(dims_type), intent(in) :: dIms
@@ -184,6 +198,7 @@ subroutine kernel(kst, kend, diMs, stRUCt, sTructs, a, b, c, d)
     !$loki end remove
 
     call another_kernel(kst, kend, c, c, f=d)
+    ji = inline_func(kst, kend, ji, ji, f=jrof)
 
 end subroutine kernel
 """
@@ -202,6 +217,7 @@ end subroutine another_kernel
 """
 
     (srcdir/'module.F90').write_text(fcode_module)
+    (srcdir/'inline_mod.F90').write_text(fcode_inline_module)
     (srcdir/'driver.F90').write_text(fcode_driver)
     (srcdir/'kernel.F90').write_text(fcode_kernel)
     (srcdir/'another_kernel.F90').write_text(fcode_another_kernel)
@@ -209,6 +225,7 @@ end subroutine another_kernel
     yield srcdir
 
     (srcdir/'module.F90').unlink()
+    (srcdir/'inline_mod.F90').unlink()
     (srcdir/'driver.F90').unlink()
     (srcdir/'kernel.F90').unlink()
     (srcdir/'another_kernel.F90').unlink()
@@ -688,6 +705,7 @@ def test_remove_code_unused_args(frontend, source_with_args, kernel_override, tm
     driver = scheduler['#driver'].ir
 
     kernel_calls = FindNodes(ir.CallStatement).visit(kernel.body)
+    kernel_inline_calls = list(FindInlineCalls().visit(kernel.body))
     driver_calls = FindNodes(ir.CallStatement).visit(driver.body)
 
     assert len(kernel_calls) == 1
@@ -701,6 +719,11 @@ def test_remove_code_unused_args(frontend, source_with_args, kernel_override, tm
     else:
         assert kernel_calls[0].arguments == ('kst', 'kend', 'c')
         assert kernel_calls[0].kwarguments == ()
+
+    assert len(kernel_inline_calls) == 1
+    assert kernel_inline_calls[0].name == 'inline_func'
+    assert kernel_inline_calls[0].arguments == ('kst', 'kend', 'ji')
+    assert kernel_inline_calls[0].kwarguments == ()
 
     kernel_vars = [v.clone(dimensions=None) for v in kernel.variables]
 

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -149,9 +149,10 @@ subroutine driver(dims, StrUct)
     type(some_unused_type), intent(in) :: struct
     type(some_unused_type) :: structs(10)
     real, dimension(dims%klon) :: a, b, c, d
+    integer :: mask_len
 
 
-    call kernel(dims%kst, dims%kend, dIms, sTRucT, STRucts, a, b, c, d)
+    call kernel(dims%kst, dims%kend, dIms, sTRucT, STRucts, a, b, c, d, mask_len, 1)
 
 end subroutine driver
 """
@@ -170,11 +171,11 @@ end module inline_mod
 """
 
     fcode_kernel = """
-subroutine kernel(kst, kend, diMs, stRUCt, sTructs, a, b, c, d)
+subroutine kernel(kst, kend, diMs, stRUCt, sTructs, a, b, c, d, mask_len, masked)
     use types_mod, only : dims_type, some_unused_type
     use inline_mod, only : inline_func
     implicit none
-    integer, intent(in) :: kst, kend
+    integer, intent(in) :: kst, kend, mask_len, masked
     type(dims_type), intent(in) :: dIms
     type(some_unused_type), intent(in) :: StrucT
     type(some_unused_type), intent(in) :: StrucTS(10)
@@ -199,6 +200,25 @@ subroutine kernel(kst, kend, diMs, stRUCt, sTructs, a, b, c, d)
 
     call another_kernel(kst, kend, c, c, f=d)
     ji = inline_func(kst, kend, ji, ji, f=jrof)
+    call internal_kernel(ji, ji, gamma=jrof)
+    call shadowing_kernel()
+
+contains
+subroutine internal_kernel(alpha, beta, gamma)
+    implicit none
+    integer, intent(in) :: alpha, beta, gamma
+    real :: tmp(mask_len)
+
+    if (alpha > 0 .and. jrof > 0 .and. struct%a > 0.) return
+end subroutine internal_kernel
+
+subroutine shadowing_kernel()
+    implicit none
+    integer :: masked
+    type(some_unused_type) :: struct
+
+    struct%a = masked
+end subroutine shadowing_kernel
 
 end subroutine kernel
 """
@@ -708,17 +728,35 @@ def test_remove_code_unused_args(frontend, source_with_args, kernel_override, tm
     kernel_inline_calls = list(FindInlineCalls().visit(kernel.body))
     driver_calls = FindNodes(ir.CallStatement).visit(driver.body)
 
-    assert len(kernel_calls) == 1
-    assert kernel_calls[0].name.name.lower() == 'another_kernel'
+    assert len(kernel_calls) == 3
+    kernel_calls = {call.name.name.lower(): call for call in kernel_calls}
+    assert set(kernel_calls) == {'another_kernel', 'internal_kernel', 'shadowing_kernel'}
     assert len(driver_calls) == 1
     assert driver_calls[0].name.name.lower() == 'kernel'
 
     if kernel_override:
-        assert kernel_calls[0].arguments == ('kst', 'kend', 'c', 'c')
-        assert kernel_calls[0].kwarguments == (('f', 'd'),)
+        assert kernel_calls['another_kernel'].arguments == ('kst', 'kend', 'c', 'c')
+        assert kernel_calls['another_kernel'].kwarguments == (('f', 'd'),)
+        assert driver_calls[0].arguments == (
+            'dims%kst', 'dims%kend', 'dims', 'struct', 'structs', 'a', 'b', 'c', 'd', 'mask_len'
+        )
     else:
-        assert kernel_calls[0].arguments == ('kst', 'kend', 'c')
-        assert kernel_calls[0].kwarguments == ()
+        assert kernel_calls['another_kernel'].arguments == ('kst', 'kend', 'c')
+        assert kernel_calls['another_kernel'].kwarguments == ()
+        assert driver_calls[0].arguments == (
+            'dims%kst', 'dims%kend', 'dims', 'struct', 'structs', 'a', 'b', 'c', 'mask_len'
+        )
+
+    assert kernel_calls['internal_kernel'].arguments == ('ji',)
+    assert kernel_calls['internal_kernel'].kwarguments == ()
+    assert kernel_calls['shadowing_kernel'].arguments == ()
+    assert kernel_calls['shadowing_kernel'].kwarguments == ()
+
+    assert len(kernel.members) == 2
+    assert kernel.members[0].name == 'internal_kernel'
+    assert kernel.members[0].arguments == ('alpha',)
+    assert kernel.members[1].name == 'shadowing_kernel'
+    assert kernel.members[1].arguments == ()
 
     assert len(kernel_inline_calls) == 1
     assert kernel_inline_calls[0].name == 'inline_func'
@@ -729,15 +767,19 @@ def test_remove_code_unused_args(frontend, source_with_args, kernel_override, tm
 
     assert 'structs' in kernel_vars
     assert 'structs' in driver_calls[0].arguments
-    if kernel_override:
-        assert not 'struct' in kernel_vars
-        assert not 'struct' in driver_calls[0].arguments
+    assert 'struct' in kernel_vars
+    assert 'struct' in driver_calls[0].arguments
+    assert 'mask_len' in kernel_vars
+    assert 'mask_len' in driver_calls[0].arguments
+    assert 'masked' not in kernel_vars
+    assert 'masked' not in driver_calls[0].arguments
 
+    if kernel_override:
         assert 'd' in kernel_vars
         assert 'd' in driver_calls[0].arguments
     else:
-        assert not any(v in kernel_vars for v in ['d', 'struct'])
-        assert not any(v in driver_calls[0].arguments for v in ['d', 'struct'])
+        assert not 'd' in kernel_vars
+        assert not 'd' in driver_calls[0].arguments
 
     assert 'used_local' in kernel_vars
     assert 'unused_local' in kernel_vars
@@ -745,6 +787,7 @@ def test_remove_code_unused_args(frontend, source_with_args, kernel_override, tm
     transformation = RemoveCodeTransformation(remove_unused_vars=True)
     scheduler.process(transformation=transformation)
 
+    kernel = scheduler['#kernel'].ir
     kernel_vars = [v.clone(dimensions=None) for v in kernel.variables]
     assert 'used_local' in kernel_vars
     assert 'unused_local' not in kernel_vars

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -183,16 +183,16 @@ subroutine kernel(kst, kend, diMs, stRUCt, sTructs, a, b, c, d)
     call an_unused_kernel(stRuCt)
     !$loki end remove
 
-    call another_kernel(kst, kend, d=C, e=D)
+    call another_kernel(kst, kend, c, c, f=d)
 
 end subroutine kernel
 """
 
     fcode_another_kernel = """
-subroutine another_kernel(kst, kend, D, E)
+subroutine another_kernel(kst, kend, D, E, F)
     implicit none
     integer, intent(in) :: kst, kend
-    real, intent(out) :: d(:), e(:)
+    real, intent(out) :: d(:), e(:), f(:)
     integer :: jrof
 
     do jrof = kst, kend
@@ -694,6 +694,13 @@ def test_remove_code_unused_args(frontend, source_with_args, kernel_override, tm
     assert kernel_calls[0].name.name.lower() == 'another_kernel'
     assert len(driver_calls) == 1
     assert driver_calls[0].name.name.lower() == 'kernel'
+
+    if kernel_override:
+        assert kernel_calls[0].arguments == ('kst', 'kend', 'c', 'c')
+        assert kernel_calls[0].kwarguments == (('f', 'd'),)
+    else:
+        assert kernel_calls[0].arguments == ('kst', 'kend', 'c')
+        assert kernel_calls[0].kwarguments == ()
 
     kernel_vars = [v.clone(dimensions=None) for v in kernel.variables]
 


### PR DESCRIPTION
This PR contributes a series of fixes and improvements for the unused argument removal utility:
- Fix for edge-case when the same argument is passed to two dummy arguments (my inner Fortran enthusiast is in pain)
- Also remove unused arguments from inline calls
- Also remove unused arguments from internal routines
- Also account for internal routines when determining unused arguments