### PR TITLE
New transformation: `SanitiseUnusedRoutineTransformation`.

### DIFF
--- a/loki/transformations/sanitise/__init__.py
+++ b/loki/transformations/sanitise/__init__.py
@@ -15,6 +15,7 @@ from loki.batch import Transformation, Pipeline
 from loki.transformations.sanitise.associates import * # noqa
 from loki.transformations.sanitise.sequence_associations import * # noqa
 from loki.transformations.sanitise.substitute import * # noqa
+from loki.transformations.sanitise.unused_routines import * # noqa
 
 
 """

--- a/loki/transformations/sanitise/unused_routines.py
+++ b/loki/transformations/sanitise/unused_routines.py
@@ -1,0 +1,110 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki.batch import SchedulerConfig, Transformation
+from loki.ir import FindNodes, Transformer, nodes as ir
+from loki.tools import as_tuple
+
+__all__ = ['SanitiseUnusedRoutineTransformation']
+
+
+class SanitiseUnusedRoutineTransformation(Transformation):
+    """
+    Sanitise configured routines that are no longer used but still need to compile.
+
+    For selected routines this transformation rewrites kept array declarations
+    in the routine specification to fully deferred shape, removes local array
+    declarations that no longer need to be represented, and replaces the
+    executable body with a configurable stub.
+
+    Parameters
+    ----------
+    routines : tuple or list of str, optional
+        Routine names or qualified scheduler item names to sanitise. Matching
+        uses :any:`SchedulerConfig.match_item_keys` with parent matching
+        enabled, so both ``routine`` and ``module#routine`` forms are
+        supported.
+    stub_kind : str, optional
+        The replacement body to insert for sanitised routines. Supported
+        values are ``'error_stop'`` for a fail-loud stub and ``'empty'`` for
+        an empty executable section. Defaults to ``'error_stop'``.
+    """
+
+    def __init__(self, routines=None, stub_kind='error_stop'):
+        self.routines = as_tuple(routines)
+        if stub_kind not in ('error_stop', 'empty'):
+            raise ValueError(
+                f'Invalid stub_kind {stub_kind!r}: expected one of ("error_stop", "empty")'
+            )
+        self.stub_kind = stub_kind
+
+    @staticmethod
+    def _matches_routine(routine, item=None, configured_routines=()):
+        """Return whether one routine matches the configured sanitisation targets."""
+        if item is not None:
+            item_name = item.name
+        elif routine.parent is not None:
+            item_name = f'{routine.parent.name.lower()}#{routine.name.lower()}'
+        else:
+            item_name = routine.name.lower()
+
+        return bool(SchedulerConfig.match_item_keys(item_name, configured_routines, match_item_parents=True))
+
+    @staticmethod
+    def _deferred_shape(symbol, routine):
+        """Clone one array symbol with all declared dimensions rewritten to deferred shape."""
+        shape = getattr(symbol.type, 'shape', None)
+        if not shape:
+            return symbol
+
+        deferred_shape = tuple(routine.parse_expr(':') for _ in shape)
+        return symbol.clone(dimensions=deferred_shape, type=symbol.type.clone(shape=deferred_shape))
+
+    @staticmethod
+    def _should_keep_with_deferred_shape(symbol):
+        """Keep arguments, pointers, and allocatables while deferring their declared shape."""
+        return bool(symbol.type.intent is not None or symbol.type.pointer or symbol.type.allocatable)
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Sanitise one configured routine by shrinking its declarations and replacing its body.
+
+        Only declarations that still matter to the routine interface or storage
+        semantics are kept, and any retained arrays are rewritten to fully
+        deferred shape so their original bounds expressions are no longer
+        required.
+        """
+        if not self._matches_routine(routine, item=kwargs.get('item'), configured_routines=self.routines):
+            return
+
+        decl_map = {}
+        for decl in FindNodes(ir.VariableDeclaration).visit(routine.spec):
+            new_symbols = []
+            for symbol in decl.symbols:
+                shape = getattr(symbol.type, 'shape', None)
+                if not shape:
+                    new_symbols.append(symbol)
+                    continue
+
+                if self._should_keep_with_deferred_shape(symbol):
+                    new_symbols.append(self._deferred_shape(symbol, routine))
+
+            new_symbols = tuple(new_symbols)
+            if not new_symbols:
+                decl_map[decl] = None
+            elif new_symbols != decl.symbols:
+                decl_map[decl] = decl.clone(symbols=new_symbols)
+
+        if decl_map:
+            routine.spec = Transformer(decl_map).visit(routine.spec)
+
+        if self.stub_kind == 'error_stop':
+            routine.body = ir.Section(body=(
+                ir.Intrinsic(text=f'error stop "Sanitised unused routine {routine.name} was called"'),
+            ))
+        else:
+            routine.body = ir.Section(body=())

--- a/loki/transformations/sanitise/unused_routines.py
+++ b/loki/transformations/sanitise/unused_routines.py
@@ -99,12 +99,20 @@ class SanitiseUnusedRoutineTransformation(Transformation):
             elif new_symbols != decl.symbols:
                 decl_map[decl] = decl.clone(symbols=new_symbols)
 
+        imp_map = {}
+        for imp in FindNodes(ir.Import).visit(routine.ir):
+            if imp.c_import:
+                imp_map[imp] = None
+        if imp_map:
+            routine.spec = Transformer(imp_map).visit(routine.spec)
+            routine.body = Transformer(imp_map).visit(routine.body)
+
         if decl_map:
             routine.spec = Transformer(decl_map).visit(routine.spec)
 
         if self.stub_kind == 'error_stop':
             routine.body = ir.Section(body=(
-                ir.Intrinsic(text=f'error stop "Sanitised unused routine {routine.name} was called"'),
+                ir.GenericStmt(text=f'error stop "Sanitised unused routine {routine.name} was called"'),
             ))
         else:
             routine.body = ir.Section(body=())

--- a/loki/transformations/tests/test_unused_routines.py
+++ b/loki/transformations/tests/test_unused_routines.py
@@ -1,0 +1,149 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from loki import Module
+from loki.frontend import OMNI, available_frontends
+from loki.ir import FindNodes, nodes as ir
+from loki.transformations import SanitiseUnusedRoutineTransformation
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_sanitise_unused_routine_transformation(frontend, tmp_path):
+    """Defer kept array shapes, drop local arrays, and replace the body with an error-stop stub."""
+    fcode = """
+module legacy_unused_mod
+  implicit none
+
+contains
+
+  subroutine legacy_unused(nblocks, pout)
+    integer, intent(in) :: nblocks
+    real, optional, intent(out) :: pout(10, nblocks, 2)
+    real, pointer, contiguous :: zoper(:, :, :)
+    real, allocatable :: zbuffer(:, :)
+    real :: zouts(10, nblocks)
+
+    nullify(zoper)
+    zouts = 0.0
+    if (present(pout)) pout(1, 1, 1) = 0.0
+  end subroutine legacy_unused
+
+  subroutine still_used(a)
+    real, intent(inout) :: a(:)
+    a = 0.0
+  end subroutine still_used
+end module legacy_unused_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['legacy_unused']
+    untouched = module['still_used']
+
+    trafo = SanitiseUnusedRoutineTransformation(routines=('legacy_unused',), stub_kind='error_stop')
+    trafo.apply(routine)
+
+    decls = FindNodes(ir.VariableDeclaration).visit(routine.spec)
+    pout_decl = next(decl for decl in decls if any(sym.name.lower() == 'pout' for sym in decl.symbols))
+    zoper_decl = next(decl for decl in decls if any(sym.name.lower() == 'zoper' for sym in decl.symbols))
+    zbuffer_decl = next(decl for decl in decls if any(sym.name.lower() == 'zbuffer' for sym in decl.symbols))
+    pout = next(sym for sym in pout_decl.symbols if sym.name.lower() == 'pout')
+    zoper = next(sym for sym in zoper_decl.symbols if sym.name.lower() == 'zoper')
+    zbuffer = next(sym for sym in zbuffer_decl.symbols if sym.name.lower() == 'zbuffer')
+    declared_names = {sym.name.lower() for decl in decls for sym in decl.symbols}
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    untouched_intrinsics = FindNodes(ir.Intrinsic).visit(untouched.body)
+
+    assert pout.type.shape == (':', ':', ':')
+    assert pout.dimensions == (':', ':', ':')
+    assert zoper.type.shape == (':', ':', ':')
+    assert zoper.dimensions == (':', ':', ':')
+    assert zbuffer.type.shape == (':', ':')
+    assert zbuffer.dimensions == (':', ':')
+    assert 'zouts' not in declared_names
+    assert len(intrinsics) == 1
+    assert 'error stop "sanitised unused routine legacy_unused was called"' in intrinsics[0].text.lower()
+    assert not untouched_intrinsics
+    assert len(FindNodes(ir.Assignment).visit(untouched.body)) == 1
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_sanitise_unused_routine_by_qualified_name(frontend, tmp_path):
+    """Match configured routines by fully qualified module-and-routine name."""
+    fcode = """
+module another_legacy_mod
+contains
+  subroutine keep_me(a)
+    real :: a(5)
+    a = 1.0
+  end subroutine keep_me
+end module another_legacy_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['keep_me']
+
+    trafo = SanitiseUnusedRoutineTransformation(
+        routines=('another_legacy_mod#keep_me',), stub_kind='error_stop'
+    )
+    trafo.apply(routine)
+
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    assert len(intrinsics) == 1
+    assert 'error stop "sanitised unused routine keep_me was called"' in intrinsics[0].text.lower()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_sanitise_unused_routine_empty_stub(frontend, tmp_path):
+    """Allow sanitised routines to use an empty executable section instead of an error-stop stub."""
+    fcode = """
+module empty_stub_mod
+contains
+  subroutine legacy_noop(a)
+    real, intent(inout) :: a(:)
+    a = 2.0
+  end subroutine legacy_noop
+end module empty_stub_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['legacy_noop']
+
+    trafo = SanitiseUnusedRoutineTransformation(routines=('legacy_noop',), stub_kind='empty')
+    trafo.apply(routine)
+
+    assert routine.body.body == ()
+    assert not FindNodes(ir.Intrinsic).visit(routine.body)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_sanitise_unused_routine_no_match(frontend, tmp_path):
+    """Leave routines unchanged when they are not configured for sanitisation."""
+    fcode = """
+module no_match_mod
+contains
+  subroutine active_kernel(a)
+    real, intent(inout) :: a(:)
+    a = 3.0
+  end subroutine active_kernel
+end module no_match_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['active_kernel']
+
+    trafo = SanitiseUnusedRoutineTransformation(routines=('other_kernel',), stub_kind='error_stop')
+    trafo.apply(routine)
+
+    assignments = FindNodes(ir.Assignment).visit(routine.body)
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+
+    assert len(assignments) == 1
+    assert not intrinsics
+
+
+def test_sanitise_unused_routine_rejects_unknown_stub_kind():
+    """Reject unsupported stub kinds early during transformation construction."""
+    with pytest.raises(ValueError, match='Invalid stub_kind'):
+        SanitiseUnusedRoutineTransformation(stub_kind='warn')

--- a/loki/transformations/tests/test_unused_routines.py
+++ b/loki/transformations/tests/test_unused_routines.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from loki import Module
+from loki import Module, Sourcefile
 from loki.frontend import OMNI, available_frontends
 from loki.ir import FindNodes, nodes as ir
 from loki.transformations import SanitiseUnusedRoutineTransformation
@@ -55,8 +55,8 @@ end module legacy_unused_mod
     zoper = next(sym for sym in zoper_decl.symbols if sym.name.lower() == 'zoper')
     zbuffer = next(sym for sym in zbuffer_decl.symbols if sym.name.lower() == 'zbuffer')
     declared_names = {sym.name.lower() for decl in decls for sym in decl.symbols}
-    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
-    untouched_intrinsics = FindNodes(ir.Intrinsic).visit(untouched.body)
+    intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
+    untouched_intrinsics = FindNodes(ir.GenericStmt).visit(untouched.body)
 
     assert pout.type.shape == (':', ':', ':')
     assert pout.dimensions == (':', ':', ':')
@@ -91,7 +91,7 @@ end module another_legacy_mod
     )
     trafo.apply(routine)
 
-    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
     assert len(intrinsics) == 1
     assert 'error stop "sanitised unused routine keep_me was called"' in intrinsics[0].text.lower()
 
@@ -115,7 +115,7 @@ end module empty_stub_mod
     trafo.apply(routine)
 
     assert routine.body.body == ()
-    assert not FindNodes(ir.Intrinsic).visit(routine.body)
+    assert not FindNodes(ir.GenericStmt).visit(routine.body)
 
 
 @pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
@@ -137,10 +137,53 @@ end module no_match_mod
     trafo.apply(routine)
 
     assignments = FindNodes(ir.Assignment).visit(routine.body)
-    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
 
     assert len(assignments) == 1
     assert not intrinsics
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI skips C imports in the frontend')]))
+def test_sanitise_unused_routine_removes_c_imports(frontend, tmp_path):
+    """Drop C-style include imports while preserving ordinary Fortran imports."""
+    filepath = tmp_path/'unused_c_import.F90'
+    include_path = tmp_path/'legacy_unused.intfb.h'
+    include_path.write_text('! interface intentionally empty\n')
+    filepath.write_text(
+        """
+module helper_mod
+  implicit none
+  integer, parameter :: rk = kind(1.0)
+end module helper_mod
+
+module c_import_unused_mod
+contains
+  subroutine legacy_unused(a)
+    use helper_mod, only: rk
+    real(kind=rk), intent(inout) :: a(:)
+#include "legacy_unused.intfb.h"
+    a = 0.0_rk
+  end subroutine legacy_unused
+end module c_import_unused_mod
+""".strip()
+    )
+    source = Sourcefile.from_file(filepath, frontend=frontend, includes=[tmp_path], xmods=[tmp_path])
+    routine = source['c_import_unused_mod']['legacy_unused']
+
+    before_imports = FindNodes(ir.Import).visit((routine.spec, routine.body))
+    assert any(imp.c_import for imp in before_imports)
+    assert any(not imp.c_import and imp.module == 'helper_mod' for imp in before_imports)
+
+    trafo = SanitiseUnusedRoutineTransformation(routines=('legacy_unused',), stub_kind='error_stop')
+    trafo.apply(routine)
+
+    imports = FindNodes(ir.Import).visit((routine.spec, routine.body))
+    intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
+
+    assert not any(imp.c_import for imp in imports)
+    assert any(not imp.c_import and imp.module == 'helper_mod' for imp in imports)
+    assert len(intrinsics) == 1
+    assert 'error stop "sanitised unused routine legacy_unused was called"' in intrinsics[0].text.lower()
 
 
 def test_sanitise_unused_routine_rejects_unknown_stub_kind():


### PR DESCRIPTION
Introduce a transformation that replaces the executable body of configured routines with a configurable stub while rewriting kept array declarations to fully deferred shape. This allows routines that are no longer called but must still compile to be safely reduced to minimal shells.
The stub_kind parameter controls the replacement body: 'error_stop' (default) inserts a fail-loud ERROR STOP statement so accidental calls are caught at runtime, while 'empty' produces a silent no-op. Routine matching supports both plain names and fully qualified module#routine scheduler item names.
Declarations with intent, pointer, or allocatable attributes are preserved with deferred shape; all other local array declarations are removed. Scalar declarations are kept unchanged.

### Description

This pull request introduces the new `SanitiseUnusedRoutineTransformation` transformation to the codebase, which allows configured routines that are no longer used to be sanitized for compilation. The transformation rewrites array declarations to use deferred shapes, removes unnecessary local arrays, and replaces the routine body with either an error-stop or an empty stub, depending on configuration. Comprehensive tests are added to verify its behavior.

**New transformation for sanitizing unused routines:**

* Added the `SanitiseUnusedRoutineTransformation` class in `loki/transformations/sanitise/unused_routines.py`, which supports rewriting array declarations to deferred shapes, removing unused local arrays, and replacing the body with a configurable stub (`error_stop` or `empty`).
* Exposed the new transformation in the `loki.transformations.sanitise` package by importing it in `__init__.py`.

**Testing and validation:**

* Added `test_unused_routines.py` with comprehensive tests for the new transformation, covering deferred shape rewriting, qualified routine name matching, stub kind selection, non-matching routines, and error handling for invalid stub kinds.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 