### PR TITLE
Loki: GNU-15 and parallel regression builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,23 +21,23 @@ jobs:
       fail-fast: false  # false: try to complete all jobs
       matrix:
         name:
-          - linux gnu-14
+          - linux gnu-15
 
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
         include:
-          - name: linux gnu-14
+          - name: linux gnu-15
             os: ubuntu-24.04
               # Enable --with-dace as soon as DaCe supports 3.13 and Numpy>2.0
             install-options: --with-omni --with-examples --with-tests --without-dace
-            toolchain: {compiler: gcc, version: 14}
+            toolchain: {compiler: gcc, version: 15}
             pkg-dependencies: graphviz gfortran byacc flex cmake meson ninja-build
 
           - name: macos
-            os: macos-14
+            os: macos-15
             python-version: '3.13'
             install-options: --with-examples --with-tests --without-dace
-            toolchain: {compiler: gcc, version: 14}
+            toolchain: {compiler: gcc, version: 15}
             pkg-dependencies: graphviz ninja meson
 
     runs-on: ${{ matrix.os }}

--- a/loki/transformations/tests/test_cloudsc.py
+++ b/loki/transformations/tests/test_cloudsc.py
@@ -53,7 +53,7 @@ def fixture_bundle_create(here, local_loki_bundle):
 ))
 def test_cloudsc(here, frontend):
     build_cmd = [
-        './cloudsc-bundle', 'build', '--retry-verbose', '--clean',
+        './cloudsc-bundle', 'build', '--retry-verbose', '--clean', '-j 4',
         '--with-loki=ON', '--loki-frontend=' + str(frontend), '--without-loki-install',
         '--with-double-precision=ON', '--with-single-precision=ON'
     ]

--- a/loki/transformations/tests/test_ecwam.py
+++ b/loki/transformations/tests/test_ecwam.py
@@ -51,7 +51,7 @@ def fixture_bundle_create(here, local_loki_bundle):
 def test_ecwam(here, mode, tmp_path):
     build_dir = tmp_path/'build'
     build_cmd = [
-        './package/bundle/ecwam-bundle', 'build', '--clean',
+        './package/bundle/ecwam-bundle', 'build', '--clean', '-j 4',
         '--with-loki', '--without-loki-install', '--loki-mode', mode,
         '--build-dir', str(build_dir)
     ]


### PR DESCRIPTION
### Description

Updating GNU compiler to use GCC-15 on CI runners to avoid spurious hangs on set up and use multiple build threads in regression tests to speed up CI turnaround.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 