### PR TITLE
Refactor SeparateModesKernel transformation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,5 @@
 # AGENTS
 
-## Local Validation Workflow
-
-When validating Loki changes locally:
-
-- always activate the local environment first with `source ./loki-activate`
-- use the repository-local pylint configuration with `pylint --rcfile .pylintrc ...`
-- include both lint and test validation in normal verification
-- prefer running targeted `pytest` suites for touched areas first, then broaden if needed
-
-Typical validation commands:
-
-```bash
-source ./loki-activate
-python -m pytest <relevant tests>
-pylint --rcfile .pylintrc <relevant paths>
-```
-
-For broader validation, keep using the same activated environment and local `.pylintrc`.
-
 ## Loki Test Conventions
 
 This repository contains Loki source code and tests.
@@ -63,4 +44,3 @@ When editing test imports, keep `loki.*` import lines ordered alphabetically by 
   - Avoid: `(str(loop.variable), str(loop.bounds.start), str(loop.bounds.stop), ... )`
 - Use stringification only when the test is explicitly about rendered output, pretty-printing, or a node type that does not compare reliably through Loki's native equality support.
 - If stringification is still necessary in a structural test, keep it narrowly scoped and document why.
-

--- a/loki/batch/tests/test_scheduler_config.py
+++ b/loki/batch/tests/test_scheduler_config.py
@@ -5,6 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from collections import defaultdict
 from functools import partial
 import re
 from pathlib import Path
@@ -693,12 +694,9 @@ def test_pipeline_config_compose(config):
     assert pipeline.transformations[3].trim_vector_sections is True
     assert pipeline.transformations[8].replace_ignore_items is True
 
-
-@pytest.mark.parametrize('as_modules', [False, True])
-@pytest.mark.parametrize('reinit_scheduler', [True, False])
-@pytest.mark.parametrize('wrong_pipeline_name', [True, False])
-def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, wrong_pipeline_name):
-    config = SchedulerConfig.from_dict({
+@pytest.fixture(name='multi_modes_config')
+def fixture_multi_modes_config():
+    return {
         'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm1', 'replicate': True},
         'routines': {
             'driver_0': {'role': 'driver', 'mode': 'm1', 'replicate': False},
@@ -714,11 +712,34 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, 
             'Idem3': {'classname': 'IdemTransformation', 'module': 'loki.transformations'}
         },
         'pipelines': {
-            f'{"m1x" if wrong_pipeline_name else "m1"}': {'transformations': {'Idem1'}},
+            # NB: The pipeline name is important here since it determines the mode of the items
+            #     that don't have an explicit mode set in the config (e.g. nested_subroutine_3)
+            'm1': {'transformations': {'Idem1'}},
             'm2': {'transformations': {'Idem2'}},
             'm3': {'transformations': {'Idem3'}}
         },
-    })
+    }
+
+def test_scheduler_multi_modes_invalid_pipeline(testdir, tmp_path, multi_modes_config):
+    """
+    Test that the scheduler raises an error when a pipeline is missing for a mode
+    """
+    config = SchedulerConfig.from_dict(multi_modes_config)
+    config.pipelines.pop('m1')
+
+    proj_multi_mode = testdir/'sources/projMultiMode'
+    builddir = tmp_path/'scheduler_multi_driver_modes_dir'
+    builddir.mkdir(exist_ok=True)
+
+    scheduler = Scheduler(paths=proj_multi_mode, config=config, xmods=[tmp_path], output_dir=builddir)
+    with pytest.raises(RuntimeError):
+        scheduler.process(config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
+
+
+@pytest.mark.parametrize('as_modules', [False, True])
+@pytest.mark.parametrize('reinit_scheduler', [True, False])
+def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_scheduler, as_modules):
+    config = SchedulerConfig.from_dict(multi_modes_config)
 
     if as_modules:
         proj_multi_mode = testdir/'sources/projMultiModeModules'
@@ -729,50 +750,79 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, 
     builddir.mkdir(exist_ok=True)
 
     scheduler = Scheduler(paths=proj_multi_mode, config=config, xmods=[tmp_path], output_dir=builddir)
-    if wrong_pipeline_name:
-        # check failure since pipeline 'm1' can't be found
-        with pytest.raises(RuntimeError):
-            scheduler.process(config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
-        return
+
+    # We manually invoke the mode propagation to check that the correct modes are assigned
+    scheduler._propagate_modes()
+    expected_modes_per_item = {
+        'driver_0_mod#driver_0': {'m1'},
+        'driver_1_mod#driver_1': {'m1'},
+        'driver_2_mod#driver_2': {'m2'},
+        'driver_3_mod#driver_3': {'m3'},
+        'driver_4_mod#driver_4': {'m3'},
+        'subroutine_1_mod#subroutine_1': {'m1'},
+        'subroutine_2_mod#subroutine_2': {'m2'},
+        'subroutine_3_mod#subroutine_3': {'m1', 'm3'},
+        'nested_subroutine_1_mod#nested_subroutine_1': {'m1', 'm3'},
+        'nested_subroutine_2_mod#nested_subroutine_2': {'m2'},
+        'nested_subroutine_3_mod#nested_subroutine_3': {'m1', 'm2', 'm3'}
+    }
+
+    if not as_modules:
+        # strip scope prefixes for non-module items
+        expected_modes_per_item = {
+            (item[item.find('#'):] if 'driver' not in item else item): modes
+            for item, modes in expected_modes_per_item.items()
+        }
+
+    assert {
+        item.name: {item.mode} if 'driver' in item.name else item.trafo_data['inherited_mode']
+        for item in scheduler.items
+    } == expected_modes_per_item
+
+    # Manually invoke the pipeline separation several times to ensure it is idempotent
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+
     scheduler.process(config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
 
-    _expected_item_mode_dic = {
+    expected_items_per_mode = {
         'm1': {
-            'nested_subroutine_3_lokim1_mod#nested_subroutine_3_lokim1',
             'driver_0_mod#driver_0',
-            'nested_subroutine_1_lokim1_mod#nested_subroutine_1_lokim1',
-            'subroutine_3_lokim1_mod#subroutine_3_lokim1',
             'driver_1_mod#driver_1',
-            'subroutine_1_mod#subroutine_1'
+            'subroutine_1_loki_m1_mod#subroutine_1_loki_m1',
+            'subroutine_3_loki_m1_mod#subroutine_3_loki_m1',
+            'nested_subroutine_1_loki_m1_mod#nested_subroutine_1_loki_m1',
+            'nested_subroutine_3_loki_m1_mod#nested_subroutine_3_loki_m1',
+            'nested_subroutine_3_mod#nested_subroutine_3',
         },
         'm2': {
-            'subroutine_2_mod#subroutine_2',
             'driver_2_mod#driver_2',
-            'nested_subroutine_3_lokim2_mod#nested_subroutine_3_lokim2',
-            'nested_subroutine_2_mod#nested_subroutine_2'
+            'subroutine_2_loki_m2_mod#subroutine_2_loki_m2',
+            'nested_subroutine_2_loki_m2_mod#nested_subroutine_2_loki_m2',
+            'nested_subroutine_3_loki_m2_mod#nested_subroutine_3_loki_m2',
         },
         'm3': {
-            'nested_subroutine_3_mod#nested_subroutine_3',
             'driver_3_mod#driver_3',
             'driver_4_mod#driver_4',
-            'nested_subroutine_1_mod#nested_subroutine_1',
-            'subroutine_3_mod#subroutine_3'
+            'subroutine_3_loki_m3_mod#subroutine_3_loki_m3',
+            'nested_subroutine_1_loki_m3_mod#nested_subroutine_1_loki_m3',
+            'nested_subroutine_3_loki_m3_mod#nested_subroutine_3_loki_m3',
         }
     }
-    if as_modules:
-        expected_item_mode_dic = _expected_item_mode_dic
-    else:
-        expected_item_mode_dic = {k: {f"#{v.split('#')[-1]}" if 'routine' in v else v for v in vals}
-                                  for k, vals in _expected_item_mode_dic.items()}
+    if not as_modules:
+        expected_items_per_mode = {
+            mod: {item[item.find('#'):] if 'driver' not in item else item for item in items}
+            for mod, items in expected_items_per_mode.items()
+        }
 
-    items = scheduler.items
-    item_mode_dic = {}
-    for item in items:
-        item_mode_dic.setdefault(item.mode, set()).add(item.name)
+    items_per_mode = defaultdict(set)
+    for item in scheduler.items:
+        items_per_mode[item.mode].add(item.name)
 
-    assert set(item_mode_dic.keys()) == set(expected_item_mode_dic.keys())
-    for _mode, _val in item_mode_dic.items():
-        assert expected_item_mode_dic[_mode] == _val
+    assert set(items_per_mode) == set(expected_items_per_mode)
+    for _mode, _val in items_per_mode.items():
+        assert expected_items_per_mode[_mode] == _val
 
     transformations = (
         ModuleWrapTransformation(module_suffix='_mod'),
@@ -808,10 +858,12 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, 
                                        for v in _expected_files_to_transform}
     _expected_files_to_append = {
         'driver_0_mod.m1', 'driver_1_mod.m1', 'driver_2_mod.m2', 'driver_3_mod.m3',
-        'driver_4_mod.m3', 'nested_subroutine_1_mod.m3', 'nested_subroutine_1_lokim1_mod.m1',
-        'nested_subroutine_2_mod.m2', 'nested_subroutine_3_mod.m3', 'nested_subroutine_3_lokim1_mod.m1',
-        'nested_subroutine_3_lokim2_mod.m2', 'subroutine_1_mod.m1', 'subroutine_2_mod.m2',
-        'subroutine_3_mod.m3', 'subroutine_3_lokim1_mod.m1'
+        'driver_4_mod.m3', 'nested_subroutine_1_loki_m1_mod.m1',
+        'nested_subroutine_1_loki_m3_mod.m3', 'nested_subroutine_2_loki_m2_mod.m2',
+        'nested_subroutine_3_mod.m1', 'nested_subroutine_3_loki_m1_mod.m1',
+        'nested_subroutine_3_loki_m2_mod.m2', 'nested_subroutine_3_loki_m3_mod.m3',
+        'subroutine_1_loki_m1_mod.m1', 'subroutine_2_loki_m2_mod.m2',
+        'subroutine_3_loki_m1_mod.m1', 'subroutine_3_loki_m3_mod.m3'
     }
     if as_modules:
         expected_files_to_append = _expected_files_to_append
@@ -834,39 +886,39 @@ def test_scheduler_multi_modes(testdir, tmp_path, reinit_scheduler, as_modules, 
 
     expected_callgraph = {
         'driver_0_mod#driver_0': {
-            'subroutine_1_test_mod#subroutine_1_test': {
-                'nested_subroutine_1_lokim1_test_mod#nested_subroutine_1_lokim1_test',
+            'subroutine_1_loki_m1_test_mod#subroutine_1_loki_m1_test': {
+                'nested_subroutine_1_loki_m1_test_mod#nested_subroutine_1_loki_m1_test',
             },
-            'subroutine_3_lokim1_test_mod#subroutine_3_lokim1_test': {
-                'nested_subroutine_1_lokim1_test_mod#nested_subroutine_1_lokim1_test',
-                'nested_subroutine_3_lokim1_test_mod#nested_subroutine_3_lokim1_test',
+            'subroutine_3_loki_m1_test_mod#subroutine_3_loki_m1_test': {
+                'nested_subroutine_1_loki_m1_test_mod#nested_subroutine_1_loki_m1_test',
+                'nested_subroutine_3_loki_m1_test_mod#nested_subroutine_3_loki_m1_test',
             },
         },
         'driver_1_mod#driver_1': {
-            'subroutine_1_test_mod#subroutine_1_test': {
-                'nested_subroutine_1_lokim1_test_mod#nested_subroutine_1_lokim1_test',
+            'subroutine_1_loki_m1_test_mod#subroutine_1_loki_m1_test': {
+                'nested_subroutine_1_loki_m1_test_mod#nested_subroutine_1_loki_m1_test',
             },
-            'subroutine_3_lokim1_test_mod#subroutine_3_lokim1_test': {
-                'nested_subroutine_1_lokim1_test_mod#nested_subroutine_1_lokim1_test',
-                'nested_subroutine_3_lokim1_test_mod#nested_subroutine_3_lokim1_test',
+            'subroutine_3_loki_m1_test_mod#subroutine_3_loki_m1_test': {
+                'nested_subroutine_1_loki_m1_test_mod#nested_subroutine_1_loki_m1_test',
+                'nested_subroutine_3_loki_m1_test_mod#nested_subroutine_3_loki_m1_test',
             }
         },
         'driver_2_mod#driver_2': {
-            'subroutine_2_test_mod#subroutine_2_test': {
-                'nested_subroutine_2_test_mod#nested_subroutine_2_test',
-                'nested_subroutine_3_lokim2_test_mod#nested_subroutine_3_lokim2_test'
+            'subroutine_2_loki_m2_test_mod#subroutine_2_loki_m2_test': {
+                'nested_subroutine_2_loki_m2_test_mod#nested_subroutine_2_loki_m2_test',
+                'nested_subroutine_3_loki_m2_test_mod#nested_subroutine_3_loki_m2_test'
             }
         },
         'driver_3_mod#driver_3': {
-            'subroutine_3_test_mod#subroutine_3_test': {
-                'nested_subroutine_1_test_mod#nested_subroutine_1_test',
-                'nested_subroutine_3_test_mod#nested_subroutine_3_test',
+            'subroutine_3_loki_m3_test_mod#subroutine_3_loki_m3_test': {
+                'nested_subroutine_1_loki_m3_test_mod#nested_subroutine_1_loki_m3_test',
+                'nested_subroutine_3_loki_m3_test_mod#nested_subroutine_3_loki_m3_test',
             }
         },
         'driver_4_mod#driver_4': {
-            'subroutine_3_test_mod#subroutine_3_test': {
-                'nested_subroutine_1_test_mod#nested_subroutine_1_test',
-                'nested_subroutine_3_test_mod#nested_subroutine_3_test',
+            'subroutine_3_loki_m3_test_mod#subroutine_3_loki_m3_test': {
+                'nested_subroutine_1_loki_m3_test_mod#nested_subroutine_1_loki_m3_test',
+                'nested_subroutine_3_loki_m3_test_mod#nested_subroutine_3_loki_m3_test',
             }
         }
     }

--- a/loki/batch/tests/test_scheduler_config.py
+++ b/loki/batch/tests/test_scheduler_config.py
@@ -720,6 +720,35 @@ def fixture_multi_modes_config():
         },
     }
 
+
+@pytest.fixture(name='check_multimodes_callgraph', scope='module')
+def fixture_check_multimodes_callgraph():
+    """
+    Fixture that provides a function to check that the call graph of the scheduler
+    is consistent with the provided callgraph dictionary
+    """
+    def check_callgraph(scheduler, callgraph):
+        if not isinstance(callgraph, dict) or not callgraph:
+            return
+        for routine in callgraph.keys():
+            routine_ir = scheduler[routine].ir
+            imports = routine_ir.imports
+            imported_symbols = ()
+            for imp in imports:
+                imported_symbols += imp.symbols
+            successors = []
+            for successor in callgraph[routine]:
+                if '#' in successor:
+                    successors.append(scheduler[successor].ir)
+            successors_local_name = [str(successor.name).lower() for successor in successors]
+            calls = FindNodes(ir.CallStatement).visit(routine_ir.body)
+            for call in calls:
+                assert str(call.name).lower() in successors_local_name
+                assert str(call.name).lower() in imported_symbols
+            check_callgraph(scheduler, callgraph[routine])
+    yield check_callgraph
+
+
 def test_scheduler_multi_modes_invalid_pipeline(testdir, tmp_path, multi_modes_config):
     """
     Test that the scheduler raises an error when a pipeline is missing for a mode
@@ -738,7 +767,7 @@ def test_scheduler_multi_modes_invalid_pipeline(testdir, tmp_path, multi_modes_c
 
 @pytest.mark.parametrize('as_modules', [False, True])
 @pytest.mark.parametrize('reinit_scheduler', [True, False])
-def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_scheduler, as_modules):
+def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_scheduler, as_modules, check_multimodes_callgraph):
     config = SchedulerConfig.from_dict(multi_modes_config)
 
     if as_modules:
@@ -923,23 +952,109 @@ def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_sch
         }
     }
 
-    def check_callgraph(callgraph):
-        if not isinstance(callgraph, dict) or not callgraph:
-            return
-        for routine in callgraph.keys():
-            routine_ir = scheduler[routine].ir
-            imports = routine_ir.imports
-            imported_symbols = ()
-            for imp in imports:
-                imported_symbols += imp.symbols
-            successors = []
-            for successor in callgraph[routine]:
-                successors.append(scheduler[successor].ir)
-            successors_local_name = [str(successor.name).lower() for successor in successors]
-            calls = FindNodes(ir.CallStatement).visit(routine_ir.body)
-            for call in calls:
-                assert str(call.name).lower() in successors_local_name
-                assert str(call.name).lower() in imported_symbols
-            check_callgraph(callgraph[routine])
+    check_multimodes_callgraph(scheduler, expected_callgraph)
 
-    check_callgraph(expected_callgraph)
+
+@pytest.mark.parametrize('proc_strategy', [ProcessingStrategy.PLAN, ProcessingStrategy.DEFAULT])
+def test_scheduler_multi_modes_imports(tmp_path, proc_strategy, check_multimodes_callgraph):
+    """
+    Test that the correct imports are added to the transformed files in multi-mode pipelines
+    """
+
+    fcode_driver1 = """
+subroutine driver1
+    use test_multi_modes_kernel1, only: kernel1, n
+    use test_multi_modes_kernel2, only: kernel2
+    implicit none
+    integer :: arr(n, n)
+    call kernel1
+    call kernel2
+end subroutine driver1
+    """.strip()
+
+    fcode_driver2 = """
+subroutine driver2
+    use test_multi_modes_kernel1, only: n
+    use test_multi_modes_kernel2, only: kernel2
+    implicit none
+    integer :: arr(n, n)
+    call kernel2
+end subroutine driver2
+    """.strip()
+
+    fcode_kernel1 = """
+module test_multi_modes_kernel1
+implicit none
+integer, parameter :: n = 10
+contains
+subroutine kernel1
+    use test_multi_modes_kernel2, only: kernel2
+    call kernel2
+end subroutine kernel1
+end module test_multi_modes_kernel1
+    """.strip()
+
+    fcode_kernel2 = """
+module test_multi_modes_kernel2
+implicit none
+contains
+subroutine kernel2
+end subroutine kernel2
+end module test_multi_modes_kernel2
+    """.strip()
+
+    config = {
+        'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm1', 'replicate': True},
+        'routines': {
+            'driver1': {'role': 'driver', 'mode': 'm1', 'replicate': False},
+            'driver2': {'role': 'driver', 'mode': 'm2', 'replicate': False},
+        },
+        'transformations': {
+            'Idem1': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'Idem2': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+        },
+        'pipelines': {
+            'm1': {'transformations': {'Idem1'}},
+            'm2': {'transformations': {'Idem2'}},
+        },
+    }
+    scheduler_config = SchedulerConfig.from_dict(config)
+
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    (src_dir/'driver1.F90').write_text(fcode_driver1)
+    (src_dir/'driver2.F90').write_text(fcode_driver2)
+    (src_dir/'test_multi_modes_kernel1.F90').write_text(fcode_kernel1)
+    (src_dir/'test_multi_modes_kernel2.F90').write_text(fcode_kernel2)
+
+    out_dir = tmp_path/'output'
+    out_dir.mkdir()
+
+    scheduler = Scheduler(paths=src_dir, config=scheduler_config, xmods=[tmp_path], output_dir=out_dir)
+    scheduler.propagate_and_separate_modes(proc_strategy=proc_strategy)
+    scheduler.process(scheduler_config.pipelines, proc_strategy=proc_strategy)
+
+    if proc_strategy != ProcessingStrategy.PLAN:
+        expected_dependencies = {
+            '#driver1': {
+                'test_multi_modes_kernel1', 'test_multi_modes_kernel1_loki_m1#kernel1_loki_m1',
+                'test_multi_modes_kernel2_loki_m1#kernel2_loki_m1'
+            },
+            '#driver2': {'test_multi_modes_kernel1', 'test_multi_modes_kernel2_loki_m2#kernel2_loki_m2'},
+            'test_multi_modes_kernel1_loki_m1#kernel1_loki_m1': {'test_multi_modes_kernel2_loki_m1#kernel2_loki_m1'},
+        }
+
+        check_multimodes_callgraph(scheduler, expected_dependencies)
+
+        expected_imports = {
+            '#driver1': {
+                'test_multi_modes_kernel1', 'test_multi_modes_kernel1_loki_m1', 'test_multi_modes_kernel2_loki_m1'
+            },
+            '#driver2': {'test_multi_modes_kernel1', 'test_multi_modes_kernel2_loki_m2'},
+            'test_multi_modes_kernel1_loki_m1#kernel1_loki_m1': {'test_multi_modes_kernel2_loki_m1'},
+        }
+        for item_name, imports in expected_imports.items():
+            item_ir = scheduler[item_name].ir
+            item_imports = item_ir.imports
+            imported_modules = {imp.module for imp in item_imports}
+            assert imported_modules == imports

--- a/loki/batch/tests/test_scheduler_config.py
+++ b/loki/batch/tests/test_scheduler_config.py
@@ -767,7 +767,8 @@ def test_scheduler_multi_modes_invalid_pipeline(testdir, tmp_path, multi_modes_c
 
 @pytest.mark.parametrize('as_modules', [False, True])
 @pytest.mark.parametrize('reinit_scheduler', [True, False])
-def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_scheduler, as_modules, check_multimodes_callgraph):
+def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_scheduler,
+                               as_modules, check_multimodes_callgraph):
     config = SchedulerConfig.from_dict(multi_modes_config)
 
     if as_modules:

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -489,7 +489,7 @@ class SeparateModesKernel(Transformation):
 
     def _create_new_items(self, item, successors, item_factory, config, ignore=None):
         """
-        Duplicate :data:`item` for each transformation mode and update teh plan
+        Duplicate :data:`item` for each transformation mode and update the plan
         dependencies accordingly.
 
         Driver items are not duplicated but their dependencies are still updated to point

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -5,6 +5,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from collections import defaultdict
 from itertools import chain
 
 from loki.batch.transformation import Transformation
@@ -389,8 +390,8 @@ class SeparateModesKernel(Transformation):
         scope_name = item.scope_name
         local_name = f'{item.local_name}{mode_rename}'
         if scope_name:
-            if "_mod" in scope_name:
-                scope_name = scope_name.replace('_mod', f'_{mode_rename}_mod').replace('__', '_')
+            if scope_name.endswith('_mod'):
+                scope_name = f'{scope_name[:-4]}{mode_rename}_mod'
             else:
                 scope_name = f'{scope_name}{mode_rename}'
 
@@ -616,6 +617,7 @@ class SeparateModesKernel(Transformation):
             return
 
         # We go through the IR, as C-imports can be attributed to the body
+        new_imports = []
         for import_ in imports:
             if import_.c_import:
                 target_symbol = import_.module.lower().split('.', maxsplit=1)[0]
@@ -628,20 +630,21 @@ class SeparateModesKernel(Transformation):
                     if not any(s.name in imports_to_rename for s in import_.symbols):
                         continue
 
-                    symbols_modules = {
-                        s.clone(name=f'{imports_to_rename[s.name].local_name}'): imports_to_rename[s.name].scope_name
-                        if s.name in imports_to_rename else (s, import_.module) for s in import_.symbols
-                    }
-                    new_modules = list(symbols_modules.values())
-                    if any(m != new_modules[0] for m in new_modules):
-                        warning((
-                            '[Loki] SeparateModesKernel: Non-matching module names during import renaming. '
-                            f'Skipping imports from module {import_.module}.'
-                        ))
-                        continue
-                    import_._update(module=new_modules[0], symbols=tuple(symbols_modules))
+                    modules_and_symbols = defaultdict(list)
+                    for s in import_.symbols:
+                        if s.name in imports_to_rename:
+                            modules_and_symbols[imports_to_rename[s.name].scope_name].append(s.clone(name=imports_to_rename[s.name].local_name))
+                        else:
+                            modules_and_symbols[import_.module].append(s)
+                    for module, symbols in modules_and_symbols.items():
+                        if module == import_.module or len(modules_and_symbols) == 1:
+                            import_._update(module=module,symbols=tuple(symbols))
+                        else:
+                            new_imports += [import_.clone(module=module, symbols=tuple(symbols))]
                 else:
                     warning(f'[Loki] SeparateModesKernel: encountered unqualified blank import for {import_.module}')
+        if new_imports:
+            item.ir.spec.prepend(as_tuple(new_imports))
 
     def rename_calls(self, item, mapping):
         """

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -633,7 +633,9 @@ class SeparateModesKernel(Transformation):
                     modules_and_symbols = defaultdict(list)
                     for s in import_.symbols:
                         if s.name in imports_to_rename:
-                            modules_and_symbols[imports_to_rename[s.name].scope_name].append(s.clone(name=imports_to_rename[s.name].local_name))
+                            modules_and_symbols[imports_to_rename[s.name].scope_name].append(
+                                s.clone(name=imports_to_rename[s.name].local_name)
+                            )
                         else:
                             modules_and_symbols[import_.module].append(s)
                     for module, symbols in modules_and_symbols.items():

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -588,6 +588,16 @@ class SeparateModesKernel(Transformation):
             )
 
     def rename_interfaces(self, item, mapping):
+        """
+        Update :any:`Interface` names to actively transformed procedures.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            The item for which to rename interfaces.
+        mapping : dict
+            A mapping from old dependency item names to new dependency items.
+        """
         intf_map = item.ir.interface_map
         intfs_to_rename = self._match_names_to_new_dependencies(list(intf_map), mapping)
 
@@ -598,6 +608,18 @@ class SeparateModesKernel(Transformation):
                         node.name = intfs_to_rename[name].ir.procedure_symbol.name
 
     def rename_imports(self, item, mapping):
+        """
+        Update :any:`Import` statements to actively transformed procedures and modules.
+
+        Updates imports of C-style headers and Fortran modules to match the new mode-specific names.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            The item for which to rename imports.
+        mapping : dict
+            A mapping from old dependency item names to new dependency items.
+        """
         imports = item.ir.imports
 
         imported_names = [
@@ -655,9 +677,10 @@ class SeparateModesKernel(Transformation):
 
         Parameters
         ----------
-        targets : list of str
-            Optional list of subroutine names for which to modify the corresponding
-            calls. If not provided, all calls are updated
+        item : :any:`Item`
+            The item for which to rename calls.
+        mapping : dict
+            A mapping from old dependency item names to new dependency items.
         """
         routine = item.ir
         calls = FindNodes(ir.CallStatement).visit(routine.body)
@@ -680,7 +703,12 @@ class SeparateModesKernel(Transformation):
                 self._update_item_config_names(item, orig_name, proc_symbol.name)
 
     def transform_subroutine(self, routine, **kwargs):
+        """
+        Transform the given subroutine by creating new items for the different modes
+        and updating the dependencies accordingly.
+        """
         item = kwargs['item']
+        assert routine is item.ir
         item_factory = kwargs.get('item_factory')
         sub_sgraph = kwargs.get('sub_sgraph')
         successors = sub_sgraph.successors(item) if sub_sgraph is not None else ()
@@ -696,7 +724,12 @@ class SeparateModesKernel(Transformation):
                 self.rename_interfaces(item_, mapping)
 
     def plan_subroutine(self, routine, **kwargs):
+        """
+        Transform the given subroutine by creating new items for the different modes
+        and registering the new dependencies in the item's plan_data accordingly.
+        """
         item = kwargs['item']
+        assert routine is item.ir
         item_factory = kwargs.get('item_factory')
         sub_sgraph = kwargs.get('sub_sgraph')
         successors = sub_sgraph.successors(item) if sub_sgraph is not None else ()

--- a/loki/transformations/dependency.py
+++ b/loki/transformations/dependency.py
@@ -5,8 +5,10 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from itertools import chain
+
 from loki.batch.transformation import Transformation
-from loki.ir import nodes as ir, Transformer, FindNodes
+from loki.ir import nodes as ir, Transformer, FindNodes, FindInlineCalls
 from loki.tools.util import as_tuple, CaseInsensitiveDict
 from loki.subroutine import Subroutine
 from loki.logging import warning
@@ -56,6 +58,7 @@ class DuplicateKernel(Transformation):
         item : :any:`Item`
             The item used to derive ``local_name``,
             ``scope_name`` and ``new_item_name``.
+
         Returns
         -------
         scope_name : str
@@ -87,6 +90,7 @@ class DuplicateKernel(Transformation):
             The :any:`ItemFactory` to use when creating the items.
         config : :any:`SchedulerConfig`
             The scheduler config to use when instantiating new items.
+
         Returns
         -------
         :any:`Item`
@@ -94,6 +98,7 @@ class DuplicateKernel(Transformation):
         """
         scope_name, local_name, new_item_name = self._get_new_item_name(item)
         new_item = item_factory.item_cache.get(new_item_name)
+
         # Try to get an item for the scope or create that first
         if new_item is None and scope_name:
             scope_item = item_factory.item_cache.get(scope_name)
@@ -107,9 +112,11 @@ class DuplicateKernel(Transformation):
                     new_item = item_factory.create_from_ir(
                         scope[local_name], scope, config=config
                     )
+
         # Create new item
         if new_item is None:
             new_item = item_factory.get_or_create_item_from_item(new_item_name, item, config=config)
+
         return new_item
 
     def _modify_sgraph(self, sgraph, item, new_items):
@@ -340,14 +347,23 @@ class SeparateModesKernel(Transformation):
 
     Therefore, this transformation creates a new item and also implements
     the relevant routines for dry-run pipeline planning runs.
+
+    Parameters:
+    -----------
+    rename_suffix : str, optional
+        Suffix to be used to append the original kernel name(s) and module name(s).
+        Must be a valid format string that accepts a ``mode`` keyword argument,
+        which is used to generate the suffix for the new item names.
     """
 
     creates_items = True
     renames_items = True
-    reverse_traversal = False
+    reverse_traversal = True
 
-    def __init__(self):
-        self.mapping = {}
+    def __init__(self, rename_suffix='_loki_{mode}'):
+        if '{mode}' not in rename_suffix:
+            raise ValueError("rename_suffix must contain '{mode}' placeholder")
+        self.rename_suffix = rename_suffix
 
     def _get_new_item_name(self, item, mode):
         """
@@ -364,18 +380,10 @@ class SeparateModesKernel(Transformation):
 
         Returns
         -------
-        scope_name : str
-            New item scope name.
-        new_item_name : str
-            New item name.
         local_name : str
-            New item local name.
+            New item fully-qualified name.
         """
-        if mode in self.mapping:
-            mode_rename = self.mapping[mode]
-        else:
-            mode_rename = f'_loki{mode.replace("-", "_")}'
-            self.mapping[mode] = mode_rename
+        mode_rename = self.rename_suffix.format(mode=mode.replace('-', '_'))
 
         # Determine new item name
         scope_name = item.scope_name
@@ -386,9 +394,7 @@ class SeparateModesKernel(Transformation):
             else:
                 scope_name = f'{scope_name}{mode_rename}'
 
-        # Try to get existing item from cache
-        new_item_name = f'{scope_name or ""}#{local_name}'
-        return scope_name, local_name, new_item_name
+        return f'{scope_name or ""}#{local_name}'
 
     def _get_or_create_or_rename_item(self, item, mode, item_factory, config):
         """
@@ -405,17 +411,19 @@ class SeparateModesKernel(Transformation):
             The :any:`ItemFactory` to use when creating the items.
         config : :any:`SchedulerConfig`
             The scheduler config to use when instantiating new items.
+
         Returns
         -------
         :any:`Item`
             Newly created item.
         """
-        scope_name, local_name, new_item_name = self._get_new_item_name(item, mode)
+        new_item_name = self._get_new_item_name(item, mode)
         new_item = item_factory.item_cache.get(new_item_name)
+
         # Try to get an item for the scope or create that first
-        if new_item is None and scope_name:
-            scope_item = item_factory.item_cache.get(scope_name)
-            if scope_item:
+        if new_item is None:
+            scope_name, local_name = new_item_name.split('#')
+            if scope_name and (scope_item := item_factory.item_cache.get(scope_name)):
                 scope = scope_item.ir
                 if local_name not in scope and item.local_name in scope:
                     # Rename the existing item to the new name
@@ -425,18 +433,72 @@ class SeparateModesKernel(Transformation):
                     new_item = item_factory.create_from_ir(
                         scope[local_name], scope, config=config
                     )
+
         # Create new item
         if new_item is None:
             new_item = as_tuple(item_factory.get_or_create_item_from_item(new_item_name, item, config=config))[0]
+
         return new_item
 
-    def _create_new_items(self, successors, item_factory, config, item, sub_sgraph,
-            rename_calls=False, ignore=None):
+    def _update_plan_dependencies(self, item, successors, item_factory, ignore=None):
         """
-        Create new/duplicated items.
+        Update plan dependencies for the given item.
 
         Parameters
         ----------
+        item : :any:`Item`
+            The item for which to update the plan dependencies.
+        successors : tuple
+            Tuple of :any:`Item`s representing the successor items for which
+            the dependencies of :data:`item` are updated.
+        item_factory : :any:`ItemFactory`
+            The :any:`ItemFactory` to fetch the new successor items from.
+        ignore : tuple, optional
+            Tuple of local names to ignore when updating dependencies.
+
+        Returns
+        -------
+        dict
+            A mapping from old successor items to new successor items that
+            were added as dependencies.
+        """
+        ignore = as_tuple(ignore)
+        item.plan_data.setdefault('additional_dependencies', ())
+        item.plan_data.setdefault('removed_dependencies', ())
+
+        new_dependencies = {}
+
+        for child in successors:
+            if child.local_name in ignore:
+                continue
+            new_child_name = self._get_new_item_name(child, item.mode)
+            new_child = item_factory.item_cache.get(new_child_name)
+
+            if new_child:
+                item.plan_data['additional_dependencies'] += (new_child,)
+                item.plan_data['removed_dependencies'] += (child,)
+                new_dependencies[child] = new_child
+            else:
+                warning((
+                    f'[Loki] SeparateModesKernel: Could not find new item {new_child_name} for '
+                    f'child {child.name} of item {item.name} in the item cache.'
+                ))
+
+        return new_dependencies
+
+    def _create_new_items(self, item, successors, item_factory, config, ignore=None):
+        """
+        Duplicate :data:`item` for each transformation mode and update teh plan
+        dependencies accordingly.
+
+        Driver items are not duplicated but their dependencies are still updated to point
+        to the new items, if applicable.
+
+        Parameters
+        ----------
+        item : :any:`Item`
+            Starting point/source item from which the successors
+            originate from
         successors : tuple
             Tuple of :any:`Item`s representing the successor items for which
             new/duplicated items are created..
@@ -444,162 +506,196 @@ class SeparateModesKernel(Transformation):
             The :any:`ItemFactory` to use when creating the items.
         config : :any:`SchedulerConfig`
             The scheduler config to use when instantiating new items.
-        item : :any:`Item`
-            Starting point/source item from which the successors
-            originate from
-        sub_sgraph : :any:`SGraph`
-            Sgraph (copy) representing the subgraph of the directed
-            overall graph.
-        rename_calls : bool, optional
-            Rename calls/imports in accordance to the duplicated
-            kernels.
+        ignore : tuple, optional
+            Tuple of local names to ignore when creating new items and updating dependencies.
+
         Returns
         -------
         tuple
             Tuple of newly created items.
         """
-        ignore = as_tuple(ignore)
-        new_items = ()
-        removed_items = ()
-        item.trafo_data.setdefault('SeparateModes', {})
-        for child in successors:
-            if child.local_name in ignore:
-                continue
-            child.trafo_data.setdefault('SeparateModes', {})
-            modes_to_duplicate = sorted(list(set(self._get_item_modes(child))))
-            if item.mode in child.trafo_data['SeparateModes']:
-                new_item = child.trafo_data['SeparateModes'][item.mode]
-                removed_items += (child,)
-                new_items += as_tuple(new_item)
-                item.trafo_data['SeparateModes'][child] = new_item
-            elif len(modes_to_duplicate) > 1:
-                mode_to_duplicate = item.mode
-                new_item = self._get_or_create_or_rename_item(child, mode_to_duplicate, item_factory, config)
-                new_item.config = child.config.copy()
-                new_item.config['mode'] = mode_to_duplicate
-                parent_items = item_factory.get_scope_and_file_items(new_item)
-                for parent_item in parent_items:
-                    parent_item.config['mode'] = mode_to_duplicate
-                child.trafo_data['inherited_mode'].discard(mode_to_duplicate)
-                removed_items += (child,)
-                new_items += as_tuple(new_item)
-                item.trafo_data['SeparateModes'][child] = new_item
-                child.trafo_data['SeparateModes'][mode_to_duplicate] = new_item
-                # recurse
-                new_item.plan_data.setdefault('removed_dependencies', ())
-                new_item.plan_data.setdefault('additional_dependencies', ())
-                new_item_new_items, new_item_removed_items = self._create_new_items(sub_sgraph.successors(child),
-                        item_factory, config, new_item, sub_sgraph)
-                new_item.plan_data['additional_dependencies'] += new_item_new_items
-                new_item.plan_data['removed_dependencies'] += new_item_removed_items
-                if rename_calls:
-                    new_dependencies = CaseInsensitiveDict((k.local_name, v) for k, v in
-                            new_item.trafo_data.get('SeparateModes', {}).items() if not isinstance(k, str))
-                    self._adapt_calls_imports(new_item.ir, new_dependencies)
-            else:
-                # like this we keep for one transformation pipeline mode the original item
-                # this is not strictly necessary but currently the MO
-                mode_to_duplicate = modes_to_duplicate[0]
-                child.config['mode'] = item.mode
-                parent_items = item_factory.get_scope_and_file_items(child)
-                for parent_item in parent_items:
-                    parent_item.config['mode'] = mode_to_duplicate
+        if item.trafo_data.get('SeparateModes'):
+            # Item has already been handled for this stage, so we
+            # can skip the item renaming to remain idempotent but
+            # still provide the mapping in case they are required for
+            # call updates
+            additional_dependencies = item.plan_data.get('additional_dependencies', ())
+            removed_dependencies = item.plan_data.get('removed_dependencies', ())
+            mapping = dict(zip(removed_dependencies, additional_dependencies))
+            return {item: mapping}
 
-        return tuple(new_items), tuple(removed_items)
+        # A map containing items that have been modified or created, with corresponding mappings from old
+        # to new dependency items
+        updated_items = {}
 
-    def rename_interfaces(self, intfs, new_dependencies):
-        for i in intfs:
-            for routine in i.body:
-                if isinstance(routine, Subroutine):
-                    if new_dependencies and routine.name.lower() in new_dependencies:
-                        routine.name = new_dependencies[routine.name.lower()].local_name
+        if item.role == 'kernel':
+            modes_to_generate = item.trafo_data.get('inherited_mode', {item.mode})
 
-    def rename_imports(self, imports, new_dependencies=None):
-        # We go through the IR, as C-imports can be attributed to the body
-        for im in imports:
-            if im.c_import:
-                target_symbol, *suffixes = im.module.lower().split('.', maxsplit=1)
-                if new_dependencies and target_symbol.lower() in new_dependencies and not 'func.h' in suffixes:
-                    # Modify the the basename of the C-style header import
-                    s = '.'.join(im.module.split('.')[1:])
-                    im._update(module=f'{new_dependencies[target_symbol].local_name}.{s}')
-            else:
-                # Modify module import if it imports any call targets
-                if new_dependencies and im.symbols and any(s in new_dependencies for s in im.symbols):
-                    relevant_symbol = [s for s in im.symbols if s in new_dependencies][0]
-                    _new_symbol = new_dependencies[relevant_symbol]
-                    new_symbol = _new_symbol.scope_ir.procedure_symbol # local_name
-                    new_module_name = _new_symbol.scope_name
-                    im._update(module=new_module_name, symbols=(new_symbol,))
-                if not im.symbols:
-                    warning('[Loki] SeparateModesKernel: encountered unqualified blank import' +
-                            f' for {im.module}')
+            for mode in modes_to_generate:
+                new_item = self._get_or_create_or_rename_item(item, mode, item_factory, config)
+                new_item.config = item.config.copy()
+                new_item.config['mode'] = mode
 
-    def _adapt_calls_imports(self, routine, new_dependencies):
-        call_map = {}
-        if not new_dependencies:
-            warning('[Loki] SeparateModesKernel: _adapt_calls_imports called with empty new_dependencies')
+
+                # Make sure that encapsulating scopes are also renamed
+                for scope_item in item_factory.get_scope_and_file_items(new_item):
+                    scope_item.config['mode'] = mode
+
+                # Update plan dependencies
+                updated_items[new_item] = self._update_plan_dependencies(
+                    new_item, successors, item_factory, ignore=ignore
+                )
+
+                new_item.trafo_data['SeparateModes'] = True
+
+        else:
+            updated_items[item] = self._update_plan_dependencies(
+                item, successors, item_factory, ignore=ignore
+            )
+
+        item.trafo_data['SeparateModes'] = True
+
+        return updated_items
+
+    def _match_names_to_new_dependencies(self, names, mapping):
+        """
+        Return the mapping from :data:`names` to new dependency items provided in :data:`mapping`
+        """
+        from loki.batch.configure import SchedulerConfig  # pylint: disable=import-outside-toplevel
+        return CaseInsensitiveDict(
+            (name, new_item)
+            for old_item, new_item in mapping.items()
+            for name in SchedulerConfig.match_item_keys(old_item.name, names)
+        )
+
+    def _update_item_config_names(self, item, orig_name, new_name):
+        """
+        Rename ``ignore`` and ``block`` entries in the item config to reflect new item names.
+        """
+        from loki.batch.configure import SchedulerConfig  # pylint: disable=import-outside-toplevel
+
+        # Update the ignore and block properties if necessary
+        if matched_keys := SchedulerConfig.match_item_keys(orig_name, item.ignore):
+            # Add the renamed but ignored items to the block list because we won't be able to
+            # find them as dependencies under their new name anymore
+            item.config['block'] = as_tuple(item.block) + tuple(
+                new_name for name in item.ignore if name in matched_keys
+            )
+            item.config['ignore'] = tuple(
+                new_name if name in matched_keys else name
+                for name in item.ignore
+            )
+
+    def rename_interfaces(self, item, mapping):
+        intf_map = item.ir.interface_map
+        intfs_to_rename = self._match_names_to_new_dependencies(list(intf_map), mapping)
+
+        for name, intf in intf_map.items():
+            if name in intfs_to_rename:
+                for node in intf.body:
+                    if isinstance(node, Subroutine):
+                        node.name = intfs_to_rename[name].ir.procedure_symbol.name
+
+    def rename_imports(self, item, mapping):
+        imports = item.ir.imports
+
+        imported_names = [
+            import_.module.lower().split('.', maxsplit=1)[0]
+            for import_ in imports
+            if import_.c_import and not import_.module.lower().endswith('func.h')
+        ]
+        imported_names += [
+            s.name.lower()
+            for import_ in imports
+            if not import_.c_import and import_.symbols
+            for s in import_.symbols
+        ]
+
+        imports_to_rename = self._match_names_to_new_dependencies(imported_names, mapping)
+        if not imports_to_rename:
             return
-        for call in FindNodes(ir.CallStatement).visit(routine.body):
-            call_name = str(call.name).lower()
-            if call_name in new_dependencies:
-                new_item = as_tuple(new_dependencies[call_name])[0]
-                proc_symbol = new_item.ir.procedure_symbol.rescope(scope=routine)
-                call_map[call] = call.clone(name=proc_symbol)
-        if call_map:
-            routine.body = Transformer(call_map).visit(routine.body)
 
-        self.rename_imports(imports=routine.imports, new_dependencies=new_dependencies)
-        intfs = FindNodes(ir.Interface).visit(routine.spec)
-        self.rename_interfaces(intfs, new_dependencies=new_dependencies)
+        # We go through the IR, as C-imports can be attributed to the body
+        for import_ in imports:
+            if import_.c_import:
+                target_symbol = import_.module.lower().split('.', maxsplit=1)[0]
+                if target_symbol in imports_to_rename:
+                    # Modify the the basename of the C-style header import
+                    s = '.'.join(import_.module.split('.')[1:])
+                    import_._update(module=f'{imports_to_rename[target_symbol].local_name}.{s}')
+            else:
+                if import_.symbols:
+                    if not any(s.name in imports_to_rename for s in import_.symbols):
+                        continue
+
+                    symbols_modules = {
+                        s.clone(name=f'{imports_to_rename[s.name].local_name}'): imports_to_rename[s.name].scope_name
+                        if s.name in imports_to_rename else (s, import_.module) for s in import_.symbols
+                    }
+                    new_modules = list(symbols_modules.values())
+                    if any(m != new_modules[0] for m in new_modules):
+                        warning((
+                            '[Loki] SeparateModesKernel: Non-matching module names during import renaming. '
+                            f'Skipping imports from module {import_.module}.'
+                        ))
+                        continue
+                    import_._update(module=new_modules[0], symbols=tuple(symbols_modules))
+                else:
+                    warning(f'[Loki] SeparateModesKernel: encountered unqualified blank import for {import_.module}')
+
+    def rename_calls(self, item, mapping):
+        """
+        Update :any:`CallStatement` and :any:`InlineCall` to actively
+        transformed procedures
+
+        Parameters
+        ----------
+        targets : list of str
+            Optional list of subroutine names for which to modify the corresponding
+            calls. If not provided, all calls are updated
+        """
+        routine = item.ir
+        calls = FindNodes(ir.CallStatement).visit(routine.body)
+        inline_calls = FindInlineCalls().visit(routine.body)
+        call_names = [str(call.name) for call in chain(calls, inline_calls)]
+
+        calls_to_rename = self._match_names_to_new_dependencies(call_names, mapping)
+        if not calls_to_rename:
+            return
+
+        for call in chain(calls, inline_calls):
+            orig_name = str(call.name)
+            if orig_name in calls_to_rename:
+                new_item = calls_to_rename[orig_name]
+                proc_symbol = new_item.ir.procedure_symbol.rescope(scope=routine)
+                if isinstance(call, ir.CallStatement):
+                    call._update(name=proc_symbol)
+                else:
+                    call.function = proc_symbol
+                self._update_item_config_names(item, orig_name, proc_symbol.name)
 
     def transform_subroutine(self, routine, **kwargs):
-        # Create new dependency items
-        item = kwargs.get('item')
-        sub_sgraph = kwargs.get('sub_sgraph', None)
+        item = kwargs['item']
+        item_factory = kwargs.get('item_factory')
+        sub_sgraph = kwargs.get('sub_sgraph')
         successors = sub_sgraph.successors(item) if sub_sgraph is not None else ()
-        ignore = tuple(str(t).lower() for t in as_tuple(kwargs.get('ignore', None)))
+        config = kwargs.get('scheduler_config')
+        ignore = tuple(str(t).lower() for t in as_tuple(kwargs.get('ignore')))
 
-        item.plan_data.setdefault('removed_dependencies', ())
-        item.plan_data.setdefault('additional_dependencies', ())
+        updated_items = self._create_new_items(item, successors, item_factory, config, ignore=ignore)
 
-        new_dependencies, removed_dependencies = self._create_new_items(
-            successors=successors,
-            item_factory=kwargs.get('item_factory'),
-            config=kwargs.get('scheduler_config'),
-            item=kwargs.get('item'),
-            sub_sgraph=sub_sgraph,
-            rename_calls=True, ignore=ignore
-        )
-
-        item.plan_data['additional_dependencies'] += new_dependencies
-        item.plan_data['removed_dependencies'] += removed_dependencies
-
-        new_dependencies = CaseInsensitiveDict((k.local_name, v) for k, v in
-                item.trafo_data.get('SeparateModes', {}).items() if not isinstance(k, str))
-        self._adapt_calls_imports(routine, new_dependencies)
-
-    def _get_item_modes(self, item):
-        inherited_modes = item.trafo_data['inherited_mode']
-        modes_to_duplicate = inherited_modes.copy() if inherited_modes is not None else set()
-        return modes_to_duplicate
+        for item_, mapping in updated_items.items():
+            if mapping:
+                self.rename_calls(item_, mapping)
+                self.rename_imports(item_, mapping)
+                self.rename_interfaces(item_, mapping)
 
     def plan_subroutine(self, routine, **kwargs):
-        item = kwargs.get('item')
-
-        sub_sgraph = kwargs.get('sub_sgraph', None)
+        item = kwargs['item']
+        item_factory = kwargs.get('item_factory')
+        sub_sgraph = kwargs.get('sub_sgraph')
         successors = sub_sgraph.successors(item) if sub_sgraph is not None else ()
-        ignore = tuple(str(t).lower() for t in as_tuple(kwargs.get('ignore', None)))
-        item.plan_data.setdefault('removed_dependencies', ())
-        item.plan_data.setdefault('additional_dependencies', ())
+        config = kwargs.get('scheduler_config')
+        ignore = tuple(str(t).lower() for t in as_tuple(kwargs.get('ignore')))
 
-        additional_dep, removed_dep = self._create_new_items(
-                successors=successors,
-                item_factory=kwargs.get('item_factory'),
-                config=kwargs.get('scheduler_config'),
-                item=item,
-                sub_sgraph=sub_sgraph,
-                ignore=ignore
-        )
-        item.plan_data['additional_dependencies'] += additional_dep
-        item.plan_data['removed_dependencies'] += removed_dep
+        self._create_new_items(item, successors, item_factory, config, ignore=ignore)


### PR DESCRIPTION
This PR refactors the SeparateModesKernel transformation towards #668 

- Always rename scheduler items to include the mode, not only for multi-mode items
- Eliminate the hidden graph traversal and recursion by converting to a reverse transformation that only updates the current item
- Adapted more sophisticated rename methods from DependencyInjection  for use in SeparateModesKernel transformation.

The intention is that this is a first step towards the overhaul of the dependency injection, putting the mode separation at the start of the transformation pipeline.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 