### PR TITLE
Batch: Resolve qualified seed names before graph population

### DIFF
--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -12,7 +12,7 @@ import networkx as nx
 
 from loki.batch.configure import SchedulerConfig
 from loki.batch.item import (
-    InterfaceItem, ProcedureItem, ProcedureBindingItem, TypeDefItem
+    InterfaceItem, ModuleItem, ProcedureItem, ProcedureBindingItem, TypeDefItem
 )
 from loki.batch.sfilter import SFilter
 from loki.logging import debug, perf, warning
@@ -143,6 +143,39 @@ class SGraph:
 
         return item
 
+    @staticmethod
+    def _get_seed_name(name, item_factory):
+        """
+        Return the cache key to use for a seed item.
+
+        Unqualified module procedure seeds are resolved against already-known
+        items before calling :meth:`_create_item`, so the regular cache lookup
+        path can be used without falling back to a module-wide candidate scan.
+        """
+        if '#' in name:
+            return name
+
+        name = name.lower()
+        procedure_name = f'#{name}'
+        if procedure_name in item_factory.item_cache:
+            return procedure_name
+
+        candidates = tuple(
+            item.name for item in item_factory.item_cache.values()
+            if isinstance(item, ProcedureItem) and item.local_name.lower() == name
+        )
+        if len(candidates) == 1:
+            return candidates[0]
+
+        candidates = tuple(
+            f'{item.name}#{name}' for item in item_factory.item_cache.values()
+            if isinstance(item, ModuleItem) and name in item.ir.subroutine_map
+        )
+        if len(candidates) == 1:
+            return candidates[0]
+
+        return name
+
     def _add_children(self, item, item_factory, config, dependencies=None):
         """
         Create items for dependencies of the :data:`item` and add them to
@@ -203,6 +236,7 @@ class SGraph:
 
         # Insert the seed objects
         for name in as_tuple(seed):
+            name = self._get_seed_name(name, item_factory)
             item = as_tuple(self._create_item(name, item_factory, config))
             if item:
                 self.add_nodes(item)

--- a/loki/batch/tests/test_batch.py
+++ b/loki/batch/tests/test_batch.py
@@ -1161,6 +1161,42 @@ def test_sgraph_from_seed(tmp_path, testdir, default_config, seed, dependencies_
     }
 
 
+def test_sgraph_from_seed_resolves_cached_procedure_item(testdir, default_config, monkeypatch):
+    """
+    Ensure unqualified module procedure seeds resolve to their fully-qualified cache key.
+    """
+    proj = testdir/'sources/projBatch'
+    suffixes = ['.f90', '.F90']
+    path_list = [f for ext in suffixes for f in proj.glob(f'**/*{ext}')]
+
+    scheduler_config = SchedulerConfig.from_dict(default_config)
+    item_factory = ItemFactory()
+
+    for path in path_list:
+        relative_path = str(path.relative_to(proj))
+        file_item = get_item(
+            FileItem, path, relative_path, RegexParserClass.ProgramUnitClass,
+            scheduler_config
+        )
+        item_factory.item_cache[relative_path] = file_item
+        item_factory.item_cache.update(
+            (item.name, item)
+            for item in file_item.create_definition_items(item_factory=item_factory, config=scheduler_config)
+        )
+
+    # Ensure the costly fallback lookup is not triggered for a cached seed item.
+    def fail_candidate_lookup(*_args, **_kwargs):
+        raise AssertionError('Seed lookup should use the existing fully-qualified cache key')
+
+    monkeypatch.setattr(
+        item_factory, 'get_or_create_module_definitions_from_candidates', fail_candidate_lookup
+    )
+
+    sgraph = SGraph.from_seed('mod_proc', item_factory, scheduler_config)
+
+    assert 'other_mod#mod_proc' in sgraph.items
+
+
 @pytest.mark.parametrize('seed,disable,active_nodes', [
     ('#comp1', ('comp2', 'a'), (
         '#comp1', 't_mod', 't_mod#t', 'header_mod', 't_mod#t%proc', 't_mod#t%no%way',


### PR DESCRIPTION
### Description

This is (I believe) a better solution to the scheduler item cache improvement in PR #683. Instead of adding aliases to the cache, we resolve all unqualified `proc_name` "seeds" when creating a new SGraph to fully qualified `mod_name#proc_name` keys. This increases the cache hit rate for re-building SGraphs from scratch (which we do a few times) quite a bit and is way less invasive. This prevents the costly re-derivation of this on a per-item level in the `ItemFactory.get_or_create_module_definitions_from_candidates` and improves full-scale batch processing (seee below):

Before:
```
(loki_env) [naml@ab6-206 ifs-source]$ loki-transform.py plan --mode idem --config cmake/loki.config -s arpifs/phys_ec/ -s arpifs/phys_radi -s arpifs/climate -s arpifs/var -s arpifs/utility -s surf/external/ -s surf/module -s radiation/module -s algor/module --plan-file=../../my_plan.cmake --log-level=perf
[Loki] Creating CMake plan file from config: cmake/loki.config
...
[Loki::Scheduler] Built SGraph from seed in 10.84s
[Loki::Scheduler] Performed initial source scan in 24.91s
[Loki-transform] Applying custom pipeline idem from config:
...
[Loki::Scheduler] Applied transformation <IdemTransformation> in 1.11s
[Loki::Scheduler] Applied transformation <ModuleWrapTransformation> in 1.26s
[Loki::Scheduler] Built SGraph from seed in 7.51s
[Loki::Scheduler] Performed initial source scan in 7.67s
[Loki::Scheduler] Applied transformation <DependencyTransformation> in 1.26s
[Loki::Scheduler] Built SGraph from seed in 7.75s
[Loki::Scheduler] Performed initial source scan in 7.91s
...
```

After:
```
(loki_env) [naml@ab6-206 ifs-source]$ loki-transform.py plan --mode idem --config cmake/loki.config -s arpifs/phys_ec/ -s arpifs/phys_radi -s arpifs/climate -s arpifs/var -s arpifs/utility -s surf/external/ -s surf/module -s radiation/module -s algor/module --plan-file=../../my_plan.cmake --log-level=perf
[Loki] Creating CMake plan file from config: cmake/loki.config
...
[Loki::Scheduler] Built SGraph from seed in 6.77s
[Loki::Scheduler] Performed initial source scan in 20.78s
[Loki-transform] Applying custom pipeline idem from config:
...
[Loki::Scheduler] Applied transformation <IdemTransformation> in 1.09s
[Loki::Scheduler] Applied transformation <ModuleWrapTransformation> in 1.24s
[Loki::Scheduler] Built SGraph from seed in 3.87s
[Loki::Scheduler] Performed initial source scan in 4.03s
[Loki::Scheduler] Applied transformation <DependencyTransformation> in 1.25s
[Loki::Scheduler] Built SGraph from seed in 3.87s
[Loki::Scheduler] Performed initial source scan in 4.03s
...
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 