### PR TITLE
Expression: Further enhance and fix `simplify`

### DIFF
--- a/loki/expression/operations.py
+++ b/loki/expression/operations.py
@@ -100,7 +100,7 @@ class ParenthesisedPow(Power):
     make_stringifier = loki_make_stringifier
 
 
-class StringConcat(pmbl._MultiChildExpression):
+class StringConcat(StrCompareMixin, pmbl._MultiChildExpression):
     """
     Implements string concatenation in a way similar to :class:`Sum`.
     """

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -276,36 +276,41 @@ def flatten_expr(expr):
     return sym.Sum(as_tuple(done))
 
 
-def sum_int_literals(expr):
+def sum_int_literals(expr, integer_arithmetic=True, floating_point=False):
     """
-    Sum up the values of all `IntLiteral` in the sum and return the reduced sum.
+    Sum up the values of all numeric literals in the sum and return the reduced sum.
     """
     def _process(child):
-        if isinstance(child, sym.IntLiteral):
-            return child.value, None
+        if (integer_arithmetic or floating_point) and isinstance(child, sym.IntLiteral):
+            return child.value, False, None
+        if floating_point and isinstance(child, sym.FloatLiteral):
+            return float(child.value), True, None
         if is_minus_prefix(child):
-            value, stripped_child = _process(strip_minus_prefix(child))
+            value, has_float, stripped_child = _process(strip_minus_prefix(child))
             if value != 0:
-                return -value, stripped_child
-        return 0, child
+                return -value, has_float, stripped_child
+        return 0, False, child
 
     if not isinstance(expr, sym.Sum):
         return expr
 
     transformed_components = list(zip(*[_process(child) for child in expr.children]))
     value = sum(transformed_components[0])
-    remaining_components = [ch for ch in transformed_components[1] if ch is not None]
+    has_float = any(transformed_components[1])
+    if not integer_arithmetic and not has_float:
+        return expr
+    remaining_components = [ch for ch in transformed_components[2] if ch is not None]
     if value != 0:
-        remaining_components = [sym.IntLiteral(value)] + remaining_components
+        remaining_components = [sym.Literal(value) if has_float else sym.IntLiteral(value)] + remaining_components
 
     if not remaining_components:
-        return sym.IntLiteral(0)
+        return sym.Literal(0.0) if has_float else sym.IntLiteral(0)
     if len(remaining_components) == 1:
         return remaining_components[0]
     return sym.Sum(as_tuple(remaining_components))
 
 
-def separate_coefficients(expr):
+def separate_coefficients(expr, integer_arithmetic=True, floating_point=False):
     """
     Helper routine that separates components of a product into constant coefficients
     and remaining factors.
@@ -315,47 +320,60 @@ def separate_coefficients(expr):
     :rtype: (int, list)
     """
     def _process(child):
-        if isinstance(child, (int, np.integer)):
-            return child, None
-        if isinstance(child, sym.IntLiteral):
-            return child.value, None
+        if (integer_arithmetic or floating_point) and isinstance(child, (int, np.integer)):
+            return child, False, None
+        if (integer_arithmetic or floating_point) and isinstance(child, sym.IntLiteral):
+            return child.value, False, None
+        if floating_point and isinstance(child, sym.FloatLiteral):
+            return float(child.value), True, None
         if is_minus_prefix(child):
             # We recurse here as products that are only there to change the sign
             # should not introduce a layer in the expression tree.
-            value, component = _process(child.children[1])
-            return -value, component
-        return 1, child
+            value, has_float, component = _process(child.children[1])
+            return -value, has_float, component
+        return 1, False, child
 
-    if isinstance(expr, sym.IntLiteral):
-        return expr.value, []
+    if (integer_arithmetic or floating_point) and isinstance(expr, sym.IntLiteral):
+        return expr.value, False, []
+    if floating_point and isinstance(expr, sym.FloatLiteral):
+        return float(expr.value), True, []
     if not isinstance(expr, sym.Product):
-        return 1, [expr]
+        return 1, False, [expr]
 
     if is_minus_prefix(expr):
-        value, remaining_components = separate_coefficients(strip_minus_prefix(expr))
-        return -value, remaining_components
+        value, has_float, remaining_components = separate_coefficients(
+            strip_minus_prefix(expr), integer_arithmetic=integer_arithmetic, floating_point=floating_point
+        )
+        return -value, has_float, remaining_components
 
     transformed_components = list(zip(*[_process(child) for child in expr.children]))
     value = reduce(_op.mul, transformed_components[0], 1)
-    remaining_components = [ch for ch in transformed_components[1] if ch is not None]
-    return value, remaining_components
+    has_float = any(transformed_components[1])
+    if not integer_arithmetic and not has_float:
+        return 1, False, [expr]
+    remaining_components = [ch for ch in transformed_components[2] if ch is not None]
+    return value, has_float, remaining_components
 
 
-def mul_int_literals(expr):
+def mul_int_literals(expr, integer_arithmetic=True, floating_point=False):
     """
     Multiply all `IntLiteral` in the given `Product` and return the reduced expression.
     """
     if not isinstance(expr, sym.Product):
         return expr
 
-    value, remaining_components = separate_coefficients(expr)
+    value, has_float, remaining_components = separate_coefficients(
+        expr, integer_arithmetic=integer_arithmetic, floating_point=floating_point
+    )
     if value == 0:
-        return sym.IntLiteral(0)
+        return sym.Literal(0.0) if has_float else sym.IntLiteral(0)
     if abs(value) != 1:
-        remaining_components = [sym.IntLiteral(abs(value))] + remaining_components
+        remaining_components = [
+            sym.Literal(abs(value)) if has_float else sym.IntLiteral(abs(value))
+        ] + remaining_components
 
     if not remaining_components:
-        ret = sym.IntLiteral(1)
+        ret = sym.Literal(1.0) if has_float else sym.IntLiteral(1)
     elif len(remaining_components) == 1:
         ret = remaining_components[0]
     else:
@@ -366,7 +384,7 @@ def mul_int_literals(expr):
     return ret
 
 
-def div_int_literals(expr):
+def div_int_literals(expr, floating_point=False):
     """
     Reduce fractions where the denominator is a `IntLiteral`.
     """
@@ -375,11 +393,16 @@ def div_int_literals(expr):
 
     if is_minus_prefix(expr.numerator):
         q = sym.Quotient(strip_minus_prefix(expr.numerator), expr.denominator)
-        return sym.Product((-1, div_int_literals(q)))
+        return sym.Product((-1, div_int_literals(q, floating_point=floating_point)))
 
     if is_minus_prefix(expr.denominator):
         q = sym.Quotient(expr.numerator, strip_minus_prefix(expr.denominator))
-        return sym.Product((-1, div_int_literals(q)))
+        return sym.Product((-1, div_int_literals(q, floating_point=floating_point)))
+
+    if isinstance(expr.numerator, sym.FloatLiteral) or isinstance(expr.denominator, sym.FloatLiteral):
+        if not floating_point:
+            return expr
+        return sym.Literal(float(expr.numerator.value) / float(expr.denominator.value))
 
     if not isinstance(expr.denominator, sym.IntLiteral):
         return expr
@@ -390,9 +413,11 @@ def div_int_literals(expr):
         denominator = sym.IntLiteral(expr.denominator.value / div)
 
     elif isinstance(expr.numerator, sym.Product):
-        value, remaining_components = separate_coefficients(expr.numerator)
+        value, _, remaining_components = separate_coefficients(expr.numerator, floating_point=floating_point)
         div = gcd(value, expr.denominator.value)
-        numerator = mul_int_literals(sym.Product((sym.IntLiteral(value / div), *remaining_components)))
+        numerator = mul_int_literals(
+            sym.Product((sym.IntLiteral(value / div), *remaining_components)), floating_point=floating_point
+        )
         denominator = sym.IntLiteral(expr.denominator.value / div)
 
     else:
@@ -423,7 +448,7 @@ def accumulate_polynomial_terms(expr):
     summands = defaultdict(int)  # map (base, coefficient) pairs
     for item in components:
         if isinstance(item, sym.Product):
-            value, remaining_components = separate_coefficients(item)
+            value, _, remaining_components = separate_coefficients(item)
             if value == 0:
                 continue
             if not remaining_components:
@@ -497,17 +522,19 @@ class Simplification(enum.Flag):
     Attributes:
         Flatten             Flatten sub-sums and distribute products.
         IntegerArithmetic   Perform arithmetic on integer literals (addition and multiplication).
+        FloatingPointArithmetic Perform arithmetic on floating point literals (addition and multiplication).
         CollectCoefficients Combine summands as far as possible.
         LogicEvaluation     Resolve logically fully determinate expressions, like ``1 == 1`` or ``1 == 6``
         ALL                 All of the above.
     """
     Flatten = enum.auto()
     IntegerArithmetic = enum.auto()
+    FloatingPointArithmetic = enum.auto()
     CollectCoefficients = enum.auto()
     LogicEvaluation = enum.auto()
 
     # pylint: disable-next=unsupported-binary-operation
-    ALL = Flatten | IntegerArithmetic | CollectCoefficients | LogicEvaluation
+    ALL = Flatten | IntegerArithmetic | FloatingPointArithmetic | CollectCoefficients | LogicEvaluation
 
 
 class SimplifyMapper(LokiIdentityMapper):
@@ -529,8 +556,12 @@ class SimplifyMapper(LokiIdentityMapper):
         if self.enabled_simplifications & Simplification.Flatten:
             new_expr = flatten_expr(new_expr)
 
-        if self.enabled_simplifications & Simplification.IntegerArithmetic:
-            new_expr = sum_int_literals(new_expr)
+        if self.enabled_simplifications & (Simplification.IntegerArithmetic | Simplification.FloatingPointArithmetic):
+            new_expr = sum_int_literals(
+                new_expr,
+                integer_arithmetic=self.enabled_simplifications & Simplification.IntegerArithmetic,
+                floating_point=self.enabled_simplifications & Simplification.FloatingPointArithmetic
+            )
 
         if self.enabled_simplifications & Simplification.CollectCoefficients:
             new_expr = collect_coefficients(new_expr)
@@ -545,8 +576,12 @@ class SimplifyMapper(LokiIdentityMapper):
         if self.enabled_simplifications & Simplification.Flatten:
             new_expr = flatten_expr(new_expr)
 
-        if self.enabled_simplifications & Simplification.IntegerArithmetic:
-            new_expr = mul_int_literals(new_expr)
+        if self.enabled_simplifications & (Simplification.IntegerArithmetic | Simplification.FloatingPointArithmetic):
+            new_expr = mul_int_literals(
+                new_expr,
+                integer_arithmetic=self.enabled_simplifications & Simplification.IntegerArithmetic,
+                floating_point=self.enabled_simplifications & Simplification.FloatingPointArithmetic
+            )
 
         if new_expr != expr:
             return self.rec(new_expr, *args, **kwargs)
@@ -560,8 +595,10 @@ class SimplifyMapper(LokiIdentityMapper):
         if self.enabled_simplifications & Simplification.Flatten:
             new_expr = flatten_expr(new_expr)
 
-        if self.enabled_simplifications & Simplification.IntegerArithmetic:
-            new_expr = div_int_literals(new_expr)
+        if self.enabled_simplifications & (Simplification.IntegerArithmetic | Simplification.FloatingPointArithmetic):
+            new_expr = div_int_literals(
+                new_expr, floating_point=self.enabled_simplifications & Simplification.FloatingPointArithmetic
+            )
 
         if new_expr != expr:
             return self.rec(new_expr, *args, **kwargs)

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -276,14 +276,23 @@ def flatten_expr(expr):
     return sym.Sum(as_tuple(done))
 
 
-def sum_int_literals(expr, integer_arithmetic=True, floating_point=False):
+def sum_int_literals(expr, int_arithmetic=True, fp_arithmetic=False):
     """
     Sum up the values of all numeric literals in the sum and return the reduced sum.
+
+    Parameters
+    ----------
+    expr : :any:`Sum`
+         The sum comprising constant and non-constant sub-expressions.
+    int_arithmetic : bool, default True
+        Perform arithmetic on integer literals
+    fp_arithmetic : bool, default False
+        Perform arithmetic on floating point literals
     """
     def _process(child):
-        if (integer_arithmetic or floating_point) and isinstance(child, sym.IntLiteral):
+        if (int_arithmetic or fp_arithmetic) and isinstance(child, sym.IntLiteral):
             return child.value, False, None
-        if floating_point and isinstance(child, sym.FloatLiteral):
+        if fp_arithmetic and isinstance(child, sym.FloatLiteral):
             return float(child.value), True, None
         if is_minus_prefix(child):
             value, has_float, stripped_child = _process(strip_minus_prefix(child))
@@ -297,7 +306,7 @@ def sum_int_literals(expr, integer_arithmetic=True, floating_point=False):
     transformed_components = list(zip(*[_process(child) for child in expr.children]))
     value = sum(transformed_components[0])
     has_float = any(transformed_components[1])
-    if not integer_arithmetic and not has_float:
+    if not int_arithmetic and not has_float:
         return expr
     remaining_components = [ch for ch in transformed_components[2] if ch is not None]
     if value != 0:
@@ -310,21 +319,31 @@ def sum_int_literals(expr, integer_arithmetic=True, floating_point=False):
     return sym.Sum(as_tuple(remaining_components))
 
 
-def separate_coefficients(expr, integer_arithmetic=True, floating_point=False):
+def separate_coefficients(expr, int_arithmetic=True, fp_arithmetic=False):
     """
     Helper routine that separates components of a product into constant coefficients
     and remaining factors.
 
-    :param sym.Product expr: the product comprising constant and non-constant sub-expressions.
-    :returns: the constant coefficient and remaining non-constant sub-expressions.
-    :rtype: (int, list)
+    Parameters
+    ----------
+    expr : :any:`Product`
+         The product comprising constant and non-constant sub-expressions.
+    int_arithmetic : bool, default True
+        Perform arithmetic on integer literals
+    fp_arithmetic : bool, default False
+        Perform arithmetic on floating point literals
+
+    Returns
+    -------
+    (int, list)
+         The constant coefficient and remaining non-constant sub-expressions.
     """
     def _process(child):
-        if (integer_arithmetic or floating_point) and isinstance(child, (int, np.integer)):
+        if (int_arithmetic or fp_arithmetic) and isinstance(child, (int, np.integer)):
             return child, False, None
-        if (integer_arithmetic or floating_point) and isinstance(child, sym.IntLiteral):
+        if (int_arithmetic or fp_arithmetic) and isinstance(child, sym.IntLiteral):
             return child.value, False, None
-        if floating_point and isinstance(child, sym.FloatLiteral):
+        if fp_arithmetic and isinstance(child, sym.FloatLiteral):
             return float(child.value), True, None
         if is_minus_prefix(child):
             # We recurse here as products that are only there to change the sign
@@ -333,37 +352,46 @@ def separate_coefficients(expr, integer_arithmetic=True, floating_point=False):
             return -value, has_float, component
         return 1, False, child
 
-    if (integer_arithmetic or floating_point) and isinstance(expr, sym.IntLiteral):
+    if (int_arithmetic or fp_arithmetic) and isinstance(expr, sym.IntLiteral):
         return expr.value, False, []
-    if floating_point and isinstance(expr, sym.FloatLiteral):
+    if fp_arithmetic and isinstance(expr, sym.FloatLiteral):
         return float(expr.value), True, []
     if not isinstance(expr, sym.Product):
         return 1, False, [expr]
 
     if is_minus_prefix(expr):
         value, has_float, remaining_components = separate_coefficients(
-            strip_minus_prefix(expr), integer_arithmetic=integer_arithmetic, floating_point=floating_point
+            strip_minus_prefix(expr), int_arithmetic=int_arithmetic, fp_arithmetic=fp_arithmetic
         )
         return -value, has_float, remaining_components
 
     transformed_components = list(zip(*[_process(child) for child in expr.children]))
     value = reduce(_op.mul, transformed_components[0], 1)
     has_float = any(transformed_components[1])
-    if not integer_arithmetic and not has_float:
+    if not int_arithmetic and not has_float:
         return 1, False, [expr]
     remaining_components = [ch for ch in transformed_components[2] if ch is not None]
     return value, has_float, remaining_components
 
 
-def mul_int_literals(expr, integer_arithmetic=True, floating_point=False):
+def mul_int_literals(expr, int_arithmetic=True, fp_arithmetic=False):
     """
     Multiply all `IntLiteral` in the given `Product` and return the reduced expression.
+
+    Parameters
+    ----------
+    expr : :any:`Product`
+         The product comprising constant and non-constant sub-expressions.
+    int_arithmetic : bool, default True
+        Perform arithmetic on integer literals
+    fp_arithmetic : bool, default False
+        Perform arithmetic on floating point literals
     """
     if not isinstance(expr, sym.Product):
         return expr
 
     value, has_float, remaining_components = separate_coefficients(
-        expr, integer_arithmetic=integer_arithmetic, floating_point=floating_point
+        expr, int_arithmetic=int_arithmetic, fp_arithmetic=fp_arithmetic
     )
     if value == 0:
         return sym.Literal(0.0) if has_float else sym.IntLiteral(0)
@@ -384,23 +412,30 @@ def mul_int_literals(expr, integer_arithmetic=True, floating_point=False):
     return ret
 
 
-def div_int_literals(expr, floating_point=False):
+def div_int_literals(expr, fp_arithmetic=False):
     """
     Reduce fractions where the denominator is a `IntLiteral`.
+
+    Parameters
+    ----------
+    expr : :any:`Expression`
+         The expression comprising constant and non-constant sub-expressions.
+    fp_arithmetic : bool, default False
+        Perform arithmetic on floating point literals
     """
     if not isinstance(expr, sym.Quotient):
         return expr
 
     if is_minus_prefix(expr.numerator):
         q = sym.Quotient(strip_minus_prefix(expr.numerator), expr.denominator)
-        return sym.Product((-1, div_int_literals(q, floating_point=floating_point)))
+        return sym.Product((-1, div_int_literals(q, fp_arithmetic=fp_arithmetic)))
 
     if is_minus_prefix(expr.denominator):
         q = sym.Quotient(expr.numerator, strip_minus_prefix(expr.denominator))
-        return sym.Product((-1, div_int_literals(q, floating_point=floating_point)))
+        return sym.Product((-1, div_int_literals(q, fp_arithmetic=fp_arithmetic)))
 
     if isinstance(expr.numerator, sym.FloatLiteral) or isinstance(expr.denominator, sym.FloatLiteral):
-        if not floating_point:
+        if not fp_arithmetic:
             return expr
         return sym.Literal(float(expr.numerator.value) / float(expr.denominator.value))
 
@@ -413,10 +448,10 @@ def div_int_literals(expr, floating_point=False):
         denominator = sym.IntLiteral(expr.denominator.value / div)
 
     elif isinstance(expr.numerator, sym.Product):
-        value, _, remaining_components = separate_coefficients(expr.numerator, floating_point=floating_point)
+        value, _, remaining_components = separate_coefficients(expr.numerator, fp_arithmetic=fp_arithmetic)
         div = gcd(value, expr.denominator.value)
         numerator = mul_int_literals(
-            sym.Product((sym.IntLiteral(value / div), *remaining_components)), floating_point=floating_point
+            sym.Product((sym.IntLiteral(value / div), *remaining_components)), fp_arithmetic=fp_arithmetic
         )
         denominator = sym.IntLiteral(expr.denominator.value / div)
 
@@ -559,8 +594,8 @@ class SimplifyMapper(LokiIdentityMapper):
         if self.enabled_simplifications & (Simplification.IntegerArithmetic | Simplification.FloatingPointArithmetic):
             new_expr = sum_int_literals(
                 new_expr,
-                integer_arithmetic=self.enabled_simplifications & Simplification.IntegerArithmetic,
-                floating_point=self.enabled_simplifications & Simplification.FloatingPointArithmetic
+                int_arithmetic=self.enabled_simplifications & Simplification.IntegerArithmetic,
+                fp_arithmetic=self.enabled_simplifications & Simplification.FloatingPointArithmetic
             )
 
         if self.enabled_simplifications & Simplification.CollectCoefficients:
@@ -579,8 +614,8 @@ class SimplifyMapper(LokiIdentityMapper):
         if self.enabled_simplifications & (Simplification.IntegerArithmetic | Simplification.FloatingPointArithmetic):
             new_expr = mul_int_literals(
                 new_expr,
-                integer_arithmetic=self.enabled_simplifications & Simplification.IntegerArithmetic,
-                floating_point=self.enabled_simplifications & Simplification.FloatingPointArithmetic
+                int_arithmetic=self.enabled_simplifications & Simplification.IntegerArithmetic,
+                fp_arithmetic=self.enabled_simplifications & Simplification.FloatingPointArithmetic
             )
 
         if new_expr != expr:
@@ -597,7 +632,7 @@ class SimplifyMapper(LokiIdentityMapper):
 
         if self.enabled_simplifications & (Simplification.IntegerArithmetic | Simplification.FloatingPointArithmetic):
             new_expr = div_int_literals(
-                new_expr, floating_point=self.enabled_simplifications & Simplification.FloatingPointArithmetic
+                new_expr, fp_arithmetic=self.enabled_simplifications & Simplification.FloatingPointArithmetic
             )
 
         if new_expr != expr:

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -614,6 +614,16 @@ class SimplifyMapper(LokiIdentityMapper):
 
         return sym.LogicalOr(children) if len(children) > 0 else sym.LogicLiteral('False')
 
+    def map_logical_not(self, expr, *args, **kwargs):
+        child = self.rec(expr.child, *args, **kwargs)
+        if self.enabled_simplifications & Simplification.LogicEvaluation:
+            if child == 'True':
+                return sym.LogicLiteral(False)
+            if child == 'False':
+                return sym.LogicLiteral(True)
+
+        return sym.LogicalNot(child)
+
 
 def simplify(expr, enabled_simplifications=Simplification.ALL):
     """

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -647,6 +647,25 @@ class SimplifyMapper(LokiIdentityMapper):
 
         return sym.LogicalNot(child)
 
+    def map_string_concat(self, expr, *args, **kwargs):
+        children = tuple(self.rec(child, *args, **kwargs) for child in expr.children)
+
+        new_children = []
+        string_parts = []
+        for child in children:
+            if isinstance(child, sym.StringLiteral):
+                string_parts.append(child.value)
+            else:
+                if string_parts:
+                    new_children.append(sym.StringLiteral(''.join(string_parts)))
+                    string_parts = []
+                new_children.append(child)
+
+        if string_parts:
+            new_children.append(sym.StringLiteral(''.join(string_parts)))
+
+        return new_children[0] if len(new_children) == 1 else sym.StringConcat(tuple(new_children))
+
 
 def simplify(expr, enabled_simplifications=Simplification.ALL):
     """

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -567,6 +567,29 @@ class SimplifyMapper(LokiIdentityMapper):
             return self.rec(new_expr, *args, **kwargs)
         return expr
 
+    def map_power(self, expr, *args, **kwargs):
+        base = self.rec(expr.base, *args, **kwargs)
+        exponent = self.rec(expr.exponent, *args, **kwargs)
+
+        if self.enabled_simplifications & Simplification.IntegerArithmetic:
+            literal_types = (sym.IntLiteral, sym.FloatLiteral)
+            base_value = float(base.value) if isinstance(base, sym.FloatLiteral) else getattr(base, 'value', None)
+            exponent_value = (
+                float(exponent.value) if isinstance(exponent, sym.FloatLiteral) else getattr(exponent, 'value', None)
+            )
+
+            if isinstance(base, literal_types) and base_value == 1:
+                return base
+            if isinstance(exponent, literal_types):
+                if exponent_value == 0:
+                    return sym.IntLiteral(1)
+                if exponent_value == 1:
+                    return base
+                if isinstance(base, literal_types) and exponent_value > 0 and float(exponent_value).is_integer():
+                    return sym.Literal(base_value ** int(exponent_value))
+
+        return sym.Power(base, exponent)
+
     map_parenthesised_add = map_sum
     map_parenthesised_mul = map_product
     map_parenthesised_div = map_quotient

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -10,7 +10,6 @@ import enum
 from functools import reduce
 from math import gcd, floor
 import operator as _op
-import numpy as np
 import pymbolic.primitives as pmbl
 
 from loki.expression.mappers import LokiIdentityMapper
@@ -339,7 +338,7 @@ def separate_coefficients(expr, int_arithmetic=True, fp_arithmetic=False):
          The constant coefficient and remaining non-constant sub-expressions.
     """
     def _process(child):
-        if (int_arithmetic or fp_arithmetic) and isinstance(child, (int, np.integer)):
+        if (int_arithmetic or fp_arithmetic) and isinstance(child, int):
             return child, False, None
         if (int_arithmetic or fp_arithmetic) and isinstance(child, sym.IntLiteral):
             return child.value, False, None
@@ -491,7 +490,7 @@ def accumulate_polynomial_terms(expr):
             else:
                 # We sort the components using their string representation
                 summands[as_tuple(sorted(remaining_components, key=str))] += value
-        elif isinstance(item, (int, np.integer)):
+        elif isinstance(item, int):
             summands[1] += item
         elif isinstance(item, sym.IntLiteral):
             summands[1] += item.value

--- a/loki/expression/symbolic.py
+++ b/loki/expression/symbolic.py
@@ -309,7 +309,7 @@ def sum_int_literals(expr, int_arithmetic=True, fp_arithmetic=False):
         return expr
     remaining_components = [ch for ch in transformed_components[2] if ch is not None]
     if value != 0:
-        remaining_components = [sym.Literal(value) if has_float else sym.IntLiteral(value)] + remaining_components
+        remaining_components = [sym.Literal(value)] + remaining_components
 
     if not remaining_components:
         return sym.Literal(0.0) if has_float else sym.IntLiteral(0)
@@ -393,11 +393,9 @@ def mul_int_literals(expr, int_arithmetic=True, fp_arithmetic=False):
         expr, int_arithmetic=int_arithmetic, fp_arithmetic=fp_arithmetic
     )
     if value == 0:
-        return sym.Literal(0.0) if has_float else sym.IntLiteral(0)
+        return sym.Literal(value)
     if abs(value) != 1:
-        remaining_components = [
-            sym.Literal(abs(value)) if has_float else sym.IntLiteral(abs(value))
-        ] + remaining_components
+        remaining_components = [sym.Literal(abs(value))] + remaining_components
 
     if not remaining_components:
         ret = sym.Literal(1.0) if has_float else sym.IntLiteral(1)

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -1021,6 +1021,9 @@ def test_string_compare():
     assert all(sym.LogicalAnd((i, u)) == exp for exp in ['i AND u', 'i and u', 'i and  U', ' I and u'])
     assert all(sym.LogicalOr((i, u)) == exp for exp in ['i OR u', 'i or u', 'i or  U', ' I oR u'])
     assert all(sym.LogicalNot(u) == exp for exp in ['not u', ' nOt u', 'not  U', ' noT u'])
+    assert all(sym.StringConcat((sym.StringLiteral('prefix'), u)) == exp for exp in [
+        "'prefix'//u", "'prefix' // u", "'prefix' //  U", " 'prefix' // u"
+    ])
 
     # Test literal behaviour
     assert sym.Literal(41) == 41

--- a/loki/expression/tests/test_symbolic.py
+++ b/loki/expression/tests/test_symbolic.py
@@ -166,6 +166,41 @@ def test_simplify_integer_arithmetic(source, ref):
 
 
 @pytest.mark.parametrize('source, ref', [
+    ('1.5 + 2.5', '1.5 + 2.5'),
+    ('1 + 2.5', '1 + 2.5'),
+    ('1.5*2.0', '1.5*2.0'),
+    ('1.0/2', '1.0 / 2'),
+])
+def test_simplify_integer_arithmetic_skips_floats(source, ref):
+    scope = Scope()
+    expr = parse_expr(source, scope)
+    expr = simplify(expr, enabled_simplifications=Simplification.IntegerArithmetic)
+    assert str(expr) == ref
+
+
+@pytest.mark.parametrize('source, ref', [
+    ('1 + 1', '1 + 1'),
+    ('1.5 + 2.5', '4.0'),
+    ('1 + 2.5', '3.5'),
+    ('1.5 + 2', '3.5'),
+    ('2.5 - 1.0', '1.5'),
+    ('1.0 - 1.0', '0.0'),
+    ('1.5*2.0', '3.0'),
+    ('2*1.5', '3.0'),
+    ('-3.0*7', '-21.0'),
+    ('3.0*7*0*10', '3.0*7*0*10'),
+    ('1.0/2.0', '0.5'),
+    ('1/2.0', '0.5'),
+    ('1.0/2', '0.5'),
+])
+def test_simplify_floating_point_arithmetic(source, ref):
+    scope = Scope()
+    expr = parse_expr(source, scope)
+    expr = simplify(expr, enabled_simplifications=Simplification.FloatingPointArithmetic)
+    assert str(expr) == ref
+
+
+@pytest.mark.parametrize('source, ref', [
     ('a + a + a', '3*a'),
     ('2*a + 1*a + a*3', '6*a'),
     ('(a + a)*(b + b)', '2*a*2*b'),
@@ -253,6 +288,7 @@ def test_simplify_logic_evaluation(source, ref):
     ('n**0.0', '1'),
     ('n**1.0', 'n'),
     ('2.0**3', '8.0'),
+    ('3.0*7*0*10', '0'),
 ])
 def test_simplify(source,ref):
     scope = Scope()

--- a/loki/expression/tests/test_symbolic.py
+++ b/loki/expression/tests/test_symbolic.py
@@ -261,6 +261,24 @@ def test_simplify(source,ref):
     assert str(expr) == ref
 
 
+def test_simplify_string_concat():
+    a = sym.Variable(name='a')
+
+    expr = sym.StringConcat((sym.StringLiteral('Hel'), sym.StringLiteral('lo')))
+    assert expr == "'Hel'//'lo'"
+    assert simplify(expr) == 'Hello'
+
+    expr = sym.StringConcat((sym.StringLiteral('Hel'), sym.StringLiteral('lo'), a, sym.StringLiteral('!')))
+    assert expr == "'Hel'//'lo'//a//'!'"
+    assert simplify(expr) == "'Hello'//a//'!'"
+
+    expr = sym.StringConcat((
+        sym.StringLiteral('Hel'), sym.StringConcat((sym.StringLiteral('l'), sym.StringLiteral('o')))
+    ))
+    assert expr == "'Hel'//'l'//'o'"
+    assert simplify(expr) == 'Hello'
+
+
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_is_dimension_constant(frontend):
     fcode = """

--- a/loki/expression/tests/test_symbolic.py
+++ b/loki/expression/tests/test_symbolic.py
@@ -216,6 +216,10 @@ def test_simplify_collect_coefficients(source, ref):
     ('.false. .or. a', 'a'),
     ('.false. .and. a', 'False'),
     ('.true. .and. a', 'a'),
+    ('.not. .true.', 'False'),
+    ('.not. .false.', 'True'),
+    ('.not. .true. .and. a', 'False'),
+    ('.not. .false. .or. a', 'True'),
 ])
 def test_simplify_logic_evaluation(source, ref):
     scope = Scope()

--- a/loki/expression/tests/test_symbolic.py
+++ b/loki/expression/tests/test_symbolic.py
@@ -245,6 +245,14 @@ def test_simplify_logic_evaluation(source, ref):
     ('(5 + 3) * a - 8 * a / 2 + a * ((7 - 1) / 3)', '6*a'),
     ('(5 + 3) == 8', 'True'),
     ('42 == 666', 'False'),
+    ('1**n', '1'),
+    ('n**0', '1'),
+    ('n**1', 'n'),
+    ('2**3', '8'),
+    ('1.0**n', '1.0'),
+    ('n**0.0', '1'),
+    ('n**1.0', 'n'),
+    ('2.0**3', '8.0'),
 ])
 def test_simplify(source,ref):
     scope = Scope()


### PR DESCRIPTION
### Description

This PR adds floating-point arithmetic simplification, as well as a range of smaller fixes to the `simplify(expr)` utility in `loki.expression`. These corner cases where found by checking against the testing in PRs #663 and #515, which were doing this as part of the constant propagation feature. With these in place, we can now re-use the underlying mapper and get full test coverage.

The smaller fixes in detail:
- Make `sym.StringConcat` use the `StrCompare` mixing for quick string-based test checks
- Extend simplify to cover string concatenation reduction
- Extend simplify to cover logical `not` reduction on constants
- Extend simplify to correctly reduce `sym.Power` expressions
- Extend simplify to do full floating-point arithmetic if the `Simplification.FloatingPointArithmetic` enum flag is set.    

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
