### PR TITLE
Batch: Add local aliases for module-scope procedures to improve caching

### DIFF
--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -643,6 +643,16 @@ class ItemFactory:
             The items matching :data:`name` in the modules given in :any:`module_names`.
             Ideally, only a single item will be found (or there would be a name conflict).
         """
+        if cached_items := self.item_cache.get(name):
+            if isinstance(cached_items, list):
+                if module_names:
+                    module_names = [module_name.lower() for module_name in module_names]
+                    cached_items = [item for item in cached_items if item.scope_name in module_names]
+                if only:
+                    cached_items = [item for item in cached_items if isinstance(item, only)]
+                if cached_items:
+                    return tuple(cached_items)
+
         if not module_names:
             module_names = [item.name for item in self.item_cache.values() if isinstance(item, ModuleItem)]
         items = []

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -227,7 +227,7 @@ class ItemFactory:
         Add an unqualified alias for module-contained procedure items.
 
         This supports fast candidate retrieval for procedures imported via
-        unqualified module imports while preserving all possible module matches.
+        unqualified module imports when the procedure name is unambiguous.
         """
         if item_cls is not ProcedureItem or item_name.count('#') != 1:
             return
@@ -236,18 +236,21 @@ class ItemFactory:
         if not scope_name or '%' in local_name:
             return
 
+        local_name = f'#{local_name}'
         cached_item = self.item_cache.get(local_name)
         if cached_item is None:
-            self.item_cache[local_name] = [item]
+            self.item_cache[local_name] = item
             return
 
-        if isinstance(cached_item, list):
-            if item not in cached_item:
-                cached_item.append(item)
+        if cached_item == item:
             return
 
-        if cached_item != item:
-            self.item_cache[local_name] = [cached_item, item]
+        if isinstance(cached_item, ProcedureItem) and cached_item.name.count('#') == 1:
+            warning(
+                f'Ambiguous module procedure name {local_name}; removing item cache alias. '
+                f'Found both {cached_item.name} and {item.name}.'
+            )
+            del self.item_cache[local_name]
 
     def get_or_create_item_from_item(self, name, item, config=None):
         """
@@ -643,16 +646,6 @@ class ItemFactory:
             The items matching :data:`name` in the modules given in :any:`module_names`.
             Ideally, only a single item will be found (or there would be a name conflict).
         """
-        if cached_items := self.item_cache.get(name):
-            if isinstance(cached_items, list):
-                if module_names:
-                    module_names = [module_name.lower() for module_name in module_names]
-                    cached_items = [item for item in cached_items if item.scope_name in module_names]
-                if only:
-                    cached_items = [item for item in cached_items if isinstance(item, only)]
-                if cached_items:
-                    return tuple(cached_items)
-
         if not module_names:
             module_names = [item.name for item in self.item_cache.values() if isinstance(item, ModuleItem)]
         items = []

--- a/loki/batch/item_factory.py
+++ b/loki/batch/item_factory.py
@@ -219,7 +219,35 @@ class ItemFactory:
             source = scope_item.source
             item = item_cls(item_name, source=source, config=item_conf)
         self.item_cache[item_name] = item
+        self._add_procedure_alias(item_cls, item_name, item)
         return item
+
+    def _add_procedure_alias(self, item_cls, item_name, item):
+        """
+        Add an unqualified alias for module-contained procedure items.
+
+        This supports fast candidate retrieval for procedures imported via
+        unqualified module imports while preserving all possible module matches.
+        """
+        if item_cls is not ProcedureItem or item_name.count('#') != 1:
+            return
+
+        scope_name, local_name = item_name.split('#')
+        if not scope_name or '%' in local_name:
+            return
+
+        cached_item = self.item_cache.get(local_name)
+        if cached_item is None:
+            self.item_cache[local_name] = [item]
+            return
+
+        if isinstance(cached_item, list):
+            if item not in cached_item:
+                cached_item.append(item)
+            return
+
+        if cached_item != item:
+            self.item_cache[local_name] = [cached_item, item]
 
     def get_or_create_item_from_item(self, name, item, config=None):
         """

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -395,12 +395,14 @@ class Scheduler:
         # Find invalid item cache entries
         renamed_keys = {
             key: item.name for key, item in self.item_factory.item_cache.items()
-            if item.name != key
+            if not isinstance(item, list) and item.name != key
         }
 
         # Find deleted item cache entries
         deleted_keys = set()
         for key, item in self.item_factory.item_cache.items():
+            if isinstance(item, list):
+                continue
             if isinstance(item, FileItem):
                 continue
             if isinstance(item, ModuleItem):
@@ -425,6 +427,8 @@ class Scheduler:
 
         # Rename item scopes where necessary
         for key, item in self.item_factory.item_cache.items():
+            if isinstance(item, list):
+                continue
             if item.scope_name in renamed_keys and key not in deleted_keys:
                 item.name = f'{renamed_keys[item.scope_name]}#{item.local_name}'
                 renamed_keys[key] = item.name
@@ -455,8 +459,10 @@ class Scheduler:
         # Rebuild item_cache to make keys match entries
         self.item_factory.item_cache = CaseInsensitiveDict(
             (item.name, item) for item in self.item_factory.item_cache.values()
-            if item.name not in deleted_keys
+            if not isinstance(item, list) and item.name not in deleted_keys
         )
+        for item in tuple(self.item_factory.item_cache.values()):
+            self.item_factory._add_procedure_alias(item.__class__, item.name, item)
 
     def process(self, transformation, proc_strategy=ProcessingStrategy.DEFAULT):
         """

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -395,14 +395,12 @@ class Scheduler:
         # Find invalid item cache entries
         renamed_keys = {
             key: item.name for key, item in self.item_factory.item_cache.items()
-            if not isinstance(item, list) and item.name != key
+            if item.name != key
         }
 
         # Find deleted item cache entries
         deleted_keys = set()
         for key, item in self.item_factory.item_cache.items():
-            if isinstance(item, list):
-                continue
             if isinstance(item, FileItem):
                 continue
             if isinstance(item, ModuleItem):
@@ -427,8 +425,6 @@ class Scheduler:
 
         # Rename item scopes where necessary
         for key, item in self.item_factory.item_cache.items():
-            if isinstance(item, list):
-                continue
             if item.scope_name in renamed_keys and key not in deleted_keys:
                 item.name = f'{renamed_keys[item.scope_name]}#{item.local_name}'
                 renamed_keys[key] = item.name
@@ -459,7 +455,7 @@ class Scheduler:
         # Rebuild item_cache to make keys match entries
         self.item_factory.item_cache = CaseInsensitiveDict(
             (item.name, item) for item in self.item_factory.item_cache.values()
-            if not isinstance(item, list) and item.name not in deleted_keys
+            if item.name not in deleted_keys
         )
         for item in tuple(self.item_factory.item_cache.values()):
             self.item_factory._add_procedure_alias(item.__class__, item.name, item)

--- a/loki/batch/tests/test_batch.py
+++ b/loki/batch/tests/test_batch.py
@@ -1756,3 +1756,70 @@ END MODULE TYPEBOUND_ITEM_TARGETS_MOD
 
     assert driver_item.create_definition_items(item_factory, scheduler_config) == ()
     assert driver_item.create_dependency_items(item_factory, scheduler_config) == ()
+
+
+def test_module_procedure_alias_candidates(default_config):
+    fcode = """
+module alias_mod_a
+contains
+  subroutine aliased_proc
+  end subroutine aliased_proc
+end module alias_mod_a
+
+module alias_mod_b
+contains
+  subroutine aliased_proc
+  end subroutine aliased_proc
+end module alias_mod_b
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=REGEX, parser_classes=RegexParserClass.ProgramUnitClass)
+    source.path = 'alias_candidates.F90'
+    item_factory = ItemFactory()
+    scheduler_config = SchedulerConfig.from_dict(default_config)
+
+    file_item = item_factory.get_or_create_file_item_from_source(source, scheduler_config)
+    module_items = file_item.create_definition_items(item_factory, scheduler_config)
+    procedure_items = tuple(
+        item for module_item in module_items
+        for item in module_item.create_definition_items(item_factory, scheduler_config)
+    )
+
+    assert procedure_items == ('alias_mod_a#aliased_proc', 'alias_mod_b#aliased_proc')
+    assert item_factory.item_cache['aliased_proc'] == list(procedure_items)
+
+    candidates = item_factory.get_or_create_module_definitions_from_candidates(
+        'aliased_proc', scheduler_config, module_names=['alias_mod_b'], only=ProcedureItem
+    )
+    assert candidates == (item_factory.item_cache['alias_mod_b#aliased_proc'],)
+
+    candidates = item_factory.get_or_create_module_definitions_from_candidates(
+        'aliased_proc', scheduler_config, module_names=['alias_mod_a', 'alias_mod_b'], only=ProcedureItem
+    )
+    assert candidates == procedure_items
+
+
+def test_module_procedure_alias_retrieval_avoids_rescan(default_config):
+    fcode = """
+module alias_retrieval_mod
+contains
+  subroutine aliased_proc
+  end subroutine aliased_proc
+end module alias_retrieval_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=REGEX, parser_classes=RegexParserClass.ProgramUnitClass)
+    source.path = 'alias_retrieval.F90'
+    item_factory = ItemFactory()
+    scheduler_config = SchedulerConfig.from_dict(default_config)
+
+    file_item = item_factory.get_or_create_file_item_from_source(source, scheduler_config)
+    module_item = file_item.create_definition_items(item_factory, scheduler_config)[0]
+    procedure_item = module_item.create_definition_items(item_factory, scheduler_config)[0]
+
+    del item_factory.item_cache['alias_retrieval_mod']
+    candidates = item_factory.get_or_create_module_definitions_from_candidates(
+        'aliased_proc', scheduler_config, module_names=['alias_retrieval_mod'], only=ProcedureItem
+    )
+
+    assert candidates == (procedure_item,)

--- a/loki/batch/tests/test_batch.py
+++ b/loki/batch/tests/test_batch.py
@@ -754,12 +754,12 @@ def test_procedure_item_from_item2(testdir, default_config):
     assert item.name == 'other_mod#mod_proc'
     assert isinstance(item, ProcedureItem)
 
-    expected_cache = {str(proj/'module/other_mod.F90').lower(), 'other_mod', 'other_mod#mod_proc'}
+    expected_cache = {str(proj/'module/other_mod.F90').lower(), 'other_mod', 'other_mod#mod_proc', 'mod_proc'}
     assert set(item_factory.item_cache) == expected_cache
 
     # Create a new item by duplicating the existing item
     new_item = item_factory.get_or_create_item_from_item('my_mod#new_proc', item, config=scheduler_config)[0]
-    expected_cache |= {str(proj/'module/my_mod.F90').lower(), 'my_mod', 'my_mod#new_proc'}
+    expected_cache |= {str(proj/'module/my_mod.F90').lower(), 'my_mod', 'my_mod#new_proc', 'new_proc'}
     assert set(item_factory.item_cache) == expected_cache
 
     # Assert the new item differs from the existing item in the name, with the original
@@ -1758,7 +1758,7 @@ END MODULE TYPEBOUND_ITEM_TARGETS_MOD
     assert driver_item.create_dependency_items(item_factory, scheduler_config) == ()
 
 
-def test_module_procedure_alias_candidates(default_config):
+def test_module_procedure_alias_ambiguity(default_config):
     fcode = """
 module alias_mod_a
 contains
@@ -1786,7 +1786,7 @@ end module alias_mod_b
     )
 
     assert procedure_items == ('alias_mod_a#aliased_proc', 'alias_mod_b#aliased_proc')
-    assert item_factory.item_cache['aliased_proc'] == list(procedure_items)
+    assert 'aliased_proc' not in item_factory.item_cache
 
     candidates = item_factory.get_or_create_module_definitions_from_candidates(
         'aliased_proc', scheduler_config, module_names=['alias_mod_b'], only=ProcedureItem
@@ -1817,6 +1817,8 @@ end module alias_retrieval_mod
     module_item = file_item.create_definition_items(item_factory, scheduler_config)[0]
     procedure_item = module_item.create_definition_items(item_factory, scheduler_config)[0]
 
+    assert item_factory.item_cache['aliased_proc'] is procedure_item
+
     del item_factory.item_cache['alias_retrieval_mod']
     candidates = item_factory.get_or_create_module_definitions_from_candidates(
         'aliased_proc', scheduler_config, module_names=['alias_retrieval_mod'], only=ProcedureItem
@@ -1843,7 +1845,7 @@ end module alias_rekey_mod
     module_item = file_item.create_definition_items(item_factory, scheduler_config)[0]
     procedure_item = module_item.create_definition_items(item_factory, scheduler_config)[0]
 
-    assert item_factory.item_cache['aliased_proc'] == [procedure_item]
+    assert item_factory.item_cache['aliased_proc'] is procedure_item
 
     module_item.ir.name = 'renamed_alias_rekey_mod'
     module_item.name = 'renamed_alias_rekey_mod'
@@ -1857,4 +1859,4 @@ end module alias_rekey_mod
     renamed_procedure = item_factory.item_cache['renamed_alias_rekey_mod#aliased_proc']
     assert renamed_procedure.name == 'renamed_alias_rekey_mod#aliased_proc'
     assert 'alias_rekey_mod#aliased_proc' not in item_factory.item_cache
-    assert item_factory.item_cache['aliased_proc'] == [renamed_procedure]
+    assert item_factory.item_cache['aliased_proc'] is renamed_procedure

--- a/loki/batch/tests/test_batch.py
+++ b/loki/batch/tests/test_batch.py
@@ -20,7 +20,7 @@ from loki import (
 from loki.batch import (
     FileItem, ModuleItem, ProcedureItem, TypeDefItem,
     ProcedureBindingItem, ExternalItem, InterfaceItem, SGraph,
-    SchedulerConfig, ItemFactory
+    Scheduler, SchedulerConfig, ItemFactory
 )
 from loki.frontend import HAVE_FP, REGEX, RegexParserClass
 from loki.ir import nodes as ir
@@ -1823,3 +1823,38 @@ end module alias_retrieval_mod
     )
 
     assert candidates == (procedure_item,)
+
+
+def test_scheduler_rekey_item_cache_with_procedure_aliases(default_config):
+    fcode = """
+module alias_rekey_mod
+contains
+  subroutine aliased_proc
+  end subroutine aliased_proc
+end module alias_rekey_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=REGEX, parser_classes=RegexParserClass.ProgramUnitClass)
+    source.path = 'alias_rekey.F90'
+    item_factory = ItemFactory()
+    scheduler_config = SchedulerConfig.from_dict(default_config)
+
+    file_item = item_factory.get_or_create_file_item_from_source(source, scheduler_config)
+    module_item = file_item.create_definition_items(item_factory, scheduler_config)[0]
+    procedure_item = module_item.create_definition_items(item_factory, scheduler_config)[0]
+
+    assert item_factory.item_cache['aliased_proc'] == [procedure_item]
+
+    module_item.ir.name = 'renamed_alias_rekey_mod'
+    module_item.name = 'renamed_alias_rekey_mod'
+
+    scheduler = object.__new__(Scheduler)
+    scheduler.item_factory = item_factory
+    scheduler.config = scheduler_config
+    scheduler.seeds = ()
+    scheduler.rekey_item_cache()
+
+    renamed_procedure = item_factory.item_cache['renamed_alias_rekey_mod#aliased_proc']
+    assert renamed_procedure.name == 'renamed_alias_rekey_mod#aliased_proc'
+    assert 'alias_rekey_mod#aliased_proc' not in item_factory.item_cache
+    assert item_factory.item_cache['aliased_proc'] == [renamed_procedure]


### PR DESCRIPTION
### Description

A large chunk of schedule batch run-time goes to the (re-)creation of `SGraph` objects. One particular issue here is the costly look to derive candidate procedures in the item factory. To improve this, we are adding a local aliasing mechanism in this PR that adds `#proc` for every `mod#proc` key to the item cache, thus improving the initial setup of the SGraph. 

Importantly, this type of caching can lead to clashes with equi-name routines from different modules. If we encounter this, we warn and remove the local alias, as keeping multiple candidates causes a lot of downstream issues due to the break in API from all other item factory methods.

Before
```
(loki_env) [naml@ab6-206 ifs-source]$ loki-transform.py convert --mode idem --config cmake/loki.config -s arpifs/phys_ec/ -s arpifs/phys_radi -s arpifs/climate -s arpifs/var -s arpifs/utility -s surf/external/ -s surf/module -s radiation/module -s algor/module --plan-file=../../my_plan.cmake --log-level=perf
[Loki] Creating CMake plan file from config: cmake/loki.config
...
**[Loki::Scheduler] Built SGraph from seed in 10.84s
**[Loki::Scheduler] Performed initial source scan in 24.97s
[Loki-transform] Applying custom pipeline idem from config:
...
[Loki::Scheduler] Applied transformation <IdemTransformation> in 1.13s
[Loki::Scheduler] Applied transformation <ModuleWrapTransformation> in 1.28s
**[Loki::Scheduler] Built SGraph from seed in 7.56s
**[Loki::Scheduler] Performed initial source scan in 7.72s
[Loki::Scheduler] Applied transformation <DependencyTransformation> in 1.27s
**[Loki::Scheduler] Built SGraph from seed in 7.59s
**[Loki::Scheduler] Performed initial source scan in 7.75s
[Loki::Scheduler] Applied transformation <FileWriteTransformation> in 0.10s
[Loki] Scheduler writing CMake plan: ../../my_plan.cmake
[Loki::Scheduler] Applied transformation <CMakePlanTransformation> in 0.14s
[Loki::Scheduler] Wrote CMake plan file in 0.14s
```

After
```
(loki_env) [naml@ab6-206 ifs-source]$ loki-transform.py convert --mode idem --config cmake/loki.config -s arpifs/phys_ec/ -s arpifs/phys_radi -s arpifs/climate -s arpifs/var -s arpifs/utility -s surf/external/ -s surf/module -s radiation/module -s algor/module --plan-file=../../my_plan.cmake --log-level=perf
[Loki] Creating CMake plan file from config: cmake/loki.config
...
Ambiguous module procedure name #trisolvers; removing item cache alias. Found both srfsn_webalsad_mod#trisolvers and srfsn_webals_mod#trisolvers.
**[Loki::Scheduler] Built SGraph from seed in 7.46s
**[Loki::Scheduler] Performed initial source scan in 21.55s
[Loki-transform] Applying custom pipeline idem from config:
...
[Loki::Scheduler] Applied transformation <IdemTransformation> in 1.10s
[Loki::Scheduler] Applied transformation <ModuleWrapTransformation> in 1.25s
Ambiguous module procedure name #trisolvers; removing item cache alias. Found both srfsn_webalsad_mod#trisolvers and srfsn_webals_mod#trisolvers.
**[Loki::Scheduler] Built SGraph from seed in 3.89s
**[Loki::Scheduler] Performed initial source scan in 5.41s
[Loki::Scheduler] Applied transformation <DependencyTransformation> in 1.30s
Ambiguous module procedure name #trisolvers; removing item cache alias. Found both srfsn_webalsad_mod#trisolvers and srfsn_webals_mod#trisolvers.
**[Loki::Scheduler] Built SGraph from seed in 3.90s
**[Loki::Scheduler] Performed initial source scan in 4.13s
[Loki::Scheduler] Applied transformation <FileWriteTransformation> in 0.10s
[Loki] Scheduler writing CMake plan: ../../my_plan.cmake
[Loki::Scheduler] Applied transformation <CMakePlanTransformation> in 0.14s
[Loki::Scheduler] Wrote CMake plan file in 0.14s
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 