### PR TITLE
Types: Make BasicType.DEFERRED behave falsey

### DIFF
--- a/loki/analyse/dataflow_analysis.py
+++ b/loki/analyse/dataflow_analysis.py
@@ -16,7 +16,6 @@ from loki.analyse.abstract_dfa import AbstractDataflowAnalysis, dfa_attached
 from loki.expression import Array, ProcedureSymbol
 from loki.ir.expr_visitors import FindLiterals
 from loki.tools import as_tuple, flatten, OrderedSet
-from loki.types import BasicType
 from loki.ir import (
     Visitor, Transformer, FindVariables, FindInlineCalls, FindTypedSymbols
 )
@@ -279,7 +278,7 @@ class DataflowAnalysisAttacher(Transformer):
         return self.visit_Node(o, defines_symbols=defines, uses_symbols=uses, **kwargs)
 
     def visit_CallStatement(self, o, **kwargs):
-        if o.routine is not BasicType.DEFERRED:
+        if o.routine:
             # With a call context provided we can determine which arguments
             # are potentially defined and which are definitely only used by
             # this call

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -17,9 +17,6 @@ from loki.module import Module
 from loki.subroutine import Subroutine
 from loki.sourcefile import Sourcefile
 from loki.tools import CaseInsensitiveDict, as_tuple
-from loki.types import BasicType
-
-
 __all__ = ['ItemFactory']
 
 
@@ -427,7 +424,7 @@ class ItemFactory:
         #     resolving one type at a time, e.g.
         #     my_var%member%procedure -> my_type%member%procedure -> member_type%procedure -> procedure
         dtype = proc_symbol.parents[0].type.dtype
-        if dtype is BasicType.DEFERRED:
+        if not dtype:
             msg = f'Missing type information for symbol {proc_symbol.parents[0]}'
             warning(msg)
             return None

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -18,7 +18,7 @@ from sys import intern
 import pymbolic.primitives as pmbl
 
 from loki.tools import as_tuple, CaseInsensitiveDict
-from loki.types import BasicType, DerivedType, ProcedureType, SymbolAttributes, Scope
+from loki.types import BasicType, DataType, DerivedType, ProcedureType, SymbolAttributes, Scope
 from loki.config import config
 
 from loki.expression.literals import (
@@ -965,12 +965,18 @@ class InlineCall(StrCompareMixin, pmbl.CallWithKwargs):
         return self.function.name
 
     @property
-    def procedure_type(self):
+    def procedure_type(self) -> DataType:
         """
         Returns the underpinning procedure type if the type is know,
         ``BasicType.DEFFERED`` otherwise.
         """
-        return self.function.type.dtype
+        procedure_type = self.function.type.dtype
+        if not isinstance(procedure_type, DataType):
+            raise TypeError(
+                f'InlineCall.function.type.dtype must be a DataType, got '
+                f'{type(procedure_type).__name__}'
+            )
+        return procedure_type
 
     @property
     def arguments(self):

--- a/loki/expression/symbols.py
+++ b/loki/expression/symbols.py
@@ -143,7 +143,7 @@ class TypedSymbol:
         ambiguous derived type components.
         """
         _type = scope.symbol_attrs.lookup(self.name)
-        if _type and _type.dtype is not BasicType.DEFERRED:
+        if _type and _type.dtype:
             # We have a clean entry in the symbol table which is not deferred
             return _type
 
@@ -248,7 +248,7 @@ class TypedSymbol:
         """
         _type = self.type
         if _type and isinstance(_type.dtype, DerivedType):
-            if _type.dtype.typedef is BasicType.DEFERRED:
+            if not _type.dtype.typedef:
                 return ()
             return tuple(
                 v.clone(name=f'{self.name}%{v.name}', scope=self.scope, type=v.type, parent=self)
@@ -326,7 +326,7 @@ class TypedSymbol:
         Resolve type-bound variables of arbitrary nested depth.
         """
         name_parts = name_str.split('%', maxsplit=1)
-        if self.type.dtype is not BasicType.DEFERRED and self.type.dtype.typedef is not BasicType.DEFERRED:
+        if self.type.dtype and self.type.dtype.typedef:
             assert self.type.dtype.typedef.variable_map[name_parts[0]]
         declared_var = Variable(name=f'{self.name}%{name_parts[0]}', scope=self.scope, parent=self)
         if len(name_parts) > 1:
@@ -863,7 +863,7 @@ class Variable:
 
         if kwargs.get('dimensions') is not None or (_type and _type.shape):
             return Array(**kwargs)
-        if _type and _type.dtype is not BasicType.DEFERRED:
+        if _type and _type.dtype:
             return Scalar(**kwargs)
         return DeferredTypeSymbol(**kwargs)
 
@@ -893,7 +893,7 @@ class Variable:
         stored_type = scope.symbol_attrs.lookup(name)
 
         # 2. For derived type members, we can try to find it via the parent instead
-        if '%' in name and (not stored_type or stored_type.dtype is BasicType.DEFERRED):
+        if '%' in name and (not stored_type or not stored_type.dtype):
             name_parts = name.split('%')
             if not parent:
                 # Build the parent if not given

--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -762,7 +762,7 @@ class FParser2IR(GenericVisitor):
 
             # Look for a previous definition of this type
             _type = kwargs['scope'].symbol_attrs.lookup(dtype.name)
-            if _type is None or _type.dtype is BasicType.DEFERRED:
+            if _type is None or not _type.dtype:
                 _type = SymbolAttributes(dtype)
 
             if o.children[0].upper() == 'CLASS':
@@ -934,7 +934,7 @@ class FParser2IR(GenericVisitor):
         scope = kwargs['scope']
         for var in symbols:
             _type = scope.symbol_attrs.lookup(var.name) or SymbolAttributes(dtype=BasicType.DEFERRED)
-            if _type.dtype == BasicType.DEFERRED:
+            if not _type.dtype:
                 dtype = ProcedureType(var.name, is_function=False)
             else:
                 dtype = ProcedureType(var.name, is_function=True, return_type=_type)
@@ -1005,7 +1005,7 @@ class FParser2IR(GenericVisitor):
         if return_type is None:
             interface = self.visit(o.children[0], **kwargs)
             interface = AttachScopesMapper()(interface, scope=scope)
-            if interface.type.dtype is BasicType.DEFERRED:
+            if not interface.type.dtype:
                 # This is (presumably!) an external function with explicit interface that we
                 # don't know because the type information is not available, e.g., because it's been
                 # imported from another module or sits in an intfb.h header file.
@@ -1454,7 +1454,7 @@ class FParser2IR(GenericVisitor):
         types = [scope.symbol_attrs.lookup(name) for name in func_names]
         types = [
             SymbolAttributes(dtype=ProcedureType(name))
-            if not t or t.dtype == BasicType.DEFERRED else t
+            if not t or not t.dtype else t
             for t, name in zip(types, func_names)
         ]
 
@@ -1645,7 +1645,7 @@ class FParser2IR(GenericVisitor):
             # This has a generic specification (and we might need to update symbol table)
             scope = kwargs['scope']
             spec_type = scope.symbol_attrs.lookup(spec.name)
-            if not spec_type or spec_type.dtype == BasicType.DEFERRED:
+            if not spec_type or not spec_type.dtype:
                 scope.symbol_attrs[spec.name] = SymbolAttributes(
                     ProcedureType(name=spec.name, is_generic=True)
                 )
@@ -2012,8 +2012,7 @@ class FParser2IR(GenericVisitor):
             return None, None
 
         if proc_type := scope.symbol_attrs.get(name):  # Look-up only in current scope!
-            if proc_type and proc_type.dtype != BasicType.DEFERRED and \
-               proc_type.dtype.procedure != BasicType.DEFERRED:
+            if proc_type and proc_type.dtype and proc_type.dtype.procedure:
                 return proc_type.dtype.procedure, proc_type
         return None, None
 
@@ -2296,7 +2295,7 @@ class FParser2IR(GenericVisitor):
         # Check if the Module node has been created before by looking it up in the scope
         if kwargs['scope'] is not None and name in kwargs['scope'].symbol_attrs:
             module_type = kwargs['scope'].symbol_attrs[name]  # Look-up only in current scope!
-            if module_type and module_type.dtype.module != BasicType.DEFERRED:
+            if module_type and module_type.dtype.module:
                 return module_type.dtype.module
 
         module = Module(name=name, parent=kwargs['scope'])
@@ -2940,7 +2939,7 @@ class FParser2IR(GenericVisitor):
         # Update type information for symbols with deferred type
         # (applies to all constant that are defined without explicit value)
         symbols = tuple(
-            s.clone(type=SymbolAttributes(BasicType.INTEGER)) if s.type.dtype is BasicType.DEFERRED else s
+            s.clone(type=SymbolAttributes(BasicType.INTEGER)) if not s.type.dtype else s
             for s in symbols
         )
 

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -317,7 +317,7 @@ class OMNI2IR(GenericVisitor):
         procedure = None
         if scope is not None and name in scope.symbol_attrs:
             proc_type = scope.symbol_attrs[name]  # Look-up only in current scope!
-            if proc_type and proc_type.dtype.procedure != BasicType.DEFERRED:
+            if proc_type and proc_type.dtype.procedure:
                 procedure = proc_type.dtype.procedure
                 if not procedure._incomplete:
                     # We return the existing object right away, unless it exists from a
@@ -479,7 +479,7 @@ class OMNI2IR(GenericVisitor):
         # Check if the Module node has been created before by looking it up in the scope
         if scope is not None and name in scope.symbol_attrs:
             module_type = scope.symbol_attrs[name]  # Look-up only in current scope
-            if module_type and module_type.dtype.module != BasicType.DEFERRED:
+            if module_type and module_type.dtype.module:
                 return module_type.dtype.module
 
         module = Module(name=name, parent=scope)
@@ -907,7 +907,7 @@ class OMNI2IR(GenericVisitor):
 
         # Check if we know that type already
         dtype = kwargs['scope'].symbol_attrs.lookup(name, recursive=True)
-        if dtype is None or dtype.dtype == BasicType.DEFERRED:
+        if dtype is None or not dtype.dtype:
             dtype = DerivedType(name=name, typedef=BasicType.DEFERRED)
         else:
             dtype = dtype.dtype

--- a/loki/frontend/regex.py
+++ b/loki/frontend/regex.py
@@ -423,7 +423,7 @@ class ModulePattern(Pattern):
         name = match['name']
         if scope is not None and name in scope.symbol_attrs:
             module_type = scope.symbol_attrs[name]  # Look-up only in current scope!
-            if module_type and module_type.dtype.module != BasicType.DEFERRED:
+            if module_type and module_type.dtype.module:
                 module = module_type.dtype.module
 
         if module is None:
@@ -510,7 +510,7 @@ class SubroutineFunctionPattern(Pattern):
         name = match['name']
         if scope is not None and name in scope.symbol_attrs:
             proc_type = scope.symbol_attrs[name]  # Look-up only in current scope!
-            if proc_type and getattr(proc_type.dtype, 'procedure', BasicType.DEFERRED) != BasicType.DEFERRED:
+            if proc_type and getattr(proc_type.dtype, 'procedure', None):
                 routine = proc_type.dtype.procedure
 
         if routine is None:

--- a/loki/ir/nodes/leaf_nodes.py
+++ b/loki/ir/nodes/leaf_nodes.py
@@ -882,7 +882,7 @@ class TypeDef(ScopedNode, InternalNode, _TypeDefBase):
         )
 
         # Inherit non-overriden symbols from parent type
-        if (parent_type := self.parent_type) and parent_type is not BasicType.DEFERRED:
+        if parent_type := self.parent_type:
             local_symbols = [s for decl in decls for s in decl.symbols]
             for decl in parent_type.declarations:
                 decl_symbols = tuple(s.clone(scope=self) for s in decl.symbols if s not in local_symbols)

--- a/loki/ir/nodes/leaf_nodes.py
+++ b/loki/ir/nodes/leaf_nodes.py
@@ -198,7 +198,7 @@ class CallStatement(LeafNode, _CallStatementBase):
         return f'Call:: {self.name}'
 
     @property
-    def procedure_type(self):
+    def procedure_type(self) -> DataType:
         """
         The :any:`ProcedureType` of the :any:`Subroutine` object of the called routine
 
@@ -213,10 +213,16 @@ class CallStatement(LeafNode, _CallStatementBase):
             The type of the called procedure. If the symbol type of the called routine
             has not been identified correctly, this may yield :any:`BasicType.DEFERRED`.
         """
-        return self.name.type.dtype
+        procedure_type = self.name.type.dtype
+        if not isinstance(procedure_type, DataType):
+            raise TypeError(
+                f'CallStatement.name.type.dtype must be a DataType, got '
+                f'{type(procedure_type).__name__}'
+            )
+        return procedure_type
 
     @property
-    def routine(self):
+    def routine(self) -> Union['Function', 'Subroutine', 'StatementFunction', BasicType]:
         """
         The :any:`Subroutine` object of the called routine
 

--- a/loki/ir/nodes/tests/test_nodes.py
+++ b/loki/ir/nodes/tests/test_nodes.py
@@ -14,8 +14,9 @@ from pydantic import ValidationError
 from loki.expression import symbols as sym, parse_expr
 from loki.function import Function
 from loki.ir import nodes as ir
+from loki.subroutine import Subroutine
 from loki.tools import as_tuple, flatten
-from loki.types import Scope
+from loki.types import BasicType, ProcedureType, Scope, SymbolAttributes
 
 
 @pytest.fixture(name='scope')
@@ -374,6 +375,39 @@ def test_callstatement(scope, one, i, n, a_i):
         )
 
     # TODO: Test pragmas, active and chevron
+
+
+def test_callstatement_routine_types(scope):
+    """Test type-checked access to call routine metadata."""
+
+    callee = Subroutine(name='callee')
+    cname = sym.ProcedureSymbol(
+        name='callee', scope=scope, type=SymbolAttributes(dtype=ProcedureType(procedure=callee))
+    )
+    call = ir.CallStatement(name=cname)
+
+    assert isinstance(call.procedure_type, ProcedureType)
+    assert call.routine is callee
+
+    unresolved = sym.ProcedureSymbol(name='unresolved')
+    unresolved.type = SymbolAttributes(dtype=BasicType.DEFERRED)
+    deferred_call = ir.CallStatement(name=unresolved)
+
+    assert deferred_call.procedure_type is BasicType.DEFERRED
+    assert deferred_call.routine is BasicType.DEFERRED
+    assert not deferred_call.routine
+
+
+def test_callstatement_invalid_routine_type():
+    """Test runtime failure for invalid call routine type metadata."""
+
+    cname = sym.ProcedureSymbol(name='broken')
+    cname.type = SymbolAttributes(dtype=BasicType.DEFERRED)
+    cname.type.dtype = object()
+    call = ir.CallStatement(name=cname)
+
+    with pytest.raises(TypeError, match=r'CallStatement\.name\.type\.dtype must be a DataType'):
+        _ = call.procedure_type
 
 
 def test_associate(scope, a_i):

--- a/loki/program_unit.py
+++ b/loki/program_unit.py
@@ -17,7 +17,7 @@ from loki.ir import (
 )
 from loki.logging import debug
 from loki.tools import CaseInsensitiveDict, as_tuple, flatten
-from loki.types import BasicType, DerivedType, ProcedureType, Scope
+from loki.types import DerivedType, ProcedureType, Scope
 
 
 __all__ = ['ProgramUnit']
@@ -368,9 +368,9 @@ class ProgramUnit(Scope):
 
                 if attrs.imported and not attrs.module:
                     updated_symbol_attrs[name] = self.parent.symbol_attrs[name]
-                elif isinstance(attrs.dtype, ProcedureType) and attrs.dtype.procedure is BasicType.DEFERRED:
+                elif isinstance(attrs.dtype, ProcedureType) and not attrs.dtype.procedure:
                     updated_symbol_attrs[name] = self.parent.symbol_attrs[name]
-                elif isinstance(attrs.dtype, DerivedType) and attrs.dtype.typedef is BasicType.DEFERRED:
+                elif isinstance(attrs.dtype, DerivedType) and not attrs.dtype.typedef:
                     updated_symbol_attrs[name] = attrs.clone(dtype=self.parent.symbol_attrs[name].dtype)
             self.symbol_attrs.update(updated_symbol_attrs)
 

--- a/loki/subroutine.py
+++ b/loki/subroutine.py
@@ -17,7 +17,7 @@ from loki.ir import (
 from loki.logging import debug
 from loki.program_unit import ProgramUnit
 from loki.tools import as_tuple, CaseInsensitiveDict
-from loki.types import BasicType, ProcedureType, SymbolAttributes
+from loki.types import ProcedureType, SymbolAttributes
 
 
 
@@ -385,16 +385,16 @@ class Subroutine(ProgramUnit):
 
                 if not routine and symbol.parent:
                     # Type-bound procedure: try to obtain procedure from typedef
-                    if (dtype := symbol.parent.type.dtype) is not BasicType.DEFERRED:
-                        if (typedef := dtype.typedef) is not BasicType.DEFERRED:
+                    if dtype := symbol.parent.type.dtype:
+                        if typedef := dtype.typedef:
                             if proc_symbol := typedef.variable_map.get(symbol.name_parts[-1]):
-                                if (dtype := proc_symbol.type.dtype) is not BasicType.DEFERRED:
-                                    if dtype.procedure is not BasicType.DEFERRED:
+                                if dtype := proc_symbol.type.dtype:
+                                    if dtype.procedure:
                                         routine = dtype.procedure
 
                 is_not_enriched = (
                     symbol.scope is None or                         # No scope attached
-                    symbol.type.dtype is BasicType.DEFERRED or      # Wrong datatype
+                    not symbol.type.dtype or                        # Wrong datatype
                     symbol.type.dtype.procedure is not routine      # ProcedureType not linked
                 )
 

--- a/loki/transformations/argument_shape.py
+++ b/loki/transformations/argument_shape.py
@@ -59,7 +59,7 @@ class ArgumentArrayShapeAnalysis(Transformation):
         for call in FindNodes(CallStatement).visit(routine.body):
 
             # Skip if call-side info is not available or call is not active
-            if call.routine is BasicType.DEFERRED or call.not_active:
+            if not call.routine or call.not_active:
                 continue
 
             routine = call.routine
@@ -164,7 +164,7 @@ class ExplicitArgumentArrayShapeTransformation(Transformation):
         for call in FindNodes(CallStatement).visit(routine.body):
 
             # Skip if call-side info is not available or call is not active
-            if call.routine is BasicType.DEFERRED or call.not_active:
+            if not call.routine or call.not_active:
                 continue
 
             callee = call.routine

--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -548,7 +548,7 @@ class LowerBlockIndexTransformation(Transformation):
         for call in FindNodes(ir.CallStatement).visit(routine.body):
             if str(call.name).lower() not in targets:
                 continue
-            if call.routine is BasicType.DEFERRED:
+            if not call.routine:
                 warning('[LowerBlockIndexTransformation] Not processing routine ' \
                         f'{call.name}. Call statement not enriched')
                 continue
@@ -729,7 +729,7 @@ class LowerBlockLoopTransformation(Transformation):
                 for loop in loops:
                     target_calls = [call for call in FindNodes(ir.CallStatement).visit(loop.body)
                             if str(call.name).lower() in targets]
-                    target_calls = [call for call in target_calls if call.routine is not BasicType.DEFERRED]
+                    target_calls = [call for call in target_calls if call.routine]
                     if not target_calls:
                         continue
                     calls += tuple(target_calls)

--- a/loki/transformations/data_offload/field_offload.py
+++ b/loki/transformations/data_offload/field_offload.py
@@ -221,7 +221,7 @@ def find_offload_variables(driver, region, field_group_types):
 
     # Do some sanity checking and warning for enclosed calls
     for call in FindNodes(ir.CallStatement).visit(region):
-        if call.routine is BasicType.DEFERRED:
+        if not call.routine:
             warning(f'[Loki] Data offload: Routine {driver.name} has not been enriched ' +
                     f'in {str(call.name).lower()}')
             continue

--- a/loki/transformations/data_offload/offload.py
+++ b/loki/transformations/data_offload/offload.py
@@ -13,9 +13,6 @@ from loki.ir import (
 )
 from loki.logging import warning, error
 from loki.tools import as_tuple
-from loki.types import BasicType
-
-
 __all__ = ['DataOffloadTransformation']
 
 
@@ -124,7 +121,7 @@ class DataOffloadTransformation(Transformation):
                 outargs = ()
 
                 for call in calls:
-                    if call.routine is BasicType.DEFERRED:
+                    if not call.routine:
                         warning(f'[Loki] Data offload: Routine {routine.name} has not been enriched ' +
                                 f'in {str(call.name).lower()}')
 

--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -130,7 +130,7 @@ class DeepcopyDataflowAnalysis(DataflowAnalysis):
         self.successor_map = successor_map
 
     def resolve_call_effects(self, call, *, attacher, **kwargs):
-        if call.routine is BasicType.DEFERRED:
+        if not call.routine:
             msg = f'[Loki::DataOffloadDeepcopyAnalysis] Cannot apply transformation without enriching calls: {call}.'
             raise RuntimeError(msg)
 

--- a/loki/transformations/inline/functions.py
+++ b/loki/transformations/inline/functions.py
@@ -15,7 +15,6 @@ from loki.ir import (
     VariableDeclaration
 )
 from loki.subroutine import Subroutine
-from loki.types import BasicType
 from loki.tools import as_tuple, OrderedSet
 
 from loki.transformations.inline.mapper import InlineSubstitutionMapper
@@ -110,7 +109,7 @@ def _inline_functions(routine, inline_elementals_only=False, functions=None):
         def map_inline_call(self, expr, *args, **kwargs):
             if not self.visit(expr, *args, **kwargs):
                 return
-            if not expr.procedure_type is BasicType.DEFERRED and expr.procedure_type.is_elemental:
+            if expr.procedure_type and expr.procedure_type.is_elemental:
                 if any(is_array(val) for val in expr.arg_map.values() if isinstance(val, sym.Array)):
                     warning(f"Call to elemental function '{expr.routine.name}' with array arguments."
                             f' There is currently no support to inline those calls!')
@@ -118,7 +117,7 @@ def _inline_functions(routine, inline_elementals_only=False, functions=None):
             self.rec(expr.function, *args, **kwargs)
             # SKIP parameters/args/kwargs on purpose
             #  under certain circumstances
-            if expr.procedure_type is BasicType.DEFERRED or\
+            if not expr.procedure_type or\
                     (self.inline_elementals_only and\
                     not(expr.procedure_type.is_function and expr.procedure_type.is_elemental)) or\
                     (self.functions and expr.routine not in self.functions):
@@ -153,7 +152,7 @@ def _inline_functions(routine, inline_elementals_only=False, functions=None):
     # in the next call to this function.
     for node, calls in FindInlineCallsSkipInlineCallParameters(with_ir_node=True).visit(routine.body):
         for call in calls:
-            if call.procedure_type is BasicType.DEFERRED or isinstance(call.routine, StatementFunction):
+            if not call.procedure_type or isinstance(call.routine, StatementFunction):
                 continue
             if not call.procedure_type.is_function:
                 continue
@@ -212,7 +211,7 @@ def inline_statement_functions(routine):
     exprmap = {}
     for call in FindInlineCalls().visit(routine.body):
         proc_type = call.procedure_type
-        if proc_type is BasicType.DEFERRED:
+        if not proc_type:
             continue
         if proc_type.is_function and isinstance(call.routine, StatementFunction):
             exprmap[call] = InlineSubstitutionMapper()(call, scope=routine)

--- a/loki/transformations/inline/mapper.py
+++ b/loki/transformations/inline/mapper.py
@@ -10,9 +10,6 @@ from loki.ir import (
     FindNodes, Assignment, StatementFunction, SubstituteExpressions
 )
 from loki.logging import detail
-from loki.types import BasicType
-
-
 __all__ = ['InlineSubstitutionMapper']
 
 
@@ -58,7 +55,7 @@ class InlineSubstitutionMapper(LokiIdentityMapper):
         return expr.clone(parent=parent)
 
     def map_inline_call(self, expr, *args, **kwargs):
-        if expr.procedure_type in (None, BasicType.DEFERRED) or expr.procedure_type.is_intrinsic:
+        if not expr.procedure_type or expr.procedure_type.is_intrinsic:
             # Unkonw inline call, potentially an intrinsic
             # We still need to recurse and ensure re-scoping
             return super().map_inline_call(expr, *args, **kwargs)

--- a/loki/transformations/inline/procedures.py
+++ b/loki/transformations/inline/procedures.py
@@ -13,7 +13,6 @@ from loki.ir import (
     pragmas_attached, is_loki_pragma, Interface, Pragma, AttachScopes
 )
 from loki.expression import symbols as sym, simplify
-from loki.types import BasicType
 from loki.tools import as_tuple, CaseInsensitiveDict
 from loki.logging import error
 from loki.subroutine import Subroutine
@@ -45,7 +44,7 @@ def resolve_sequence_association_for_inlined_calls(routine, inline_internals, in
                 (inline_internals and call.routine in routine.routines)
             )
             if condition:
-                if call.routine == BasicType.DEFERRED:
+                if not call.routine:
                     # NOTE: Throwing error here instead of continuing, because the user has explicitly
                     # asked sequence assoc to happen with inlining, so source for routine should be
                     # found in calls to be inlined.
@@ -136,7 +135,7 @@ def map_call_to_procedure_body(call, caller, callee=None):
 
     # Get callee from the procedure type
     callee = callee or call.routine
-    if callee is BasicType.DEFERRED:
+    if not callee:
         error(
             '[Loki::TransformInline] Need procedure definition to resolve '
             f'call to {call.name} from {caller}'
@@ -354,7 +353,7 @@ def inline_marked_subroutines(routine, allowed_aliases=None, adjust_imports=True
         call_sets = defaultdict(list)
         no_call_sets = defaultdict(list)
         for call in FindNodes(CallStatement).visit(routine.body):
-            if call.routine == BasicType.DEFERRED:
+            if not call.routine:
                 continue
 
             if is_loki_pragma(call.pragma, starts_with='inline'):

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -22,9 +22,6 @@ from loki.ir.pragma_utils import (
 )
 from loki.program_unit import ProgramUnit
 from loki.tools import flatten, as_tuple, OrderedSet
-from loki.types import BasicType
-
-
 __all__ = [
     'RemoveCodeTransformation',
     'do_remove_dead_code', 'RemoveDeadCodeTransformer',
@@ -262,7 +259,7 @@ def do_remove_unused_call_args(routine, unused_args_map):
 
     inline_call_map = {}
     for call in chain(FindNodes(ir.CallStatement).visit(routine.body), FindInlineCalls().visit(routine.body)):
-        if call.routine is BasicType.DEFERRED or not unused_args_map.get(call.routine, None):
+        if not call.routine or not unused_args_map.get(call.routine, None):
             continue
 
         unused_positions = {c for c in unused_args_map[call.routine].values() if c < len(call.arguments)}

--- a/loki/transformations/routine_signatures.py
+++ b/loki/transformations/routine_signatures.py
@@ -18,8 +18,6 @@ from loki.ir import (
     SubstituteExpressions
 )
 from loki.tools import as_tuple, flatten
-from loki.types import BasicType
-
 __all__ = ['RemoveDuplicateArgs', 'remove_duplicate_args_from_calls',
            'modify_variable_declarations']
 
@@ -150,7 +148,7 @@ def remove_duplicate_args_from_calls(routine, rename_common=False):
     relevant_calls = []
     # adapt call statements (and remove duplicate args/kwargs)
     for call in calls:
-        if call.routine is BasicType.DEFERRED:
+        if not call.routine:
             continue
         call_arg_map[call.routine] = remove_duplicate_args_call(call)
         relevant_calls.append(call)

--- a/loki/transformations/sanitise/sequence_associations.py
+++ b/loki/transformations/sanitise/sequence_associations.py
@@ -9,9 +9,6 @@ from loki.batch import Transformation
 from loki.expression import Array, RangeIndex
 from loki.ir import Transformer
 from loki.tools import as_tuple
-from loki.types import BasicType
-
-
 __all__ = [
     'SequenceAssociationTransformation',
     'do_resolve_sequence_association',
@@ -102,7 +99,7 @@ class SequenceAssociationTransformer(Transformer):
         Resolve sequence association patterns in arguments and return
         new :any:`CallStatement` object if any were found.
         """
-        if call.procedure_type is BasicType.DEFERRED:
+        if not call.procedure_type:
             return call
 
         new_args = []

--- a/loki/transformations/single_column/devector.py
+++ b/loki/transformations/single_column/devector.py
@@ -14,7 +14,6 @@ from loki.ir import (
     NestedTransformer, is_loki_pragma, pragmas_attached,
 )
 from loki.tools import as_tuple, flatten
-from loki.types import BasicType
 from loki.expression import symbols as sym
 
 from loki.transformations.utilities import (
@@ -116,7 +115,7 @@ class SCCDevectorTransformation(Transformation):
         for call in calls:
 
             # check if calls have been enriched
-            if not call.routine is BasicType.DEFERRED:
+            if call.routine:
                 # check if called routine is marked as sequential
                 if check_routine_sequential(routine=call.routine):
                     continue

--- a/loki/transformations/single_column/scc_cuf.py
+++ b/loki/transformations/single_column/scc_cuf.py
@@ -747,7 +747,7 @@ class SccLowLevelDataOffload(Transformation):
             # insert_index = routine.body.body.index(calls[-1])
             # insert_index = None
             for call in calls:
-                if call.routine is BasicType.DEFERRED:
+                if not call.routine:
                     # warning(f'[Loki] Data offload: Routine {routine.name} has not been enriched with ' +
                     #     f'in {str(call.name).lower()}')
                     continue

--- a/loki/transformations/temporaries/hoist_variables.py
+++ b/loki/transformations/temporaries/hoist_variables.py
@@ -91,7 +91,6 @@ from loki.ir import (
 from loki.tools.util import (
     is_iterable, as_tuple, CaseInsensitiveDict, flatten, OrderedSet
 )
-from loki.types import BasicType
 from loki.logging import warning
 
 from loki.transformations.utilities import single_variable_declaration
@@ -167,7 +166,7 @@ class HoistVariablesAnalysis(Transformation):
             if not isinstance(child, ProcedureItem):
                 continue
 
-            if call_map[child.local_name].routine is BasicType.DEFERRED:
+            if not call_map[child.local_name].routine:
                 warning((
                     '[Loki::HoistVariablesAnalysis] '
                     f''
@@ -292,7 +291,7 @@ class HoistVariablesTransformation(Transformation):
             if str(call.name) not in successor_map:
                 continue
 
-            if call.routine is BasicType.DEFERRED:
+            if not call.routine:
                 warning((
                     '[Loki::HoistVariablesTransformation] '
                     f''

--- a/loki/transformations/temporaries/pool_allocator.py
+++ b/loki/transformations/temporaries/pool_allocator.py
@@ -922,7 +922,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                 if call.name in [s for i in FindNodes(Interface).visit(routine.spec) for s in i.symbols]:
                     _ = self._get_stack_arg(call.routine)
 
-                if call.routine != BasicType.DEFERRED and stack_arg_name in call.routine.arguments:
+                if call.routine and stack_arg_name in call.routine.arguments:
                     call_map[call] = call.clone(
                         kwarguments=call.kwarguments + new_kwarguments
                     )

--- a/loki/transformations/temporaries/stack_allocator.py
+++ b/loki/transformations/temporaries/stack_allocator.py
@@ -93,7 +93,7 @@ class BaseStackTransformation(Transformation):
 
         # TODO: probably shouldn't happen here ...
         for call in FindNodes(CallStatement).visit(routine.body):
-            if call.routine is not BasicType.DEFERRED:
+            if call.routine:
                 call.convert_kwargs_to_args()
 
         if role == 'kernel':
@@ -172,7 +172,7 @@ class BaseStackTransformation(Transformation):
         """
         arg_map = {}
         for call in FindNodes(CallStatement).visit(routine.body):
-            if call.routine is not BasicType.DEFERRED:
+            if call.routine:
                 arg_map.update(dict(call.arg_iter()))
 
         var = Variable(name=self.horizontal.size, scope=routine, type=self.int_type)

--- a/loki/transformations/transform_derived_types.py
+++ b/loki/transformations/transform_derived_types.py
@@ -28,7 +28,7 @@ from loki.ir import (
 from loki.logging import warning, debug
 from loki.module import Module
 from loki.tools import as_tuple, flatten, CaseInsensitiveDict, OrderedSet
-from loki.types import BasicType, DerivedType, ProcedureType
+from loki.types import DerivedType, ProcedureType
 
 from loki.transformations.utilities import recursive_expression_map_update
 
@@ -482,7 +482,7 @@ class DerivedTypeArgumentsTransformation(Transformation):
             type_ = arg.type
             if isinstance(type_.dtype, DerivedType) and type_.dtype.name not in symbol_map:
                 typedef = type_.dtype.typedef
-                if typedef is BasicType.DEFERRED:
+                if not typedef:
                     warning((
                         '[Loki::DerivedTypeArgumentsTransformation] '
                         f'Cannot insert import for derived type "{type_.dtype.name}" in {routine.name}. '
@@ -586,7 +586,7 @@ def get_procedure_symbol_from_typebound_procedure_symbol(proc_symbol, routine_na
         return proc_symbol.type.bind_names[0]
 
     parent = proc_symbol.parents[0]
-    if parent.type.dtype.typedef is not BasicType.DEFERRED:
+    if parent.type.dtype.typedef:
         # Fiddle our way through derived type nesting until we obtain the symbol corresponding
         # to the procedure-binding in the TypeDef
         local_parent = None

--- a/loki/transformations/transpile/fortran_c.py
+++ b/loki/transformations/transpile/fortran_c.py
@@ -75,7 +75,7 @@ class DeReferenceTrafo(Transformer):
 
     def visit_CallStatement(self, o, **kwargs):
         new_args = ()
-        if o.routine is BasicType.DEFERRED:
+        if not o.routine:
             debug(f'DeReferenceTrafo: Skipping call to {o.name!s} due to missing procedure enrichment')
             return o
         call_arg_map = dict((v,k) for k,v in o.arg_map.items())
@@ -193,7 +193,7 @@ class FortranCTransformation(Transformation):
         # inline calls (to functions)
         inline_call_map = {}
         for inline_call in as_tuple(FindInlineCalls().visit(routine.body)):
-            if str(inline_call.name).lower() in as_tuple(targets) and inline_call.routine is not BasicType.DEFERRED:
+            if str(inline_call.name).lower() in as_tuple(targets) and inline_call.routine:
                 inline_call_map[inline_call] = inline_call.clone_with_kwargs_as_args()
         if inline_call_map:
             routine.body = SubstituteExpressions(inline_call_map).visit(routine.body)
@@ -347,7 +347,7 @@ class FortranCTransformation(Transformation):
         # inline calls (to functions)
         callmap = {}
         for call in FindInlineCalls(unique=False).visit(routine.body):
-            if call.routine is not BasicType.DEFERRED and (targets is None or call.name in as_tuple(targets)):
+            if call.routine and (targets is None or call.name in as_tuple(targets)):
                 callmap[call.function] = call.function.clone(name=f'{call.name}_c')
         routine.body = SubstituteExpressions(callmap).visit(routine.body)
 

--- a/loki/types/datatypes.py
+++ b/loki/types/datatypes.py
@@ -46,7 +46,7 @@ class BasicType(DataType, int, Enum):
     heuristically converted.
     """
 
-    DEFERRED = -1
+    DEFERRED = 0
     LOGICAL = 1
     INTEGER = 2
     REAL = 3

--- a/loki/types/derived_type.py
+++ b/loki/types/derived_type.py
@@ -36,7 +36,7 @@ class DerivedType(DataType):
 
     @property
     def name(self):
-        return self._name if self.typedef is BasicType.DEFERRED else self.typedef.name
+        return self._name if not self.typedef else self.typedef.name
 
     def __str__(self):
         return self.name

--- a/loki/types/module_type.py
+++ b/loki/types/module_type.py
@@ -45,7 +45,7 @@ class ModuleType(DataType):
         This looks up the name in the linked :attr:`module` if available, otherwise
         returns the name stored during instantiation of the :any:`ModuleType` object.
         """
-        return self._name if self.module is BasicType.DEFERRED else self.module.name
+        return self._name if not self.module else self.module.name
 
     @property
     def module(self):

--- a/loki/types/procedure_type.py
+++ b/loki/types/procedure_type.py
@@ -77,7 +77,7 @@ class ProcedureType(DataType):
         This looks up the name in the linked :attr:`procedure` if available, otherwise
         returns the name stored during instanation of the :any:`ProcedureType` object.
         """
-        return self._name if self.procedure is BasicType.DEFERRED else self.procedure.name
+        return self._name if not self.procedure else self.procedure.name
 
     @property
     def procedure(self):
@@ -107,7 +107,7 @@ class ProcedureType(DataType):
         """
         Return `True` if the procedure is a function, otherwise `False`
         """
-        if self.procedure is BasicType.DEFERRED:
+        if not self.procedure:
             return self._is_function
         return self.procedure.is_function
 
@@ -116,7 +116,7 @@ class ProcedureType(DataType):
         """
         Return ``True`` if the procedure has the ``elemental`` prefix, otherwise ``False``
         """
-        if self.procedure is BasicType.DEFERRED:
+        if not self.procedure:
             return False
         if not hasattr(self.procedure, 'prefix'):
             # StatementFunction objects have no prefix!
@@ -131,7 +131,7 @@ class ProcedureType(DataType):
         """
         if not self.is_function:
             return None
-        if self.procedure is BasicType.DEFERRED:
+        if not self.procedure:
             return self._return_type
         return self.procedure.return_type
 


### PR DESCRIPTION
### Description

This PR makes the basic `DEFERRED` type behave as `False` in comparisons and then adjusts its usage throughout the Loki core sub-packages and the transformations. It also adds small runtime checks to symbols and `CallStatement` IR nodes that the respective getters always return `DataType` objects, so that this access is safe, as well as some small tests.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 