### PR TITLE
Add core infrastructure fixes for small-kernels pipeline

### DIFF
--- a/loki/expression/mappers.py
+++ b/loki/expression/mappers.py
@@ -226,10 +226,14 @@ class LokiWalkMapper(WalkMapper):
     """
     # pylint: disable=abstract-method
 
+    def __init__(self, recurse_var_parent=True, **kwargs):
+        super().__init__(**kwargs)
+        self.recurse_var_parent = recurse_var_parent
+
     def map_variable_symbol(self, expr, *args, **kwargs):
         if not self.visit(expr):
             return
-        if expr.parent:
+        if expr.parent and self.recurse_var_parent:
             self.rec(expr.parent, *args, **kwargs)
         self.post_visit(expr, *args, **kwargs)
 
@@ -745,8 +749,12 @@ class SubstituteExpressionsMapper(LokiIdentityMapper):
 
     def __init__(self, expr_map):
         super().__init__()
+        from loki.expression.symbols import MetaSymbol  # pylint: disable=import-outside-toplevel,cyclic-import
 
-        self.expr_map = expr_map
+        self.expr_map = dict(expr_map)
+        for expr, replacement in list(expr_map.items()):
+            if isinstance(expr, MetaSymbol) and expr._symbol not in self.expr_map:
+                self.expr_map[expr._symbol] = replacement
         for expr in self.expr_map.keys():
             setattr(self, expr.mapper_method, self.map_from_expr_map)
 

--- a/loki/expression/tests/test_expression.py
+++ b/loki/expression/tests/test_expression.py
@@ -24,7 +24,7 @@ from loki.frontend import (
     available_frontends, OMNI, HAVE_FP, parse_fparser_expression
 )
 from loki.ir import (
-    nodes as ir, FindNodes, FindVariables, FindExpressions,
+    nodes as ir, FindNodes, FindUsedVariables, FindVariables, FindExpressions,
     FindInlineCalls, SubstituteExpressions
 )
 from loki.tools import (
@@ -1377,6 +1377,28 @@ def test_nested_derived_type_substitution():
     new_expr = SubstituteExpressions({original:replace}).visit(expr)
 
     assert fgen(new_expr) == 'ydml_phy_mf%yrphy3%n_spband'
+
+
+def test_find_used_variables_skips_parent_components():
+    """Collect only the used member expression rather than its parent chain."""
+    expr = sym.Array(
+        name='field',
+        parent=sym.Scalar(name='geom', parent=sym.Scalar(name='state')),
+        dimensions=(sym.Scalar(name='jk'),)
+    )
+
+    all_variables = FindVariables(unique=False).visit(expr)
+    used_variables = FindUsedVariables(unique=False).visit(expr)
+
+    assert any(var == 'state%geom%field(jk)' for var in all_variables)
+    assert any(var == 'state%geom' for var in all_variables)
+    assert any(var == 'state' for var in all_variables)
+    assert any(var == 'jk' for var in all_variables)
+
+    assert any(var == 'state%geom%field(jk)' for var in used_variables)
+    assert any(var == 'jk' for var in used_variables)
+    assert not any(var == 'state%geom' for var in used_variables)
+    assert not any(var == 'state' for var in used_variables)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/ir/expr_visitors.py
+++ b/loki/ir/expr_visitors.py
@@ -26,7 +26,7 @@ from loki.expression.symbols import (
 )
 
 __all__ = [
-    'ExpressionFinder', 'FindExpressions', 'FindVariables',
+    'ExpressionFinder', 'FindExpressions', 'FindVariables', 'FindUsedVariables',
     'FindTypedSymbols', 'FindInlineCalls', 'FindLiterals',
     'FindRealLiterals', 'ExpressionTransformer',
     'SubstituteExpressions', 'SubstituteStringExpressions',
@@ -182,6 +182,18 @@ class FindVariables(ExpressionFinder):
     See :class:`ExpressionFinder` for further details
     """
     retriever = ExpressionRetriever(lambda e: isinstance(e, (Scalar, Array, DeferredTypeSymbol)))
+
+
+class FindUsedVariables(ExpressionFinder):
+    """
+    A visitor to collect variables without recursing into parent components
+    of derived-type member accesses.
+
+    See :class:`ExpressionFinder` for further details.
+    """
+    retriever = ExpressionRetriever(
+        lambda e: isinstance(e, (Scalar, Array, DeferredTypeSymbol)), recurse_var_parent=False
+    )
 
 
 class FindInlineCalls(ExpressionFinder):

--- a/loki/transformations/__init__.py
+++ b/loki/transformations/__init__.py
@@ -23,6 +23,7 @@ from loki.transformations.field_api import * # noqa
 from loki.transformations.idempotence import * # noqa
 from loki.transformations.inline import * # noqa
 from loki.transformations.parametrise import * # noqa
+from loki.transformations.replace_kernel import * # noqa
 from loki.transformations.remove_code import * # noqa
 from loki.transformations.sanitise import * # noqa
 from loki.transformations.single_column import * # noqa

--- a/loki/transformations/array_indexing/promote.py
+++ b/loki/transformations/array_indexing/promote.py
@@ -27,7 +27,7 @@ __all__ = [
 ]
 
 
-def promote_variables(routine, variable_names, pos, index=None, size=None):
+def promote_variables(routine, variable_names, pos, index=None, size=None, ignore_index_undefined=False):
     """
     Promote a list of variables by inserting new array dimensions of given size
     and updating all uses of these variables with a given index expression.
@@ -56,6 +56,9 @@ def promote_variables(routine, variable_names, pos, index=None, size=None):
         The size of the dimension (or tuple for multi-dimension promotion) to
         insert at `pos`. When this is provided, the declaration of variables
         is updated accordingly.
+    ignore_index_undefined : bool, optional
+        When `True`, keep the provided index expression even if dataflow
+        analysis cannot prove it is live at a particular use site.
     """
     variable_names = {name.lower() for name in variable_names}
 
@@ -80,8 +83,11 @@ def promote_variables(routine, variable_names, pos, index=None, size=None):
 
                 # We use the given index expression in this node if all
                 # variables therein are defined, otherwise we use `:`
-                node_index = tuple(i if v <= node.live_symbols else sym.RangeIndex((None, None))
-                                   for i, v in zip(index, index_vars))
+                if not ignore_index_undefined:
+                    node_index = tuple(i if v <= node.live_symbols else sym.RangeIndex((None, None))
+                                       for i, v in zip(index, index_vars))
+                else:
+                    node_index = tuple(i for i, _ in zip(index, index_vars))
 
                 var_map = {}
                 for var in var_list:

--- a/loki/transformations/array_indexing/tests/test_array_promote.py
+++ b/loki/transformations/array_indexing/tests/test_array_promote.py
@@ -12,6 +12,7 @@ from loki import Subroutine
 from loki.jit_build import jit_compile_and_run
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends
+from loki.ir import FindNodes, nodes as ir
 
 from loki.transformations.array_indexing.promote import promote_variables
 
@@ -134,3 +135,30 @@ end subroutine transform_promote_variables
     assert scalar == n*(n+1)//2
     assert np.all(vector[:-1] == np.array(list(range(n + 1, 2*n)), order='F', dtype=np.int32))
     assert vector[-1] == 3*n
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_promote_variables_keeps_explicit_index_when_requested(frontend):
+    """Keep an unresolved promotion index verbatim when requested by the caller."""
+    fcode = """
+subroutine promote_unknown_index(arr, n)
+  implicit none
+  integer, intent(in) :: n
+  integer, intent(inout) :: arr(n)
+  integer :: idx
+  integer :: tmp(n)
+
+  arr(:) = tmp(:)
+end subroutine promote_unknown_index
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    promote_variables(
+        routine, ['tmp'], pos=-1, index=routine.variable_map['idx'], size=routine.variable_map['n'],
+        ignore_index_undefined=True
+    )
+
+    assign = FindNodes(ir.Assignment).visit(routine.body)[0]
+
+    assert routine.variable_map['tmp'].shape == (routine.variable_map['n'], routine.variable_map['n'])
+    assert assign.rhs == 'tmp(:, idx)'

--- a/loki/transformations/replace_kernel.py
+++ b/loki/transformations/replace_kernel.py
@@ -1,0 +1,532 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from pathlib import Path
+
+from loki.batch import ModuleItem, ProcedureItem, Transformation
+from loki.ir import FindNodes, Transformer, nodes as ir
+from loki.logging import warning
+from loki.tools import CaseInsensitiveDict, as_tuple
+from loki.types import BasicType
+
+__all__ = ['ReplaceKernels']
+
+
+class ReplaceKernels(Transformation):
+    """
+    Replace configured kernel calls with alternative routines.
+
+    This transformation supports:
+
+    - replacing selected call targets by routine name;
+    - remapping arguments by direct rename;
+    - remapping arguments by extracting a member from a derived-type actual;
+    - remapping arguments by formatting a custom expression template;
+    - overriding an argument with a positional value;
+    - overriding an argument with a literal or expression string;
+    - rewriting ``USE`` imports and ``.intfb.h`` include-style imports;
+    - optionally keeping the replacement routine out of scheduler traversal and
+      CMake planning via ``block=True``.
+
+    Conceptually, the transformation walks each call site in the processed
+    routine, looks for names listed in ``replace_kernels_map``, resolves the
+    replacement routine, and reconstructs the actual argument list against the
+    replacement signature. When the original call target is unresolved in the
+    IR, the transformation also tries to resolve the original routine from
+    source so that remapping can still be done against the original dummy
+    argument names instead of the raw actual expressions. Once the replacement
+    call has been rebuilt, the transformation updates imports/includes to match
+    the new callee and optionally marks the replacement routine as blocked for
+    further scheduler traversal.
+
+    The replacement map accepts entries of the form::
+
+        {
+            'old_kernel': {
+                'routine': 'new_kernel',
+                'args': {
+                    'old_dummy': 'new_dummy',
+                    'struct_arg': {'map_to': 'new_dummy', 'member': 'MEMBER'},
+                    'old_end': {
+                        'map_to': 'new_end',
+                        'expr': 'MOD({geom}%TOTAL%NGPTOT, {geom}%DIM%NPROMA)',
+                        'placeholders': {'geom': 'geom'},
+                    },
+                    'old_start': {'position': 1},
+                    'new_flag': '.true.',
+                },
+                'block': True,
+            }
+        }
+
+    Parameters
+    ----------
+    replace_kernels_map : dict, optional
+        Case-insensitive mapping from original routine name to replacement
+        configuration. Each configuration entry supports the following keys:
+
+        ``routine``
+            Name of the replacement routine.
+
+        ``args``
+            Optional mapping that controls how actual arguments are rebuilt for
+            the replacement call. Supported forms are:
+
+            ``'old_dummy': 'new_dummy'``
+                Map the actual argument of ``old_dummy`` onto the replacement
+                dummy ``new_dummy``.
+
+            ``'old_dummy': {'position': 1}``
+                Pass a positional literal or expression to the replacement
+                dummy named ``old_dummy``.
+
+            ``'old_dummy': {'map_to': 'new_dummy', 'member': 'MEMBER'}``
+                Pass ``actual%MEMBER`` from the original argument ``old_dummy``
+                to the replacement dummy ``new_dummy``.
+
+            ``'old_dummy': {'map_to': 'new_dummy', 'expr': '...',
+            'placeholders': {'name': 'old_dummy_name'}}``
+                Build an expression by formatting the template string with the
+                resolved original actual arguments and pass the result to the
+                replacement dummy ``new_dummy``.
+
+            ``'new_dummy': '.true.'``
+                Pass a literal or expression string directly to the replacement
+                dummy ``new_dummy``.
+
+        ``block``
+            If true, mark the replacement routine/module as blocked in the
+            current scheduler item so that it is not traversed or added to the
+            generated plan.
+    """
+
+    creates_items = True
+
+    def __init__(self, replace_kernels_map=None):
+        self.replace_kernels_map = CaseInsensitiveDict(replace_kernels_map or {})
+
+    @staticmethod
+    def _get_replacement_item_from_cache(replacement_name, item_factory):
+        """Return a cached procedure item for the requested replacement name."""
+        item_cache = item_factory.item_cache
+
+        if replacement_name in item_cache and isinstance(item_cache[replacement_name], ProcedureItem):
+            return item_cache[replacement_name]
+
+        qualified_matches = [
+            item for item in item_cache.values()
+            if isinstance(item, ProcedureItem) and item.local_name.lower() == replacement_name.lower()
+        ]
+        if len(qualified_matches) == 1:
+            return qualified_matches[0]
+
+        for key, item in item_cache.items():
+            if isinstance(item, ProcedureItem) and replacement_name.lower() in key.lower():
+                return item
+
+        return None
+
+    @staticmethod
+    def _complete_replacement_source(replacement_item, scheduler_config, build_args):
+        """Complete the parsed source for a replacement item with scheduler frontend settings."""
+        frontend_args = {
+            key: value for key, value in build_args.items()
+            if key in ('definitions', 'preprocess', 'includes', 'defines', 'xmods', 'omni_includes', 'frontend')
+        }
+        frontend_args = scheduler_config.create_frontend_args(replacement_item.source.path, frontend_args)
+        replacement_item.source.make_complete(**frontend_args)
+
+    def _load_replacement_item_from_source(self, replacement_name, item_factory, scheduler_config, build_args):
+        """Search configured source roots for a replacement routine and load its definition items."""
+        paths = as_tuple(build_args.get('paths', ()))
+        if not paths:
+            paths = as_tuple(build_args.get('includes', ()))
+
+        for root in paths:
+            root = Path(root)
+            if not root.exists():
+                continue
+            for path in root.glob('**/*'):
+                if not path.is_file() or replacement_name.lower() not in path.stem.lower():
+                    continue
+
+                frontend_args = {
+                    key: value for key, value in build_args.items()
+                    if key in ('definitions', 'preprocess', 'includes', 'defines', 'xmods', 'omni_includes', 'frontend')
+                }
+                file_item = item_factory.get_or_create_file_item_from_path(path, scheduler_config, frontend_args)
+                frontend_args = scheduler_config.create_frontend_args(path, frontend_args)
+                file_item.source.make_complete(**frontend_args)
+                definition_items = file_item.create_definition_items(
+                    item_factory=item_factory, config=scheduler_config
+                )
+                for definition_item in definition_items:
+                    if isinstance(definition_item, ModuleItem):
+                        definition_item.create_definition_items(item_factory=item_factory, config=scheduler_config)
+
+                replacement_item = self._get_replacement_item_from_cache(replacement_name, item_factory)
+                if replacement_item is not None:
+                    return replacement_item
+
+        return None
+
+    def _get_complete_replacement_item(self, replacement_name, **kwargs):
+        """Resolve, load, and complete the replacement routine item if available."""
+        item_factory = kwargs.get('item_factory')
+        scheduler_config = kwargs.get('scheduler_config')
+        build_args = dict(kwargs.get('build_args', {}))
+
+        replacement_item = self._get_replacement_item_from_cache(replacement_name, item_factory)
+        if replacement_item is None:
+            replacement_item = self._load_replacement_item_from_source(
+                replacement_name, item_factory, scheduler_config, build_args
+            )
+        if replacement_item is None:
+            return None
+
+        self._complete_replacement_source(replacement_item, scheduler_config, build_args)
+        return replacement_item
+
+    def _get_complete_item(self, routine_name, **kwargs):
+        """Resolve, load, and complete an arbitrary routine item by name."""
+        item_factory = kwargs.get('item_factory')
+        scheduler_config = kwargs.get('scheduler_config')
+        build_args = dict(kwargs.get('build_args', {}))
+
+        routine_item = self._get_replacement_item_from_cache(routine_name, item_factory)
+        if routine_item is None:
+            routine_item = self._load_replacement_item_from_source(
+                routine_name, item_factory, scheduler_config, build_args
+            )
+        if routine_item is None:
+            return None
+
+        self._complete_replacement_source(routine_item, scheduler_config, build_args)
+        return routine_item
+
+    @staticmethod
+    def _mark_replacement_as_blocked(item, replacement_item):
+        """Add the replacement routine and module names to the current scheduler block list."""
+        block_entries = list(as_tuple(item.config.get('block', ())))
+        candidates = [replacement_item.local_name]
+        if replacement_item.scope_name:
+            candidates.append(replacement_item.scope_name)
+
+        for candidate in candidates:
+            if candidate not in block_entries:
+                block_entries.append(candidate)
+
+        item.config['block'] = tuple(block_entries)
+
+    @staticmethod
+    def _split_argument_rules(replacement_args, new_routine):
+        """
+        Categorize argument remapping rules for one replacement routine.
+
+        The returned dictionaries split the user-provided mapping into rename,
+        literal override, positional override, member extraction, and
+        expression-template based remapping so that the call reconstruction step
+        can process the replacement signature in a single pass.
+        """
+        replacement_dummy_names = {arg.name.lower() for arg in new_routine.arguments}
+        renamed_args = {}
+        override_args = CaseInsensitiveDict()
+        position_args = CaseInsensitiveDict()
+        member_args = CaseInsensitiveDict()
+        expr_args = CaseInsensitiveDict()
+
+        for old_name, rule in CaseInsensitiveDict(replacement_args).items():
+            if isinstance(rule, dict):
+                position = rule.get('position')
+                map_to = rule.get('map_to')
+                member = rule.get('member')
+                expr = rule.get('expr')
+                placeholders = rule.get('placeholders')
+
+                if position is not None:
+                    if any(value is not None for value in (map_to, member, expr, placeholders)):
+                        raise RuntimeError(
+                            f'Invalid replacement argument rule for {old_name}: position cannot be combined '
+                            'with map_to/member/expr/placeholders'
+                        )
+                    position_args[old_name.lower()] = str(position)
+                    continue
+
+                if map_to is None:
+                    raise RuntimeError(
+                        f'Invalid replacement argument rule for {old_name}: expected map_to'
+                    )
+
+                if member is not None and expr is not None:
+                    raise RuntimeError(
+                        f'Invalid replacement argument rule for {old_name}: member and expr are mutually exclusive'
+                    )
+
+                if member is not None:
+                    member_args[old_name.lower()] = {
+                        'map_to': str(map_to).lower(),
+                        'member': str(member),
+                    }
+                elif expr is not None:
+                    if not isinstance(placeholders, dict) or not placeholders:
+                        raise RuntimeError(
+                            f'Invalid replacement argument rule for {old_name}: expected expr/placeholders'
+                        )
+                    expr_args[old_name.lower()] = {
+                        'map_to': str(map_to).lower(),
+                        'expr': str(expr),
+                        'placeholders': CaseInsensitiveDict(
+                            (str(name), str(dummy).lower()) for name, dummy in placeholders.items()
+                        ),
+                    }
+                else:
+                    raise RuntimeError(
+                        f'Invalid replacement argument rule for {old_name}: expected member or expr'
+                    )
+            elif str(rule).lower() in replacement_dummy_names:
+                renamed_args[old_name.lower()] = str(rule).lower()
+            else:
+                override_args[old_name.lower()] = str(rule)
+
+        return renamed_args, override_args, position_args, member_args, expr_args
+
+    @staticmethod
+    def _build_member_expr(routine, actual, member):
+        """Build a parsed member-access expression from an original actual argument."""
+        member = member.lstrip('%')
+        return routine.parse_expr(f'{actual}%{member}')
+
+    @staticmethod
+    def _build_template_expr(routine, old_arg_map, expr_rule):
+        """Format and parse a replacement expression template from original actuals."""
+        resolved_placeholders = {}
+        for placeholder, old_name in expr_rule['placeholders'].items():
+            actual = old_arg_map.get(old_name)
+            if actual is None:
+                raise RuntimeError(
+                    f'Cannot resolve placeholder {placeholder} from original argument {old_name}'
+                )
+            resolved_placeholders[placeholder] = str(actual)
+
+        try:
+            expr = expr_rule['expr'].format(**resolved_placeholders)
+        except KeyError as exc:
+            raise RuntimeError(
+                f'Unknown placeholder {exc.args[0]} in replacement expression {expr_rule["expr"]}'
+            ) from exc
+
+        return routine.parse_expr(expr)
+
+    def _adapt_arguments(self, call, caller_routine, new_routine, **kwargs):
+        """
+        Rebuild the call arguments against the replacement routine signature.
+
+        The replacement signature is treated as authoritative: each replacement
+        dummy is visited in order and its actual argument is derived either from
+        an explicit remapping rule or from an implicit name-based match against
+        the original call. When the original callee is unresolved, the
+        transformation tries to resolve that routine from source first so that
+        remapping still uses the original dummy names instead of the rendered
+        actual expressions.
+        """
+        replacement = self.replace_kernels_map[str(call.name).lower()]
+        replacement_args = replacement.get('args', {})
+        renamed_args, override_args, position_args, member_args, expr_args = self._split_argument_rules(
+            replacement_args, new_routine
+        )
+
+        if call.routine is not None and call.routine is not BasicType.DEFERRED:
+            old_arg_map = CaseInsensitiveDict((dummy.name, actual) for dummy, actual in call.arg_map.items())
+        else:
+            # Current main does not always link the original callee in the IR,
+            # so resolve it from source if possible and rebuild the original
+            # dummy-to-actual mapping from its signature.
+            old_routine_item = self._get_complete_item(str(call.name), **kwargs)
+            if old_routine_item is not None:
+                old_arg_map = CaseInsensitiveDict()
+                positional_arguments = iter(call.arguments)
+                for old_dummy in old_routine_item.ir.arguments:
+                    kwarg_actual = next(
+                        (
+                            value for name, value in call.kwarguments
+                            if name.lower() == old_dummy.name.lower()
+                        ),
+                        None,
+                    )
+                    if kwarg_actual is not None:
+                        old_arg_map[old_dummy.name] = kwarg_actual
+                    else:
+                        actual = next(positional_arguments, None)
+                        if actual is not None:
+                            old_arg_map[old_dummy.name] = actual
+            else:
+                old_arg_map = CaseInsensitiveDict((kw[0], kw[1]) for kw in call.kwarguments)
+                for actual in call.arguments:
+                    old_arg_map.setdefault(str(actual).lower(), actual)
+
+        reverse_renamed_args = {new_name: old_name for old_name, new_name in renamed_args.items()}
+        reverse_member_args = {rule['map_to']: old_name for old_name, rule in member_args.items()}
+        reverse_expr_args = {rule['map_to']: old_name for old_name, rule in expr_args.items()}
+        arguments = []
+        kwarguments = []
+        keep_positional = True
+
+        for new_dummy in new_routine.arguments:
+            new_name = new_dummy.name.lower()
+            actual = None
+            use_keyword = not keep_positional
+            override_name = next(
+                (old_name for old_name, mapped_name in renamed_args.items() if mapped_name == new_name), None
+            )
+
+            if new_name in reverse_member_args:
+                old_name = reverse_member_args[new_name]
+                actual = self._build_member_expr(
+                    caller_routine, old_arg_map[old_name], member_args[old_name]['member']
+                )
+                use_keyword = True
+            elif new_name in reverse_expr_args:
+                old_name = reverse_expr_args[new_name]
+                actual = self._build_template_expr(caller_routine, old_arg_map, expr_args[old_name])
+                use_keyword = True
+            elif new_name in position_args:
+                actual = caller_routine.parse_expr(position_args[new_name])
+            elif override_name and override_name in override_args:
+                actual = caller_routine.parse_expr(override_args[override_name])
+                use_keyword = True
+            elif new_name in override_args:
+                actual = caller_routine.parse_expr(override_args[new_name])
+                use_keyword = True
+            elif new_name in reverse_renamed_args:
+                actual = old_arg_map.get(reverse_renamed_args[new_name])
+                use_keyword = True
+            elif new_name in old_arg_map:
+                actual = old_arg_map[new_name]
+
+            if actual is None:
+                if new_dummy.type.optional:
+                    warning(
+                        '[Loki::ReplaceKernels] Omitting optional replacement argument %s when replacing %s '
+                        'with %s in %s', new_dummy.name, call.name, new_routine.name, caller_routine.name
+                    )
+                    continue
+                raise RuntimeError(
+                    f'Cannot map required replacement argument {new_dummy.name} when replacing '
+                    f'{call.name} with {new_routine.name} in {caller_routine.name}'
+                )
+
+            if use_keyword:
+                kwarguments.append((new_dummy.name, actual))
+                keep_positional = False
+            else:
+                arguments.append(actual)
+
+        return tuple(arguments), tuple(kwarguments)
+
+    @staticmethod
+    def _replace_import(scope, import_map, new_imports):
+        """Rewrite matching imports in one scope and append any newly required module imports."""
+        if import_map:
+            scope.spec = Transformer(import_map).visit(scope.spec)
+        if new_imports:
+            use_positions = [
+                index for index, node in enumerate(scope.spec.body)
+                if isinstance(node, ir.Import) and not node.c_import and not node.f_include
+            ]
+            insert_pos = use_positions[-1] + 1 if use_positions else 0
+            scope.spec.insert(insert_pos, new_imports)
+
+    def _transform_subroutine(self, routine, **kwargs):
+        """
+        Replace matching calls in one routine and update the corresponding
+        imports/includes.
+
+        The transformation collects existing imports in both the routine scope
+        and its parent scope, rewrites matching call statements, and then
+        updates the relevant import location depending on whether the original
+        dependency came from a local ``USE`` import, a parent-scope import, a
+        ``.intfb.h`` include, or no explicit import at all.
+        """
+        item = kwargs.get('item')
+
+        import_by_symbol = CaseInsensitiveDict()
+        intfb_import_by_name = CaseInsensitiveDict()
+
+        for imprt in FindNodes(ir.Import).visit(routine.spec):
+            if imprt.c_import and imprt.module and '.intfb.h' in imprt.module:
+                kernel_name = imprt.module.replace('.intfb.h', '')
+                intfb_import_by_name[kernel_name] = ('routine', imprt)
+            for symbol in imprt.symbols:
+                import_by_symbol[str(symbol).lower()] = ('routine', imprt)
+
+        parent_import_by_symbol = CaseInsensitiveDict()
+        parent_intfb_import_by_name = CaseInsensitiveDict()
+        if routine.parent is not None and getattr(routine.parent, 'spec', None) is not None:
+            for imprt in FindNodes(ir.Import).visit(routine.parent.spec):
+                if imprt.c_import and imprt.module and '.intfb.h' in imprt.module:
+                    kernel_name = imprt.module.replace('.intfb.h', '')
+                    parent_intfb_import_by_name[kernel_name] = imprt
+                for symbol in imprt.symbols:
+                    parent_import_by_symbol[str(symbol).lower()] = imprt
+
+        call_map = {}
+        new_imports = []
+        parent_new_imports = []
+        routine_import_map = {}
+        parent_import_map = {}
+
+        for call in FindNodes(ir.CallStatement).visit(routine.body):
+            call_name = str(call.name).lower()
+            if call_name not in self.replace_kernels_map:
+                continue
+
+            replacement = self.replace_kernels_map[call_name]
+            replacement_name = replacement.get('routine')
+            replacement_item = self._get_complete_replacement_item(replacement_name, **kwargs)
+            if replacement_item is None:
+                continue
+
+            proc_symbol = replacement_item.ir.procedure_symbol.rescope(scope=routine)
+            arguments, kwarguments = self._adapt_arguments(call, routine, replacement_item.ir, **kwargs)
+            call_map[call] = call.clone(name=proc_symbol, arguments=arguments, kwarguments=kwarguments)
+
+            # Prefer rewriting the import where the original dependency was
+            # declared. Fall back to inserting a new module import if the call
+            # was unresolved or came from an ``.intfb.h`` include.
+            if call_name in import_by_symbol:
+                imprt = import_by_symbol[call_name][1]
+                routine_import_map[imprt] = imprt.clone(module=replacement_item.scope_name, symbols=(proc_symbol,))
+            elif call_name in parent_import_by_symbol:
+                imprt = parent_import_by_symbol[call_name]
+                parent_import_map[imprt] = imprt.clone(module=replacement_item.scope_name, symbols=(proc_symbol,))
+            elif call_name in intfb_import_by_name:
+                imprt = intfb_import_by_name[call_name][1]
+                routine_import_map[imprt] = None
+                new_imports.append(ir.Import(module=replacement_item.scope_name, symbols=(proc_symbol,)))
+            elif call_name in parent_intfb_import_by_name:
+                imprt = parent_intfb_import_by_name[call_name]
+                parent_import_map[imprt] = None
+                parent_new_imports.append(ir.Import(module=replacement_item.scope_name, symbols=(proc_symbol,)))
+            else:
+                new_imports.append(ir.Import(module=replacement_item.scope_name, symbols=(proc_symbol,)))
+
+            if item is not None and replacement.get('block', False):
+                # Blocking the replacement item keeps it out of traversal and
+                # plan generation while still allowing the caller rewrite.
+                self._mark_replacement_as_blocked(item, replacement_item)
+
+        if call_map:
+            routine.body = Transformer(call_map).visit(routine.body)
+        self._replace_import(routine, routine_import_map, new_imports)
+        if routine.parent is not None and getattr(routine.parent, 'spec', None) is not None:
+            self._replace_import(routine.parent, parent_import_map, parent_new_imports)
+
+    def transform_subroutine(self, routine, **kwargs):
+        self._transform_subroutine(routine, **kwargs)
+
+    def plan_subroutine(self, routine, **kwargs):
+        self._transform_subroutine(routine, **kwargs)

--- a/loki/transformations/replace_kernel.py
+++ b/loki/transformations/replace_kernel.py
@@ -110,23 +110,36 @@ class ReplaceKernels(Transformation):
         self.replace_kernels_map = CaseInsensitiveDict(replace_kernels_map or {})
 
     @staticmethod
-    def _get_replacement_item_from_cache(replacement_name, item_factory):
+    def _get_replacement_item_from_cache(replacement_name, item_factory, config):
         """Return a cached procedure item for the requested replacement name."""
         item_cache = item_factory.item_cache
+        replacement_name = replacement_name.lower()
 
         if replacement_name in item_cache and isinstance(item_cache[replacement_name], ProcedureItem):
             return item_cache[replacement_name]
 
         qualified_matches = [
             item for item in item_cache.values()
-            if isinstance(item, ProcedureItem) and item.local_name.lower() == replacement_name.lower()
+            if isinstance(item, ProcedureItem) and item.local_name.lower() == replacement_name
         ]
         if len(qualified_matches) == 1:
             return qualified_matches[0]
 
-        for key, item in item_cache.items():
-            if isinstance(item, ProcedureItem) and replacement_name.lower() in key.lower():
+        for key, item in tuple(item_cache.items()):
+            # relevant procedure item can be found in item_cache
+            if isinstance(item, ProcedureItem) and replacement_name in key.lower():
                 return item
+            # relevant module item can be found and corresponding procedure item can
+            # be reused, but only if the module actually defines the procedure.
+            if isinstance(item, ModuleItem) and replacement_name in key.lower():
+                module_item = item
+                definition_items = module_item.create_definition_items(item_factory, config=config)
+                for definition_item in definition_items:
+                    if (
+                        isinstance(definition_item, ProcedureItem)
+                        and definition_item.local_name.lower() == replacement_name
+                    ):
+                        return definition_item
 
         return None
 
@@ -168,7 +181,8 @@ class ReplaceKernels(Transformation):
                     if isinstance(definition_item, ModuleItem):
                         definition_item.create_definition_items(item_factory=item_factory, config=scheduler_config)
 
-                replacement_item = self._get_replacement_item_from_cache(replacement_name, item_factory)
+                replacement_item = self._get_replacement_item_from_cache(replacement_name, item_factory,
+                        config=scheduler_config)
                 if replacement_item is not None:
                     return replacement_item
 
@@ -180,12 +194,13 @@ class ReplaceKernels(Transformation):
         scheduler_config = kwargs.get('scheduler_config')
         build_args = dict(kwargs.get('build_args', {}))
 
-        replacement_item = self._get_replacement_item_from_cache(replacement_name, item_factory)
+        replacement_item = self._get_replacement_item_from_cache(replacement_name, item_factory,
+                config=scheduler_config)
         if replacement_item is None:
             replacement_item = self._load_replacement_item_from_source(
                 replacement_name, item_factory, scheduler_config, build_args
             )
-        if replacement_item is None:
+        if replacement_item is None or replacement_item.source is None:
             return None
 
         self._complete_replacement_source(replacement_item, scheduler_config, build_args)
@@ -197,12 +212,13 @@ class ReplaceKernels(Transformation):
         scheduler_config = kwargs.get('scheduler_config')
         build_args = dict(kwargs.get('build_args', {}))
 
-        routine_item = self._get_replacement_item_from_cache(routine_name, item_factory)
+        routine_item = self._get_replacement_item_from_cache(routine_name, item_factory,
+                config=scheduler_config)
         if routine_item is None:
             routine_item = self._load_replacement_item_from_source(
                 routine_name, item_factory, scheduler_config, build_args
             )
-        if routine_item is None:
+        if routine_item is None or routine_item.source is None:
             return None
 
         self._complete_replacement_source(routine_item, scheduler_config, build_args)

--- a/loki/transformations/sanitise/__init__.py
+++ b/loki/transformations/sanitise/__init__.py
@@ -15,6 +15,7 @@ from loki.batch import Transformation, Pipeline
 from loki.transformations.sanitise.associates import * # noqa
 from loki.transformations.sanitise.sequence_associations import * # noqa
 from loki.transformations.sanitise.substitute import * # noqa
+from loki.transformations.sanitise.unused_routines import * # noqa
 
 
 """

--- a/loki/transformations/sanitise/unused_routines.py
+++ b/loki/transformations/sanitise/unused_routines.py
@@ -1,0 +1,110 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from loki.batch import SchedulerConfig, Transformation
+from loki.ir import FindNodes, Transformer, nodes as ir
+from loki.tools import as_tuple
+
+__all__ = ['SanitiseUnusedRoutineTransformation']
+
+
+class SanitiseUnusedRoutineTransformation(Transformation):
+    """
+    Sanitise configured routines that are no longer used but still need to compile.
+
+    For selected routines this transformation rewrites kept array declarations
+    in the routine specification to fully deferred shape, removes local array
+    declarations that no longer need to be represented, and replaces the
+    executable body with a configurable stub.
+
+    Parameters
+    ----------
+    routines : tuple or list of str, optional
+        Routine names or qualified scheduler item names to sanitise. Matching
+        uses :any:`SchedulerConfig.match_item_keys` with parent matching
+        enabled, so both ``routine`` and ``module#routine`` forms are
+        supported.
+    stub_kind : str, optional
+        The replacement body to insert for sanitised routines. Supported
+        values are ``'error_stop'`` for a fail-loud stub and ``'empty'`` for
+        an empty executable section. Defaults to ``'error_stop'``.
+    """
+
+    def __init__(self, routines=None, stub_kind='error_stop'):
+        self.routines = as_tuple(routines)
+        if stub_kind not in ('error_stop', 'empty'):
+            raise ValueError(
+                f'Invalid stub_kind {stub_kind!r}: expected one of ("error_stop", "empty")'
+            )
+        self.stub_kind = stub_kind
+
+    @staticmethod
+    def _matches_routine(routine, item=None, configured_routines=()):
+        """Return whether one routine matches the configured sanitisation targets."""
+        if item is not None:
+            item_name = item.name
+        elif routine.parent is not None:
+            item_name = f'{routine.parent.name.lower()}#{routine.name.lower()}'
+        else:
+            item_name = routine.name.lower()
+
+        return bool(SchedulerConfig.match_item_keys(item_name, configured_routines, match_item_parents=True))
+
+    @staticmethod
+    def _deferred_shape(symbol, routine):
+        """Clone one array symbol with all declared dimensions rewritten to deferred shape."""
+        shape = getattr(symbol.type, 'shape', None)
+        if not shape:
+            return symbol
+
+        deferred_shape = tuple(routine.parse_expr(':') for _ in shape)
+        return symbol.clone(dimensions=deferred_shape, type=symbol.type.clone(shape=deferred_shape))
+
+    @staticmethod
+    def _should_keep_with_deferred_shape(symbol):
+        """Keep arguments, pointers, and allocatables while deferring their declared shape."""
+        return bool(symbol.type.intent is not None or symbol.type.pointer or symbol.type.allocatable)
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Sanitise one configured routine by shrinking its declarations and replacing its body.
+
+        Only declarations that still matter to the routine interface or storage
+        semantics are kept, and any retained arrays are rewritten to fully
+        deferred shape so their original bounds expressions are no longer
+        required.
+        """
+        if not self._matches_routine(routine, item=kwargs.get('item'), configured_routines=self.routines):
+            return
+
+        decl_map = {}
+        for decl in FindNodes(ir.VariableDeclaration).visit(routine.spec):
+            new_symbols = []
+            for symbol in decl.symbols:
+                shape = getattr(symbol.type, 'shape', None)
+                if not shape:
+                    new_symbols.append(symbol)
+                    continue
+
+                if self._should_keep_with_deferred_shape(symbol):
+                    new_symbols.append(self._deferred_shape(symbol, routine))
+
+            new_symbols = tuple(new_symbols)
+            if not new_symbols:
+                decl_map[decl] = None
+            elif new_symbols != decl.symbols:
+                decl_map[decl] = decl.clone(symbols=new_symbols)
+
+        if decl_map:
+            routine.spec = Transformer(decl_map).visit(routine.spec)
+
+        if self.stub_kind == 'error_stop':
+            routine.body = ir.Section(body=(
+                ir.Intrinsic(text=f'error stop "Sanitised unused routine {routine.name} was called"'),
+            ))
+        else:
+            routine.body = ir.Section(body=())

--- a/loki/transformations/sanitise/unused_routines.py
+++ b/loki/transformations/sanitise/unused_routines.py
@@ -99,12 +99,20 @@ class SanitiseUnusedRoutineTransformation(Transformation):
             elif new_symbols != decl.symbols:
                 decl_map[decl] = decl.clone(symbols=new_symbols)
 
+        imp_map = {}
+        for imp in FindNodes(ir.Import).visit(routine.ir):
+            if imp.c_import:
+                imp_map[imp] = None
+        if imp_map:
+            routine.spec = Transformer(imp_map).visit(routine.spec)
+            routine.body = Transformer(imp_map).visit(routine.body)
+
         if decl_map:
             routine.spec = Transformer(decl_map).visit(routine.spec)
 
         if self.stub_kind == 'error_stop':
             routine.body = ir.Section(body=(
-                ir.Intrinsic(text=f'error stop "Sanitised unused routine {routine.name} was called"'),
+                ir.GenericStmt(text=f'error stop "Sanitised unused routine {routine.name} was called"'),
             ))
         else:
             routine.body = ir.Section(body=())

--- a/loki/transformations/temporaries/pool_allocator.py
+++ b/loki/transformations/temporaries/pool_allocator.py
@@ -407,6 +407,20 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         )
         return stack_type
 
+    def get_block_index(self, routine, variable_map):
+        """Resolve the configured block index, including derived-type forms."""
+        block_index = variable_map.get(self.block_dim.index, None)
+        if block_index is not None:
+            return block_index
+
+        block_indices = [
+            index for index in self.block_dim.indices
+            if index.split('%', maxsplit=1)[0].lower() in variable_map
+        ]
+        if block_indices:
+            return routine.resolve_typebound_var(block_indices[0], variable_map)
+        return None
+
     def _get_stack_storage_and_size_var(self, routine, stack_size):
         """
         Utility routine to obtain storage array and size variable for the pool allocator
@@ -855,7 +869,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
                         function=Variable(name='LOC'),
                         parameters=(
                             stack_storage.clone(
-                                dimensions=(Literal(1), Variable(name=self.block_dim.index, scope=routine))
+                                dimensions=(Literal(1), self.get_block_index(routine, routine.variable_map))
                             ),
                         ),
                         kw_parameters=None

--- a/loki/transformations/temporaries/tests/test_pool_allocator.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator.py
@@ -8,7 +8,7 @@
 import pytest
 
 from loki.expression.parser import parse_expr
-from loki import Dimension
+from loki import Dimension, Subroutine
 from loki.batch import Scheduler, SchedulerConfig
 from loki.expression import (
         InlineCall, RangeIndex, simplify, Sum,
@@ -1430,3 +1430,24 @@ end module kernel_mod
 
     # check that array size was imported to the driver
     assert 'n' in driver.imported_symbols
+
+
+def test_pool_allocator_resolves_derived_type_block_index():
+    """Resolve a derived-type block index via the configured dimension aliases."""
+    fcode = """
+subroutine driver(geom)
+  implicit none
+  type dim_type
+    integer :: ib
+  end type dim_type
+  type geom_type
+    type(dim_type) :: blk_dim
+  end type geom_type
+  type(geom_type), intent(in) :: geom
+end subroutine driver
+    """.strip()
+    routine = Subroutine.from_source(fcode)
+    block_dim = Dimension(name='block', size='geom%blk_dim%nb', index=('missing%ib', 'geom%blk_dim%ib'))
+    transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
+
+    assert transformation.get_block_index(routine, routine.variable_map) == 'geom%blk_dim%ib'

--- a/loki/transformations/tests/test_replace_kernel.py
+++ b/loki/transformations/tests/test_replace_kernel.py
@@ -1,0 +1,365 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import re
+from pathlib import Path
+
+import pytest
+
+from loki import Scheduler, SchedulerConfig
+from loki.batch import Pipeline, ProcessingStrategy
+from loki.frontend import OMNI, available_frontends
+from loki.ir import CallStatement, FindNodes, Import
+from loki.transformations import IdemTransformation, ReplaceKernels
+from loki.transformations.build_system import (
+    DependencyTransformation, FileWriteTransformation, ModuleWrapTransformation,
+)
+
+
+@pytest.fixture(scope='module', name='here')
+def fixture_here():
+    return Path(__file__).parent
+
+
+def _read_plan_dict(plan_file):
+    """Parse the generated CMake plan into a stem-only dictionary for assertions."""
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+    loki_plan = plan_file.read_text()
+    plan_dict = {key: value.split() for key, value in plan_pattern.findall(loki_plan)}
+    return {key: {Path(item).stem for item in value} for key, value in plan_dict.items()}
+
+
+def _scheduler_config(driver_names):
+    """Create a minimal scheduler config with the selected routines marked as drivers."""
+    return SchedulerConfig.from_dict({
+        'default': {
+            'mode': 'idem',
+            'role': 'kernel',
+            'expand': True,
+            'strict': False,
+        },
+        'routines': {name: {'role': 'driver'} for name in driver_names},
+    })
+
+
+def _write_replace_sources(tmp_path):
+    """Write anonymized Fortran sources that cover the replacement-call patterns under test."""
+    # These fixtures mirror the relevant call-shape patterns we care about for
+    # PR 1 without pulling in real IFS names or source files.
+    sources = {
+        'geom_types_mod.F90': """
+module geom_types_mod
+  implicit none
+  type dim_type
+    integer :: nproma
+    integer :: ngpblks
+  end type dim_type
+  type total_type
+    integer :: ngptot
+  end type total_type
+  type geometry_type
+    type(dim_type) :: dim
+    type(total_type) :: total
+  end type geometry_type
+end module geom_types_mod
+""".strip(),
+        'leaf_mod.F90': """
+module leaf_mod
+implicit none
+contains
+subroutine leaf(flag1, flag2, start_idx, end_idx, geom, field)
+  use geom_types_mod, only: geometry_type
+  logical, intent(in) :: flag1, flag2
+  integer, intent(in) :: start_idx, end_idx
+  type(geometry_type), intent(in) :: geom
+  real, intent(inout) :: field(:)
+  field(start_idx:end_idx) = field(start_idx:end_idx) + 1.0
+end subroutine leaf
+end module leaf_mod
+""".strip(),
+        'leaf_replacement_mod.F90': """
+module leaf_replacement_mod
+implicit none
+contains
+subroutine leaf_replacement(flag1, flag2_renamed, field, start_idx, block_count, end_in, on_gpu, optional_flag)
+  logical, intent(in) :: flag1, flag2_renamed
+  real, intent(inout) :: field(:)
+  integer, intent(in) :: start_idx, block_count, end_in
+  logical, intent(in) :: on_gpu
+  logical, intent(in), optional :: optional_flag
+  field(start_idx:end_in) = field(start_idx:end_in) + real(block_count)
+end subroutine leaf_replacement
+end module leaf_replacement_mod
+""".strip(),
+        'leaf_passthrough_replacement_mod.F90': """
+module leaf_passthrough_replacement_mod
+implicit none
+contains
+subroutine leaf_passthrough_replacement(flag1, flag2, start_idx, end_idx, geom, field, optional_flag)
+  use geom_types_mod, only: geometry_type
+  logical, intent(in) :: flag1, flag2
+  integer, intent(in) :: start_idx, end_idx
+  type(geometry_type), intent(in) :: geom
+  real, intent(inout) :: field(:)
+  logical, intent(in), optional :: optional_flag
+  field(start_idx:end_idx) = field(start_idx:end_idx) + real(geom%dim%ngpblks)
+end subroutine leaf_passthrough_replacement
+end module leaf_passthrough_replacement_mod
+""".strip(),
+        'include_driver.F90': """
+module include_driver_mod
+implicit none
+contains
+subroutine include_driver(start_idx, end_idx, geom, field)
+  use geom_types_mod, only: geometry_type
+  implicit none
+  integer, intent(in) :: start_idx, end_idx
+  type(geometry_type), intent(in) :: geom
+  real, intent(inout) :: field(:)
+#include "leaf.intfb.h"
+  call leaf(.false., .true., start_idx, end_idx, geom, field)
+end subroutine include_driver
+end module include_driver_mod
+""".strip(),
+        'leaf.intfb.h': '#include "leaf_mod.intfb.h"\n',
+        'pipeline_driver_mod.F90': """
+module pipeline_driver_mod
+implicit none
+contains
+subroutine tile_driver_parallel(span, geom, field)
+  use geom_types_mod, only: geometry_type
+  use pipeline_band_mod, only: band_kernel
+  implicit none
+  type span_type
+    integer :: begin_idx
+    integer :: end_idx
+  end type span_type
+  type(span_type), intent(in) :: span
+  type(geometry_type), intent(in) :: geom
+  real, intent(inout) :: field(:)
+  call band_kernel(span, geom, field)
+end subroutine tile_driver_parallel
+end module pipeline_driver_mod
+""".strip(),
+        'pipeline_band_mod.F90': """
+module pipeline_band_mod
+implicit none
+contains
+subroutine band_kernel(span, geom, field)
+  use geom_types_mod, only: geometry_type
+  use edge_wrapper_mod, only: edge_wrapper
+  implicit none
+  type span_type
+    integer :: begin_idx
+    integer :: end_idx
+  end type span_type
+  type(span_type), intent(in) :: span
+  type(geometry_type), intent(in) :: geom
+  real, intent(inout) :: field(:)
+  call edge_wrapper(span%begin_idx, span%end_idx, geom, field)
+end subroutine band_kernel
+end module pipeline_band_mod
+""".strip(),
+        'edge_wrapper_mod.F90': """
+module edge_wrapper_mod
+implicit none
+contains
+subroutine edge_wrapper(start_idx, end_idx, geom, field)
+  use geom_types_mod, only: geometry_type
+  use leaf_mod, only: leaf
+  implicit none
+  integer, intent(in) :: start_idx, end_idx
+  type(geometry_type), intent(in) :: geom
+  real, intent(inout) :: field(:)
+  call leaf(.true., .false., start_idx, end_idx, geom, field)
+end subroutine edge_wrapper
+end module edge_wrapper_mod
+""".strip(),
+    }
+    for name, code in sources.items():
+        (tmp_path/name).write_text(code)
+
+
+def _get_item_map(scheduler):
+    """Index scheduler items by fully qualified item name for direct lookup in tests."""
+    return {item.name: item for item in scheduler.items}
+
+
+def _get_routine_and_calls(item_map, item_name):
+    """Return one routine together with its calls and local or parent imports."""
+    item = item_map[item_name]
+    routine = item.source[item.local_name]
+    calls = FindNodes(CallStatement).visit(routine.body)
+    imports = FindNodes(Import).visit(routine.spec)
+    parent_imports = ()
+    if routine.parent is not None and getattr(routine.parent, 'spec', None) is not None:
+        parent_imports = FindNodes(Import).visit(routine.parent.spec)
+    return routine, calls, imports, parent_imports
+
+
+@pytest.fixture(name='replace_source_dir')
+def fixture_replace_source_dir(tmp_path):
+    _write_replace_sources(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_replace_kernel_argument_remap(frontend, replace_source_dir, tmp_path):
+    """Remap replacement arguments across rename, member, template, position, and literal rules."""
+    # This replacement exercises the full remapping surface in one focused test.
+    scheduler = Scheduler(
+        paths=[replace_source_dir],
+        config=_scheduler_config(('include_driver', 'tile_driver_parallel')),
+        frontend=frontend,
+        xmods=[tmp_path],
+        includes=[replace_source_dir],
+    )
+    scheduler.process(transformation=ReplaceKernels({
+        'leaf': {
+            'routine': 'leaf_replacement',
+            'args': {
+                'flag2': 'flag2_renamed',
+                'geom': {'map_to': 'block_count', 'member': 'DIM%NGPBLKS'},
+                'end_idx': {
+                    'map_to': 'end_in',
+                    'placeholders': {'geom': 'geom'},
+                    'expr': 'MOD({geom}%TOTAL%NGPTOT, {geom}%DIM%NPROMA)',
+                },
+                'start_idx': {'position': 1},
+                'on_gpu': '.true.',
+            },
+        }
+    }))
+
+    item_map = _get_item_map(scheduler)
+    assert 'leaf_replacement_mod#leaf_replacement' in item_map
+
+    _, calls, imports, parent_imports = _get_routine_and_calls(item_map, 'include_driver_mod#include_driver')
+    call = calls[0]
+
+    assert call.name == 'leaf_replacement'
+    assert len(call.arguments) == 1
+    assert call.arguments[0] == 'false'
+    assert ('flag2_renamed', 'true') in call.kwarguments
+    assert ('field', 'field') in call.kwarguments
+    assert ('start_idx', 1) in call.kwarguments
+    assert ('block_count', 'geom%dim%ngpblks') in call.kwarguments
+    assert ('end_in', 'mod(geom%total%ngptot, geom%dim%nproma)') in call.kwarguments
+    assert ('on_gpu', 'true') in call.kwarguments
+    assert any(imp.module == 'leaf_replacement_mod' for imp in imports + parent_imports)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_replace_kernel_omits_optional_argument(frontend, replace_source_dir, tmp_path, caplog):
+    """Skip unmapped optional replacement arguments and emit a warning for the omission."""
+    scheduler = Scheduler(
+        paths=[replace_source_dir],
+        config=_scheduler_config(('include_driver',)),
+        frontend=frontend,
+        xmods=[tmp_path],
+        includes=[replace_source_dir],
+    )
+
+    with caplog.at_level('WARNING'):
+        # The passthrough replacement keeps the original dummy names so this
+        # test isolates optional-argument omission from remapping behavior.
+        scheduler.process(transformation=ReplaceKernels({
+            'leaf': {'routine': 'leaf_passthrough_replacement'}
+        }))
+
+    item_map = _get_item_map(scheduler)
+    _, calls, _, _ = _get_routine_and_calls(item_map, 'include_driver_mod#include_driver')
+    assert all(name.lower() != 'optional_flag' for name, _ in calls[0].kwarguments)
+    assert any('optional replacement argument' in message for message in caplog.messages)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_replace_kernel_rewrites_intfb_include(frontend, replace_source_dir, tmp_path):
+    """Replace include-style imports with the replacement module import when needed."""
+    scheduler = Scheduler(
+        paths=[replace_source_dir],
+        config=_scheduler_config(('include_driver',)),
+        frontend=frontend,
+        xmods=[tmp_path],
+        includes=[replace_source_dir],
+    )
+    scheduler.process(transformation=ReplaceKernels({
+        'leaf': {'routine': 'leaf_passthrough_replacement'}
+    }))
+
+    item_map = _get_item_map(scheduler)
+    routine, calls, imports, parent_imports = _get_routine_and_calls(item_map, 'include_driver_mod#include_driver')
+
+    assert calls[0].name == 'leaf_passthrough_replacement'
+    c_imports = tuple(imp for imp in FindNodes(Import).visit(routine.spec) if imp.c_import)
+    assert not any(imp.module and 'leaf.intfb.h' in imp.module.lower() for imp in c_imports)
+    assert any(imp.module == 'leaf_passthrough_replacement_mod' for imp in imports + parent_imports)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+@pytest.mark.parametrize('block_replacement', [False, True])
+def test_replace_kernel_updates_plan_and_block_list(frontend, replace_source_dir, tmp_path, block_replacement):
+    """Block flagged replacements from traversal and generated plan output while still rewriting calls."""
+    output_dir = tmp_path/'build'
+    output_dir.mkdir()
+    config = _scheduler_config(('include_driver',))
+    replace_map = {'leaf': {'routine': 'leaf_passthrough_replacement', 'block': block_replacement}}
+    pipeline = Pipeline(classes=(
+        IdemTransformation,
+        ReplaceKernels,
+        ModuleWrapTransformation,
+        DependencyTransformation,
+        FileWriteTransformation,
+    ), replace_kernels_map=replace_map, module_suffix='_mod', suffix='_test')
+
+    scheduler = Scheduler(
+        paths=[replace_source_dir], config=config, frontend=frontend, xmods=[tmp_path], output_dir=output_dir,
+        includes=[replace_source_dir],
+    )
+    plan_file = tmp_path/'replace_plan.cmake'
+    scheduler.process(pipeline, proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.write_cmake_plan(filepath=plan_file, rootpath=replace_source_dir)
+    plan_dict = _read_plan_dict(plan_file)
+    item_names = {item.name for item in scheduler.items}
+
+    if block_replacement:
+        assert 'leaf_passthrough_replacement_mod#leaf_passthrough_replacement' not in item_names
+        assert 'leaf_passthrough_replacement_mod' not in plan_dict['LOKI_SOURCES_TO_TRANSFORM']
+    else:
+        assert 'leaf_passthrough_replacement_mod#leaf_passthrough_replacement' in item_names
+        assert 'leaf_passthrough_replacement_mod' in plan_dict['LOKI_SOURCES_TO_TRANSFORM']
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_replace_kernel_pipeline_fixture(frontend, replace_source_dir, tmp_path):
+    """Rewrite a downstream kernel call inside a small pipeline-shaped anonymized call chain."""
+    scheduler = Scheduler(
+        paths=[replace_source_dir],
+        config=_scheduler_config(('tile_driver_parallel',)),
+        frontend=frontend,
+        xmods=[tmp_path],
+        includes=[replace_source_dir],
+    )
+    scheduler.process(transformation=ReplaceKernels({
+        'leaf': {
+            'routine': 'leaf_replacement',
+            'args': {
+                'flag2': 'flag2_renamed',
+                'geom': {'map_to': 'block_count', 'member': 'DIM%NGPBLKS'},
+                'end_idx': 'end_in',
+                'on_gpu': '.false.',
+            },
+        }
+    }))
+
+    item_map = _get_item_map(scheduler)
+    _, calls, imports, _ = _get_routine_and_calls(item_map, 'edge_wrapper_mod#edge_wrapper')
+
+    assert len(calls) == 1
+    assert calls[0].name == 'leaf_replacement'
+    assert ('block_count', 'geom%dim%ngpblks') in calls[0].kwarguments
+    assert any(imp.module == 'leaf_replacement_mod' for imp in imports)

--- a/loki/transformations/tests/test_unused_routines.py
+++ b/loki/transformations/tests/test_unused_routines.py
@@ -1,0 +1,149 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from loki import Module
+from loki.frontend import OMNI, available_frontends
+from loki.ir import FindNodes, nodes as ir
+from loki.transformations import SanitiseUnusedRoutineTransformation
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_sanitise_unused_routine_transformation(frontend, tmp_path):
+    """Defer kept array shapes, drop local arrays, and replace the body with an error-stop stub."""
+    fcode = """
+module legacy_unused_mod
+  implicit none
+
+contains
+
+  subroutine legacy_unused(nblocks, pout)
+    integer, intent(in) :: nblocks
+    real, optional, intent(out) :: pout(10, nblocks, 2)
+    real, pointer, contiguous :: zoper(:, :, :)
+    real, allocatable :: zbuffer(:, :)
+    real :: zouts(10, nblocks)
+
+    nullify(zoper)
+    zouts = 0.0
+    if (present(pout)) pout(1, 1, 1) = 0.0
+  end subroutine legacy_unused
+
+  subroutine still_used(a)
+    real, intent(inout) :: a(:)
+    a = 0.0
+  end subroutine still_used
+end module legacy_unused_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['legacy_unused']
+    untouched = module['still_used']
+
+    trafo = SanitiseUnusedRoutineTransformation(routines=('legacy_unused',), stub_kind='error_stop')
+    trafo.apply(routine)
+
+    decls = FindNodes(ir.VariableDeclaration).visit(routine.spec)
+    pout_decl = next(decl for decl in decls if any(sym.name.lower() == 'pout' for sym in decl.symbols))
+    zoper_decl = next(decl for decl in decls if any(sym.name.lower() == 'zoper' for sym in decl.symbols))
+    zbuffer_decl = next(decl for decl in decls if any(sym.name.lower() == 'zbuffer' for sym in decl.symbols))
+    pout = next(sym for sym in pout_decl.symbols if sym.name.lower() == 'pout')
+    zoper = next(sym for sym in zoper_decl.symbols if sym.name.lower() == 'zoper')
+    zbuffer = next(sym for sym in zbuffer_decl.symbols if sym.name.lower() == 'zbuffer')
+    declared_names = {sym.name.lower() for decl in decls for sym in decl.symbols}
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    untouched_intrinsics = FindNodes(ir.Intrinsic).visit(untouched.body)
+
+    assert pout.type.shape == (':', ':', ':')
+    assert pout.dimensions == (':', ':', ':')
+    assert zoper.type.shape == (':', ':', ':')
+    assert zoper.dimensions == (':', ':', ':')
+    assert zbuffer.type.shape == (':', ':')
+    assert zbuffer.dimensions == (':', ':')
+    assert 'zouts' not in declared_names
+    assert len(intrinsics) == 1
+    assert 'error stop "sanitised unused routine legacy_unused was called"' in intrinsics[0].text.lower()
+    assert not untouched_intrinsics
+    assert len(FindNodes(ir.Assignment).visit(untouched.body)) == 1
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_sanitise_unused_routine_by_qualified_name(frontend, tmp_path):
+    """Match configured routines by fully qualified module-and-routine name."""
+    fcode = """
+module another_legacy_mod
+contains
+  subroutine keep_me(a)
+    real :: a(5)
+    a = 1.0
+  end subroutine keep_me
+end module another_legacy_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['keep_me']
+
+    trafo = SanitiseUnusedRoutineTransformation(
+        routines=('another_legacy_mod#keep_me',), stub_kind='error_stop'
+    )
+    trafo.apply(routine)
+
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    assert len(intrinsics) == 1
+    assert 'error stop "sanitised unused routine keep_me was called"' in intrinsics[0].text.lower()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_sanitise_unused_routine_empty_stub(frontend, tmp_path):
+    """Allow sanitised routines to use an empty executable section instead of an error-stop stub."""
+    fcode = """
+module empty_stub_mod
+contains
+  subroutine legacy_noop(a)
+    real, intent(inout) :: a(:)
+    a = 2.0
+  end subroutine legacy_noop
+end module empty_stub_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['legacy_noop']
+
+    trafo = SanitiseUnusedRoutineTransformation(routines=('legacy_noop',), stub_kind='empty')
+    trafo.apply(routine)
+
+    assert routine.body.body == ()
+    assert not FindNodes(ir.Intrinsic).visit(routine.body)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
+def test_sanitise_unused_routine_no_match(frontend, tmp_path):
+    """Leave routines unchanged when they are not configured for sanitisation."""
+    fcode = """
+module no_match_mod
+contains
+  subroutine active_kernel(a)
+    real, intent(inout) :: a(:)
+    a = 3.0
+  end subroutine active_kernel
+end module no_match_mod
+"""
+    module = Module.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = module['active_kernel']
+
+    trafo = SanitiseUnusedRoutineTransformation(routines=('other_kernel',), stub_kind='error_stop')
+    trafo.apply(routine)
+
+    assignments = FindNodes(ir.Assignment).visit(routine.body)
+    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+
+    assert len(assignments) == 1
+    assert not intrinsics
+
+
+def test_sanitise_unused_routine_rejects_unknown_stub_kind():
+    """Reject unsupported stub kinds early during transformation construction."""
+    with pytest.raises(ValueError, match='Invalid stub_kind'):
+        SanitiseUnusedRoutineTransformation(stub_kind='warn')

--- a/loki/transformations/tests/test_unused_routines.py
+++ b/loki/transformations/tests/test_unused_routines.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from loki import Module
+from loki import Module, Sourcefile
 from loki.frontend import OMNI, available_frontends
 from loki.ir import FindNodes, nodes as ir
 from loki.transformations import SanitiseUnusedRoutineTransformation
@@ -55,8 +55,8 @@ end module legacy_unused_mod
     zoper = next(sym for sym in zoper_decl.symbols if sym.name.lower() == 'zoper')
     zbuffer = next(sym for sym in zbuffer_decl.symbols if sym.name.lower() == 'zbuffer')
     declared_names = {sym.name.lower() for decl in decls for sym in decl.symbols}
-    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
-    untouched_intrinsics = FindNodes(ir.Intrinsic).visit(untouched.body)
+    intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
+    untouched_intrinsics = FindNodes(ir.GenericStmt).visit(untouched.body)
 
     assert pout.type.shape == (':', ':', ':')
     assert pout.dimensions == (':', ':', ':')
@@ -91,7 +91,7 @@ end module another_legacy_mod
     )
     trafo.apply(routine)
 
-    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
     assert len(intrinsics) == 1
     assert 'error stop "sanitised unused routine keep_me was called"' in intrinsics[0].text.lower()
 
@@ -115,7 +115,7 @@ end module empty_stub_mod
     trafo.apply(routine)
 
     assert routine.body.body == ()
-    assert not FindNodes(ir.Intrinsic).visit(routine.body)
+    assert not FindNodes(ir.GenericStmt).visit(routine.body)
 
 
 @pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI module type definitions not available')]))
@@ -137,10 +137,53 @@ end module no_match_mod
     trafo.apply(routine)
 
     assignments = FindNodes(ir.Assignment).visit(routine.body)
-    intrinsics = FindNodes(ir.Intrinsic).visit(routine.body)
+    intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
 
     assert len(assignments) == 1
     assert not intrinsics
+
+
+@pytest.mark.parametrize('frontend', available_frontends(skip=[(OMNI, 'OMNI skips C imports in the frontend')]))
+def test_sanitise_unused_routine_removes_c_imports(frontend, tmp_path):
+    """Drop C-style include imports while preserving ordinary Fortran imports."""
+    filepath = tmp_path/'unused_c_import.F90'
+    include_path = tmp_path/'legacy_unused.intfb.h'
+    include_path.write_text('! interface intentionally empty\n')
+    filepath.write_text(
+        """
+module helper_mod
+  implicit none
+  integer, parameter :: rk = kind(1.0)
+end module helper_mod
+
+module c_import_unused_mod
+contains
+  subroutine legacy_unused(a)
+    use helper_mod, only: rk
+    real(kind=rk), intent(inout) :: a(:)
+#include "legacy_unused.intfb.h"
+    a = 0.0_rk
+  end subroutine legacy_unused
+end module c_import_unused_mod
+""".strip()
+    )
+    source = Sourcefile.from_file(filepath, frontend=frontend, includes=[tmp_path], xmods=[tmp_path])
+    routine = source['c_import_unused_mod']['legacy_unused']
+
+    before_imports = FindNodes(ir.Import).visit((routine.spec, routine.body))
+    assert any(imp.c_import for imp in before_imports)
+    assert any(not imp.c_import and imp.module == 'helper_mod' for imp in before_imports)
+
+    trafo = SanitiseUnusedRoutineTransformation(routines=('legacy_unused',), stub_kind='error_stop')
+    trafo.apply(routine)
+
+    imports = FindNodes(ir.Import).visit((routine.spec, routine.body))
+    intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
+
+    assert not any(imp.c_import for imp in imports)
+    assert any(not imp.c_import and imp.module == 'helper_mod' for imp in imports)
+    assert len(intrinsics) == 1
+    assert 'error stop "sanitised unused routine legacy_unused was called"' in intrinsics[0].text.lower()
 
 
 def test_sanitise_unused_routine_rejects_unknown_stub_kind():


### PR DESCRIPTION
* Fix SubstituteExpressionsMapper to also register the underlying VariableSymbol when the expression map key is a MetaSymbol, so that derived-type parent substitution (e.g. geom -> geom_new propagating to geom%dim%nproma) works correctly.
* Add a recurse_var_parent flag to LokiWalkMapper (default True, backward compatible) and a new FindUsedVariables expression finder that collects variables as they are used without decomposing derived-type parents into separate entries.
* Add get_block_index to TemporariesPoolAllocatorTransformation so the pool allocator can resolve derived-type block-dimension indices (e.g. geom%blk_dim%ib) instead of only matching simple variable names. Add ignore_index_undefined flag to promote_variables so callers can keep an explicit index expression even when dataflow analysis cannot prove it is live at every use site.

### Description

This pull request introduces several enhancements and fixes to variable handling in expression mapping, array promotion, and temporary pool allocator transformations. The main changes focus on providing more precise variable collection, supporting explicit index retention in array promotions, and improving the resolution of derived-type block indices. Comprehensive tests are added to ensure the correctness of these new behaviors.

**Expression mapping and variable collection:**

* Added a new `FindUsedVariables` visitor in `loki/ir/expr_visitors.py` that collects only the used member expressions without recursing into their parent chains, improving the precision of variable usage analysis. (`[loki/ir/expr_visitors.pyR187-R198](diffhunk://#diff-cd38c31e937a1478653d40a9f97adea800fadd922039b18b42b013e9b2b6c4b5R187-R198)`)
* Updated `LokiWalkMapper` to allow controlling recursion into parent components via a new `recurse_var_parent` argument. (`[loki/expression/mappers.pyR229-R236](diffhunk://#diff-86dcd26846fd8111831a312d147a885c713b6397e5d43bdf4180abebdba96b11R229-R236)`)
* Added a test to verify that `FindUsedVariables` skips parent components as intended. (`[loki/expression/tests/test_expression.pyR1381-R1402](diffhunk://#diff-edcf72b91a67e888e51fc7cabcd6cb87e6e4b561a8e2d60c38e2e3358d816025R1381-R1402)`)

**Array promotion transformation:**

* Enhanced `promote_variables` to accept an `ignore_index_undefined` argument, allowing explicit retention of unresolved promotion indices when requested. (`[[1]](diffhunk://#diff-8afd2442c2d2f132b71a1eb4c2ba566fe746d19438462919cc0cd58b67cd2f3bL30-R30)`, `[[2]](diffhunk://#diff-8afd2442c2d2f132b71a1eb4c2ba566fe746d19438462919cc0cd58b67cd2f3bR59-R61)`, `[[3]](diffhunk://#diff-8afd2442c2d2f132b71a1eb4c2ba566fe746d19438462919cc0cd58b67cd2f3bR86-R90)`)
* Added a test to ensure unresolved indices are kept verbatim when `ignore_index_undefined=True`. (`[loki/transformations/array_indexing/tests/test_array_promote.pyR144-R170](diffhunk://#diff-25ca74992672348eefeb9c76bc8d9a890c46cdca3bf7b08cbbce4dd035e529d5R144-R170)`)

**Temporary pool allocator transformation:**

* Added logic to resolve derived-type block indices via configured dimension aliases in `get_block_index`, improving support for more complex block index forms. (`[[1]](diffhunk://#diff-dee9adcde30167e25ddb24c4b6de20aae9bcba38017850a137261592e44be4bcR410-R423)`, `[[2]](diffhunk://#diff-dee9adcde30167e25ddb24c4b6de20aae9bcba38017850a137261592e44be4bcL858-R872)`)
* Added a test to verify that derived-type block indices are resolved as intended. (`[loki/transformations/temporaries/tests/test_pool_allocator.pyR1432-R1452](diffhunk://#diff-a999af48b93ac47f0c05921f255e19c790f6e7fd1a22a9927a6addf758d93400R1432-R1452)`)

**Other improvements:**

* Improved `SubstituteExpressionsMapper` to handle `MetaSymbol` keys by also mapping their underlying symbols. (`[loki/expression/mappers.pyR752-R757](diffhunk://#diff-86dcd26846fd8111831a312d147a885c713b6397e5d43bdf4180abebdba96b11R752-R757)`)
* Minor import and test updates to support the new features. (`[[1]](diffhunk://#diff-edcf72b91a67e888e51fc7cabcd6cb87e6e4b561a8e2d60c38e2e3358d816025L27-R27)`, `[[2]](diffhunk://#diff-cd38c31e937a1478653d40a9f97adea800fadd922039b18b42b013e9b2b6c4b5L29-R29)`, `[[3]](diffhunk://#diff-25ca74992672348eefeb9c76bc8d9a890c46cdca3bf7b08cbbce4dd035e529d5R15)`, `[[4]](diffhunk://#diff-a999af48b93ac47f0c05921f255e19c790f6e7fd1a22a9927a6addf758d93400L11-R11)`)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 