### PR TITLE
Loki: Mark OMNI as skip instead of xfail

### DIFF
--- a/loki/analyse/tests/test_analyse_dataflow.py
+++ b/loki/analyse/tests/test_analyse_dataflow.py
@@ -542,7 +542,7 @@ end subroutine test
             assert assign.live_symbols == {'ia', 'ib', 'ic'}
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI fails to read without full module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI fails to read without full module')]))
 def test_analyse_typeconditional(frontend):
     fcode = """
 subroutine test(arg)

--- a/loki/backend/tests/test_fgen.py
+++ b/loki/backend/tests/test_fgen.py
@@ -143,7 +143,7 @@ end subroutine data_stmt
         assert '31*0' in spec_code
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Loki likes only valid code')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Loki likes only valid code')]))
 def test_multiline_inline_conditional(frontend):
     """
     Test correct formatting of an inline :any:`Conditional` that
@@ -177,7 +177,7 @@ end subroutine test_fgen
             assert len(line.split('&')[1]) > 60
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Loki likes only valid code')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Loki likes only valid code')]))
 def test_multiline_inline_conditional_long(frontend):
     """
     Test correct formatting of an inline :any:`Conditional` that
@@ -320,7 +320,7 @@ END SUBROUTINE SPCMNEW
     assert 'procedure(real), pointer, intent(out) :: func' in source.to_fortran().lower()
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'SELECT TYPE not implemented')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'SELECT TYPE not implemented')]))
 def test_fgen_select_type(frontend, tmp_path):
     fcode_module = """
 module select_type_mod

--- a/loki/backend/tests/test_pygen.py
+++ b/loki/backend/tests/test_pygen.py
@@ -516,7 +516,7 @@ end subroutine pygen_downcasing
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI strictly needs type definitions')])
+    skip=[(OMNI, 'OMNI strictly needs type definitions')])
 )
 def test_pygen_derived_type_members(tmp_path, frontend):
     """

--- a/loki/backend/tests/test_stringifier.py
+++ b/loki/backend/tests/test_stringifier.py
@@ -188,7 +188,7 @@ END MODULE some_mod
     ).visit(module).strip() == w_ref
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI fails to read without full module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI fails to read without full module')]))
 def test_pprint_select_type(frontend, tmp_path):
     fcode = """
 subroutine select_type_routine(arg)

--- a/loki/batch/tests/test_scheduler.py
+++ b/loki/batch/tests/test_scheduler.py
@@ -3074,7 +3074,7 @@ def test_pipeline_config_compose(config):
     assert pipeline.transformations[8].replace_ignore_items is True
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(skip={OMNI: "OMNI fails on missing module"}))
 @pytest.mark.parametrize('enable_imports', [False, True])
 @pytest.mark.parametrize('import_level', ['module', 'subroutine'])
 def test_scheduler_indirect_import(frontend, tmp_path, enable_imports, import_level):
@@ -3117,8 +3117,7 @@ contains
     end subroutine c
 end module c_mod
 """
-
-    # Set-up paths and write sources
+   # Set-up paths and write sources
     src_path = tmp_path/'src'
     src_path.mkdir()
     out_path = tmp_path/'build'
@@ -3138,17 +3137,10 @@ end module c_mod
         },
         'routines': {'c': {'role': 'driver'}}
     })
-    try:
-        scheduler = Scheduler(
-            paths=[src_path], config=config, frontend=frontend,
-            output_dir=out_path, xmods=[out_path]
-        )
-    except CalledProcessError as e:
-        if frontend == OMNI and not enable_imports:
-            # Without taking care of imports, OMNI will fail to parse the files
-            # because it is missing the xmod files for the header modules
-            pytest.xfail('Without parsing imports, OMNI does not have the xmod for imported modules')
-        raise e
+    scheduler = Scheduler(
+        paths=[src_path], config=config, frontend=frontend,
+        output_dir=out_path, xmods=[out_path]
+    )
 
     # Check for all items in the dependency graph
     expected_items = {'a_mod', 'b_mod', 'b_mod#type_b', 'c_mod#c'}

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -246,7 +246,9 @@ end subroutine boz_literals
         assert stmts[5].rhs.parameters[0].value == 'z"babe"'
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip={OMNI: 'OMNI wrongfully assigns the same kind to real and imaginary part'}
+))
 def test_complex_literals(tmp_path, frontend):
     """
     Test complex literal values.
@@ -274,12 +276,7 @@ end subroutine complex_literals
     # Note: tmp_path, for inconsistency, FP converts the exponential letter 'e' to lower case...
     assert isinstance(stmts[1].rhs, sym.IntrinsicLiteral) and stmts[1].rhs.value.lower() == '(3, 2e8)'
     assert isinstance(stmts[2].rhs, sym.IntrinsicLiteral)
-    try:
-        assert stmts[2].rhs.value == '(21_2, 4._8)'
-    except AssertionError as excinfo:
-        if frontend == OMNI:
-            pytest.xfail('OMNI wrongfully assigns the same kind to real and imaginary part')
-        raise excinfo
+    assert stmts[2].rhs.value == '(21_2, 4._8)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -412,7 +409,7 @@ end subroutine array_constructor
     clean_test(filepath)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Precedence not honoured')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Precedence not honoured')]))
 def test_parenthesis(frontend):
     """
     Test explicit parenthesis in provided source code.

--- a/loki/frontend/tests/test_nodes_annotations.py
+++ b/loki/frontend/tests/test_nodes_annotations.py
@@ -137,7 +137,7 @@ end subroutine test_comment_block
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI strips comments during parse')]
+    skip=[(OMNI, 'OMNI strips comments during parse')]
 ))
 def test_inline_comments(frontend):
     """
@@ -184,7 +184,7 @@ end subroutine test_inline_comments
     assert comments[0].text == comments[2].text == comments[3].text == ''
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI does not like Loki pragmas, yet!')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI does not like Loki pragmas, yet!')]))
 def test_routine_variables_dimension_pragmas(frontend):
     """
     Test that `!$loki dimension` pragmas can be used to override the
@@ -246,7 +246,7 @@ end subroutine routine_variables_dimensions
     assert isinstance(routine.variable_map['v6'].shape[2], sym.Quotient)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI does not like Loki pragmas, yet!')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI does not like Loki pragmas, yet!')]))
 def test_module_variables_dimension_pragmas(frontend, tmp_path):
     """
     Test that `!$loki dimension` pragmas can be used to override the

--- a/loki/frontend/tests/test_nodes_control_flow.py
+++ b/loki/frontend/tests/test_nodes_control_flow.py
@@ -16,7 +16,7 @@ from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI fails to read without full module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI fails to read without full module')]))
 def test_select_type(frontend, tmp_path):
     fcode = """
 module select_type_mod

--- a/loki/frontend/tests/test_nodes_imports.py
+++ b/loki/frontend/tests/test_nodes_imports.py
@@ -62,7 +62,7 @@ end module test_access_spec_mod
     assert new_module.private_access_spec == ('routine',)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Inlines access-spec as declaration attr')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Inlines access-spec as declaration attr')]))
 def test_module_access_spec_private(frontend, tmp_path):
     """
     Test correct parsing of access-spec statements with default private
@@ -111,7 +111,7 @@ end module test_access_spec_mod
     assert new_module.private_access_spec == ()
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Inlines access-spec as declaration attr')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Inlines access-spec as declaration attr')]))
 def test_module_access_spec_public(frontend, tmp_path):
     """
     Test correct parsing of access-spec statements with default public

--- a/loki/frontend/tests/test_nodes_interfaces.py
+++ b/loki/frontend/tests/test_nodes_interfaces.py
@@ -59,7 +59,7 @@ end subroutine interface_subroutine_integration
 
 
 @pytest.mark.parametrize(
-    'frontend', available_frontends(xfail=[(OMNI, 'OMNI separates generic interfaces differently')])
+    'frontend', available_frontends(skip=[(OMNI, 'OMNI separates generic interfaces differently')])
 )
 def test_interface_generic_spec(frontend, tmp_path):
     """

--- a/loki/frontend/tests/test_nodes_procedures.py
+++ b/loki/frontend/tests/test_nodes_procedures.py
@@ -235,7 +235,7 @@ end subroutine my_routine
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI frontend interface does not provide interfaces')]
+    skip=[(OMNI, 'OMNI frontend interface does not provide interfaces')]
 ))
 def test_routine_bind(frontend, tmp_path):
     """ Test matching of 'bind" suffix for subroutines in interfaces """

--- a/loki/frontend/tests/test_nodes_statements.py
+++ b/loki/frontend/tests/test_nodes_statements.py
@@ -112,7 +112,7 @@ end module alloc_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not like intrinsic shading for member functions!')]
+    skip=[(OMNI, 'OMNI does not like intrinsic shading for member functions!')]
 ))
 def test_intrinsic_shadowing(tmp_path, frontend):
     """

--- a/loki/frontend/tests/test_regex_frontend.py
+++ b/loki/frontend/tests/test_regex_frontend.py
@@ -556,7 +556,7 @@ END SUBROUTINE driver
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'Non-standard notation needs full preprocessing')]
+    skip=[(OMNI, 'Non-standard notation needs full preprocessing')]
 ))
 def test_make_complete_sanitize(frontend):
     """

--- a/loki/frontend/tests/test_scope_associate.py
+++ b/loki/frontend/tests/test_scope_associate.py
@@ -105,7 +105,7 @@ end module
     assert item.scalar == 17.0 and (item.vector == [1., 5., 10.]).all()
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI fails to read without full module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI fails to read without full module')]))
 def test_associates_deferred(frontend):
     """
     Verify that reading in subroutines with deferred external type definitions

--- a/loki/frontend/tests/test_source_model.py
+++ b/loki/frontend/tests/test_source_model.py
@@ -10,7 +10,6 @@ Verify correct frontend behaviour for source-level model handling.
 """
 
 from pathlib import Path
-from subprocess import CalledProcessError
 
 import pytest
 
@@ -189,7 +188,9 @@ end function function_d
     assert all(comment.text.strip() in ['! Some comment', '! Other comment'] for comment in comments)
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip={OMNI, 'F_Front segfault is a known issue on some platforms'}
+))
 def test_sourcefile_lazy_construction(frontend, tmp_path):
     """
     Test delayed ("lazy") parsing of sourcefile content
@@ -246,12 +247,7 @@ end function function_d
     assert len(FindNodes(RawSource).visit(source['routine_a'].ir)) == 1
 
     # Trigger the full parse
-    try:
-        source.make_complete(frontend=frontend, xmods=[tmp_path])
-    except CalledProcessError as ex:
-        if frontend == OMNI and ex.returncode == -11:
-            pytest.skip('F_Front segfault is a known issue on some platforms')
-        raise
+    source.make_complete(frontend=frontend, xmods=[tmp_path])
     assert not source._incomplete
 
     # Make sure no RawSource nodes are left

--- a/loki/frontend/tests/test_source_model.py
+++ b/loki/frontend/tests/test_source_model.py
@@ -94,10 +94,9 @@ def test_frontend_source_lineno(frontend):
     assert calls[0].source.lines[0] < calls[1].source.lines[0] < calls[2].source.lines[0]
 
 
-@pytest.mark.parametrize(
-    'frontend',
-    available_frontends(include_regex=True, xfail=[(OMNI, 'OMNI may segfault on empty files')])
-)
+@pytest.mark.parametrize('frontend', available_frontends(
+    include_regex=True, skip=[(OMNI, 'OMNI may segfault on empty files')]
+))
 @pytest.mark.parametrize('fcode', ['', '\n', '\n\n\n\n'])
 def test_frontend_empty_file(frontend, fcode):
     """Ensure that all frontends can handle empty source files correctly (#186)"""
@@ -251,7 +250,7 @@ end function function_d
         source.make_complete(frontend=frontend, xmods=[tmp_path])
     except CalledProcessError as ex:
         if frontend == OMNI and ex.returncode == -11:
-            pytest.xfail('F_Front segfault is a known issue on some platforms')
+            pytest.skip('F_Front segfault is a known issue on some platforms')
         raise
     assert not source._incomplete
 

--- a/loki/ir/tests/test_control_flow.py
+++ b/loki/ir/tests/test_control_flow.py
@@ -497,7 +497,7 @@ END FUNCTION FUNC
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-        xfail=[(OMNI, 'Renames index variable to omnitmp000')]
+        skip=[(OMNI, 'Renames index variable to omnitmp000')]
 ))
 def test_single_line_forall_stmt(tmp_path, frontend):
     fcode = """
@@ -554,7 +554,7 @@ end subroutine forall_stmt
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-        xfail=[(OMNI, 'Renames index variable to omnitmp000')]
+        skip=[(OMNI, 'Renames index variable to omnitmp000')]
 ))
 def test_single_line_forall_masked_stmt(tmp_path, frontend):
     fcode = """
@@ -607,7 +607,7 @@ end subroutine forall_masked_stmt
     assert expected_fcode in routine.to_fortran()
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[
+@pytest.mark.parametrize('frontend', available_frontends(skip=[
     (OMNI, 'Renames index variable to omnitmp000'),
 ]))
 def test_multi_line_forall_construct(tmp_path, frontend):
@@ -678,7 +678,7 @@ end subroutine forall_construct
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'No support for Cray Pointers')]
+    skip=[(OMNI, 'No support for Cray Pointers')]
 ))
 def test_cray_pointers(frontend):
     fcode = """

--- a/loki/tests/test_modules.py
+++ b/loki/tests/test_modules.py
@@ -245,7 +245,7 @@ end module type_mod
     assert fexprgen(arr.shape) == exptected_array_shape
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Loki annotation break parser')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Loki annotation break parser')]))
 def test_dimension_pragmas(frontend, tmp_path):
     """
     Test that loki-specific dimension annotations are detected and
@@ -266,7 +266,7 @@ end module type_mod
     assert fexprgen(mytype.variables[0].shape) == '(size,)'
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Loki annotation break parser')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Loki annotation break parser')]))
 def test_nested_types_dimension_pragmas(frontend, tmp_path):
     """
     Test that loki-specific dimension annotations are detected and
@@ -448,7 +448,7 @@ integer :: c
     assert module_vars == ['jprb', 'x', 'y', 'a', 'b(x)', 'c']
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parsing fails without dummy module provided')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parsing fails without dummy module provided')]))
 def test_module_rescope_symbols(frontend, tmp_path):
     """
     Test the rescoping of variables.
@@ -488,7 +488,7 @@ end module test_module_rescope
         fgen(other_module_copy)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parsing fails without dummy module provided')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parsing fails without dummy module provided')]))
 def test_module_rescope_clone(frontend, tmp_path):
     """
     Test the rescoping of variables in clone.
@@ -526,7 +526,7 @@ end module test_module_rescope_clone
         fgen(other_module_copy)
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'Parsing fails without dummy module provided')]
+    skip=[(OMNI, 'Parsing fails without dummy module provided')]
 ))
 def test_module_deep_clone(frontend, tmp_path):
     """

--- a/loki/tests/test_nested_types/test_nested_types.py
+++ b/loki/tests/test_nested_types/test_nested_types.py
@@ -12,7 +12,7 @@ from loki import Sourcefile, fexprgen
 from loki.frontend import available_frontends, OMNI
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Loki annotations break frontend parser')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Loki annotations break frontend parser')]))
 def test_nested_types(frontend, tmp_path):
     """
     Regression test that ensures that nested types are correctly

--- a/loki/tests/test_pickle.py
+++ b/loki/tests/test_pickle.py
@@ -179,7 +179,7 @@ end module my_type_mod
     assert module == loads(dumps(module))
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'No external module available')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'No external module available')]))
 def test_pickle_subroutine_with_member(frontend):
     """
     Ensure that :any:`Subroutine` and its components are picklable.

--- a/loki/tests/test_source_identity.py
+++ b/loki/tests/test_source_identity.py
@@ -21,7 +21,7 @@ from loki.ir import nodes as ir, FindNodes
 from loki.frontend import available_frontends, OMNI
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI stores no source.string')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI stores no source.string')]))
 def test_raw_source_loop(tmp_path, frontend):
     """Verify that the raw_source property is correctly used to annotate
     AST nodes with source strings for loops."""
@@ -88,7 +88,7 @@ end subroutine routine_raw_source_loop
     clean_test(filename)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI stores no source.string')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI stores no source.string')]))
 def test_raw_source_conditional(tmp_path, frontend):
     """Verify that the raw_source property is correctly used to annotate
     AST nodes with source strings for conditionals."""
@@ -145,7 +145,7 @@ end subroutine routine_raw_source_cond
     clean_test(filename)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI stores no source.string')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI stores no source.string')]))
 def test_raw_source_multicond(tmp_path, frontend):
     """Verify that the raw_source property is correctly used to annotate
     AST nodes with source strings for multi conditionals."""
@@ -202,7 +202,7 @@ end subroutine routine_raw_source_multicond
     clean_test(filename)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'This is outright impossible')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'This is outright impossible')]))
 def test_subroutine_conservative(frontend):
     """
     Test that conservative output of fgen reproduces the original source string for
@@ -234,7 +234,7 @@ END SUBROUTINE CONSERVATIVE
     assert source == fcode
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'This is outright impossible')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'This is outright impossible')]))
 def test_subroutine_simple_fgen(frontend):
     """
     Test that non-conservative output produces the original source string for
@@ -274,7 +274,7 @@ END SUBROUTINE SIMPLE_FGEN
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does it for you BUT WITHOUT DELETING THE KEYWORD!!!')])
+    skip=[(OMNI, 'OMNI does it for you BUT WITHOUT DELETING THE KEYWORD!!!')])
 )
 def test_multiline_pragma(frontend):
     """

--- a/loki/tests/test_sourcefile.py
+++ b/loki/tests/test_sourcefile.py
@@ -20,7 +20,7 @@ def fixture_here():
     return Path(__file__).parent
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Files are preprocessed')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Files are preprocessed')]))
 def test_sourcefile_pp_macros(here, frontend):
     filepath = here/'sources/sourcefile_pp_macros.F90'
     routine = Sourcefile.from_file(filepath, frontend=frontend)['routine_pp_macros']
@@ -29,7 +29,7 @@ def test_sourcefile_pp_macros(here, frontend):
     assert all(node.text.startswith('#') for node in directives)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[
+@pytest.mark.parametrize('frontend', available_frontends(skip=[
     (OMNI, 'Files are preprocessed')
 ]))
 def test_sourcefile_pp_directives(here, frontend):

--- a/loki/tests/test_subroutine.py
+++ b/loki/tests/test_subroutine.py
@@ -374,7 +374,7 @@ end subroutine routine_typedefs_simple
     assert fexprgen(vmap['item%matrix'].shape) == '(3, 3)'
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI does not like Loki pragmas, yet!')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI does not like Loki pragmas, yet!')]))
 def test_routine_variables_dimension_pragmas(frontend):
     """
     Test that `!$loki dimension` pragmas can be used to verride the

--- a/loki/transformations/build_system/tests/test_dependency.py
+++ b/loki/transformations/build_system/tests/test_dependency.py
@@ -326,7 +326,7 @@ END MODULE DRIVER_MOD
     assert 'some_const' in [str(s) for s in driver['driver_mod'].spec.body[1].symbols]
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'C-imports need pre-processing for OMNI')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'C-imports need pre-processing for OMNI')]))
 def test_dependency_transformation_header_includes(tmp_path, frontend):
     """
     Test injection of suffixed kernels into unchanged driver
@@ -387,7 +387,7 @@ END SUBROUTINE myfunc
     header_file.unlink()
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'C-imports need pre-processing for OMNI')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'C-imports need pre-processing for OMNI')]))
 @pytest.mark.parametrize('use_scheduler', [False, True])
 @pytest.mark.parametrize('replace_ignore_items', [False, True])
 def test_dependency_transformation_module_wrap(frontend, use_scheduler, replace_ignore_items, tmp_path, config):

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -21,7 +21,9 @@ from loki.logging import log_levels
 from loki.transformations.build_system import FileWriteTransformation
 
 
-@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip={OMNI: 'Without parsing imports, OMNI does not have the xmod for imported modules'}
+))
 @pytest.mark.parametrize('enable_imports', [False, True])
 @pytest.mark.parametrize('import_level', ['module', 'subroutine'])
 @pytest.mark.parametrize('qualified_imports', [False, True])
@@ -147,7 +149,7 @@ end module d_mod
             # If not all header modules appear in the dependency graph, then these
             # will not be parsed by OMNI and therefore the required xmod files will
             # not be generated, thus making modules 'c' and 'd' fail at parsing
-            pytest.xfail('Without parsing imports, OMNI does not have the xmod for imported modules')
+            pytest.skip('Without parsing imports, OMNI does not have the xmod for imported modules')
         raise e
 
     # Check the dependency graph

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -11,7 +11,6 @@ Tests for build system interaction
 
 from pathlib import Path
 import re
-from subprocess import CalledProcessError
 
 import pytest
 
@@ -138,19 +137,10 @@ end module d_mod
         },
         'routines': {'d': {'role': 'driver'}}
     })
-    try:
-        scheduler = Scheduler(
-            paths=[src_path], config=config, frontend=frontend,
-            output_dir=out_path, xmods=[tmp_path]
-        )
-    except CalledProcessError as e:
-        all_modules_expected = 'a_mod' in expected_items and (expected_items | {'b_mod', 'b_mod#type_b'})
-        if frontend == OMNI and not (enable_imports and all_modules_expected):
-            # If not all header modules appear in the dependency graph, then these
-            # will not be parsed by OMNI and therefore the required xmod files will
-            # not be generated, thus making modules 'c' and 'd' fail at parsing
-            pytest.skip('Without parsing imports, OMNI does not have the xmod for imported modules')
-        raise e
+    scheduler = Scheduler(
+        paths=[src_path], config=config, frontend=frontend,
+        output_dir=out_path, xmods=[tmp_path]
+    )
 
     # Check the dependency graph
     assert expected_items == {item.name for item in scheduler.items}

--- a/loki/transformations/extract/tests/test_extract_internal.py
+++ b/loki/transformations/extract/tests/test_extract_internal.py
@@ -175,7 +175,7 @@ def test_extract_internal_procedures_existing_call_args(frontend):
     assert kwargdict['x'] == 1
     assert kwargdict['y'] == 1
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parser fails on missing constants module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parser fails on missing constants module')]))
 def test_extract_internal_procedures_basic_import(frontend):
     """
     Tests that a global imported binding is correctly introduced to the contained subroutine.
@@ -205,7 +205,7 @@ def test_extract_internal_procedures_basic_import(frontend):
     assert "c1" not in inner.import_map
     assert 'c2' not in inner.arguments
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parser fails on missing type_mod module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parser fails on missing type_mod module')]))
 def test_extract_internal_procedures_recursive_definition(frontend):
     """
     Tests that whenever a global in the contained subroutine depends on another
@@ -273,7 +273,7 @@ def test_extract_internal_procedures_recursive_definition(frontend):
     assert klon.type.intent == "in"
     assert klev.type.intent == "in"
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parser fails on missing parkind1 module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parser fails on missing parkind1 module')]))
 def test_extract_internal_procedures_recursive_definition_import(frontend):
     """
     Tests that whenever globals in the contained subroutine depend on imported bindings,
@@ -323,7 +323,7 @@ def test_extract_internal_procedures_recursive_definition_import(frontend):
     assert "jpim" in symbols
     assert len(symbols) == 2
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parser fails on missing parkind1 module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parser fails on missing parkind1 module')]))
 def test_extract_internal_procedures_kind_resolution(frontend):
     """
     Tests that an unresolved kind parameter in inner scope is resolved from import in outer scope.
@@ -346,7 +346,7 @@ def test_extract_internal_procedures_kind_resolution(frontend):
     inner = routines[0]
     assert "jpim" in inner.import_map
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parser fails on missing stuff module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parser fails on missing stuff module')]))
 def test_extract_internal_procedures_derived_type_resolution(frontend):
     """
     Tests that an unresolved derived type in inner scope is resolved from import in outer scope.
@@ -369,7 +369,7 @@ def test_extract_internal_procedures_derived_type_resolution(frontend):
     inner = routines[0]
     assert "mytype" in inner.import_map
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parser fails on missing types module')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parser fails on missing types module')]))
 def test_extract_internal_procedures_derived_type_field(frontend):
     """
     Test that when a derived type field, i.e 'a%b' is a global in the scope of the contained subroutine,
@@ -457,7 +457,7 @@ def test_extract_internal_procedures_intent(frontend):
     assert outer.variable_map['x'].type.intent is None
     assert outer.variable_map['p'].type.intent == "out"
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Parser fails on undefined symbols')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Parser fails on undefined symbols')]))
 def test_extract_internal_procedures_undefined_in_parent(frontend):
     """
     This test is just to document current behaviour:

--- a/loki/transformations/inline/tests/test_procedures.py
+++ b/loki/transformations/inline/tests/test_procedures.py
@@ -224,7 +224,7 @@ end subroutine member_routines_arg_dimensions
     assert loops[1].bounds == '1:3'
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'No header information in test')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'No header information in test')]))
 def test_inline_member_routines_derived_type_member(frontend):
     """
     Test inlining of member subroutines when the member routine
@@ -505,7 +505,7 @@ end subroutine acraneb_transt
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_inline_member_routines_with_optionals(frontend):
     """
@@ -840,7 +840,7 @@ end module util_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI has no sense of humour!')])
+    skip=[(OMNI, 'OMNI has no sense of humour!')])
 )
 def test_inline_marked_subroutines_with_associates(frontend):
     """ Test subroutine inlining via marker pragmas with nested associates. """
@@ -954,7 +954,7 @@ end module inline_declarations
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'No header information in test')]
+    skip=[(OMNI, 'No header information in test')]
 ))
 def test_inline_marked_subroutines_imports(frontend, tmp_path):
     """Test propagation of necessary imports to the parent function"""

--- a/loki/transformations/tests/test_block_index_inject.py
+++ b/loki/transformations/tests/test_block_index_inject.py
@@ -262,7 +262,7 @@ end subroutine empty_kernel
     rmtree(workdir)
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI,
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI,
                          'OMNI fails to import undefined module.')]))
 @pytest.mark.parametrize('force_inject_arrays', [True, False])
 def test_blockview_to_fieldview_pipeline(horizontal, blocking, config, frontend, blockview_to_fieldview_code,
@@ -338,7 +338,7 @@ def test_blockview_to_fieldview_pipeline(horizontal, blocking, config, frontend,
     assert assigns[0].rhs == '1.'
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI,
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI,
                          'OMNI fails to import undefined module.')]))
 @pytest.mark.parametrize('global_gfl_ptr', [False, True])
 def test_blockview_to_fieldview_only(horizontal, blocking, config, frontend, blockview_to_fieldview_code,
@@ -406,7 +406,7 @@ def test_blockview_to_fieldview_only(horizontal, blocking, config, frontend, blo
     assert field_ptr[0].type.polymorphic
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI,
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI,
                          'OMNI correctly complains about rank mismatch in assignment.')]))
 def test_simple_blockindex_inject(blocking, frontend):
     fcode = """
@@ -444,7 +444,7 @@ end subroutine kernel
     assert 'var(:,:,1,ibl)' in calls[0].arguments
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI,
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI,
                          'OMNI complains about undefined type.')]))
 def test_blockview_to_fieldview_exception(frontend, horizontal):
     fcode = """

--- a/loki/transformations/tests/test_drhook.py
+++ b/loki/transformations/tests/test_drhook.py
@@ -126,7 +126,7 @@ end module rick_rolled
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'Incomplete source tree impossible with OMNI')]
+    skip=[(OMNI, 'Incomplete source tree impossible with OMNI')]
 ))
 def test_dr_hook_transformation(frontend, config, source, tmp_path):
     """Test DrHook transformation for a renamed Subroutine"""
@@ -159,7 +159,7 @@ def test_dr_hook_transformation(frontend, config, source, tmp_path):
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'Incomplete source tree impossible with OMNI')]
+    skip=[(OMNI, 'Incomplete source tree impossible with OMNI')]
 ))
 def test_dr_hook_transformation_remove(frontend, config, source, tmp_path):
     """Test DrHook transformation in remove mode"""
@@ -200,7 +200,7 @@ def test_dr_hook_transformation_remove(frontend, config, source, tmp_path):
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'Incomplete source tree impossible with OMNI')]
+    skip=[(OMNI, 'Incomplete source tree impossible with OMNI')]
 ))
 def test_dr_hook_transformation_rename(frontend, config, source):
     """Test DrHook transformation in remove mode"""

--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -285,7 +285,7 @@ end subroutine rename_variables
     assert 'rename_arg' not in routine.symbol_attrs
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle missing type definitions')]
+    skip=[(OMNI, 'OMNI does not handle missing type definitions')]
 ))
 def test_transform_utilites_rename_variables_extended(frontend):
     fcode = """

--- a/loki/types/tests/test_derived_types.py
+++ b/loki/types/tests/test_derived_types.py
@@ -1487,7 +1487,7 @@ end module derived_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends(
-    xfail=[(OMNI, 'OMNI does not handle type-bound procedures')]
+    skip=[(OMNI, 'OMNI does not handle type-bound procedures')]
 ))
 def test_derived_type_type_bound_call_proctype(frontend):
     """

--- a/loki/types/tests/test_types.py
+++ b/loki/types/tests/test_types.py
@@ -84,7 +84,7 @@ end subroutine test_type_declarations
     assert routine.symbol_attrs['e'].contiguous
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'Segfault with pragmas in derived types')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'Segfault with pragmas in derived types')]))
 def test_pragmas(frontend):
     """
     Test detection of `!$loki dimension` pragmas to indicate intended shapes.
@@ -183,7 +183,7 @@ end module test_type_derived_type_mod
     assert routine.symbol_attrs['c%b'].shape == (':',':')
 
 
-@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot deal with deferred type info')]))
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI cannot deal with deferred type info')]))
 def test_type_module_imports(frontend):
     """
     Test the detection of known / unknown symbols types from module imports.


### PR DESCRIPTION
### Description

Instead of marking OMNI tests as `xfail` we can skip them outright to speed up the CI test turnaround.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 