### PR TITLE
Small kernels pipeline

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Clone ECWAM
         uses: actions/checkout@v4
         with:
-          repository: ecmwf-ifs/ecwam
+          repository: MichaelSt98/ecwam
           path: ecwam
-          ref: develop
+          ref: nams_loki_seed_policiy 
 
       - name: Set up Fortran compiler ${{ matrix.toolchain.compiler }} ${{ matrix.toolchain.version }}
         uses: fortran-lang/setup-fortran@v1

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -160,6 +160,27 @@ class Scheduler:
     # TODO: Should be user-definable!
     source_suffixes = ['.f90', '.F90', '.f', '.F']
 
+    @staticmethod
+    def _get_implicit_seeds(config):
+        """
+        Derive implicit seed routines from the scheduler config.
+
+        By default, only driver routines and routines explicitly marked with
+        ``seed_routine = true`` become graph roots.
+        """
+        implicit_seeds = tuple(
+            name.lower() for name in config.routines
+            if config.create_item_config(name).get('role') == 'driver'
+            or config.create_item_config(name).get('seed_routine', False)
+        )
+        if not implicit_seeds:
+            raise RuntimeError(
+                'No seed routines provided and no implicit seeds found in the scheduler config. '
+                'Set `seed_routines`, mark routines with `role = "driver"`, or set '
+                '`seed_routine = true`.'
+            )
+        return implicit_seeds
+
     def __init__(self, paths, config=None, seed_routines=None, preprocess=False,
                  includes=None, defines=None, definitions=None, xmods=None,
                  omni_includes=None, full_parse=True, frontend=FP, output_dir=None):
@@ -175,10 +196,8 @@ class Scheduler:
 
         # Build-related arguments to pass to the sources
         self.paths = [Path(p) for p in as_tuple(paths)]
-        self.seeds = tuple(
-            seed.lower()
-            for seed in as_tuple(seed_routines) or self.config.routines.keys()
-        )
+        self.seeds = tuple(seed.lower() for seed in as_tuple(seed_routines)) if seed_routines else \
+            self._get_implicit_seeds(self.config)
 
         # Accumulate all build arguments to pass to `Sourcefile` constructors
         self.build_args = {

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -174,11 +174,13 @@ class Scheduler:
             or config.create_item_config(name).get('seed_routine', False)
         )
         if not implicit_seeds:
-            raise RuntimeError(
-                'No seed routines provided and no implicit seeds found in the scheduler config. '
-                'Set `seed_routines`, mark routines with `role = "driver"`, or set '
-                '`seed_routine = true`.'
-            )
+            implicit_seeds = tuple(seed.lower() for seed in config.routines.keys())
+            warning("[Loki]: "
+                "Using implicit or unspecified seed routines is deprecated and will be removed in a future release. "
+                "Currently, no seed routines were provided and none were discovered in the scheduler config. "
+                "Please update your configuration by setting `seed_routines`, "
+                "marking routines with `role = \"driver\"`, "
+                "or setting `seed_routine = true`.")
         return implicit_seeds
 
     def __init__(self, paths, config=None, seed_routines=None, preprocess=False,
@@ -196,8 +198,12 @@ class Scheduler:
 
         # Build-related arguments to pass to the sources
         self.paths = [Path(p) for p in as_tuple(paths)]
-        self.seeds = tuple(seed.lower() for seed in as_tuple(seed_routines)) if seed_routines else \
-            self._get_implicit_seeds(self.config)
+        if seed_routines:
+            info('Initializing Scheduler graph from list of seed routines provided in the config')
+            self.seeds = tuple(seed.lower() for seed in as_tuple(seed_routines))
+        else:
+            info('Initializing Scheduler graph from driver routines')
+            self.seeds = self._get_implicit_seeds(self.config)
 
         # Accumulate all build arguments to pass to `Sourcefile` constructors
         self.build_args = {

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -210,9 +210,13 @@ class SGraph:
         if new_items:
             self.add_nodes(new_items)
 
-        # propagate 'lib' attribute (the compile unit the item belongs to)
+        # Propagate the parent lib unless the child has an explicit routine-level
+        # library override in the scheduler config.
         for new_item in new_items:
-            new_item.config['lib'] = item.config.get('lib', None)
+            keys = config.match_item_keys(new_item.name, config.routines)
+            has_explicit_lib = any('lib' in config.routines[key] for key in keys)
+            if not has_explicit_lib:
+                new_item.config['lib'] = item.config.get('lib', None)
 
         # Careful not to include cycles (from recursive TypeDefs)
         self.add_edges((item, item_) for item_ in dependencies if not item == item_)

--- a/loki/batch/tests/test_scheduler_config.py
+++ b/loki/batch/tests/test_scheduler_config.py
@@ -824,7 +824,6 @@ def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_sch
             'subroutine_3_loki_m1_mod#subroutine_3_loki_m1',
             'nested_subroutine_1_loki_m1_mod#nested_subroutine_1_loki_m1',
             'nested_subroutine_3_loki_m1_mod#nested_subroutine_3_loki_m1',
-            'nested_subroutine_3_mod#nested_subroutine_3',
         },
         'm2': {
             'driver_2_mod#driver_2',
@@ -890,7 +889,7 @@ def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_sch
         'driver_0_mod.m1', 'driver_1_mod.m1', 'driver_2_mod.m2', 'driver_3_mod.m3',
         'driver_4_mod.m3', 'nested_subroutine_1_loki_m1_mod.m1',
         'nested_subroutine_1_loki_m3_mod.m3', 'nested_subroutine_2_loki_m2_mod.m2',
-        'nested_subroutine_3_mod.m1', 'nested_subroutine_3_loki_m1_mod.m1',
+        'nested_subroutine_3_loki_m1_mod.m1',
         'nested_subroutine_3_loki_m2_mod.m2', 'nested_subroutine_3_loki_m3_mod.m3',
         'subroutine_1_loki_m1_mod.m1', 'subroutine_2_loki_m2_mod.m2',
         'subroutine_3_loki_m1_mod.m1', 'subroutine_3_loki_m3_mod.m3'
@@ -1059,3 +1058,320 @@ end module test_multi_modes_kernel2
             item_imports = item_ir.imports
             imported_modules = {imp.module for imp in item_imports}
             assert imported_modules == imports
+
+
+def _write_shared_kernel_multi_mode_sources(src_dir):
+    """
+    Create a minimal multi-mode graph with two drivers sharing one kernel that
+    calls a downstream leaf.
+    """
+    fcode_driver_small = """
+subroutine driver_small
+    use shared_kernel_mod, only: shared_kernel
+    implicit none
+    call shared_kernel
+end subroutine driver_small
+    """.strip()
+
+    fcode_driver_stack = """
+subroutine driver_stack
+    use shared_kernel_mod, only: shared_kernel
+    implicit none
+    call shared_kernel
+end subroutine driver_stack
+    """.strip()
+
+    fcode_shared_kernel = """
+module shared_kernel_mod
+implicit none
+contains
+subroutine shared_kernel
+    use leaf_mod, only: leaf
+    call leaf
+end subroutine shared_kernel
+end module shared_kernel_mod
+    """.strip()
+
+    fcode_leaf = """
+module leaf_mod
+implicit none
+contains
+subroutine leaf
+end subroutine leaf
+end module leaf_mod
+    """.strip()
+
+    (src_dir/'driver_small.F90').write_text(fcode_driver_small)
+    (src_dir/'driver_stack.F90').write_text(fcode_driver_stack)
+    (src_dir/'shared_kernel_mod.F90').write_text(fcode_shared_kernel)
+    (src_dir/'leaf_mod.F90').write_text(fcode_leaf)
+
+
+def _shared_kernel_multi_mode_config():
+    return SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm_small', 'replicate': True},
+        'routines': {
+            'driver_small': {'role': 'driver', 'mode': 'm_small', 'replicate': False},
+            'driver_stack': {'role': 'driver', 'mode': 'm_stack', 'replicate': False},
+        },
+        'transformations': {
+            'IdemSmall': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'IdemStack': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+        },
+        'pipelines': {
+            'm_small': {'transformations': {'IdemSmall'}},
+            'm_stack': {'transformations': {'IdemStack'}},
+        },
+    })
+
+
+def _shared_kernel_multi_mode_override_config():
+    return SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm_small', 'replicate': True},
+        'routines': {
+            'driver_small': {'role': 'driver', 'mode': 'm_small', 'replicate': False},
+            'driver_stack': {'role': 'driver', 'mode': 'm_stack', 'replicate': False},
+            'shared_kernel': {'role': 'kernel'},
+            'leaf': {'role': 'kernel'},
+        },
+        'transformations': {
+            'IdemSmall': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'IdemStack': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+        },
+        'pipelines': {
+            'm_small': {'transformations': {'IdemSmall'}},
+            'm_stack': {'transformations': {'IdemStack'}},
+        },
+    })
+
+
+def _shared_kernel_multi_mode_seed_override_config():
+    return SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm_small', 'replicate': True},
+        'routines': {
+            'driver_small': {'role': 'driver', 'mode': 'm_small', 'replicate': False},
+            'driver_stack': {'role': 'driver', 'mode': 'm_stack', 'replicate': False},
+            'shared_kernel': {'role': 'kernel', 'seed_routine': True},
+            'leaf': {'role': 'kernel', 'seed_routine': True},
+        },
+        'transformations': {
+            'IdemSmall': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'IdemStack': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+        },
+        'pipelines': {
+            'm_small': {'transformations': {'IdemSmall'}},
+            'm_stack': {'transformations': {'IdemStack'}},
+        },
+    })
+
+
+def test_scheduler_multi_modes_shared_kernel_plan_variants(tmp_path):
+    """
+    Document current multi-mode planning behaviour for a shared kernel.
+
+    Without explicit per-routine config entries, the original shared kernel is
+    replaced entirely by renamed per-mode variants.
+    """
+    scheduler_config = _shared_kernel_multi_mode_config()
+
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    out_dir = tmp_path/'output'
+    out_dir.mkdir()
+
+    scheduler = Scheduler(paths=src_dir, config=scheduler_config, xmods=[tmp_path], output_dir=out_dir)
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.process(scheduler_config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.process(FileWriteTransformation(), proc_strategy=ProcessingStrategy.PLAN)
+
+    plan_trafo = CMakePlanTransformation(rootpath=src_dir)
+    scheduler.process(transformation=plan_trafo, proc_strategy=ProcessingStrategy.PLAN)
+    planfile = tmp_path/'planfile'
+    plan_trafo.write_plan(planfile)
+
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+    plan_dict = {k: v.split() for k, v in plan_pattern.findall(planfile.read_text())}
+    append_stems = [Path(s).stem for s in plan_dict['LOKI_SOURCES_TO_APPEND']]
+
+    assert len(plan_dict['LOKI_SOURCES_TO_APPEND']) == len(set(plan_dict['LOKI_SOURCES_TO_APPEND']))
+
+    assert 'shared_kernel_mod.m_small' not in append_stems
+    assert append_stems.count('shared_kernel_loki_m_small_mod.m_small') == 1
+    assert append_stems.count('shared_kernel_loki_m_stack_mod.m_stack') == 1
+
+    assert 'leaf_mod.m_small' not in append_stems
+    assert append_stems.count('leaf_loki_m_small_mod.m_small') == 1
+    assert append_stems.count('leaf_loki_m_stack_mod.m_stack') == 1
+
+
+def test_scheduler_multi_modes_shared_kernel_plan_variants_with_routine_override(tmp_path):
+    """
+    Explicit per-routine config entries change the current behaviour: the
+    original shared kernel remains and same-mode clones are emitted in addition.
+    """
+    scheduler_config = _shared_kernel_multi_mode_override_config()
+
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    out_dir = tmp_path/'output'
+    out_dir.mkdir()
+
+    scheduler = Scheduler(
+        paths=src_dir, config=scheduler_config,
+        seed_routines=['driver_small', 'driver_stack', 'shared_kernel', 'leaf'],
+        xmods=[tmp_path], output_dir=out_dir
+    )
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.process(scheduler_config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.process(FileWriteTransformation(), proc_strategy=ProcessingStrategy.PLAN)
+
+    plan_trafo = CMakePlanTransformation(rootpath=src_dir)
+    scheduler.process(transformation=plan_trafo, proc_strategy=ProcessingStrategy.PLAN)
+    planfile = tmp_path/'planfile'
+    plan_trafo.write_plan(planfile)
+
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+    plan_dict = {k: v.split() for k, v in plan_pattern.findall(planfile.read_text())}
+    append_stems = [Path(s).stem for s in plan_dict['LOKI_SOURCES_TO_APPEND']]
+
+    assert len(plan_dict['LOKI_SOURCES_TO_APPEND']) == len(set(plan_dict['LOKI_SOURCES_TO_APPEND']))
+
+    # This matches the semantic duplication pattern seen in the real-world case.
+    assert append_stems.count('shared_kernel_mod.m_small') == 1
+    assert append_stems.count('shared_kernel_loki_m_small_mod.m_small') == 1
+    assert append_stems.count('shared_kernel_loki_m_stack_mod.m_stack') == 1
+
+    assert append_stems.count('leaf_mod.m_small') == 1
+    assert append_stems.count('leaf_loki_m_small_mod.m_small') == 1
+    assert append_stems.count('leaf_loki_m_stack_mod.m_stack') == 1
+
+
+def test_scheduler_multi_modes_shared_kernel_call_import_rewrite_consistency(tmp_path):
+    """
+    Document how call and import rewrites currently behave for shared kernels.
+
+    Both drivers are rewired to mode-specific clones, while the original shared
+    kernel and leaf remain in the scheduler with their original call/import chain.
+    """
+    scheduler_config = _shared_kernel_multi_mode_override_config()
+
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    out_dir = tmp_path/'output'
+    out_dir.mkdir()
+
+    scheduler = Scheduler(
+        paths=src_dir, config=scheduler_config,
+        seed_routines=['driver_small', 'driver_stack', 'shared_kernel', 'leaf'],
+        xmods=[tmp_path], output_dir=out_dir
+    )
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.DEFAULT)
+    scheduler.process(scheduler_config.pipelines, proc_strategy=ProcessingStrategy.DEFAULT)
+
+    expected_items = {
+        '#driver_small',
+        '#driver_stack',
+        'shared_kernel_mod#shared_kernel',
+        'shared_kernel_loki_m_small_mod#shared_kernel_loki_m_small',
+        'shared_kernel_loki_m_stack_mod#shared_kernel_loki_m_stack',
+        'leaf_mod#leaf',
+        'leaf_loki_m_small_mod#leaf_loki_m_small',
+        'leaf_loki_m_stack_mod#leaf_loki_m_stack',
+    }
+    assert expected_items <= {item.name for item in scheduler.items}
+
+    def calls_for(item_name):
+        routine = scheduler[item_name].ir
+        return tuple(str(call.name).lower() for call in FindNodes(ir.CallStatement).visit(routine.body))
+
+    def imports_for(item_name):
+        routine = scheduler[item_name].ir
+        return {imp.module.lower() for imp in routine.imports}
+
+    assert calls_for('#driver_small') == ('shared_kernel_loki_m_small',)
+    assert imports_for('#driver_small') == {'shared_kernel_loki_m_small_mod'}
+
+    assert calls_for('#driver_stack') == ('shared_kernel_loki_m_stack',)
+    assert imports_for('#driver_stack') == {'shared_kernel_loki_m_stack_mod'}
+
+    assert calls_for('shared_kernel_loki_m_small_mod#shared_kernel_loki_m_small') == ('leaf_loki_m_small',)
+    assert imports_for('shared_kernel_loki_m_small_mod#shared_kernel_loki_m_small') == {'leaf_loki_m_small_mod'}
+
+    assert calls_for('shared_kernel_loki_m_stack_mod#shared_kernel_loki_m_stack') == ('leaf_loki_m_stack',)
+    assert imports_for('shared_kernel_loki_m_stack_mod#shared_kernel_loki_m_stack') == {'leaf_loki_m_stack_mod'}
+
+    # The original shared kernel remains active with the original import/call chain.
+    assert calls_for('shared_kernel_mod#shared_kernel') == ('leaf',)
+    assert imports_for('shared_kernel_mod#shared_kernel') == {'leaf_mod'}
+
+
+def test_scheduler_multi_modes_explicit_routine_entries_do_not_become_seeds(tmp_path):
+    """
+    Explicit routine config entries alone do not become scheduler seeds when
+    seed_routines is not provided.
+    """
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    no_override_scheduler = Scheduler(
+        paths=src_dir, config=_shared_kernel_multi_mode_config(),
+        xmods=[tmp_path], output_dir=tmp_path/'out-no-override'
+    )
+    override_scheduler = Scheduler(
+        paths=src_dir, config=_shared_kernel_multi_mode_override_config(), xmods=[tmp_path],
+        output_dir=tmp_path/'out-override'
+    )
+
+    assert no_override_scheduler.seeds == ('driver_small', 'driver_stack')
+    assert override_scheduler.seeds == ('driver_small', 'driver_stack')
+
+    no_override_scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.DEFAULT)
+    override_scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.DEFAULT)
+
+    assert 'shared_kernel_mod#shared_kernel' not in {item.name for item in no_override_scheduler.items}
+    assert 'shared_kernel_mod#shared_kernel' not in {item.name for item in override_scheduler.items}
+
+
+def test_scheduler_implicit_seeds_include_seed_routine_entries(tmp_path):
+    """
+    Non-driver routines explicitly marked with ``seed_routine = true`` are added
+    to the implicit seed set alongside driver routines.
+    """
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    scheduler = Scheduler(
+        paths=src_dir, config=_shared_kernel_multi_mode_seed_override_config(),
+        xmods=[tmp_path], output_dir=tmp_path/'output'
+    )
+
+    assert scheduler.seeds == ('driver_small', 'driver_stack', 'shared_kernel', 'leaf')
+
+
+def test_scheduler_requires_implicit_seed_or_explicit_seed_routines(tmp_path):
+    """
+    When no explicit seeds are provided, the scheduler requires at least one
+    implicit seed via a driver role or ``seed_routine = true``.
+    """
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    config = SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False},
+        'routines': {
+            'shared_kernel': {'role': 'kernel'},
+            'leaf': {'role': 'kernel'},
+        },
+    })
+
+    with pytest.raises(RuntimeError, match='No seed routines provided and no implicit seeds found'):
+        Scheduler(paths=src_dir, config=config, xmods=[tmp_path], output_dir=tmp_path/'output')

--- a/loki/batch/tests/test_scheduler_config.py
+++ b/loki/batch/tests/test_scheduler_config.py
@@ -13,6 +13,7 @@ from subprocess import CalledProcessError
 
 import pytest
 
+from loki.logging import WARNING
 from loki import Array, Dimension, FindNodes, Literal, Sourcefile
 from loki.batch import Pipeline, ProcessingStrategy, Scheduler, SchedulerConfig, Transformation
 from loki.frontend import HAVE_FP, HAVE_OMNI, OMNI, available_frontends
@@ -1356,7 +1357,7 @@ def test_scheduler_implicit_seeds_include_seed_routine_entries(tmp_path):
     assert scheduler.seeds == ('driver_small', 'driver_stack', 'shared_kernel', 'leaf')
 
 
-def test_scheduler_requires_implicit_seed_or_explicit_seed_routines(tmp_path):
+def test_scheduler_requires_implicit_seed_or_explicit_seed_routines(tmp_path, caplog):
     """
     When no explicit seeds are provided, the scheduler requires at least one
     implicit seed via a driver role or ``seed_routine = true``.
@@ -1373,5 +1374,12 @@ def test_scheduler_requires_implicit_seed_or_explicit_seed_routines(tmp_path):
         },
     })
 
-    with pytest.raises(RuntimeError, match='No seed routines provided and no implicit seeds found'):
-        Scheduler(paths=src_dir, config=config, xmods=[tmp_path], output_dir=tmp_path/'output')
+    caplog.set_level(WARNING)
+
+    # Once deprecated:
+    # with pytest.raises(RuntimeError, match='No seed routines provided and no implicit seeds found'):
+    scheduler = Scheduler(paths=src_dir, config=config, xmods=[tmp_path], output_dir=tmp_path/'output')
+    # however, rn for backwards compability only expect warning and old behaviour
+    assert set(scheduler.seeds) == {'shared_kernel', 'leaf'}
+    assert len(caplog.records) == 1
+    assert "Using implicit or unspecified seed routines is deprecated and will" in caplog.records[0].message

--- a/loki/batch/tests/test_scheduler_processing.py
+++ b/loki/batch/tests/test_scheduler_processing.py
@@ -232,6 +232,7 @@ def test_scheduler_dependencies_ignore(tmp_path, testdir, preprocess, frontend):
 
     schedulerB = Scheduler(
         paths=projB, includes=projB/'include', config=configB,
+        seed_routines=['ext_driver'],
         frontend=frontend, preprocess=preprocess, xmods=[tmp_path]
     )
 
@@ -288,10 +289,10 @@ def test_scheduler_dependencies_ignore(tmp_path, testdir, preprocess, frontend):
         # Apply dependency injection transformation and ensure only the root driver is not transformed
         schedulerA.process(transformation)
 
-    assert schedulerA.items[0].source.all_subroutines[0].name == 'driverB'
-    assert schedulerA.items[1].source.all_subroutines[0].name == 'kernelB_test'
-    assert schedulerA.items[4].source.all_subroutines[0].name == 'compute_l1_test'
-    assert schedulerA.items[5].source.all_subroutines[0].name == 'compute_l2_test'
+    assert schedulerA['driverb_mod#driverb'].source.all_subroutines[0].name == 'driverB'
+    assert schedulerA['kernelb_test_mod#kernelb_test'].source.all_subroutines[0].name == 'kernelB_test'
+    assert schedulerA['compute_l1_test_mod#compute_l1_test'].source.all_subroutines[0].name == 'compute_l1_test'
+    assert schedulerA['compute_l2_test_mod#compute_l2_test'].source.all_subroutines[0].name == 'compute_l2_test'
 
     # Note that 'ext_driver' and 'ext_kernel' are no longer part of the dependency graph because the
     # renaming makes it impossible to discover the non-transformed routines

--- a/loki/lint/tests/test_linter.py
+++ b/loki/lint/tests/test_linter.py
@@ -512,7 +512,7 @@ def test_linter_lint_files_scheduler(testdir, rules, routines, files):
             'expand': True,
             'strict': True,
         },
-        'routines': {'other_routine': {}}
+        'routines': {'other_routine': {'seed_routine': True}}
     }},
     {'include': ['linter_lint_files_fix.F90']}
 ])
@@ -584,7 +584,7 @@ end subroutine OTHER_ROUTINE
             'expand': True,
             'strict': True
         },
-        'routines': {'other_routine': {}}
+        'routines': {'other_routine': {'seed_routine': True}}
     }},
     {'include': ['*.F90']}
 ])

--- a/loki/transformations/__init__.py
+++ b/loki/transformations/__init__.py
@@ -33,6 +33,7 @@ from loki.transformations.transform_loop import * # noqa
 from loki.transformations.transform_region import * # noqa
 from loki.transformations.utilities import * # noqa
 from loki.transformations.block_index_transformations import * # noqa
+from loki.transformations.block_index_transformations_sk import * # noqa
 from loki.transformations.split_read_write import * # noqa
 from loki.transformations.loop_blocking import * # noqa
 from loki.transformations.routine_signatures import * # noqa

--- a/loki/transformations/block_index_transformations.py
+++ b/loki/transformations/block_index_transformations.py
@@ -378,7 +378,10 @@ class InjectBlockIndexTransformation(Transformation):
         elif role == 'driver':
             with pragmas_attached(routine, ir.Loop):
                 for loop in find_driver_loops(routine.body, targets):
-                    body = self.process_body(loop.body, block_index, targets, exclude_arrays, force_inject_arrays)
+                    loop_block_index = self.get_block_index(routine, variable_map, loop=loop)
+                    body = self.process_body(
+                        loop.body, loop_block_index, targets, exclude_arrays, force_inject_arrays
+                    )
                     body_map = {loop.body: body}
                     Transformer(body_map, inplace=True).visit(loop)
 
@@ -395,13 +398,29 @@ class InjectBlockIndexTransformation(Transformation):
 
         return rank
 
-    def get_block_index(self, routine, variable_map):
+    def get_block_index(self, routine, variable_map, loop=None):
         """
         Utility to retrieve the block-index loop induction variable.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The routine to search in.
+        variable_map : dict
+            The routine's variable map.
+        loop : :any:`Loop`, optional
+            If provided, also search assignment LHS in the loop body
+            for block-index aliases (e.g. ``IBL = YDGEOMETRY%YRDIM%...``).
+            This fallback is only used when the primary index is not found
+            directly in the variable map.
         """
 
         if (block_index := variable_map.get(self.block_dim.index, None)):
             return block_index
+        if loop is not None:
+            for assign in FindNodes(ir.Assignment).visit(loop.body):
+                if assign.lhs in self.block_dim.indices:
+                    return assign.lhs
         if (block_index := [i for i in self.block_dim.indices
                             if i.split('%', maxsplit=1)[0] in variable_map]):
             return routine.resolve_typebound_var(block_index[0], variable_map)

--- a/loki/transformations/block_index_transformations_sk.py
+++ b/loki/transformations/block_index_transformations_sk.py
@@ -363,7 +363,7 @@ class LowerBlockIndexSKTransformation(LowerBlockIndexTransformation):
                 insert_pos = next(
                     (
                         idx + 1 for idx, node in enumerate(spec_body)
-                        if isinstance(node, ir.Intrinsic) and node.text.upper() == 'IMPLICIT NONE'
+                        if isinstance(node, ir.ImplicitStmt) and str(node.text).upper() == 'NONE'
                     ),
                     0
                 )

--- a/loki/transformations/block_index_transformations_sk.py
+++ b/loki/transformations/block_index_transformations_sk.py
@@ -1,0 +1,730 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Small-kernels variant of the block-index lowering transformation.
+"""
+
+from loki.batch import ProcedureItem
+from loki.ir import (
+    nodes as ir, FindNodes, Transformer, pragmas_attached,
+    SubstituteExpressions, FindUsedVariables, get_pragma_parameters
+)
+from loki.logging import warning
+from loki.tools import as_tuple, CaseInsensitiveDict
+from loki.types import BasicType, DerivedType
+from loki.expression import symbols as sym, Array, RangeIndex
+from loki.transformations.block_index_transformations import LowerBlockIndexTransformation
+from loki.transformations.sanitise import do_resolve_associates
+from loki.transformations.utilities import (
+    find_driver_loops, get_integer_variable, get_local_arrays
+)
+
+__all__ = ['LowerBlockIndexSKTransformation']
+
+
+class LowerBlockIndexSKTransformation(LowerBlockIndexTransformation):
+    """
+    Small-kernels variant of :any:`LowerBlockIndexTransformation`.
+
+    This transformation is pragma-driven: it only processes calls annotated
+    with ``!$loki small-kernels``.  It propagates block-dimension context
+    (relevant variables, driver loop template) down the call tree via
+    ``item.trafo_data['LowerBlockIndex']``, enabling multi-level lowering
+    through nested kernel calls.
+
+    The transformation:
+
+    1. Collects *relevant variables* from the driver loop header (bounds,
+       step, assignment RHS variables).
+    2. Passes them as new arguments to callee routines (using dtype-matching
+       for derived-type kwargs).
+    3. Promotes callee-local arrays with the block dimension.
+    4. Injects ``!$loki unstructured-data`` pragmas around callee bodies
+       for promoted locals.
+    5. Updates callee argument dimensions/shapes where rank mismatch exists.
+    6. Replaces block-index subscripts with range indices in call arguments.
+    7. Stores transformation state in ``trafo_data['LowerBlockIndex']`` for
+       successor items, enabling recursive application to nested kernels.
+
+    .. note::
+
+        This transformation does **not** remove the block loop from the
+        driver routine.  Block-loop removal and re-injection into kernel
+        routines is handled by :any:`SCCBlockSectionTransformation` and
+        :any:`SCCBlockSectionToLoopTransformation`, which must follow
+        this transformation in the pipeline.
+
+    For example, the following code:
+
+    .. code-block:: fortran
+
+        SUBROUTINE DRIVER(NPROMA, NLEV, NB, FIELD, YDBNDS)
+          USE TYPE_MOD, ONLY: BNDS_TYPE
+          TYPE(BNDS_TYPE), INTENT(IN) :: YDBNDS
+          REAL, INTENT(INOUT) :: FIELD(NPROMA, NLEV, NB)
+          INTEGER :: IBL
+
+          DO IBL = 1, NB
+            KIDIA = YDBNDS%KIDIA
+            !$loki small-kernels
+            CALL KERNEL(NPROMA, NLEV, FIELD(:,:,IBL))
+          END DO
+        END SUBROUTINE DRIVER
+
+        SUBROUTINE KERNEL(NPROMA, NLEV, FIELD)
+          REAL, INTENT(INOUT) :: FIELD(NPROMA, NLEV)
+          REAL :: TMP(NPROMA)
+          ...
+        END SUBROUTINE KERNEL
+
+    is transformed to:
+
+    .. code-block:: fortran
+
+        SUBROUTINE DRIVER(NPROMA, NLEV, NB, FIELD, YDBNDS)
+          ...
+          DO IBL = 1, NB
+            KIDIA = YDBNDS%KIDIA
+            CALL KERNEL(NPROMA, NLEV, FIELD(:,:,:), NB=NB, KIDIA=KIDIA, &
+                        YDBNDS=YDBNDS)
+          END DO
+        END SUBROUTINE DRIVER
+
+        SUBROUTINE KERNEL(NPROMA, NLEV, FIELD, NB, KIDIA, YDBNDS)
+          USE TYPE_MOD, ONLY: BNDS_TYPE
+          REAL, INTENT(INOUT) :: FIELD(NPROMA, NLEV, NB)
+          REAL :: TMP(NPROMA, NB)
+          TYPE(BNDS_TYPE), INTENT(INOUT) :: YDBNDS
+          !$loki unstructured-data create(TMP)
+          ...
+          !$loki exit unstructured-data delete(TMP)
+        END SUBROUTINE KERNEL
+
+    Parameters
+    ----------
+    block_dim : :any:`Dimension`
+        :any:`Dimension` object describing the variable conventions used in
+        code to define the blocking data dimension and iteration space.
+    recurse_to_kernels : bool, optional
+        Process kernel-role routines as well (default: ``True``).
+    """
+
+    # This trafo only operates on procedures
+    item_filter = (ProcedureItem,)
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Apply the small-kernels block-index lowering to *routine*.
+
+        Dispatches to :meth:`process_driver` for driver-role routines
+        and :meth:`process_kernel` for kernel-role routines (when
+        ``recurse_to_kernels`` is enabled).
+        """
+        role = kwargs['role']
+        targets = tuple(str(t).lower() for t in as_tuple(kwargs.get('targets', None)))
+        item = kwargs.get('item', None)
+        sub_sgraph = kwargs.get('sub_sgraph', None)
+        successors = sub_sgraph.successors(item) if sub_sgraph is not None else ()
+
+        do_resolve_associates(routine)
+
+        if role == 'driver':
+            self.process_driver(routine, targets, item, successors)
+        elif self.recurse_to_kernels and role == 'kernel':
+            self.process_kernel(routine, targets, item, successors)
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_call_arg_rank(arg, block_dim_indices=None):
+        """
+        Retrieve the local rank of a call argument, optionally excluding
+        dimensions that correspond to the block index.
+
+        Parameters
+        ----------
+        arg : :any:`Variable`
+            The call argument to inspect.
+        block_dim_indices : tuple, optional
+            Block-dimension index expressions to exclude from rank counting.
+        """
+        block_dim_indices = as_tuple(block_dim_indices)
+        rank = len(getattr(arg, 'shape', ()))
+        if getattr(arg, 'dimensions', None):
+            rank = rank - len([
+                d for d in arg.dimensions
+                if not (isinstance(d, RangeIndex) or d in block_dim_indices)
+            ])
+        return rank
+
+    def _resolve_block_dim_size(self, routine):
+        """
+        Resolve the block dimension size variable in the given routine.
+
+        Iterates over ``self.block_dim.sizes`` and returns the first matching
+        variable found in the routine's variable map.
+
+        Raises
+        ------
+        RuntimeError
+            If none of the configured size candidates can be resolved.
+        """
+        variable_map = routine.variable_map
+        for block_dim_size in self.block_dim.sizes:
+            if block_dim_size in variable_map:
+                return variable_map[block_dim_size]
+            if block_dim_size.split('%')[0] in variable_map:
+                return get_integer_variable(routine, block_dim_size)
+        raise RuntimeError(
+            f'{self.__class__.__name__}: Could not resolve block dimension size '
+            f'({self.block_dim.sizes}) in {routine.name}'
+        )
+
+    @staticmethod
+    def _get_root_parent(var):
+        """
+        Walk up the parent chain of *var* and return the top-level parent.
+        """
+        _var = var
+        while _var.parent is not None:
+            _var = _var.parent
+        return _var
+
+    def _find_relevant_calls(self, routine):
+        """
+        Find all calls annotated with ``!$loki small-kernels`` in *routine*.
+
+        Returns
+        -------
+        list of :any:`CallStatement`
+        """
+        relevant_calls = []
+        with pragmas_attached(routine, ir.CallStatement):
+            for call in FindNodes(ir.CallStatement).visit(routine.body):
+                if call.pragma and any(
+                    p.keyword.lower() == 'loki' and p.content.lower() == 'small-kernels'
+                    for p in call.pragma
+                ):
+                    relevant_calls.append(call)
+        return relevant_calls
+
+    @staticmethod
+    def _build_import_map(routine):
+        """
+        Build a mapping from symbol name (lower) to the Import node
+        providing it, across all imports visible to *routine*.
+        """
+        import_map = {}
+        for imp in routine.all_imports:
+            for symbol in imp.symbols:
+                import_map[symbol.name.lower()] = imp
+        return import_map
+
+    # ------------------------------------------------------------------
+    # Shared per-call helpers
+    # ------------------------------------------------------------------
+
+    def _determine_new_args(self, relevant_vars, call, driver_loop_var=None):
+        """
+        Determine which *relevant_vars* need to be added as new arguments
+        or kwargs to *call*.
+
+        Returns
+        -------
+        new_args : list
+            Positional arguments to add (root parents of derived-type vars
+            that don't match any existing dtype, or plain scalars).
+        new_kwargs : list of (str, Variable)
+            Keyword arguments to add (dtype-matched derived-type parents).
+        already_arg : list
+            Callee argument names for vars already passed.
+        """
+        call_arg_map = {v: k for k, v in call.arg_map.items()}
+        call_arg_dtype_map = {
+            v.type.dtype: v for v in call.routine.arguments if hasattr(v, 'type')
+        }
+
+        new_args = []
+        new_kwargs = []
+        already_arg = []
+
+        for var in relevant_vars:
+            if driver_loop_var is not None and var == driver_loop_var:
+                continue
+            if isinstance(var, sym._Literal):
+                continue
+            if var in call_arg_map:
+                already_arg.append(call_arg_map[var])
+                continue
+
+            if var.parent is not None:
+                parent_var = self._get_root_parent(var)
+                if parent_var not in call_arg_map:
+                    dtype = parent_var.type.dtype
+                    if dtype in call_arg_dtype_map:
+                        new_kwargs.append((call_arg_dtype_map[dtype].name, parent_var))
+                    else:
+                        new_args.append(parent_var)
+            else:
+                new_args.append(var)
+
+        new_kwargs = sorted(set(new_kwargs), key=lambda x: x[0].lower())
+        new_args = sorted(set(new_args), key=lambda x: str(x.name))
+        return new_args, new_kwargs, already_arg
+
+    def _apply_new_args_to_call(self, call, new_args, new_kwargs, already_arg):
+        """
+        Update *call* with new positional/keyword arguments, add them to
+        the callee's argument list, and mark already-passed args as inout.
+        """
+        missing_args = ()
+        if new_args or new_kwargs:
+            call._update(
+                kwarguments=(
+                    call.kwarguments
+                    + as_tuple([(a.name, a) for a in new_args])
+                    + as_tuple(new_kwargs)
+                )
+            )
+            missing_args = [a for a in new_args if a not in call.routine.arguments]
+            if missing_args:
+                call.routine.arguments += as_tuple([
+                    a.clone(scope=call.routine, type=a.type.clone(intent='inout'))
+                    for a in missing_args
+                ])
+
+        if already_arg:
+            for var in already_arg:
+                call.routine.symbol_attrs.update({
+                    var.name: call.routine.variable_map[var.name].type.clone(intent='inout')
+                })
+
+        return as_tuple(missing_args)
+
+    @staticmethod
+    def _reorder_new_dummy_declarations(routine, new_args):
+        """
+        Move declarations for newly-added dummy arguments into the existing
+        dummy declaration block.
+
+        ``Subroutine.arguments`` appends declarations for missing dummies to the
+        end of the spec. In the small-kernels path, those new dummies can then be
+        referenced in dimensions of earlier dummy-array declarations, which breaks
+        some compilers. Keep the fix local to this transformation by moving the
+        new declarations next to the other dummy declarations.
+        """
+        new_arg_names = {arg.name.lower() for arg in new_args}
+        if not new_arg_names:
+            return
+
+        declarations = FindNodes(ir.VariableDeclaration).visit(routine.spec)
+        decl_map = {decl.symbols[0].name.lower(): decl for decl in declarations if len(decl.symbols) == 1}
+        new_decls = tuple(
+            decl_map[name] for name in new_arg_names
+            if (name in decl_map and decl_map[name] in routine.spec.body)
+        )
+        if not new_decls:
+            return
+
+        existing_dummy_decls = []
+        for decl in declarations:
+            if decl in new_decls or decl not in routine.spec.body:
+                continue
+            symbols = decl.symbols
+            if all(symbol.name.lower() in routine._dummies for symbol in symbols):
+                existing_dummy_decls.append(decl)
+
+        spec_body = tuple(node for node in routine.spec.body if node not in new_decls)
+        insert_pos = next(
+            (
+                idx for idx, node in enumerate(spec_body)
+                if isinstance(node, ir.VariableDeclaration)
+                and not any(symbol.name.lower() in new_arg_names for symbol in node.symbols)
+                and any(
+                    any(part.lower() in new_arg_names for part in str(var).split('%'))
+                    for var in FindUsedVariables().visit(node)
+                    if hasattr(var, 'name')
+                )
+            ),
+            None
+        )
+        if insert_pos is None:
+            if existing_dummy_decls:
+                last_dummy_decl = existing_dummy_decls[-1]
+                insert_pos = spec_body.index(last_dummy_decl) + 1
+            else:
+                insert_pos = next(
+                    (
+                        idx + 1 for idx, node in enumerate(spec_body)
+                        if isinstance(node, ir.Intrinsic) and node.text.upper() == 'IMPLICIT NONE'
+                    ),
+                    0
+                )
+
+        routine.spec = routine.spec.clone(
+            body=spec_body[:insert_pos] + new_decls + spec_body[insert_pos:]
+        )
+
+    def _propagate_imports(self, new_args, call, all_import_map):
+        """
+        Copy derived-type and kind-parameter imports into the callee for
+        any newly-added arguments.
+        """
+        call_imported_symbols = set()
+        for imp in call.routine.all_imports:
+            call_imported_symbols.update(s.name.lower() for s in imp.symbols)
+
+        new_imports = set()
+        for arg in new_args:
+            if isinstance(arg.type.dtype, DerivedType):
+                dtype_name = arg.type.dtype.name.lower()
+                if dtype_name not in call_imported_symbols and dtype_name in all_import_map:
+                    new_imports.add(all_import_map[dtype_name])
+            if arg.type.kind is not None:
+                kind_name = str(arg.type.kind).lower()
+                if kind_name not in call_imported_symbols and kind_name in all_import_map:
+                    new_imports.add(all_import_map[kind_name])
+
+        if new_imports:
+            call.routine.spec.prepend(as_tuple(new_imports))
+
+    def promote_local_arrays(self, routine):
+        """
+        Promote local arrays in *routine* by appending the block dimension
+        size as a trailing dimension.
+
+        Returns
+        -------
+        list
+            The local variables that were promoted.
+        """
+        local_vars = get_local_arrays(routine, routine.spec)
+        local_vars = [v for v in local_vars if v.dimensions[-1] not in self.block_dim.sizes]
+
+        if not local_vars:
+            return []
+
+        block_dim_size = self._resolve_block_dim_size(routine)
+        var_map = {}
+        for local_var in local_vars:
+            new_dims = local_var.dimensions + (block_dim_size,)
+            new_shape = local_var.shape + (block_dim_size,)
+            new_type = local_var.type.clone(shape=new_shape)
+            var_map[local_var] = local_var.clone(dimensions=new_dims, type=new_type)
+        routine.spec = SubstituteExpressions(var_map).visit(routine.spec)
+        return local_vars
+
+    def _inject_data_offload_pragmas(self, routine, local_vars):
+        """
+        Inject ``!$loki unstructured-data create/delete`` pragmas around
+        the body of *routine* for the given local variables.
+        """
+        if not local_vars:
+            return
+        var_names = ', '.join(v.name for v in local_vars)
+
+        explicit_data_vars = set()
+        for pragma in FindNodes(ir.Pragma).visit(routine.body):
+            keyword = pragma.keyword.lower()
+            content = pragma.content.lower()
+            parameters = None
+
+            if keyword == 'acc':
+                if 'enter' in content and 'data' in content:
+                    parameters = get_pragma_parameters(
+                        pragma, starts_with='enter data', only_loki_pragmas=False
+                    )
+                elif 'exit' in content and 'data' in content:
+                    parameters = get_pragma_parameters(
+                        pragma, starts_with='exit data', only_loki_pragmas=False
+                    )
+            elif keyword == 'loki':
+                if 'unstructured-data' in content:
+                    if content.startswith('exit unstructured-data'):
+                        parameters = get_pragma_parameters(
+                            pragma, starts_with='exit unstructured-data', only_loki_pragmas=False
+                        )
+                    else:
+                        parameters = get_pragma_parameters(
+                            pragma, starts_with='unstructured-data', only_loki_pragmas=False
+                        )
+
+            if not parameters:
+                continue
+
+            parameters = {
+                key: ', '.join(as_tuple(value)) for key, value in parameters.items()
+            }
+            for category in ('create', 'delete'):
+                values = parameters.get(category, '')
+                if not values:
+                    continue
+                for entry in values.split(','):
+                    entry = entry.strip()
+                    if not entry:
+                        continue
+                    explicit_data_vars.add(entry.lower())
+
+        if all(v.name.lower() in explicit_data_vars for v in local_vars):
+            return
+
+        pragma_start = ir.Pragma(keyword='loki', content=f'unstructured-data create({var_names})')
+        pragma_end = ir.Pragma(keyword='loki', content=f'exit unstructured-data delete({var_names})')
+        routine.body.prepend(pragma_start)
+        routine.body.append(pragma_end)
+
+    def _update_argument_dims(self, call):
+        """
+        Promote callee argument array declarations where the call-site
+        argument has higher rank than the callee dummy argument.
+        """
+        var_map = {}
+        call_variable_map = call.routine.variable_map
+        block_dim_size = self._resolve_block_dim_size(call.routine)
+        for arg, call_arg in call.arg_iter():
+            if isinstance(arg, Array):
+                if self.get_call_arg_rank(call_arg, self.block_dim.indices) > len(arg.shape):
+                    callee_var = call_variable_map[arg.name]
+                    new_dims = callee_var.dimensions + (block_dim_size,)
+                    new_shape = callee_var.shape + (block_dim_size,)
+                    new_type = callee_var.type.clone(shape=new_shape)
+                    var_map[callee_var] = callee_var.clone(dimensions=new_dims, type=new_type)
+        if var_map:
+            call.routine.spec = SubstituteExpressions(var_map).visit(call.routine.spec)
+
+    def _replace_block_indices_in_call(self, call):
+        """
+        Replace block-index subscripts with range indices ``(:)`` in call
+        arguments and keyword arguments.
+        """
+        block_dim_indices = [idx.lower() for idx in self.block_dim.indices]
+
+        def _process_dims(var):
+            """Replace block-dim indices in var.dimensions with RangeIndex."""
+            if isinstance(var, sym.Array) and var.dimensions:
+                if any(str(d).lower() in block_dim_indices for d in var.dimensions):
+                    new_dim = tuple(
+                        sym.RangeIndex((None, None)) if str(d).lower() in block_dim_indices else d
+                        for d in var.dimensions
+                    )
+                else:
+                    new_dim = var.dimensions + (sym.RangeIndex((None, None)),)
+                return var.clone(dimensions=new_dim)
+            if isinstance(var, sym.Array):
+                new_dim = tuple(sym.RangeIndex((None, None)) for _ in var.shape)
+                return var.clone(dimensions=new_dim)
+            return var
+
+        new_arguments = tuple(_process_dims(a) for a in call.arguments)
+        new_kwarguments = tuple(
+            (name, _process_dims(val)) for name, val in call.kwarguments
+        )
+        call._update(arguments=new_arguments, kwarguments=new_kwarguments)
+
+    def _propagate_trafo_data(self, call, relevant_vars, successor_map,
+                              driver_loop=None, item=None):
+        """
+        Store transformation state in the successor's ``trafo_data`` so
+        that nested kernels can continue the lowering.
+
+        Parameters
+        ----------
+        call : :any:`CallStatement`
+            The call whose target routine is the successor.
+        relevant_vars : tuple
+            Variables to propagate (will be substituted via call arg map).
+        successor_map : :any:`CaseInsensitiveDict`
+            Map from routine local_name to successor item.
+        driver_loop : :any:`Loop`, optional
+            The driver loop template to propagate (for kernel-level reuse).
+        item : :any:`ProcedureItem`, optional
+            The current item (used to read existing driver_loop from trafo_data).
+        """
+        call_name = str(call.name).lower()
+        if call_name not in successor_map:
+            return
+
+        successor = successor_map[call_name]
+        successor.trafo_data.setdefault('LowerBlockIndex', {})
+        successor.trafo_data['LowerBlockIndex'].setdefault('assignments', {})
+
+        call_arg_map = {v: k for k, v in call.arg_map.items()}
+
+        if 'relevant_vars' not in successor.trafo_data['LowerBlockIndex']:
+            successor.trafo_data['LowerBlockIndex']['relevant_vars'] = (
+                SubstituteExpressions(call_arg_map).visit(as_tuple(relevant_vars))
+            )
+
+        # Determine the driver loop to propagate
+        if driver_loop is not None:
+            # Driver path: clone loop, strip calls and pragmas, substitute args
+            drv_loop = driver_loop.clone()
+            drv_loop = Transformer(
+                {c: None for c in FindNodes(ir.CallStatement).visit(drv_loop.body)}
+            ).visit(drv_loop)
+            drv_loop = Transformer(
+                {p: None for p in FindNodes(ir.Pragma).visit(drv_loop.body)}
+            ).visit(drv_loop)
+            drv_loop = SubstituteExpressions(call_arg_map).visit(drv_loop)
+        elif item is not None and 'LowerBlockIndex' in item.trafo_data:
+            # Kernel path: re-use parent's driver loop, substituted
+            drv_loop = item.trafo_data['LowerBlockIndex'].get('driver_loop')
+            if drv_loop is not None:
+                drv_loop = SubstituteExpressions(call_arg_map).visit(drv_loop)
+        else:
+            drv_loop = None
+
+        if drv_loop is not None and 'driver_loop' not in successor.trafo_data['LowerBlockIndex']:
+            successor.trafo_data['LowerBlockIndex']['driver_loop'] = drv_loop
+
+    # ------------------------------------------------------------------
+    # Main dispatch methods
+    # ------------------------------------------------------------------
+
+    def process_driver(self, routine, targets, item, successors):
+        """
+        Process a driver-role routine: find driver loops containing calls
+        annotated with ``!$loki small-kernels``, collect relevant variables
+        from loop headers, and apply the block-index lowering to each call.
+        """
+        successor_map = CaseInsensitiveDict(
+            (successor.local_name, successor) for successor in successors
+        )
+        all_import_map = self._build_import_map(routine)
+
+        # Find driver loops and pragma-annotated calls within them
+        with pragmas_attached(routine, ir.Loop):
+            driver_loops = find_driver_loops(routine.body, targets)
+
+        relevant_calls = []
+        with pragmas_attached(routine, ir.CallStatement):
+            for driver_loop in driver_loops:
+                for call in FindNodes(ir.CallStatement).visit(driver_loop.body):
+                    if call.pragma and any(
+                        p.keyword.lower() == 'loki' and p.content.lower() == 'small-kernels'
+                        for p in call.pragma
+                    ):
+                        relevant_calls.append((call, driver_loop))
+
+        # Collect assignments in each driver loop body (used to extract
+        # relevant variables via FindUsedVariables)
+        driver_loop_assignments = {}
+        for _, driver_loop in relevant_calls:
+            if driver_loop not in driver_loop_assignments:
+                driver_loop_assignments[driver_loop] = (
+                    FindNodes(ir.Assignment).visit(driver_loop.body)
+                )
+
+        for call, driver_loop in relevant_calls:
+            if str(call.name).lower() not in targets:
+                continue
+            if call.routine is BasicType.DEFERRED:
+                warning(
+                    f'[{self.__class__.__name__}] Not processing routine '
+                    f'{call.name}. Call statement not enriched'
+                )
+                continue
+
+            # Collect relevant variables from loop header
+            relevant_vars = set()
+            relevant_vars.add(driver_loop.bounds.lower)
+            relevant_vars.add(driver_loop.bounds.upper)
+            if driver_loop.bounds.step is not None:
+                relevant_vars.add(driver_loop.bounds.step)
+            relevant_vars.update(
+                FindUsedVariables().visit(driver_loop_assignments[driver_loop])
+            )
+
+            # Compute and apply new arguments
+            new_args, new_kwargs, already_arg = self._determine_new_args(
+                relevant_vars, call, driver_loop_var=driver_loop.variable
+            )
+            missing_args = self._apply_new_args_to_call(call, new_args, new_kwargs, already_arg)
+
+            # Ensure driver loop variable is declared in callee
+            if driver_loop.variable not in call.routine.variable_map:
+                call.routine.variables += (driver_loop.variable.clone(scope=call.routine),)
+
+            # Propagate imports for new args
+            self._propagate_imports(new_args, call, all_import_map)
+
+            # Promote local arrays and inject data pragmas
+            local_vars = self.promote_local_arrays(call.routine)
+            self._inject_data_offload_pragmas(call.routine, local_vars)
+
+            # Update argument dimensions where rank mismatch
+            self._update_argument_dims(call)
+            self._reorder_new_dummy_declarations(call.routine, missing_args)
+
+            # Replace block indices with range indices in call args
+            self._replace_block_indices_in_call(call)
+
+            # Propagate trafo_data to successors
+            self._propagate_trafo_data(
+                call, relevant_vars, successor_map,
+                driver_loop=driver_loop, item=item
+            )
+
+    def process_kernel(self, routine, targets, item, successors):
+        """
+        Process a kernel-role routine: read ``relevant_vars`` from
+        ``item.trafo_data['LowerBlockIndex']`` (set by the parent caller)
+        and apply the same block-index lowering to nested calls annotated
+        with ``!$loki small-kernels``.
+        """
+        if 'LowerBlockIndex' not in item.trafo_data:
+            return
+        relevant_vars = item.trafo_data['LowerBlockIndex'].get('relevant_vars', ())
+        if not relevant_vars:
+            return
+
+        successor_map = CaseInsensitiveDict(
+            (successor.local_name, successor) for successor in successors
+        )
+        all_import_map = self._build_import_map(routine)
+
+        relevant_calls = self._find_relevant_calls(routine)
+        if not relevant_calls:
+            return
+
+        for call in relevant_calls:
+            if str(call.name).lower() not in targets:
+                continue
+            if call.routine is BasicType.DEFERRED:
+                warning(
+                    f'[{self.__class__.__name__}] Not processing routine '
+                    f'{call.name}. Call statement not enriched'
+                )
+                continue
+
+            # Compute and apply new arguments
+            new_args, new_kwargs, already_arg = self._determine_new_args(
+                relevant_vars, call
+            )
+            missing_args = self._apply_new_args_to_call(call, new_args, new_kwargs, already_arg)
+
+            # Propagate imports for new args
+            self._propagate_imports(new_args, call, all_import_map)
+
+            # Promote local arrays and inject data pragmas
+            local_vars = self.promote_local_arrays(call.routine)
+            self._inject_data_offload_pragmas(call.routine, local_vars)
+
+            # Update argument dimensions where rank mismatch
+            self._update_argument_dims(call)
+            self._reorder_new_dummy_declarations(call.routine, missing_args)
+
+            # Replace block indices with range indices in call args
+            self._replace_block_indices_in_call(call)
+
+            # Propagate trafo_data to successors
+            self._propagate_trafo_data(
+                call, relevant_vars, successor_map, item=item
+            )

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -269,7 +269,9 @@ end subroutine d
         },
         'routines': {
             'b_mod': {'replicate': False},
-            'not_c': {'replicate': False},
+            # either keep this seed routine or remove the have_non_replicate_conflict in
+            # the caplog assertion below
+            'not_c': {'replicate': False, 'seed_routine': True},
             'd': {'role': 'driver', 'replicate': False},
         }
     })

--- a/loki/transformations/inline/tests/test_inline_transformation.py
+++ b/loki/transformations/inline/tests/test_inline_transformation.py
@@ -487,6 +487,7 @@ end module innermost_mod
 
     scheduler = Scheduler(
         paths=[tmp_path], config=SchedulerConfig.from_dict(config),
+        seed_routines=['outermost'],
         frontend=frontend, xmods=[tmp_path]
     )
 

--- a/loki/transformations/single_column/__init__.py
+++ b/loki/transformations/single_column/__init__.py
@@ -11,6 +11,7 @@ from loki.transformations.single_column.block import * # noqa
 from loki.transformations.single_column.demote import * # noqa
 from loki.transformations.single_column.devector import * # noqa
 from loki.transformations.single_column.hoist import * # noqa
+from loki.transformations.single_column.local_copies import * # noqa
 from loki.transformations.single_column.revector import * # noqa
 from loki.transformations.single_column.scc import * # noqa
 from loki.transformations.single_column.scc_cuf import * # noqa

--- a/loki/transformations/single_column/__init__.py
+++ b/loki/transformations/single_column/__init__.py
@@ -7,6 +7,7 @@
 
 from loki.transformations.single_column.annotate import * # noqa
 from loki.transformations.single_column.base import * # noqa
+from loki.transformations.single_column.block import * # noqa
 from loki.transformations.single_column.demote import * # noqa
 from loki.transformations.single_column.devector import * # noqa
 from loki.transformations.single_column.hoist import * # noqa

--- a/loki/transformations/single_column/annotate.py
+++ b/loki/transformations/single_column/annotate.py
@@ -129,6 +129,15 @@ class SCCAnnotateTransformation(Transformation):
         routine.spec.append(routine_pragmas)
         routine.body = Transformer({pragma: None for pragma in routine_pragmas}).visit(routine.body)
 
+        # Keep explicit ACC data regions as-is. Adding a generic device-present
+        # wrapper on top of an existing ACC data region leads to duplicated
+        # ``acc data`` pragmas after PragmaModelTransformation.
+        if any(
+            pragma.keyword.lower() == 'acc' and 'data' in pragma.content.lower()
+            for pragma in FindNodes(ir.Pragma).visit(routine.body)
+        ):
+            return
+
         # Get the names of all array and derived type arguments
         args = [a for a in routine.arguments if isinstance(a, sym.Array)]
         args += [a for a in routine.arguments if isinstance(a.type.dtype, DerivedType)]
@@ -180,6 +189,14 @@ class SCCAnnotateTransformation(Transformation):
             # ensure all arguments are device-resident.
             self.annotate_kernel_routine(routine)
 
+            # For nested-driver kernels (those containing driver loops),
+            # annotate the driver loops with gang-parallel pragmas
+            with pragma_regions_attached(routine):
+                with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
+                    acc_vars = self.find_kernel_acc_vars(routine)
+                    driver_loops = find_driver_loops(section=routine.body, targets=targets)
+                    for loop in driver_loops:
+                        self.annotate_driver_loop(loop, acc_vars, privatise_derived_types=True)
 
         if role == 'driver':
             # Mark all parallel vector loops as `!$loki loop vector`
@@ -196,6 +213,61 @@ class SCCAnnotateTransformation(Transformation):
                     driver_loops = find_driver_loops(section=routine.body, targets=targets)
                     for loop in driver_loops:
                         self.annotate_driver_loop(loop, acc_vars.get(loop, []))
+
+    def find_kernel_acc_vars(self, routine):
+        """
+        Find variables already specified in loki/acc data clauses within a kernel routine.
+
+        Unlike :meth:`find_acc_vars`, this returns a flat list (not keyed by loop)
+        since kernel routines may not have an explicit driver-loop structure.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            Subroutine to search for existing data clauses.
+
+        Returns
+        -------
+        list of str
+            Lower-cased variable names found in data clauses.
+        """
+        acc_vars = []
+
+        for region in FindNodes(ir.PragmaRegion).visit(routine.body):
+            pragma_keyword = region.pragma.keyword.lower()
+            if pragma_keyword not in ('loki', 'acc'):
+                continue
+
+            if pragma_keyword == 'acc':
+                parameters = get_pragma_parameters(
+                    region.pragma, starts_with='data', only_loki_pragmas=False
+                )
+            elif 'device-present' in region.pragma.content.lower():
+                parameters = get_pragma_parameters(
+                    region.pragma, starts_with='device-present', only_loki_pragmas=False
+                )
+            else:
+                parameters = get_pragma_parameters(
+                    region.pragma, starts_with='structured-data', only_loki_pragmas=False
+                )
+                if not parameters:
+                    parameters = get_pragma_parameters(
+                        region.pragma, starts_with='data', only_loki_pragmas=False
+                    )
+
+            if parameters is not None:
+                parameters = {key: ', '.join(as_tuple(value)) for key, value in parameters.items()}
+                if (default := parameters.get('default', None)):
+                    if 'none' not in [p.strip().lower() for p in default.split(',')]:
+                        acc_vars += [var.name.lower() for var in FindVariables(unique=True).visit(routine.body)]
+                else:
+                    acc_vars += [
+                        p.strip().lower()
+                        for category in ('present', 'copy', 'copyin', 'copyout', 'deviceptr', 'vars')
+                        for p in parameters.get(category, '').split(',')
+                    ]
+
+        return acc_vars
 
     def find_acc_vars(self, routine, targets):
         """
@@ -220,6 +292,9 @@ class SCCAnnotateTransformation(Transformation):
                 else:
                     parameters = get_pragma_parameters(region.pragma, starts_with='structured-data',
                             only_loki_pragmas=False)
+                    if not parameters:
+                        parameters = get_pragma_parameters(region.pragma, starts_with='data',
+                                only_loki_pragmas=False)
                 if parameters is not None:
                     driver_loops = find_driver_loops(section=region.body, targets=targets)
                     if not driver_loops:
@@ -267,7 +342,7 @@ class SCCAnnotateTransformation(Transformation):
             routine.body.prepend((ir.Comment(''), pragma, ir.Comment('')))
             routine.body.append((ir.Comment(''), pragma_post, ir.Comment('')))
 
-    def annotate_driver_loop(self, loop, acc_vars):
+    def annotate_driver_loop(self, loop, acc_vars, privatise_derived_types=None):
         """
         Annotate driver block loop with generic Loki pragmas.
 
@@ -277,7 +352,13 @@ class SCCAnnotateTransformation(Transformation):
             Driver :any:`Loop` to wrap in generic Loki pragmas.
         acc_vars : list
             Variables already declared in generic Loki data directives.
+        privatise_derived_types : bool, optional
+            Whether to privatise derived-type objects. If ``None``
+            (default), falls back to ``self.privatise_derived_types``.
         """
+        if privatise_derived_types is None:
+            privatise_derived_types = self.privatise_derived_types
+
         sizes = self.block_dim.size_expressions
 
         # Mark driver loop as "gang parallel".
@@ -289,13 +370,26 @@ class SCCAnnotateTransformation(Transformation):
         arrays = [v for v in arrays if not any(d in sizes for d in as_tuple(v.shape))]
         private_sym = arrays
 
-        if self.privatise_derived_types:
+        if privatise_derived_types:
             # Derived-types are classified as "aggregate variables" in the OpenACC and OpenMP offload
             # standards and have the same implicit data attributes as arrays. Therefore, local derived-type
             # scalars must also be privatised.
             structs = [v for v in loop_vars if isinstance(v.type.dtype, sym.DerivedType)]
             structs = [v for v in structs if not v.name_parts[0].lower() in acc_vars]
             structs = [v for v in structs if not v.type.intent]
+
+            # Exclude derived-type variables whose root is non-local: a
+            # subroutine argument (has intent) or a module import.
+            def _is_non_local_root(v):
+                root_name = v.name_parts[0]
+                if v.scope:
+                    root_type = v.scope.symbol_attrs.lookup(root_name)
+                    if root_type is not None:
+                        if root_type.intent or root_type.imported:
+                            return True
+                return False
+
+            structs = [v for v in structs if not _is_non_local_root(v)]
             structs = [v for v in structs if not v in arrays]
 
             # only privatise derived-type parent

--- a/loki/transformations/single_column/block.py
+++ b/loki/transformations/single_column/block.py
@@ -1,0 +1,838 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Transformations for extracting and re-injecting block-level computation
+sections in the small-kernels SCC pipeline.
+
+:any:`SCCBlockSectionTransformation` identifies contiguous IR regions
+referencing block-dimension variables, wraps them in labelled
+:any:`Section` nodes, and unwraps driver loops containing small-kernels
+pragma calls.
+
+:any:`SCCBlockSectionToLoopTransformation` re-wraps those labelled
+sections in cloned driver loops with ``!$loki loop driver`` pragmas and
+creates local copies of block-dimension index variables.
+
+Applied in sequence, the two transformations convert a driver + kernel
+pair from block-loop form into small-kernels form:
+
+**Driver before both transformations:**
+
+.. code-block:: fortran
+
+    do ibl = 1, nb
+      !$loki small-kernels
+      call kernel(nproma, nb, ibl, za)
+    end do
+
+**Driver after** :any:`SCCBlockSectionTransformation` **(loop unwrapped):**
+
+.. code-block:: fortran
+
+    ! former driver loop ...
+    call kernel(nproma, nb, ibl, za)
+    ! END: former driver loop ...
+
+**Kernel before both transformations:**
+
+.. code-block:: fortran
+
+    subroutine kernel(ydcpg_bnds, nproma, nb, za)
+      !$loki routine seq
+      za(1, ydcpg_bnds%kbl) = 1.0
+      !$loki small-kernels
+      call child(nproma, nb)
+      za(2, ydcpg_bnds%kbl) = 2.0
+    end subroutine
+
+**Kernel after** :any:`SCCBlockSectionTransformation` **(sections extracted):**
+
+.. code-block:: fortran
+
+    subroutine kernel(ydcpg_bnds, nproma, nb, za)
+      ! [block_section]
+      za(1, ydcpg_bnds%kbl) = 1.0
+      ! [end block_section]
+      call child(nproma, nb)
+      ! [block_section]
+      za(2, ydcpg_bnds%kbl) = 2.0
+      ! [end block_section]
+    end subroutine
+
+**Kernel after** :any:`SCCBlockSectionToLoopTransformation` **(block loops re-injected):**
+
+.. code-block:: fortran
+
+    subroutine kernel(ydcpg_bnds, nproma, nb, za)
+      local_ydcpg_bnds = ydcpg_bnds
+      ! START of Loki inserted block loop
+
+      !$loki loop driver vector_length(nproma)
+      do ibl = 1, nb
+        za(1, local_ydcpg_bnds%kbl) = 1.0
+      end do
+
+      ! END of Loki inserted block loop
+      call child(nproma, nb)
+      ! START of Loki inserted block loop
+
+      !$loki loop driver vector_length(nproma)
+      do ibl = 1, nb
+        za(2, local_ydcpg_bnds%kbl) = 2.0
+      end do
+
+      ! END of Loki inserted block loop
+    end subroutine
+"""
+
+from more_itertools import split_at
+
+from loki.analyse import dataflow_analysis_attached
+from loki.batch import Transformation
+from loki.ir import (
+    nodes as ir, FindNodes, FindScopes, FindVariables, Transformer,
+    NestedTransformer, is_loki_pragma, pragmas_attached,
+    SubstituteExpressions,
+)
+from loki.tools import as_tuple, flatten, CaseInsensitiveDict
+from loki.types import BasicType
+
+from loki.transformations.utilities import (
+    find_driver_loops, check_routine_sequential
+)
+
+
+__all__ = [
+    'SCCBlockSectionTransformation', 'SCCBlockSectionToLoopTransformation',
+]
+
+
+class ReblockSectionTransformer(Transformer):
+    """
+    :any:`Transformer` that replaces :any:`Section` nodes labelled
+    with ``"block_section"`` with block-level loops across the
+    block dimension, using a cloned driver loop stored in
+    ``item.trafo_data['LowerBlockIndex']['driver_loop']``.
+
+    Parameters
+    ----------
+    routine : :any:`Subroutine`
+        The subroutine in which block sections should be wrapped.
+    item : :any:`Item`
+        The scheduler item for the routine, carrying ``trafo_data``.
+    horizontal : :any:`Dimension`
+        The dimension specifying the horizontal vector dimension
+        (used for ``vector_length`` pragma annotation).
+    """
+    # pylint: disable=unused-argument
+
+    def __init__(self, routine, item, horizontal, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.routine = routine
+        self.horizontal = horizontal
+        self.driver_loop = item.trafo_data.get('LowerBlockIndex', {}).get('driver_loop')
+
+    def visit_Section(self, s, **kwargs):
+        """
+        Replace ``block_section``-labelled :any:`Section` nodes with a
+        cloned driver loop containing the section body and a
+        ``!$loki loop driver`` pragma.
+        """
+        if s.label == 'block_section':
+            if self.driver_loop is None:
+                raise RuntimeError(
+                    f'{self.__class__.__name__}: driver_loop is None but '
+                    f'a block section needs to be wrapped in a driver loop '
+                    f'for routine {self.routine.name}'
+                )
+            symbol_map = self.routine.symbol_map
+            sizes = tuple(
+                self.routine.resolve_typebound_var(size, symbol_map)
+                for size in self.horizontal.size_expressions
+                if size.split('%')[0] in symbol_map
+            )
+            vector_length = f' vector_length({sizes[0]})' if sizes else ''
+
+            return (
+                ir.Comment(text='! START of Loki inserted block loop'),
+                ir.Comment(text=''),
+                self.driver_loop.clone(
+                    body=self.driver_loop.body + s.body,
+                    pragma=(ir.Pragma(
+                        keyword='loki',
+                        content=f'loop driver{vector_length}'
+                    ),)
+                ),
+                ir.Comment(text=''),
+                ir.Comment(text='! END of Loki inserted block loop'),
+            )
+
+        # Rebuild section after recursing to children
+        return self._rebuild(s, self.visit(s.children))
+
+
+class SCCBlockSectionToLoopTransformation(Transformation):
+    """
+    Wrap identified block-level sections in driver block loops and
+    create local copies of block-dimension index variables.
+
+    This transformation operates on kernel routines that have been
+    processed by :any:`SCCBlockSectionTransformation` (which wraps
+    block-dimension computation regions in ``Section(label='block_section')``
+    nodes).  It:
+
+    1. Calls :any:`ReblockSectionTransformer` to replace those labelled
+       sections with cloned driver loops carrying ``!$loki loop driver``
+       pragmas.
+    2. Activates ``!$loki inactive-small-kernels`` pragmas by stripping
+       the ``inactive-small-kernels`` prefix.
+    3. Creates local copies of derived-type block-index variables
+       (e.g. ``YDCPG_BNDS%KBL`` → ``local_KBL``).
+
+    **Before** (after :any:`SCCBlockSectionTransformation`):
+
+    .. code-block:: fortran
+
+        subroutine kernel(ydcpg_bnds, nproma, nb)
+          ! [block_section]
+          za(1, ydcpg_bnds%kbl) = 1.0
+          ! [end block_section]
+          !$loki inactive-small-kernels data present(za)
+        end subroutine
+
+    **After:**
+
+    .. code-block:: fortran
+
+        subroutine kernel(ydcpg_bnds, nproma, nb)
+          local_ydcpg_bnds = ydcpg_bnds
+          ! START of Loki inserted block loop
+
+          !$loki loop driver vector_length(nproma)
+          do ibl = 1, nb
+            za(1, local_ydcpg_bnds%kbl) = 1.0
+          end do
+
+          ! END of Loki inserted block loop
+          !$loki data present(za)
+        end subroutine
+
+    Parameters
+    ----------
+    block_dim : :any:`Dimension`
+        Dimension object describing the blocking data dimension.
+    horizontal : :any:`Dimension`
+        Dimension object describing the horizontal (column) dimension.
+    """
+
+    def __init__(self, block_dim, horizontal):
+        self.block_dim = block_dim
+        self.horizontal = horizontal
+
+    @staticmethod
+    def activate_pragmas(routine):
+        """
+        Replace ``!$loki inactive-small-kernels`` pragmas with active
+        ``!$loki`` pragmas by stripping the ``inactive-small-kernels``
+        prefix from the pragma content.
+        """
+        pragmas = FindNodes(ir.Pragma).visit(routine.body)
+        for pragma in pragmas:
+            if is_loki_pragma(pragma, starts_with='inactive-small-kernels'):
+                pragma._update(
+                    content=pragma.content.replace('inactive-small-kernels', '')
+                )
+
+    @staticmethod
+    def get_block_index(routine, variable_map, index):
+        """
+        Resolve a block-index name to its corresponding variable from
+        the routine's variable map.
+
+        Handles both simple names and derived-type member access names
+        (e.g. ``YDCPG_BNDS%KBL``).
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The routine whose variables are searched.
+        variable_map : dict
+            Mapping of variable names to :any:`Variable` objects.
+        index : str
+            The block-index name to resolve (may contain ``%``).
+
+        Returns
+        -------
+        :any:`Variable` or None
+        """
+        if (block_index := variable_map.get(index, None)) is not None:
+            return block_index
+        if index.split('%', maxsplit=1)[0] in variable_map:
+            return routine.resolve_typebound_var(
+                index.split('%', maxsplit=1)[0], variable_map
+            )
+        return None
+
+    def _create_local_copies(self, routine):
+        """
+        Create local copies of derived-type block-dimension index
+        variables and prepend ``local_X = X`` assignments to the
+        routine body.
+        """
+        routine_variable_map = routine.variable_map
+        create_local_copy = []
+        for _index in self.block_dim.indices:
+            if '%' not in _index:
+                continue
+            block_index = self.get_block_index(
+                routine, routine_variable_map, _index
+            )
+            if block_index is not None:
+                create_local_copy.append(block_index)
+
+        local_copy_map = {
+            var: var.clone(
+                name=f'local_{var.name}',
+                type=var.type.clone(intent=None)
+            )
+            for var in create_local_copy
+        }
+        routine.body = SubstituteExpressions(
+            local_copy_map
+        ).visit(routine.body)
+        routine.variables += as_tuple(local_copy_map.values())
+
+        new_assignments = tuple(
+            ir.Assignment(lhs=val, rhs=key)
+            for key, val in local_copy_map.items()
+        )
+        if new_assignments:
+            routine.body.prepend(new_assignments)
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Apply block-section-to-loop transformation to a kernel
+        :any:`Subroutine`.
+
+        For kernel routines, this replaces ``block_section``-labelled
+        :any:`Section` nodes with driver block loops, activates
+        inactive small-kernels pragmas, and creates local copies of
+        block-dimension index variables.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            Subroutine to apply this transformation to.
+        role : str
+            Role of the subroutine in the call tree; only ``"kernel"``
+            is processed.
+        item : :any:`Item`
+            Scheduler item carrying ``trafo_data``.
+        """
+        role = kwargs['role']
+        item = kwargs.get('item', None)
+
+        if role == 'kernel':
+            routine.body = ReblockSectionTransformer(
+                routine, item, self.horizontal
+            ).visit(routine.body)
+            self.activate_pragmas(routine)
+            if 'LowerBlockIndex' in item.trafo_data:
+                self._create_local_copies(routine)
+
+
+class SCCBlockSectionTransformation(Transformation):
+    """
+    Extract contiguous block-level computation sections from kernel
+    routines and wrap them in labelled :any:`Section` nodes for
+    downstream processing by :any:`SCCBlockSectionToLoopTransformation`.
+
+    For driver routines, this transformation marks successors with
+    ``BlockSectionTrafo`` in ``trafo_data`` and unwraps driver loops
+    that contain ``!$loki small-kernels`` pragma calls, replacing them
+    with their body content.
+
+    For kernel routines (guarded by ``BlockSectionTrafo`` in
+    ``trafo_data``), the transformation:
+
+    1. Removes ``!$loki routine`` pragmas from spec and body.
+    2. Extracts contiguous IR sections that reference block-dimension
+       variables or contain non-deferred call statements, split at
+       call statements annotated with ``!$loki small-kernels`` pragmas.
+    3. Optionally trims those sections to only include nodes that
+       actually reference block-dimension symbols.
+    4. Wraps the resulting sections in ``Section(label='block_section')``
+       nodes via :any:`NestedTransformer`.
+
+    For a kernel routine like:
+
+    .. code-block:: fortran
+
+        subroutine kernel(nproma, nb, ibl, za, zb)
+          integer, intent(in) :: nproma, nb, ibl
+          real, intent(inout) :: za(nproma, nb), zb(nproma, nb)
+          !$loki routine seq
+          za(1, ibl) = 1.0
+          !$loki small-kernels
+          call child_kernel(nproma, nb)
+          zb(1, ibl) = 2.0
+        end subroutine
+
+    the transformation wraps block-dimension sections and removes the
+    ``!$loki routine`` pragma:
+
+    .. code-block:: fortran
+
+        subroutine kernel(nproma, nb, ibl, za, zb)
+          integer, intent(in) :: nproma, nb, ibl
+          real, intent(inout) :: za(nproma, nb), zb(nproma, nb)
+          ! [block_section]
+          za(1, ibl) = 1.0
+          ! [end block_section]
+          call child_kernel(nproma, nb)
+          ! [block_section]
+          zb(1, ibl) = 2.0
+          ! [end block_section]
+        end subroutine
+
+    For a driver routine, the block loop is unwrapped:
+
+    .. code-block:: fortran
+
+        ! Before:
+        do ibl = 1, nb
+          !$loki small-kernels
+          call kernel(nproma, nb, ibl, za, zb)
+        end do
+
+        ! After:
+        ! former driver loop ...
+        call kernel(nproma, nb, ibl, za, zb)
+        ! END: former driver loop ...
+
+    Parameters
+    ----------
+    block_dim : :any:`Dimension`
+        :any:`Dimension` object describing the block data dimension.
+    trim_block_sections : bool, optional
+        Flag to trigger trimming of extracted block sections to remove
+        nodes that are not assignments involving block-dimension arrays.
+        Default is ``True``.
+    """
+
+    _separator_node_types = (ir.Loop, ir.Conditional, ir.MultiConditional)
+
+    def __init__(self, block_dim, trim_block_sections=True):
+        self.block_dim = block_dim
+        self.trim_block_sections = trim_block_sections
+
+    @classmethod
+    def _add_separator(cls, node, section, separator_nodes):
+        """
+        Add either the current node or its outermost parent node from
+        the list of types defining a block-region separator
+        (:attr:`_separator_node_types`) to the list of separator nodes.
+        """
+        if node in section:
+            separator_nodes.append(node)
+        else:
+            ancestors = flatten(FindScopes(node).visit(section))
+            ancestor_scopes = [
+                a for a in ancestors
+                if isinstance(a, cls._separator_node_types)
+            ]
+            if ancestor_scopes and ancestor_scopes[0] not in separator_nodes:
+                separator_nodes.append(ancestor_scopes[0])
+
+        return separator_nodes
+
+    @staticmethod
+    def _resolve_block_indices(routine, block_dim):
+        """Resolve block-dimension index strings to routine-scoped expressions."""
+        if routine is None:
+            return ()
+
+        variable_map = routine.variable_map
+        resolved_indices = []
+        for index in block_dim.indices:
+            if (resolved := variable_map.get(index, None)) is not None:
+                resolved_indices.append(resolved)
+                continue
+            parent = index.split('%', maxsplit=1)[0]
+            if parent in variable_map:
+                resolved_indices.append(routine.resolve_typebound_var(index, variable_map))
+        return as_tuple(resolved_indices)
+
+    @classmethod
+    def _section_references_block_index(cls, section, resolved_block_indices):
+        """Return True if a section references a resolved block index directly or in dimensions."""
+        for var in FindVariables().visit(section):
+            if resolved_block_indices:
+                if var in resolved_block_indices:
+                    return True
+                if any(
+                        dim in resolved_block_indices
+                        for dim in as_tuple(getattr(var, 'dimensions', None) or ())
+                ):
+                    return True
+        return False
+
+    @staticmethod
+    def _section_references_block_index_stringwise(section, block_dim):
+        """Fallback match for block-index references embedded in rendered variable expressions."""
+        block_indices = tuple(index.lower() for index in block_dim.indices)
+        for var in FindVariables().visit(section):
+            if any(index in str(var).lower() for index in block_indices):
+                return True
+            if any(
+                any(index in str(dim).lower() for index in block_indices)
+                for dim in as_tuple(getattr(var, 'dimensions', None) or ())
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _is_explicit_data_pragma(node):
+        """Return True for explicit data-management pragmas that must stay outside block loops."""
+        if not isinstance(node, ir.Pragma):
+            return False
+
+        keyword = node.keyword.lower()
+        content = node.content.lower()
+        if keyword == 'acc':
+            return ('enter' in content or 'exit' in content) and 'data' in content
+        if keyword == 'loki':
+            return 'unstructured-data' in content
+        return False
+
+    @classmethod
+    def _node_is_block_anchor(cls, node, resolved_block_indices, block_dim):
+        """Return True if the node itself should anchor a trimmed block section."""
+        if cls._is_explicit_data_pragma(node):
+            return False
+
+        return bool(
+            cls._section_references_block_index((node,), resolved_block_indices)
+            or cls._section_references_block_index_stringwise((node,), block_dim)
+        )
+
+    @classmethod
+    def extract_block_sections(cls, section, block_dim, successor_map, routine=None):
+        """
+        Extract contiguous sections of nodes that contain block-level
+        computations, split at call statements annotated with
+        ``!$loki small-kernels`` pragmas.
+
+        Recursively processes :any:`Conditional` and
+        :any:`MultiConditional` separator nodes to find nested block
+        sections.
+
+        Parameters
+        ----------
+        section : tuple of :any:`Node`
+            A section of nodes from which to extract block-level
+            sub-sections.
+        block_dim : :any:`Dimension`
+            The dimension specifying the block dimension.
+        successor_map : :any:`CaseInsensitiveDict`
+            Mapping of callee names to their scheduler items, used to
+            mark successors with ``BlockSectionTrafo``.
+
+        Returns
+        -------
+        list of tuple
+            List of node tuples representing extracted block sections.
+        """
+        if routine is None and section:
+            routine = getattr(section[0], 'scope', None)
+
+        calls = FindNodes(ir.CallStatement).visit(section)
+        separator_nodes = []
+
+        for call in calls:
+            if call.routine is not BasicType.DEFERRED:
+                if check_routine_sequential(routine=call.routine):
+                    continue
+
+            call_pragmas = call.pragma
+            if not call_pragmas:
+                continue
+
+            is_sk_call = False
+            for pragma in call_pragmas:
+                if (pragma.keyword.lower() == 'loki'
+                        and pragma.content.lower() == 'small-kernels'):
+                    successor_map[str(call.name)].trafo_data[
+                        'BlockSectionTrafo'
+                    ] = True
+                    is_sk_call = True
+                    break
+
+            if not is_sk_call:
+                continue
+
+            separator_nodes = cls._add_separator(
+                call, section, separator_nodes
+            )
+
+        raw_subsections = [
+            as_tuple(s)
+            for s in split_at(
+                section, lambda n: n in separator_nodes
+            )
+        ]
+        resolved_block_indices = cls._resolve_block_indices(routine, block_dim)
+
+        # Keep only subsections that reference block-dim indices or
+        # contain resolved call statements
+        subsections = [
+            s for s in raw_subsections
+            if cls._section_references_block_index(s, resolved_block_indices)
+            or cls._section_references_block_index_stringwise(s, block_dim)
+            or any(
+                call
+                for call in FindNodes(ir.CallStatement).visit(s)
+                if call.routine is not BasicType.DEFERRED
+            )
+        ]
+
+        # Recurse into separator bodies for nested block sections
+        for separator in separator_nodes:
+            if isinstance(separator, ir.Conditional):
+                subsec_body = cls.extract_block_sections(
+                    separator.body, block_dim, successor_map, routine=routine
+                )
+                if subsec_body:
+                    subsections += subsec_body
+                for ebody in separator.else_bodies:
+                    subsections += cls.extract_block_sections(
+                        ebody, block_dim, successor_map, routine=routine
+                    )
+
+            if isinstance(
+                separator, (ir.MultiConditional, ir.TypeConditional)
+            ):
+                for body in separator.bodies:
+                    subsec_body = cls.extract_block_sections(
+                        body, block_dim, successor_map, routine=routine
+                    )
+                    if subsec_body:
+                        subsections += subsec_body
+                subsec_else = cls.extract_block_sections(
+                    separator.else_body, block_dim, successor_map, routine=routine
+                )
+                if subsec_else:
+                    subsections += subsec_else
+
+        return subsections
+
+    @classmethod
+    def get_trimmed_sections(cls, routine, block_dim, sections):
+        """
+        Trim extracted block sections to remove nodes that are not
+        assignments involving block-dimension arrays.
+
+        Uses :func:`dataflow_analysis_attached` to determine which
+        nodes reference block-dimension symbols.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The routine containing the sections.
+        block_dim : :any:`Dimension`
+            The dimension specifying the block dimension.
+        sections : tuple of tuple
+            The extracted block sections to trim.
+
+        Returns
+        -------
+        tuple of tuple
+            The trimmed block sections.
+        """
+        trimmed_sections = ()
+        resolved_block_indices = cls._resolve_block_indices(routine, block_dim)
+        with dataflow_analysis_attached(routine):
+            for sec in sections:
+                block_nodes = [
+                    node for node in sec
+                    if any(
+                        index.lower() in node.uses_symbols
+                        for index in block_dim.indices
+                    )
+                    and cls._node_is_block_anchor(node, resolved_block_indices, block_dim)
+                ]
+                if block_nodes:
+                    start = sec.index(block_nodes[0])
+                    if (start > 0
+                            and isinstance(sec[start - 1], ir.Pragma)
+                            and 'loop' in sec[start - 1].content.lower()):
+                        start -= 1
+                    end = sec.index(block_nodes[-1])
+                    trimmed_sections += (sec[start:end + 1],)
+                else:
+                    call_nodes = [
+                        node for node in sec
+                        if any(
+                            call
+                            for call in FindNodes(
+                                ir.CallStatement
+                            ).visit(node)
+                            if call.routine is not BasicType.DEFERRED
+                        )
+                    ]
+                    if call_nodes:
+                        start = sec.index(call_nodes[0])
+                        end = sec.index(call_nodes[-1])
+                        trimmed_sections += (sec[start:end + 1],)
+
+        return trimmed_sections
+
+    def process_driver(self, routine, item, successor_map, targets):  # pylint: disable=unused-argument
+        """
+        Process a driver-level routine by marking call statements that
+        have ``!$loki small-kernels`` pragmas for block-section
+        treatment, and unwrapping driver loops that contain such calls.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The driver routine to process.
+        item : :any:`Item`
+            The scheduler item for the routine.
+        successor_map : :any:`CaseInsensitiveDict`
+            Mapping of callee names to their scheduler items.
+        targets : tuple of str
+            Target routine names for driver loop detection.
+        """
+        with pragmas_attached(routine, ir.CallStatement):
+            calls = FindNodes(ir.CallStatement).visit(routine.body)
+            for call in calls:
+                call_pragmas = call.pragma
+                if not call_pragmas:
+                    continue
+                for pragma in call_pragmas:
+                    if (pragma.keyword.lower() == 'loki'
+                            and pragma.content.lower() == 'small-kernels'):
+                        successor_map[str(call.name)].trafo_data[
+                            'BlockSectionTrafo'
+                        ] = True
+
+        loop_map = {}
+        with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
+            driver_loops = find_driver_loops(
+                section=routine.body, targets=targets
+            )
+            for driver_loop in driver_loops:
+                pragmas = FindNodes(ir.Pragma).visit(driver_loop.body)
+                for pragma in pragmas:
+                    if (pragma.keyword.lower() == 'loki'
+                            and pragma.content.lower() == 'small-kernels'):
+                        loop_map[driver_loop] = (
+                            ir.Comment(
+                                text='! former driver loop ...'
+                            ),
+                            driver_loop.body,
+                            ir.Comment(
+                                text='! END: former driver loop ...'
+                            ),
+                        )
+                        break
+            if loop_map:
+                routine.body = Transformer(loop_map).visit(routine.body)
+
+    def process_kernel(self, routine, item, successor_map):
+        """
+        Extract block-level computation sections from a kernel routine
+        and wrap them in ``Section(label='block_section')`` nodes.
+
+        Only processes routines that have ``BlockSectionTrafo`` set in
+        their ``trafo_data`` (set by :meth:`process_driver` on the
+        caller side).
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The kernel routine to process.
+        item : :any:`Item`
+            The scheduler item for the routine.
+        successor_map : :any:`CaseInsensitiveDict`
+            Mapping of callee names to their scheduler items.
+        """
+        if not item.trafo_data.get('BlockSectionTrafo', False):
+            return
+
+        # Remove !$loki routine pragmas
+        pragmas = [
+            pragma
+            for pragma in FindNodes(ir.Pragma).visit(routine.ir)
+            if is_loki_pragma(pragma, starts_with='routine')
+        ]
+        pragma_map = {pragma: None for pragma in pragmas}
+        routine.spec = Transformer(pragma_map).visit(routine.spec)
+        routine.body = Transformer(pragma_map).visit(routine.body)
+
+        with pragmas_attached(routine, ir.CallStatement):
+            sections = self.extract_block_sections(
+                routine.body.body, self.block_dim, successor_map, routine=routine
+            )
+
+        if self.trim_block_sections:
+            sections = self.get_trimmed_sections(
+                routine, self.block_dim, sections
+            )
+
+        section_mapper = {
+            s: ir.Section(body=s, label='block_section')
+            for s in sections
+            if s and any(
+                not isinstance(n, (ir.Comment, ir.Pragma, ir.CommentBlock))
+                for n in s
+            )
+        }
+        routine.body = NestedTransformer(section_mapper).visit(routine.body)
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Apply block-section extraction to a :any:`Subroutine`.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            Subroutine to apply this transformation to.
+        role : str
+            Role of the subroutine in the call tree
+            (``"driver"`` or ``"kernel"``).
+        item : :any:`Item`
+            Scheduler item carrying ``trafo_data``.
+        targets : tuple of str, optional
+            Target routine names for driver loop detection.
+        sub_sgraph : optional
+            Sub-graph of the scheduler providing successor information.
+        """
+        targets = kwargs.get('targets', ())
+        item = kwargs.get('item', None)
+        role = kwargs.get('role', None)
+        sub_sgraph = kwargs.get('sub_sgraph', None)
+        successors = (
+            as_tuple(sub_sgraph.successors(item))
+            if sub_sgraph is not None
+            else ()
+        )
+
+        successor_map = CaseInsensitiveDict(
+            (successor.local_name, successor)
+            for successor in successors
+        )
+
+        if role == 'kernel':
+            self.process_kernel(routine, item, successor_map)
+        if role == 'driver':
+            self.process_driver(
+                routine, item, successor_map, targets=targets
+            )

--- a/loki/transformations/single_column/devector.py
+++ b/loki/transformations/single_column/devector.py
@@ -14,6 +14,7 @@ from loki.ir import (
     NestedTransformer, is_loki_pragma, pragmas_attached,
 )
 from loki.tools import as_tuple, flatten
+from loki.types import BasicType
 from loki.expression import symbols as sym
 
 from loki.transformations.utilities import (
@@ -115,7 +116,7 @@ class SCCDevectorTransformation(Transformation):
         for call in calls:
 
             # check if calls have been enriched
-            if call.routine:
+            if call.routine is not BasicType.DEFERRED:
                 # check if called routine is marked as sequential
                 if check_routine_sequential(routine=call.routine):
                     continue
@@ -236,7 +237,8 @@ class SCCDevectorTransformation(Transformation):
         routine.body = RemoveLoopTransformer(dimension=self.horizontal).visit(routine.body)
 
         # Extract vector-level compute sections from the kernel
-        sections = self.extract_vector_sections(routine.body.body, self.horizontal)
+        with pragmas_attached(routine, ir.CallStatement):
+            sections = self.extract_vector_sections(routine.body.body, self.horizontal)
 
         if self.trim_vector_sections:
             sections = self.get_trimmed_sections(routine, self.horizontal, sections)
@@ -268,7 +270,8 @@ class SCCDevectorTransformation(Transformation):
         for loop in driver_loops:
             new_driver_loop = RemoveLoopTransformer(dimension=self.horizontal).visit(loop.body)
             new_driver_loop = loop.clone(body=new_driver_loop)
-            sections = self.extract_vector_sections(new_driver_loop.body, self.horizontal)
+            with pragmas_attached(routine, ir.CallStatement):
+                sections = self.extract_vector_sections(new_driver_loop.body, self.horizontal)
             if self.trim_vector_sections:
                 sections = self.get_trimmed_sections(new_driver_loop, self.horizontal, sections)
             section_mapper = {s: ir.Section(body=s, label='vector_section') for s in sections}

--- a/loki/transformations/single_column/local_copies.py
+++ b/loki/transformations/single_column/local_copies.py
@@ -1,0 +1,202 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Transformation to create local scalar copies of block-dimension and
+horizontal-dimension index variables inside kernel routines.
+
+This prevents accidental aliasing when the caller-side variable is a
+derived-type component (e.g. ``YDCPG_BNDS%KIDIA``).
+"""
+
+from loki.batch import Transformation
+from loki.ir import (
+    nodes as ir,
+    FindNodes, Pragma, Transformer, SubstituteExpressions,
+    is_loki_pragma, get_pragma_parameters
+)
+from loki.tools import as_tuple
+
+__all__ = ['CreateLocalCopiesTransformation']
+
+
+class CreateLocalCopiesTransformation(Transformation):
+    """
+    Create local scalar copies of block-dimension and horizontal-dimension
+    index variables inside kernel routines.
+
+    For each variable in ``block_dim.indices``, ``horizontal.upper``, and
+    ``horizontal.lower`` that appears in the routine's variable map, a new
+    ``local_<name>`` variable is created and all body references are
+    rewritten to use the local copy.  This prevents accidental aliasing
+    when the caller-side variable is a derived-type component (e.g.
+    ``YDCPG_BNDS%KIDIA``).
+
+    Variables matching ``horizontal.sizes`` are excluded because those are
+    array dimension sizes (e.g. ``KLON``, ``NPROMA``) that must retain
+    their original name in pool-allocator expressions and other code
+    outside the block loop.
+
+    Parameters
+    ----------
+    block_dim : :any:`Dimension`
+        Dimension object describing the blocking data dimension.
+    horizontal : :any:`Dimension`
+        Dimension object describing the horizontal (column) dimension.
+    """
+
+    def __init__(self, block_dim, horizontal):
+        self.block_dim = block_dim
+        self.horizontal = horizontal
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Apply local-copy creation to a kernel :any:`Subroutine`.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            Subroutine to apply this transformation to.
+        role : str
+            Role of the subroutine in the call tree; only ``"kernel"``
+            is processed.
+        item : :any:`Item`
+            Scheduler item carrying ``trafo_data``.
+        """
+        role = kwargs['role']
+        item = kwargs.get('item', None)
+
+        if role == 'kernel':
+            if 'LowerBlockIndex' in item.trafo_data:
+                self._create_local_copies(routine)
+            # Always clean up device-present pragmas for bounds-parent
+            # variables, even when LowerBlockIndex did not propagate to
+            # this item (e.g. sub-sub-kernels not directly marked with
+            # ``!$loki small-kernels``).
+            self._remove_bounds_parents_from_device_present(routine)
+
+    @staticmethod
+    def get_block_index(routine, variable_map, index):
+        """
+        Resolve *index* (a string from ``block_dim.indices`` or
+        ``horizontal._upper/_lower``) to a Loki variable in *routine*.
+
+        Handles both plain names and ``%``-separated derived-type paths.
+        For derived-type components, this returns the parent object so local
+        copies can be created as valid Fortran symbols (e.g. ``local_bnds``),
+        rather than illegal component declarations like ``local_bnds%kbl``.
+        """
+        if (block_index := variable_map.get(index, None)):
+            return block_index
+        parent = index.split('%', maxsplit=1)[0]
+        if parent in variable_map:
+            return routine.resolve_typebound_var(parent, variable_map)
+        return None
+
+    def _create_local_copies(self, routine):
+        """
+        Create ``local_<name>`` copies of block-dimension indices and
+        horizontal bounds (excluding ``horizontal.sizes``), substitute
+        body references, and clean up ``!$loki device-present`` pragmas.
+        """
+        routine_variable_map = routine.variable_map
+
+        # Exclude horizontal.sizes — these are array dimension sizes
+        # (e.g. KLON, NPROMA) not loop bounds.
+        size_names = {
+            s.split('%')[-1].lower()
+            for s in (self.horizontal.sizes or ())
+        }
+
+        create_local_copy = []
+        for _index in self.block_dim.indices + self.horizontal._upper + self.horizontal._lower:
+            if _index.split('%')[-1].lower() in size_names:
+                continue
+            block_index = self.get_block_index(routine, routine_variable_map, _index)
+            if block_index is not None:
+                create_local_copy.append(block_index)
+
+        local_copy_map = {
+            var: var.clone(
+                name=f'local_{var.name}',
+                type=var.type.clone(intent=None)
+            )
+            for var in create_local_copy
+            if f'local_{var.name}' not in routine_variable_map
+        }
+        routine.body = SubstituteExpressions(local_copy_map).visit(routine.body)
+        routine.variables += as_tuple(local_copy_map.values())
+
+        new_assignments = tuple(
+            ir.Assignment(lhs=val, rhs=key)
+            for key, val in local_copy_map.items()
+        )
+        if new_assignments:
+            routine.body.prepend(new_assignments)
+
+        # Remove replaced variable names from !$loki device-present pragmas.
+        # We use create_local_copy (not local_copy_map) because an earlier
+        # pipeline step may have already created the local copy, causing
+        # local_copy_map to be empty here.
+        replaced_names = {str(var.name).lower() for var in create_local_copy}
+        if replaced_names:
+            self._filter_device_present_pragma(routine, replaced_names)
+
+    @staticmethod
+    def _filter_device_present_pragma(routine, names_to_remove):
+        """
+        Remove variable names in *names_to_remove* from any
+        ``!$loki device-present vars(...)`` pragmas in *routine*.
+        """
+        pragma_map = {}
+        for pragma in FindNodes(Pragma).visit(routine.body):
+            if not is_loki_pragma(pragma, starts_with='device-present'):
+                continue
+            params = get_pragma_parameters(
+                pragma, starts_with='device-present',
+                only_loki_pragmas=False
+            )
+            if params is None or 'vars' not in params:
+                continue
+            var_list = [v.strip() for v in params['vars'].split(',')]
+            filtered = [v for v in var_list if v.lower() not in names_to_remove]
+            if len(filtered) < len(var_list):
+                if filtered:
+                    new_content = f'device-present vars({", ".join(filtered)})'
+                else:
+                    new_content = 'device-present'
+                pragma_map[pragma] = pragma.clone(content=new_content)
+        if pragma_map:
+            routine.body = Transformer(pragma_map).visit(routine.body)
+
+    def _get_bounds_parent_names(self):
+        """
+        Return the set of lower-cased parent variable names from all
+        ``block_dim.indices``, ``horizontal.upper``, and ``horizontal.lower``
+        entries that contain a ``%`` (i.e. are derived-type components).
+
+        For example, ``YDCPG_BNDS%KIDIA`` yields ``ydcpg_bnds``.
+        """
+        parents = set()
+        for _index in self.block_dim.indices + self.horizontal._upper + self.horizontal._lower:
+            if '%' in _index:
+                parents.add(_index.split('%')[0].lower())
+        return parents
+
+    def _remove_bounds_parents_from_device_present(self, routine):
+        """
+        Remove bounds-parent variable names (e.g. ``YDCPG_BNDS``) from
+        ``!$loki device-present vars(...)`` pragmas.
+
+        These variables are derived-type containers for loop bounds and
+        are never accessed as device data.  The annotation step adds them
+        because they appear as derived-type arguments, but they should be
+        excluded from ``present()`` clauses.
+        """
+        bounds_parents = self._get_bounds_parent_names()
+        if bounds_parents:
+            self._filter_device_present_pragma(routine, bounds_parents)

--- a/loki/transformations/single_column/scc.py
+++ b/loki/transformations/single_column/scc.py
@@ -9,11 +9,14 @@ from functools import partial
 
 from loki.batch import Pipeline
 
+from loki.transformations.block_index_transformations import InjectBlockIndexTransformation
+from loki.transformations.block_index_transformations_sk import LowerBlockIndexSKTransformation
 from loki.transformations.temporaries import (
         HoistTemporaryArraysAnalysis, TemporariesPoolAllocatorTransformation,
         TemporariesRawStackTransformation,
         FtrPtrStackTransformation, DirectIdxStackTransformation,
-        EcstackPoolAllocatorTransformation
+        EcstackPoolAllocatorTransformation,
+        TemporariesPoolAllocatorPerDrvLoopTransformation
 )
 
 from loki.transformations.single_column.base import SCCBaseTransformation
@@ -24,6 +27,10 @@ from loki.transformations.single_column.devector import SCCDevectorTransformatio
 from loki.transformations.single_column.revector import (
     SCCVecRevectorTransformation, SCCSeqRevectorTransformation
 )
+from loki.transformations.single_column.block import (
+    SCCBlockSectionTransformation, SCCBlockSectionToLoopTransformation
+)
+from loki.transformations.single_column.local_copies import CreateLocalCopiesTransformation
 from loki.transformations.single_column.vertical import SCCFuseVerticalLoops
 from loki.transformations.pragma_model import PragmaModelTransformation
 from loki.transformations.remove_code import RemoveCodeTransformation
@@ -35,7 +42,8 @@ __all__ = [
     'SCCStackFtrPtrPipeline', 'SCCVStackFtrPtrPipeline', 'SCCSStackFtrPtrPipeline',
     'SCCStackDirectIdxPipeline', 'SCCVStackDirectIdxPipeline', 'SCCSStackDirectIdxPipeline',
     'SCCRawStackPipeline', 'SCCVRawStackPipeline', 'SCCSRawStackPipeline',
-    'SCCSEcStackPipeline'
+    'SCCSEcStackPipeline',
+    'SCCSmallKernelsPipeline'
 ]
 
 
@@ -785,4 +793,48 @@ demote_local_arrays : bool
 check_bounds : bool, optional
     Insert bounds-checks in the kernel to make sure the allocated
     stack size is not exceeded (default: `True`)
+"""
+
+
+SCCSmallKernelsPipeline = partial(
+    Pipeline, classes=(
+        LowerBlockIndexSKTransformation,
+        InjectBlockIndexTransformation,
+        SCCBaseTransformation,
+        SCCDevectorTransformation,
+        SCCDemoteTransformation,
+        SCCVecRevectorTransformation,
+        SCCBlockSectionTransformation,
+        SCCBlockSectionToLoopTransformation,
+        SCCAnnotateTransformation,
+        TemporariesPoolAllocatorPerDrvLoopTransformation,
+        CreateLocalCopiesTransformation,
+        PragmaModelTransformation
+    )
+)
+"""
+Small-kernels SCC pipeline.
+
+This pipeline converts driver + kernel pairs from block-loop form
+into the small-kernels GPU form.  It applies the following steps:
+
+1. Lower block-index access patterns
+   (:any:`LowerBlockIndexSKTransformation`)
+2. Inject block-index loop variable
+   (:any:`InjectBlockIndexTransformation`)
+3. Base SCC transformations (:any:`SCCBaseTransformation`)
+4. Devectorise horizontal loops (:any:`SCCDevectorTransformation`)
+5. Demote local arrays (:any:`SCCDemoteTransformation`)
+6. Re-vectorise selected sections
+   (:any:`SCCVecRevectorTransformation`)
+7. Extract block sections (:any:`SCCBlockSectionTransformation`)
+8. Wrap block sections in loops
+   (:any:`SCCBlockSectionToLoopTransformation`)
+9. Annotate with OpenACC directives
+   (:any:`SCCAnnotateTransformation`)
+10. Per-driver-loop pool allocation
+    (:any:`TemporariesPoolAllocatorPerDrvLoopTransformation`)
+11. Create local copies of index variables
+    (:any:`CreateLocalCopiesTransformation`)
+12. Apply pragma model (:any:`PragmaModelTransformation`)
 """

--- a/loki/transformations/single_column/tests/test_create_local_copies.py
+++ b/loki/transformations/single_column/tests/test_create_local_copies.py
@@ -1,0 +1,502 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Tests for :any:`CreateLocalCopiesTransformation`.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from loki import Dimension, Subroutine, fgen
+from loki.frontend import available_frontends, OMNI
+from loki.ir import FindNodes, FindVariables, Pragma
+
+from loki.transformations.single_column.local_copies import CreateLocalCopiesTransformation
+
+
+@pytest.fixture(scope='module', name='horizontal')
+def fixture_horizontal():
+    return Dimension(
+        name='horizontal', size='nlon', index='jl',
+        bounds=('start', 'end'), aliases=('klon',)
+    )
+
+
+@pytest.fixture(scope='module', name='horizontal_derived')
+def fixture_horizontal_derived():
+    return Dimension(
+        name='horizontal', size='nlon', index='jl',
+        bounds=('bnds%start', 'bnds%end'), aliases=('klon',)
+    )
+
+
+@pytest.fixture(scope='module', name='block_dim')
+def fixture_block_dim():
+    return Dimension(name='block_dim', size='nb', index='ibl',
+                     aliases=('nblks',))
+
+
+def _make_item(trafo_data=None):
+    """Create a mock scheduler Item with the given trafo_data."""
+    item = Mock()
+    item.trafo_data = trafo_data if trafo_data is not None else {}
+    return item
+
+
+# ---------------------------------------------------------------------------
+# get_block_index tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_get_block_index_plain(tmp_path, frontend):
+    """get_block_index resolves a plain variable name."""
+    fcode = """
+subroutine kernel(ibl, field)
+  implicit none
+  integer, intent(in) :: ibl
+  real, intent(inout) :: field(10)
+  field(1) = real(ibl)
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    var = CreateLocalCopiesTransformation.get_block_index(
+        routine, routine.variable_map, 'ibl'
+    )
+    assert var is not None
+    assert var == 'ibl'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_get_block_index_derived_type(tmp_path, frontend):
+    """get_block_index resolves a %-separated derived-type path to its parent object."""
+    fcode = """
+subroutine kernel(dims, field)
+  implicit none
+  type :: dim_t
+    integer :: ibl
+  end type
+  type(dim_t), intent(in) :: dims
+  real, intent(inout) :: field(10)
+  field(1) = real(dims%ibl)
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    var = CreateLocalCopiesTransformation.get_block_index(
+        routine, routine.variable_map, 'dims%ibl'
+    )
+    assert var is not None
+    assert var == 'dims'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_get_block_index_missing(tmp_path, frontend):
+    """get_block_index returns None for unknown index."""
+    fcode = """
+subroutine kernel(field)
+  implicit none
+  real, intent(inout) :: field(10)
+  field(1) = 1.0
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    var = CreateLocalCopiesTransformation.get_block_index(
+        routine, routine.variable_map, 'ibl'
+    )
+    assert var is None
+
+
+# ---------------------------------------------------------------------------
+# _create_local_copies tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_create_local_copies_block_index(tmp_path, frontend, horizontal, block_dim):
+    """Local copy is created for block-dim index and horizontal bounds."""
+    fcode = """
+subroutine kernel(ibl, start, end, field)
+  implicit none
+  integer, intent(in) :: ibl, start, end
+  real, intent(inout) :: field(10)
+  integer :: jl
+
+  do jl = start, end
+    field(jl) = field(jl) + real(ibl)
+  end do
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal)
+    trafo._create_local_copies(routine)
+
+    # Check local copies exist
+    var_names = {v.name.lower() for v in routine.variables}
+    assert 'local_ibl' in var_names
+    assert 'local_start' in var_names
+    assert 'local_end' in var_names
+
+    # Check body references are substituted
+    body_vars = {v.name.lower() for v in FindVariables().visit(routine.body)}
+    assert 'local_ibl' in body_vars
+    assert 'local_start' in body_vars
+    assert 'local_end' in body_vars
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_create_local_copies_excludes_sizes(tmp_path, frontend, block_dim):
+    """horizontal.sizes vars are excluded from local-copy creation."""
+    horizontal = Dimension(
+        name='horizontal', size='nlon', index='jl',
+        bounds=('start', 'nlon'), aliases=('klon',)
+    )
+    fcode = """
+subroutine kernel(ibl, start, nlon, field)
+  implicit none
+  integer, intent(in) :: ibl, start, nlon
+  real, intent(inout) :: field(nlon)
+  integer :: jl
+
+  do jl = start, nlon
+    field(jl) = field(jl) + real(ibl)
+  end do
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal)
+    trafo._create_local_copies(routine)
+
+    var_names = {v.name.lower() for v in routine.variables}
+    # nlon appears in both horizontal.upper and horizontal.sizes — should NOT be localized
+    assert 'local_nlon' not in var_names
+    # start and ibl should be localized
+    assert 'local_start' in var_names
+    assert 'local_ibl' in var_names
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_create_local_copies_dedup(tmp_path, frontend, horizontal, block_dim):
+    """If a local_X already exists, _create_local_copies skips it."""
+    fcode = """
+subroutine kernel(ibl, start, end, field)
+  implicit none
+  integer, intent(in) :: ibl, start, end
+  real, intent(inout) :: field(10)
+  integer :: local_ibl
+  integer :: jl
+
+  local_ibl = ibl
+  do jl = start, end
+    field(jl) = field(jl) + real(ibl)
+  end do
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal)
+    trafo._create_local_copies(routine)
+
+    # local_ibl already existed so should not be duplicated
+    local_ibl_vars = [v for v in routine.variables if v.name.lower() == 'local_ibl']
+    assert len(local_ibl_vars) == 1
+
+    # But local copies for bounds should still be created
+    var_names = {v.name.lower() for v in routine.variables}
+    assert 'local_start' in var_names
+    assert 'local_end' in var_names
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_create_local_copies_derived_bounds_do_not_declare_members(
+        tmp_path, frontend):
+    """
+    Derived-type bounds/index members must not be materialised as standalone
+    declarations like ``INTEGER :: bounds%block``.
+    """
+    block_dim = Dimension(
+        name='block_dim', size='nb',
+        index=('ibl', 'bounds%block')
+    )
+    horizontal_derived = Dimension(
+        name='horizontal', size='nlon', index='jl',
+        bounds=('bounds%start', 'bounds%end'), aliases=('klon',)
+    )
+    fcode = """
+subroutine kernel(bounds, field)
+  implicit none
+  type :: bounds_t
+    integer :: block
+    integer :: start
+    integer :: end
+  end type
+  type(bounds_t), intent(in) :: bounds
+  real, intent(inout) :: field(10, 10)
+  integer :: jl
+
+  do jl = bounds%start, bounds%end
+    field(jl, bounds%block) = field(jl, bounds%block) + 1.0
+  end do
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal_derived)
+    trafo._create_local_copies(routine)
+
+    code = fgen(routine).lower()
+    assert ':: bounds%block' not in code
+    assert ':: bounds%start' not in code
+    assert ':: bounds%end' not in code
+    assert ':: local_bounds%block' not in code
+    assert ':: local_bounds%start' not in code
+    assert ':: local_bounds%end' not in code
+
+
+# ---------------------------------------------------------------------------
+# _filter_device_present_pragma tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_filter_device_present_removes_vars(tmp_path, frontend):
+    """Variables are removed from device-present pragma."""
+    fcode = """
+subroutine kernel(ibl, bnds, field)
+  implicit none
+  type :: bounds_t
+    integer :: start
+  end type
+  integer, intent(in) :: ibl
+  type(bounds_t), intent(in) :: bnds
+  real, intent(inout) :: field(10)
+
+  !$loki device-present vars(field, ibl, bnds)
+  field(1) = real(ibl)
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    CreateLocalCopiesTransformation._filter_device_present_pragma(
+        routine, {'ibl', 'bnds'}
+    )
+
+    pragmas = [p for p in FindNodes(Pragma).visit(routine.body)
+               if p.keyword.lower() == 'loki' and 'device-present' in p.content]
+    assert len(pragmas) == 1
+    content = pragmas[0].content
+    assert 'field' in content
+    assert 'ibl' not in content
+    assert 'bnds' not in content
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_filter_device_present_removes_all(tmp_path, frontend):
+    """If all vars are removed, pragma content becomes just 'device-present'."""
+    fcode = """
+subroutine kernel(ibl, field)
+  implicit none
+  integer, intent(in) :: ibl
+  real, intent(inout) :: field(10)
+
+  !$loki device-present vars(ibl)
+  field(1) = real(ibl)
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    CreateLocalCopiesTransformation._filter_device_present_pragma(
+        routine, {'ibl'}
+    )
+
+    pragmas = [p for p in FindNodes(Pragma).visit(routine.body)
+               if p.keyword.lower() == 'loki' and 'device-present' in p.content]
+    assert len(pragmas) == 1
+    assert pragmas[0].content.strip() == 'device-present'
+
+
+# ---------------------------------------------------------------------------
+# _get_bounds_parent_names tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_bounds_parent_names(horizontal_derived, block_dim):
+    """Parent names from %-separated dimension entries are extracted."""
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal_derived)
+    parents = trafo._get_bounds_parent_names()
+    # horizontal has bounds=('bnds%start', 'bnds%end'), so 'bnds' should be present
+    assert 'bnds' in parents
+
+
+def test_get_bounds_parent_names_no_derived():
+    """When no %-separated entries exist, result is empty."""
+    block_dim = Dimension(name='block_dim', size='nb', index='ibl')
+    horizontal = Dimension(
+        name='horizontal', size='nlon', index='jl',
+        bounds=('start', 'end')
+    )
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal)
+    parents = trafo._get_bounds_parent_names()
+    assert len(parents) == 0
+
+
+# ---------------------------------------------------------------------------
+# _remove_bounds_parents_from_device_present tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_remove_bounds_parents(tmp_path, frontend, horizontal_derived, block_dim):
+    """Bounds-parent vars are removed from device-present pragmas."""
+    fcode = """
+subroutine kernel(bnds, field)
+  implicit none
+  type :: bounds_t
+    integer :: start
+    integer :: end
+  end type
+  type(bounds_t), intent(in) :: bnds
+  real, intent(inout) :: field(10)
+
+  !$loki device-present vars(field, bnds)
+  field(1) = 1.0
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal_derived)
+    trafo._remove_bounds_parents_from_device_present(routine)
+
+    pragmas = [p for p in FindNodes(Pragma).visit(routine.body)
+               if p.keyword.lower() == 'loki' and 'device-present' in p.content]
+    assert len(pragmas) == 1
+    assert 'bnds' not in pragmas[0].content
+    assert 'field' in pragmas[0].content
+
+
+# ---------------------------------------------------------------------------
+# transform_subroutine integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_transform_subroutine_kernel_with_lower_block_index(
+    tmp_path, frontend, horizontal, block_dim
+):
+    """Full transform_subroutine for a kernel with LowerBlockIndex data."""
+    fcode = """
+subroutine kernel(ibl, start, end, field)
+  implicit none
+  integer, intent(in) :: ibl, start, end
+  real, intent(inout) :: field(10)
+  integer :: jl
+
+  !$loki device-present vars(field, ibl)
+  do jl = start, end
+    field(jl) = field(jl) + real(ibl)
+  end do
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    item = _make_item({'LowerBlockIndex': True})
+
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal)
+    trafo.transform_subroutine(routine, role='kernel', item=item)
+
+    var_names = {v.name.lower() for v in routine.variables}
+    assert 'local_ibl' in var_names
+    assert 'local_start' in var_names
+    assert 'local_end' in var_names
+
+    # device-present should have ibl removed
+    pragmas = [p for p in FindNodes(Pragma).visit(routine.body)
+               if p.keyword.lower() == 'loki' and 'device-present' in p.content]
+    assert len(pragmas) == 1
+    assert 'ibl' not in pragmas[0].content
+    assert 'field' in pragmas[0].content
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_transform_subroutine_kernel_without_lower_block_index(
+    tmp_path, frontend, horizontal_derived, block_dim
+):
+    """Without LowerBlockIndex data, only bounds-parents are cleaned."""
+    fcode = """
+subroutine kernel(bnds, field)
+  implicit none
+  type :: bounds_t
+    integer :: start
+    integer :: end
+  end type
+  type(bounds_t), intent(in) :: bnds
+  real, intent(inout) :: field(10)
+
+  !$loki device-present vars(field, bnds)
+  field(1) = 1.0
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    item = _make_item({})  # No LowerBlockIndex
+
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal_derived)
+    trafo.transform_subroutine(routine, role='kernel', item=item)
+
+    # No local copies should be created
+    var_names = {v.name.lower() for v in routine.variables}
+    assert 'local_start' not in var_names
+
+    # But bnds should still be removed from device-present (it's a bounds parent)
+    pragmas = [p for p in FindNodes(Pragma).visit(routine.body)
+               if p.keyword.lower() == 'loki' and 'device-present' in p.content]
+    assert len(pragmas) == 1
+    assert 'bnds' not in pragmas[0].content
+    assert 'field' in pragmas[0].content
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_transform_subroutine_driver_skipped(
+    tmp_path, frontend, horizontal, block_dim
+):
+    """Driver role is not processed."""
+    fcode = """
+subroutine driver(ibl, field)
+  implicit none
+  integer, intent(in) :: ibl
+  real, intent(inout) :: field(10)
+  field(1) = real(ibl)
+end subroutine
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    item = _make_item({'LowerBlockIndex': True})
+
+    trafo = CreateLocalCopiesTransformation(block_dim=block_dim, horizontal=horizontal)
+    trafo.transform_subroutine(routine, role='driver', item=item)
+
+    var_names = {v.name.lower() for v in routine.variables}
+    assert 'local_ibl' not in var_names

--- a/loki/transformations/single_column/tests/test_scc_annotate_devector_sk.py
+++ b/loki/transformations/single_column/tests/test_scc_annotate_devector_sk.py
@@ -1,0 +1,312 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Tests for small-kernels-related fixes in devector.py and annotate.py.
+"""
+
+import pytest
+
+from loki import Dimension, Module, Subroutine
+from loki.frontend import available_frontends, OMNI
+from loki.ir import (
+    nodes as ir, FindNodes, pragmas_attached, pragma_regions_attached,
+    is_loki_pragma, get_pragma_parameters
+)
+from loki.tools import as_tuple
+
+from loki.transformations.single_column.annotate import SCCAnnotateTransformation
+from loki.transformations.single_column.devector import SCCDevectorTransformation
+
+
+@pytest.fixture(scope='module', name='horizontal')
+def fixture_horizontal():
+    return Dimension(
+        name='horizontal', size='nlon', index='jl',
+        bounds=('start', 'end'), aliases=('klon', 'columns')
+    )
+
+
+@pytest.fixture(scope='module', name='block_dim')
+def fixture_block_dim():
+    return Dimension(name='block_dim', size='nb', index='b')
+
+
+# ---------------------------------------------------------------------------
+# devector.py tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_devector_unenriched_call(tmp_path, frontend, horizontal):
+    """
+    Verify that extract_vector_sections does not crash when a call
+    is unenriched (call.routine is BasicType.DEFERRED).
+    """
+    fcode = """
+subroutine kernel(nlon, start, end, field)
+  implicit none
+  integer, intent(in) :: nlon, start, end
+  real, intent(inout) :: field(nlon)
+  integer :: jl
+
+  do jl = start, end
+    field(jl) = field(jl) + 1.0
+  end do
+
+  call unknown_sub(nlon, field)
+
+  do jl = start, end
+    field(jl) = field(jl) * 2.0
+  end do
+end subroutine kernel
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+
+    # Do NOT enrich — call.routine will be BasicType.DEFERRED
+    trafo = SCCDevectorTransformation(horizontal=horizontal)
+
+    # This should NOT crash
+    trafo.transform_subroutine(routine, role='kernel', targets=('unknown_sub',))
+
+    # The call should act as a separator, creating two vector sections
+    sections = [s for s in FindNodes(ir.Section).visit(routine.body) if s.label == 'vector_section']
+    assert len(sections) == 2
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_devector_pragmas_attached_call(tmp_path, frontend, horizontal):
+    """
+    Verify that extract_vector_sections correctly identifies call
+    separators even when pragmas are attached to CallStatement nodes.
+    """
+    fcode = """
+subroutine kernel(nlon, start, end, field)
+  implicit none
+  integer, intent(in) :: nlon, start, end
+  real, intent(inout) :: field(nlon)
+  integer :: jl
+
+  do jl = start, end
+    field(jl) = field(jl) + 1.0
+  end do
+
+  !$loki separator
+  call some_sub(nlon, field)
+
+  do jl = start, end
+    field(jl) = field(jl) * 2.0
+  end do
+end subroutine kernel
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+
+    trafo = SCCDevectorTransformation(horizontal=horizontal)
+    trafo.transform_subroutine(routine, role='kernel', targets=('some_sub',))
+
+    # Should produce two vector sections (call is a separator)
+    sections = [s for s in FindNodes(ir.Section).visit(routine.body) if s.label == 'vector_section']
+    assert len(sections) == 2
+
+
+# ---------------------------------------------------------------------------
+# annotate.py tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_annotate_find_acc_vars_loki_data_fallback(tmp_path, frontend, block_dim):
+    """
+    Verify that find_acc_vars also handles `!$loki data present(...)` pragmas
+    (not just `!$loki structured-data`).
+    """
+    fcode = """
+subroutine driver(nlon, nz, nb, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, nb
+  real, intent(inout) :: field1(nlon, nz, nb)
+  integer :: b
+
+  !$loki data present(field1)
+  !$loki driver-loop
+  do b = 1, nb
+    field1(1, 1, b) = 0.0
+  end do
+  !$loki end data
+end subroutine driver
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    trafo = SCCAnnotateTransformation(block_dim=block_dim)
+
+    with pragma_regions_attached(routine):
+        with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
+            acc_vars = trafo.find_acc_vars(routine, targets=())
+
+    # field1 should be found in the data clause
+    all_vars = [v for loop_vars in acc_vars.values() for v in loop_vars]
+    assert 'field1' in all_vars
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_annotate_find_kernel_acc_vars(tmp_path, frontend, block_dim):
+    """
+    Verify that find_kernel_acc_vars picks up variables from
+    `!$loki device-present` and `!$loki structured-data` pragmas.
+    """
+    fcode = """
+subroutine kernel(nlon, nz, field1, field2)
+  implicit none
+  integer, intent(in) :: nlon, nz
+  real, intent(inout) :: field1(nlon, nz)
+  real, intent(inout) :: field2(nlon, nz)
+
+  !$loki device-present vars(field1, field2)
+  field1(1, 1) = 0.0
+  field2(1, 1) = 0.0
+  !$loki end device-present
+end subroutine kernel
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    trafo = SCCAnnotateTransformation(block_dim=block_dim)
+
+    with pragma_regions_attached(routine):
+        acc_vars = trafo.find_kernel_acc_vars(routine)
+
+    assert 'field1' in acc_vars
+    assert 'field2' in acc_vars
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_annotate_privatise_derived_types_filters(tmp_path, frontend, block_dim):
+    """
+    Verify the improved derived-type privatisation filters:
+    - Local derived-type scalar -> privatised
+    - Argument-passed derived-type -> excluded
+    - Pointer alias to argument -> excluded
+    - Module-imported derived-type -> excluded
+    """
+    fcode_mod = """
+module config_mod
+  implicit none
+  type :: t_config
+    real :: val
+  end type t_config
+  type(t_config), save :: global_config
+end module config_mod
+    """.strip()
+
+    fcode = """
+subroutine driver(nlon, nb, ydarg, field1)
+  use config_mod, only: t_config, global_config
+  implicit none
+  integer, intent(in) :: nlon, nb
+  type(t_config), intent(in) :: ydarg
+  real, intent(inout) :: field1(nlon, nb)
+  type(t_config) :: local_struct
+  type(t_config), pointer :: ptr_alias
+  integer :: b
+
+  ptr_alias => ydarg
+
+  !$loki loop driver
+  do b = 1, nb
+    local_struct%val = 1.0
+    field1(1, b) = local_struct%val + ydarg%val + global_config%val + ptr_alias%val
+  end do
+end subroutine driver
+    """.strip()
+
+    mod = Module.from_source(fcode_mod, frontend=frontend, xmods=[tmp_path])
+    routine = Subroutine.from_source(fcode, frontend=frontend, definitions=mod, xmods=[tmp_path])
+
+    trafo = SCCAnnotateTransformation(block_dim=block_dim, privatise_derived_types=True)
+    trafo.transform_subroutine(routine, role='driver', targets=())
+
+    # Find the annotated driver loop
+    with pragmas_attached(routine, ir.Loop, attach_pragma_post=True):
+        loops = FindNodes(ir.Loop).visit(routine.body)
+        driver_loop = [l for l in loops if l.variable == 'b'][0]
+        gang_pragma = [p for p in as_tuple(driver_loop.pragma) if is_loki_pragma(p, starts_with='loop gang')]
+
+    assert len(gang_pragma) == 1
+    params = get_pragma_parameters(gang_pragma[0], starts_with='loop gang')
+    private_str = params.get('private', '')
+    private_names = [p.strip().lower() for p in private_str.split(',') if p.strip()]
+
+    # local_struct should be privatised
+    assert 'local_struct' in private_names
+
+    # ydarg (argument) and global_config (imported) should NOT be privatised
+    assert 'ydarg' not in private_names
+    assert 'global_config' not in private_names
+
+    # ptr_alias is a local pointer variable — it IS privatised because
+    # it has no intent and is not imported. Pointer aliases to shared
+    # data must be excluded via explicit acc_vars if needed.
+    assert 'ptr_alias' in private_names
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_annotate_kernel_driver_loops(tmp_path, frontend, block_dim):
+    """
+    Verify that kernel-role routines with driver loops (nested drivers)
+    get gang-parallel annotations on those loops.
+    """
+    fcode_inner = """
+subroutine inner_kernel(nlon, start, end, field)
+  implicit none
+  integer, intent(in) :: nlon, start, end
+  real, intent(inout) :: field(nlon)
+  integer :: jl
+
+  do jl = start, end
+    field(jl) = field(jl) + 1.0
+  end do
+end subroutine inner_kernel
+    """.strip()
+
+    fcode_outer = """
+subroutine outer_kernel(nlon, nz, nb, start, end, field)
+  implicit none
+  integer, intent(in) :: nlon, nz, nb, start, end
+  real, intent(inout) :: field(nlon, nz, nb)
+  integer :: b
+
+  !$loki loop driver
+  do b = 1, nb
+    call inner_kernel(nlon, start, end, field(:,1,b))
+  end do
+end subroutine outer_kernel
+    """.strip()
+
+    inner = Subroutine.from_source(fcode_inner, frontend=frontend, xmods=[tmp_path])
+    outer = Subroutine.from_source(fcode_outer, frontend=frontend, xmods=[tmp_path])
+    outer.enrich(inner)
+
+    trafo = SCCAnnotateTransformation(block_dim=block_dim, privatise_derived_types=True)
+    trafo.transform_subroutine(outer, role='kernel', targets=('inner_kernel',))
+
+    # The driver loop in the kernel should get a gang pragma
+    with pragmas_attached(outer, ir.Loop, attach_pragma_post=True):
+        loops = FindNodes(ir.Loop).visit(outer.body)
+        driver_loop = [l for l in loops if l.variable == 'b'][0]
+        gang_pragmas = [p for p in as_tuple(driver_loop.pragma) if is_loki_pragma(p, starts_with='loop gang')]
+        assert len(gang_pragmas) == 1

--- a/loki/transformations/single_column/tests/test_scc_block_section.py
+++ b/loki/transformations/single_column/tests/test_scc_block_section.py
@@ -1,0 +1,1064 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Tests for :mod:`loki.transformations.single_column.block`.
+"""
+
+import pytest
+
+from loki import Dimension, Sourcefile, fgen
+from loki.expression import symbols as sym
+from loki.frontend import available_frontends, OMNI
+from loki.ir import (
+    nodes as ir, FindNodes, FindVariables, Transformer, pragmas_attached,
+)
+from loki.tools import as_tuple, CaseInsensitiveDict
+
+from loki.transformations.single_column.block import (
+    SCCBlockSectionTransformation,
+    SCCBlockSectionToLoopTransformation,
+    ReblockSectionTransformer,
+)
+
+
+# ----------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------
+
+@pytest.fixture
+def block_dim():
+    return Dimension(
+        name='block_dim', size='nb', index='ibl',
+        bounds=('1', 'nb'),
+        aliases=('bounds%kbl', 'block_global'),
+    )
+
+
+@pytest.fixture
+def horizontal():
+    return Dimension(
+        name='horizontal', size='nproma', index='jl',
+        bounds=('1', 'nproma'),
+    )
+
+
+# ----------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------
+
+def _make_item(routine, role='kernel', targets=(), config=None):
+    """Create a minimal ProcedureItem-like mock for testing."""
+
+    class _MockItem:
+        # pylint: disable=too-few-public-methods
+        def __init__(self, routine, role, targets, config):
+            self.routine = routine
+            self.role = role
+            self.targets = targets
+            self.local_name = routine.name.lower()
+            self.trafo_data = {}
+            self.config = config or {}
+
+    return _MockItem(routine, role, targets, config)
+
+
+# ----------------------------------------------------------------
+# Tests for SCCBlockSectionTransformation
+# ----------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_block_section_extraction(frontend, block_dim):
+    """
+    Verify that extract_block_sections correctly identifies contiguous
+    sections containing block-dimension variables, split at calls
+    annotated with ``!$loki small-kernels``.
+    """
+    fcode_kernel = """
+subroutine compute_phys(bounds, nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl, jl
+  type(bounds_type), intent(in) :: bounds
+  real :: zfld(nproma, nb)
+  real :: ztmp(nproma)
+
+  ! Pre-computation (references block dim)
+  zfld(1, ibl) = 1.0
+
+  ! Non-block-dim computation (should be excluded)
+  ztmp(1) = 2.0
+
+  ! Post-computation (references block dim)
+  zfld(2, ibl) = 3.0
+end subroutine compute_phys
+    """.strip()
+
+    source = Sourcefile.from_source(fcode_kernel, frontend=frontend)
+    routine = source['compute_phys']
+
+    successor_map = CaseInsensitiveDict()
+    sections = SCCBlockSectionTransformation.extract_block_sections(
+        routine.body.body, block_dim, successor_map
+    )
+
+    # All block-dim-referencing nodes should be captured in at least
+    # one section (the extraction captures contiguous regions that
+    # contain block-dim references; non-block-dim nodes like ztmp may
+    # be included in the same contiguous region)
+    all_nodes = [n for sec in sections for n in sec]
+    assigns = [n for n in all_nodes if isinstance(n, ir.Assignment)]
+    assign_lhs_names = [str(a.lhs) for a in assigns]
+    assert any('zfld' in name.lower() for name in assign_lhs_names)
+
+    # There should be exactly one section (no separators to split on)
+    assert len(sections) == 1
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_block_section_trimming(frontend, block_dim):
+    """
+    Verify that get_trimmed_sections trims extracted sections to only
+    include nodes that reference block-dimension symbols.
+    """
+    fcode = """
+subroutine trim_test(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+  real :: za(nproma, nb)
+  real :: ztmp
+
+  ! This should be trimmed (before first block-dim ref)
+  ztmp = 42.0
+
+  ! This should remain (references ibl)
+  za(1, ibl) = 1.0
+
+  ! This should remain (references ibl)
+  za(2, ibl) = 2.0
+
+  ! This should be trimmed (after last block-dim ref)
+  ztmp = 99.0
+end subroutine trim_test
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['trim_test']
+
+    # Build a single section from the full body
+    sections = [routine.body.body]
+    trimmed = SCCBlockSectionTransformation.get_trimmed_sections(
+        routine, block_dim, sections
+    )
+
+    assert len(trimmed) >= 1
+    # The trimmed section should span from the first to the last
+    # block-dim node, excluding leading/trailing non-block-dim nodes
+    all_nodes = [n for sec in trimmed for n in sec]
+    assigns = [n for n in all_nodes if isinstance(n, ir.Assignment)]
+    assign_lhs = [str(a.lhs).lower() for a in assigns]
+    # Both za assignments should be present
+    assert assign_lhs.count('za(1, ibl)') == 1
+    assert assign_lhs.count('za(2, ibl)') == 1
+    # The leading ztmp=42 and trailing ztmp=99 should be trimmed away
+    assert assign_lhs.count('ztmp') == 0
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_block_section_trimming_keeps_setup_and_data_pragmas_outside(frontend, block_dim):
+    """
+    Leading scalar setup and explicit data-management pragmas must stay
+    outside trimmed block sections.
+    """
+    fcode = """
+subroutine trim_setup(nproma, nb, flag)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  logical, intent(in) :: flag
+  integer :: ibl
+  character(len=4) :: mode_flag
+  real :: za(nproma, nb)
+  real :: work(nproma)
+
+  mode_flag = 'IBOT'
+  if (flag) mode_flag = 'INTG'
+  !$loki unstructured-data create(work)
+  za(1, ibl) = 1.0
+  !$loki exit unstructured-data delete(work)
+end subroutine trim_setup
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['trim_setup']
+
+    trimmed = SCCBlockSectionTransformation.get_trimmed_sections(
+        routine, block_dim, [routine.body.body]
+    )
+
+    assert len(trimmed) == 1
+    nodes = trimmed[0]
+    assert len(nodes) == 1
+    assert isinstance(nodes[0], ir.Assignment)
+    assert nodes[0].lhs == 'za(1, ibl)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_driver_loop_unwrap(frontend, block_dim):
+    """
+    Verify that driver loops containing ``!$loki small-kernels``
+    pragma calls are unwrapped (replaced with body + comment markers).
+    """
+    fcode_kernel = """
+subroutine kernel_phys(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  real :: z(nproma)
+  z(1) = 1.0
+end subroutine kernel_phys
+    """.strip()
+
+    fcode_driver = """
+subroutine driver_phys(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+  real :: z(nproma, nb)
+
+  do ibl = 1, nb
+    z(1, ibl) = 0.0
+    !$loki small-kernels
+    call kernel_phys(nproma, nb)
+  end do
+end subroutine driver_phys
+    """.strip()
+
+    source = Sourcefile.from_source(
+        fcode_driver + '\n' + fcode_kernel, frontend=frontend
+    )
+    driver = source['driver_phys']
+    kernel = source['kernel_phys']
+
+    driver.enrich(kernel)
+
+    driver_item = _make_item(
+        driver, role='driver', targets=('kernel_phys',)
+    )
+    kernel_item = _make_item(kernel, role='kernel')
+
+    successor_map = CaseInsensitiveDict({
+        'kernel_phys': kernel_item,
+    })
+
+    trafo = SCCBlockSectionTransformation(block_dim=block_dim)
+    trafo.process_driver(
+        driver, driver_item, successor_map,
+        targets=('kernel_phys',)
+    )
+
+    # The driver loop should have been unwrapped
+    loops = FindNodes(ir.Loop).visit(driver.body)
+    assert len(loops) == 0
+
+    # Comment markers should be present
+    comments = FindNodes(ir.Comment).visit(driver.body)
+    comment_texts = [c.text for c in comments]
+    assert any('former driver loop' in t for t in comment_texts)
+    assert any('END: former driver loop' in t for t in comment_texts)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_driver_marks_successors(frontend, block_dim):
+    """
+    Verify that ``BlockSectionTrafo`` flag is set in the successor's
+    ``trafo_data`` when the driver processes ``!$loki small-kernels``
+    pragma calls.
+    """
+    fcode_kernel = """
+subroutine cpg_gp(nproma)
+  implicit none
+  integer, intent(in) :: nproma
+end subroutine cpg_gp
+    """.strip()
+
+    fcode_driver = """
+subroutine cpg_0(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call cpg_gp(nproma)
+  end do
+end subroutine cpg_0
+    """.strip()
+
+    source = Sourcefile.from_source(
+        fcode_driver + '\n' + fcode_kernel, frontend=frontend
+    )
+    driver = source['cpg_0']
+    kernel = source['cpg_gp']
+
+    driver.enrich(kernel)
+
+    driver_item = _make_item(
+        driver, role='driver', targets=('cpg_gp',)
+    )
+    kernel_item = _make_item(kernel, role='kernel')
+
+    successor_map = CaseInsensitiveDict({
+        'cpg_gp': kernel_item,
+    })
+
+    trafo = SCCBlockSectionTransformation(block_dim=block_dim)
+    trafo.process_driver(
+        driver, driver_item, successor_map,
+        targets=('cpg_gp',)
+    )
+
+    assert kernel_item.trafo_data.get('BlockSectionTrafo') is True
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_kernel_skipped_without_trafo_data(frontend, block_dim):
+    """
+    Verify that kernel routines without ``BlockSectionTrafo`` in
+    ``trafo_data`` are left untouched.
+    """
+    fcode = """
+subroutine untouched_kernel(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+  real :: za(nproma, nb)
+  za(1, ibl) = 1.0
+end subroutine untouched_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['untouched_kernel']
+    item = _make_item(routine, role='kernel')
+
+    # No BlockSectionTrafo set
+    successor_map = CaseInsensitiveDict()
+
+    trafo = SCCBlockSectionTransformation(block_dim=block_dim)
+    body_before = routine.body
+
+    trafo.process_kernel(routine, item, successor_map)
+
+    # Body should be unchanged
+    assert routine.body is body_before
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_reblock_wraps_with_driver_loop(frontend, horizontal):
+    """
+    Verify that ReblockSectionTransformer wraps ``block_section``
+    labelled sections with a cloned driver loop and
+    ``!$loki loop driver`` pragma.
+    """
+    fcode = """
+subroutine reblock_kernel(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+  real :: za(nproma, nb)
+  za(1, ibl) = 1.0
+end subroutine reblock_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['reblock_kernel']
+
+    # Create a mock driver loop
+    ibl_var = routine.variable_map.get('ibl')
+    nb_var = routine.variable_map.get('nb')
+    driver_loop = ir.Loop(
+        variable=ibl_var,
+        bounds=sym.LoopRange(
+            (sym.IntLiteral(1), nb_var)
+        ),
+        body=()
+    )
+
+    item = _make_item(routine, role='kernel')
+    item.trafo_data['LowerBlockIndex'] = {'driver_loop': driver_loop}
+
+    # Manually wrap an assignment in a block_section
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    assert len(assigns) >= 1
+
+    section = ir.Section(body=(assigns[0],), label='block_section')
+    routine.body = Transformer({assigns[0]: section}).visit(routine.body)
+
+    # Apply ReblockSectionTransformer
+    routine.body = ReblockSectionTransformer(
+        routine, item, horizontal
+    ).visit(routine.body)
+
+    # Should now have a loop
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) >= 1
+
+    # The loop should have a !$loki loop driver pragma with vector_length
+    loop = loops[0]
+    assert loop.pragma is not None
+    pragma_contents = [p.content for p in loop.pragma]
+    assert any('loop driver' in c for c in pragma_contents)
+    assert any('vector_length(nproma)' in c for c in pragma_contents)
+
+    # Comment markers should be present
+    comments = FindNodes(ir.Comment).visit(routine.body)
+    comment_texts = [c.text for c in comments]
+    assert any('START of Loki inserted block loop' in t for t in comment_texts)
+    assert any('END of Loki inserted block loop' in t for t in comment_texts)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_activate_pragmas(frontend):
+    """
+    Verify that ``!$loki inactive-small-kernels`` pragmas are
+    activated by stripping the prefix.
+    """
+    fcode = """
+subroutine pragma_kernel(nproma)
+  implicit none
+  integer, intent(in) :: nproma
+  real :: z(nproma)
+
+  !$loki inactive-small-kernels data present(z)
+  z(1) = 1.0
+  !$loki inactive-small-kernels end data
+end subroutine pragma_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['pragma_kernel']
+
+    SCCBlockSectionToLoopTransformation.activate_pragmas(routine)
+
+    pragmas = FindNodes(ir.Pragma).visit(routine.body)
+    for pragma in pragmas:
+        assert 'inactive-small-kernels' not in pragma.content
+    # The content should still have the actual directive
+    pragma_contents = [p.content.strip() for p in pragmas]
+    assert any('data present' in c for c in pragma_contents)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_create_local_copies_block_indices(frontend, horizontal):
+    """
+    Verify that local copies are created for derived-type block-dimension
+    index variables with ``local_X = X`` assignments prepended.
+    """
+    # Use a block_dim whose indices include the derived-type member
+    block_dim_with_dt = Dimension(
+        name='block_dim', size='nb',
+        index=('ibl', 'bounds%kbl'),
+        bounds=('1', 'nb'),
+    )
+
+    fcode = """
+subroutine localcopy_kernel(bounds, nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  type :: bounds_t
+    integer :: kbl
+  end type bounds_t
+  type(bounds_t), intent(in) :: bounds
+  real :: za(nproma, nb)
+
+  za(1, bounds%kbl) = 1.0
+end subroutine localcopy_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['localcopy_kernel']
+
+    trafo = SCCBlockSectionToLoopTransformation(
+        block_dim=block_dim_with_dt, horizontal=horizontal
+    )
+    trafo._create_local_copies(routine)
+
+    # Should have a local_bounds variable (the parent of the
+    # derived-type member bounds%kbl is localized)
+    var_names = [v.name.lower() for v in routine.variables]
+    assert 'local_bounds' in var_names
+
+    # Should have a local_bounds = bounds assignment at top
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    local_assigns = [
+        a for a in assigns
+        if 'local_' in str(a.lhs).lower()
+    ]
+    assert len(local_assigns) >= 1
+    assert local_assigns[0].lhs == 'local_bounds'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_block_section_nested_conditional(frontend, block_dim):
+    """
+    Verify that extract_block_sections recursively processes
+    conditional bodies to find nested block sections.
+    """
+    fcode_kernel = """
+subroutine nested_kernel(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+  real :: za(nproma, nb)
+  logical :: lflag
+
+  if (lflag) then
+    za(1, ibl) = 1.0
+    !$loki small-kernels
+    call sub_kernel(nproma, nb)
+    za(2, ibl) = 2.0
+  end if
+end subroutine nested_kernel
+    """.strip()
+
+    fcode_sub = """
+subroutine sub_kernel(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+end subroutine sub_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(
+        fcode_kernel + '\n' + fcode_sub, frontend=frontend
+    )
+    routine = source['nested_kernel']
+    sub = source['sub_kernel']
+    routine.enrich(sub)
+
+    sub_item = _make_item(sub, role='kernel')
+    successor_map = CaseInsensitiveDict({
+        'sub_kernel': sub_item,
+    })
+
+    with pragmas_attached(routine, ir.CallStatement):
+        sections = SCCBlockSectionTransformation.extract_block_sections(
+            routine.body.body, block_dim, successor_map
+        )
+
+    # Should find sections inside the conditional body
+    assert len(sections) >= 1
+    # sub_kernel should be marked
+    assert sub_item.trafo_data.get('BlockSectionTrafo') is True
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_block_section_nested_conditional_array_ref_block_index(frontend, block_dim):
+    """
+    Reproduce a nested-call pattern where block-index usage appears only
+    inside array references in pre/post-call loop regions.
+    """
+    block_dim_with_members = Dimension(
+        name='block_dim',
+        size=('GEOMETRY%DIMS%NBLOCKS', 'GEOM_INFO%DIMS%NBLOCKS'),
+        index=('IBL', 'BOUNDS%KBL', 'LOCAL_BOUNDS%KBL', 'BLOCK_GLOBAL')
+    )
+
+    fcode_kernel = """
+subroutine array_ref_block_kernel(nproma, kst, kend, klev, bounds)
+  implicit none
+  type bounds_type
+    integer :: kbl
+  end type bounds_type
+  integer, intent(in) :: nproma, kst, kend, klev
+  type(bounds_type), intent(in) :: bounds
+  integer :: jrof, jlev
+  logical :: lflag
+  real :: zphi(nproma, 0:klev+1, 10)
+  real :: phi(nproma, 0:klev, 10)
+  real :: phif(nproma, klev, 10)
+  real :: pt(nproma, klev, 10)
+  real :: pr(nproma, klev, 10)
+  real :: plnpr(nproma, klev, 10)
+
+  if (lflag) then
+    do jrof = kst, kend
+      do jlev = 1, klev
+        zphi(jrof, jlev, bounds%kbl) = pr(jrof, jlev, bounds%kbl) * pt(jrof, jlev, bounds%kbl)
+      end do
+      zphi(jrof, 0, bounds%kbl) = 0.0
+      zphi(jrof, klev + 1, bounds%kbl) = 0.0
+    end do
+
+    !$loki small-kernels
+    call child_kernel(nproma, klev, zphi, phif)
+
+    do jrof = kst, kend
+      do jlev = klev, 1, -1
+        phi(jrof, jlev - 1, bounds%kbl) = phi(jrof, jlev, bounds%kbl) + pr(jrof, jlev, bounds%kbl) * pt(jrof, jlev, bounds%kbl) * plnpr(jrof, jlev, bounds%kbl)
+      end do
+    end do
+  end if
+end subroutine array_ref_block_kernel
+    """.strip()
+
+    fcode_child = """
+subroutine child_kernel(nproma, klev, zphi, phif)
+  implicit none
+  integer, intent(in) :: nproma, klev
+  real, intent(in) :: zphi(nproma, 0:klev+1, 10)
+  real, intent(out) :: phif(nproma, klev, 10)
+end subroutine child_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(
+        fcode_kernel + '\n' + fcode_child, frontend=frontend
+    )
+    routine = source['array_ref_block_kernel']
+    child = source['child_kernel']
+    routine.enrich(child)
+
+    child_item = _make_item(child, role='kernel')
+    successor_map = CaseInsensitiveDict({
+        'child_kernel': child_item,
+    })
+
+    with pragmas_attached(routine, ir.CallStatement):
+        sections = SCCBlockSectionTransformation.extract_block_sections(
+            routine.body.body, block_dim_with_members, successor_map
+        )
+
+    assert len(sections) == 2
+    assert child_item.trafo_data.get('BlockSectionTrafo') is True
+
+    for sec in sections:
+        vars_in_sec = tuple(FindVariables().visit(sec))
+        assert 'BOUNDS%KBL' in vars_in_sec
+        assert any('bounds%kbl' in str(var).lower() for var in vars_in_sec)
+
+    section_code = [tuple(fgen(node).lower() for node in sec) for sec in sections]
+    assert any(any('zphi(' in node for node in sec) for sec in section_code)
+    assert any(any('phi(' in node for node in sec) for sec in section_code)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_block_section_separator_at_call(frontend, block_dim):
+    """
+    Verify that calls annotated with ``!$loki small-kernels`` act as
+    separator nodes, splitting the IR into separate block sections.
+    """
+    fcode_kernel = """
+subroutine split_kernel(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+  real :: za(nproma, nb), zb(nproma, nb)
+
+  ! Section 1
+  za(1, ibl) = 1.0
+
+  !$loki small-kernels
+  call child_kernel(nproma, nb)
+
+  ! Section 2
+  zb(1, ibl) = 2.0
+end subroutine split_kernel
+    """.strip()
+
+    fcode_child = """
+subroutine child_kernel(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+end subroutine child_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(
+        fcode_kernel + '\n' + fcode_child, frontend=frontend
+    )
+    routine = source['split_kernel']
+    child = source['child_kernel']
+    routine.enrich(child)
+
+    child_item = _make_item(child, role='kernel')
+    successor_map = CaseInsensitiveDict({
+        'child_kernel': child_item,
+    })
+
+    with pragmas_attached(routine, ir.CallStatement):
+        sections = SCCBlockSectionTransformation.extract_block_sections(
+            routine.body.body, block_dim, successor_map
+        )
+
+    # The call should split the body into at least 2 sections
+    assert len(sections) >= 2
+
+    # Each section should contain block-dim references
+    for sec in sections:
+        all_vars = list(FindVariables().visit(sec))
+        var_names = [str(v).lower() for v in all_vars]
+        assert any('ibl' in name for name in var_names)
+
+
+# ----------------------------------------------------------------
+# Additional coverage tests
+# ----------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_process_kernel_wraps_block_sections(frontend, block_dim):
+    """
+    End-to-end test for ``process_kernel``: verify that block-dimension
+    computation regions are wrapped in ``Section(label='block_section')``
+    nodes in the resulting IR.
+    """
+    fcode_kernel = """
+subroutine phys_kernel(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+  real :: za(nproma, nb), zb(nproma, nb)
+
+  za(1, ibl) = 1.0
+  !$loki small-kernels
+  call sub_phys(nproma, nb)
+  zb(1, ibl) = 2.0
+end subroutine phys_kernel
+    """.strip()
+
+    fcode_sub = """
+subroutine sub_phys(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+end subroutine sub_phys
+    """.strip()
+
+    source = Sourcefile.from_source(
+        fcode_kernel + '\n' + fcode_sub, frontend=frontend
+    )
+    routine = source['phys_kernel']
+    sub = source['sub_phys']
+    routine.enrich(sub)
+
+    item = _make_item(routine, role='kernel')
+    item.trafo_data['BlockSectionTrafo'] = True
+    sub_item = _make_item(sub, role='kernel')
+
+    successor_map = CaseInsensitiveDict({
+        'sub_phys': sub_item,
+    })
+
+    trafo = SCCBlockSectionTransformation(block_dim=block_dim)
+    trafo.process_kernel(routine, item, successor_map)
+
+
+    # There should be Section nodes labelled 'block_section'
+    sections = [
+        s for s in FindNodes(ir.Section).visit(routine.body)
+        if s.label == 'block_section'
+    ]
+    assert len(sections) >= 2
+
+    # Each block_section should contain an assignment
+    for sec in sections:
+        assigns = FindNodes(ir.Assignment).visit(sec)
+        assert len(assigns) >= 1
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_process_kernel_removes_loki_routine_pragma(frontend, block_dim):
+    """
+    Verify that ``!$loki routine seq`` pragmas are removed from the
+    kernel spec and body during ``process_kernel``.
+    """
+    fcode = """
+subroutine seq_kernel(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+  real :: za(nproma, nb)
+  !$loki routine seq
+
+  za(1, ibl) = 1.0
+end subroutine seq_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['seq_kernel']
+
+    item = _make_item(routine, role='kernel')
+    item.trafo_data['BlockSectionTrafo'] = True
+    successor_map = CaseInsensitiveDict()
+
+    # Verify pragma exists before
+    pragmas_before = [
+        p for p in FindNodes(ir.Pragma).visit(routine.ir)
+        if p.keyword.lower() == 'loki' and 'routine' in p.content.lower()
+    ]
+    assert len(pragmas_before) >= 1
+
+    trafo = SCCBlockSectionTransformation(block_dim=block_dim)
+    trafo.process_kernel(routine, item, successor_map)
+
+    # Verify pragma is removed after
+    pragmas_after = [
+        p for p in FindNodes(ir.Pragma).visit(routine.ir)
+        if p.keyword.lower() == 'loki' and 'routine' in p.content.lower()
+    ]
+    assert len(pragmas_after) == 0
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_reblock_without_trafo_data_is_noop_without_block_section(frontend, horizontal):
+    """
+    Verify that ``ReblockSectionTransformer`` is a no-op for kernels
+    without ``LowerBlockIndex`` when no ``block_section`` nodes exist.
+    """
+    fcode = """
+subroutine noop_kernel(nproma)
+  implicit none
+  integer, intent(in) :: nproma
+  real :: z(nproma)
+  z(1) = 1.0
+end subroutine noop_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['noop_kernel']
+
+    item = _make_item(routine, role='kernel')
+    assigns_before = tuple(FindNodes(ir.Assignment).visit(routine.body))
+
+    routine.body = ReblockSectionTransformer(routine, item, horizontal).visit(routine.body)
+
+    assert tuple(FindNodes(ir.Assignment).visit(routine.body)) == assigns_before
+    assert not FindNodes(ir.Loop).visit(routine.body)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_reblock_raises_without_driver_loop_for_block_section(frontend, horizontal):
+    """
+    Verify that ``ReblockSectionTransformer`` raises ``RuntimeError``
+    only when a ``block_section`` is encountered without a driver loop.
+    """
+    fcode = """
+subroutine raise_kernel(nproma)
+  implicit none
+  integer, intent(in) :: nproma
+  real :: z(nproma)
+  z(1) = 1.0
+end subroutine raise_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['raise_kernel']
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    routine.body = Transformer({
+        assigns[0]: ir.Section(body=(assigns[0],), label='block_section')
+    }).visit(routine.body)
+
+    item = _make_item(routine, role='kernel')
+
+    with pytest.raises(RuntimeError, match='driver_loop is None'):
+        routine.body = ReblockSectionTransformer(routine, item, horizontal).visit(routine.body)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_reblock_mixed_call_tree_skips_kernel_without_block_section(
+        frontend, block_dim, horizontal):
+    """
+    Verify that only kernels reached through ``!$loki small-kernels``
+    are reblocked, while other discovered kernels pass through.
+    """
+    fcode_driver = """
+subroutine mixed_driver(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+
+  do ibl = 1, nb
+    call plain_kernel(nproma, nb, ibl)
+  end do
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call sk_kernel(nproma, nb, ibl)
+  end do
+end subroutine mixed_driver
+    """.strip()
+
+    fcode_plain = """
+subroutine plain_kernel(nproma, nb, ibl)
+  implicit none
+  integer, intent(in) :: nproma, nb, ibl
+  real :: z(nproma)
+  z(ibl) = 1.0
+end subroutine plain_kernel
+    """.strip()
+
+    fcode_sk = """
+subroutine sk_kernel(nproma, nb, ibl)
+  implicit none
+  integer, intent(in) :: nproma, nb, ibl
+  real :: z(nproma)
+  z(ibl) = 2.0
+end subroutine sk_kernel
+    """.strip()
+
+    source = Sourcefile.from_source(
+        '\n'.join((fcode_driver, fcode_plain, fcode_sk)), frontend=frontend
+    )
+    driver = source['mixed_driver']
+    plain_kernel = source['plain_kernel']
+    sk_kernel = source['sk_kernel']
+
+    driver.enrich(plain_kernel)
+    driver.enrich(sk_kernel)
+
+    driver_item = _make_item(
+        driver, role='driver', targets=('plain_kernel', 'sk_kernel')
+    )
+    plain_item = _make_item(plain_kernel, role='kernel')
+    sk_item = _make_item(sk_kernel, role='kernel')
+    successor_map = CaseInsensitiveDict({
+        'plain_kernel': plain_item,
+        'sk_kernel': sk_item,
+    })
+
+    block_trafo = SCCBlockSectionTransformation(block_dim=block_dim)
+    block_trafo.process_driver(
+        driver, driver_item, successor_map,
+        targets=('plain_kernel', 'sk_kernel')
+    )
+
+    assert not plain_item.trafo_data.get('BlockSectionTrafo', False)
+    assert sk_item.trafo_data.get('BlockSectionTrafo') is True
+
+    block_trafo.process_kernel(plain_kernel, plain_item, successor_map)
+    block_trafo.process_kernel(sk_kernel, sk_item, successor_map)
+
+    sections = [
+        section for section in FindNodes(ir.Section).visit(sk_kernel.body)
+        if section.label == 'block_section'
+    ]
+    assert sections
+    assert not [
+        section for section in FindNodes(ir.Section).visit(plain_kernel.body)
+        if section.label == 'block_section'
+    ]
+
+    driver_loop = ir.Loop(
+        variable=sk_kernel.variable_map['ibl'],
+        bounds=sym.LoopRange((sym.IntLiteral(1), sk_kernel.variable_map['nb'])),
+        body=(),
+    )
+    sk_item.trafo_data['LowerBlockIndex'] = {'driver_loop': driver_loop}
+
+    reblock_trafo = SCCBlockSectionToLoopTransformation(
+        block_dim=block_dim, horizontal=horizontal
+    )
+    plain_assigns_before = tuple(FindNodes(ir.Assignment).visit(plain_kernel.body))
+
+    reblock_trafo.transform_subroutine(plain_kernel, role='kernel', item=plain_item)
+    reblock_trafo.transform_subroutine(sk_kernel, role='kernel', item=sk_item)
+
+    assert tuple(FindNodes(ir.Assignment).visit(plain_kernel.body)) == plain_assigns_before
+    assert not FindNodes(ir.Loop).visit(plain_kernel.body)
+    loops = FindNodes(ir.Loop).visit(sk_kernel.body)
+    assert loops
+    assert any(
+        pragma.keyword.lower() == 'loki' and 'loop driver' in pragma.content.lower()
+        for loop in loops for pragma in as_tuple(loop.pragma)
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full module header')]
+))
+def test_driver_preserves_non_sk_loops(frontend, block_dim):
+    """
+    Verify that driver loops without ``!$loki small-kernels`` pragma
+    calls are preserved (not unwrapped).
+    """
+    fcode_kernel = """
+subroutine keep_kernel(nproma)
+  implicit none
+  integer, intent(in) :: nproma
+end subroutine keep_kernel
+    """.strip()
+
+    fcode_driver = """
+subroutine keep_driver(nproma, nb)
+  implicit none
+  integer, intent(in) :: nproma, nb
+  integer :: ibl
+
+  ! This loop has no small-kernels pragma — should be preserved
+  do ibl = 1, nb
+    call keep_kernel(nproma)
+  end do
+end subroutine keep_driver
+    """.strip()
+
+    source = Sourcefile.from_source(
+        fcode_driver + '\n' + fcode_kernel, frontend=frontend
+    )
+    driver = source['keep_driver']
+    kernel = source['keep_kernel']
+    driver.enrich(kernel)
+
+    driver_item = _make_item(
+        driver, role='driver', targets=('keep_kernel',)
+    )
+    kernel_item = _make_item(kernel, role='kernel')
+    successor_map = CaseInsensitiveDict({
+        'keep_kernel': kernel_item,
+    })
+
+    trafo = SCCBlockSectionTransformation(block_dim=block_dim)
+    trafo.process_driver(
+        driver, driver_item, successor_map,
+        targets=('keep_kernel',)
+    )
+
+    # The loop should still be there
+    loops = FindNodes(ir.Loop).visit(driver.body)
+    assert len(loops) == 1
+
+    # No BlockSectionTrafo should be set on the successor
+    assert not kernel_item.trafo_data.get('BlockSectionTrafo', False)

--- a/loki/transformations/single_column/tests/test_scc_block_section.py
+++ b/loki/transformations/single_column/tests/test_scc_block_section.py
@@ -9,6 +9,8 @@
 Tests for :mod:`loki.transformations.single_column.block`.
 """
 
+# pylint: disable=redefined-outer-name
+
 import pytest
 
 from loki import Dimension, Sourcefile, fgen
@@ -577,7 +579,7 @@ end subroutine sub_kernel
 @pytest.mark.parametrize('frontend', available_frontends(
     skip=[(OMNI, 'OMNI needs full module header')]
 ))
-def test_block_section_nested_conditional_array_ref_block_index(frontend, block_dim):
+def test_block_section_nested_conditional_array_ref_block_index(frontend):
     """
     Reproduce a nested-call pattern where block-index usage appears only
     inside array references in pre/post-call loop regions.

--- a/loki/transformations/single_column/tests/test_scc_small_kernels_pipeline.py
+++ b/loki/transformations/single_column/tests/test_scc_small_kernels_pipeline.py
@@ -5,6 +5,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+# pylint: disable=too-many-lines
+
 """
 End-to-end tests for ``SCCSmallKernelsPipeline``.
 
@@ -20,10 +22,7 @@ import pytest
 from loki import Dimension, Module, Sourcefile, fgen
 from loki.batch import Pipeline, ProcedureItem, SGraph
 from loki.frontend import OMNI, available_frontends
-from loki.ir import (
-    Allocation, Assignment, CallStatement, Deallocation,
-    FindNodes, Intrinsic, Loop, Pragma,
-)
+from loki.ir import nodes as ir, FindNodes
 from loki.transformations import (
     BlockViewToFieldViewTransformation, DataOffloadDeepcopyAnalysis,
     DataOffloadDeepcopyTransformation, InlineTransformation,
@@ -301,7 +300,7 @@ def _build_and_apply_4level_full_pipeline(
 
 def _has_block_loop(routine, block_dim):
     """Return True if ``routine`` contains a loop over a block_dim index."""
-    for loop in FindNodes(Loop).visit(routine.body):
+    for loop in FindNodes(ir.Loop).visit(routine.body):
         var = str(loop.variable).lower().replace('local_', '')
         if var in [idx.lower() for idx in block_dim.indices]:
             return True
@@ -311,7 +310,7 @@ def _has_block_loop(routine, block_dim):
 def _get_block_loops(routine, block_dim):
     """Return all loops whose variable matches a block_dim index."""
     result = []
-    for loop in FindNodes(Loop).visit(routine.body):
+    for loop in FindNodes(ir.Loop).visit(routine.body):
         var = str(loop.variable).lower().replace('local_', '')
         if var in [idx.lower() for idx in block_dim.indices]:
             result.append(loop)
@@ -325,7 +324,7 @@ def _routine_var_names(routine):
 
 def _find_calls_by_name(routine, callee_name):
     """Find all CallStatements in routine.body matching callee_name."""
-    return [c for c in FindNodes(CallStatement).visit(routine.body)
+    return [c for c in FindNodes(ir.CallStatement).visit(routine.body)
             if callee_name.lower() in str(c.name).lower()]
 
 
@@ -438,8 +437,8 @@ def test_top_driver_pool_allocator_removed(frontend, horizontal, block_dim, tmp_
     assert 'istsz' not in var_names
     assert 'zstack' not in var_names
 
-    allocs = FindNodes(Allocation).visit(driver.body)
-    deallocs = FindNodes(Deallocation).visit(driver.body)
+    allocs = FindNodes(ir.Allocation).visit(driver.body)
+    deallocs = FindNodes(ir.Deallocation).visit(driver.body)
     assert not any('zstack' in str(a).lower() for a in allocs)
     assert not any('zstack' in str(d).lower() for d in deallocs)
 
@@ -685,8 +684,8 @@ def test_leaf_kernel_temp_promotion(frontend, horizontal, block_dim, tmp_path):
     # ztmp should be promoted and have data directives
     # (The pool allocator may convert it to Cray pointer instead;
     # either approach is valid)
-    all_pragmas = FindNodes(Pragma).visit(leaf.body)
-    cray_ptrs = FindNodes(Intrinsic).visit(leaf.spec)
+    all_pragmas = FindNodes(ir.Pragma).visit(leaf.body)
+    cray_ptrs = FindNodes(ir.GenericStmt).visit(leaf.spec)
     has_cray = any('ztmp' in i.text.lower() for i in cray_ptrs
                     if 'pointer' in i.text.lower())
 
@@ -1266,8 +1265,8 @@ def test_real_pipeline_conditional_acc_prologue_outside_first_block_loop(
     assert block_loops, f"Expected block loop in transformed sub-kernel.\nCode:\n{fgen(sub)}"
     first_loop = block_loops[0]
 
-    pragmas = FindNodes(Pragma).visit(first_loop.body)
-    assignments = FindNodes(Assignment).visit(first_loop.body)
+    pragmas = FindNodes(ir.Pragma).visit(first_loop.body)
+    assignments = FindNodes(ir.Assignment).visit(first_loop.body)
     enter_data_inside = [
         p for p in pragmas
         if p.keyword.lower() == 'acc'
@@ -1744,7 +1743,7 @@ def test_multi_driver_loop_max_istsz(frontend, horizontal, block_dim, tmp_path):
         f"Code:\n{fgen(driver)}"
     )
 
-    allocs = FindNodes(Allocation).visit(driver.body)
+    allocs = FindNodes(ir.Allocation).visit(driver.body)
     assert any('zstack' in str(a).lower() for a in allocs), (
         f"Driver must ALLOCATE ZSTACK.\n"
         f"Allocations: {[fgen(a) for a in allocs]}\n"
@@ -1752,7 +1751,7 @@ def test_multi_driver_loop_max_istsz(frontend, horizontal, block_dim, tmp_path):
     )
 
     # ISTSZ should use MAX (aggregating across loops)
-    assigns = FindNodes(Assignment).visit(driver.body)
+    assigns = FindNodes(ir.Assignment).visit(driver.body)
     istsz_assigns = [a for a in assigns if str(a.lhs).lower() == 'istsz']
     assert istsz_assigns, f"Driver must have ISTSZ assignment.\nCode:\n{fgen(driver)}"
 
@@ -1799,10 +1798,10 @@ def test_multi_driver_loop_loc_assigns(frontend, horizontal, block_dim, tmp_path
     )
 
     # Find LOC(ZSTACK) assignments inside driver loops
-    driver_loops = FindNodes(Loop).visit(driver.body)
+    driver_loops = FindNodes(ir.Loop).visit(driver.body)
     loc_count = 0
     for dl in driver_loops:
-        loop_assigns = FindNodes(Assignment).visit(dl.body)
+        loop_assigns = FindNodes(ir.Assignment).visit(dl.body)
         loc_assigns = [a for a in loop_assigns
                        if 'ylstack_l' in str(a.lhs).lower()
                        and 'loc' in str(a.rhs).lower()
@@ -2023,7 +2022,7 @@ def test_acc_exit_data_outside_block_loop(frontend, horizontal, block_dim, tmp_p
 
     # Check that !$acc enter/exit data are NOT inside the block loop
     for bl in block_loops:
-        block_pragmas = FindNodes(Pragma).visit(bl.body)
+        block_pragmas = FindNodes(ir.Pragma).visit(bl.body)
         enter_inside = [p for p in block_pragmas
                         if p.keyword.lower() == 'acc'
                         and 'enter' in p.content.lower()
@@ -2079,7 +2078,7 @@ def test_real_pipeline_explicit_acc_data_regions_not_duplicated(
         '#explicit_acc_data_sub_kernel', '#explicit_acc_data_leaf_kernel'
     )
 
-    acc_pragmas = [p for p in FindNodes(Pragma).visit(sub.body) if p.keyword.lower() == 'acc']
+    acc_pragmas = [p for p in FindNodes(ir.Pragma).visit(sub.body) if p.keyword.lower() == 'acc']
     acc_data = [p for p in acc_pragmas if p.content.lower().startswith('data ')]
     acc_end_data = [p for p in acc_pragmas if p.content.lower() == 'end data']
     acc_enter_data = [p for p in acc_pragmas if p.content.lower().startswith('enter data')]

--- a/loki/transformations/single_column/tests/test_scc_small_kernels_pipeline.py
+++ b/loki/transformations/single_column/tests/test_scc_small_kernels_pipeline.py
@@ -1,0 +1,2091 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+End-to-end tests for ``SCCSmallKernelsPipeline``.
+
+Each test runs the full 12-step pipeline on a small Fortran call tree
+that mimics production-style transformation shapes and verifies the
+structural properties of the transformed IR.
+"""
+
+import re
+
+import pytest
+
+from loki import Dimension, Module, Sourcefile, fgen
+from loki.batch import Pipeline, ProcedureItem, SGraph
+from loki.frontend import OMNI, available_frontends
+from loki.ir import (
+    Allocation, Assignment, CallStatement, Deallocation,
+    FindNodes, Intrinsic, Loop, Pragma,
+)
+from loki.transformations import (
+    BlockViewToFieldViewTransformation, DataOffloadDeepcopyAnalysis,
+    DataOffloadDeepcopyTransformation, InlineTransformation,
+    InjectBlockIndexTransformation, RemoveCodeTransformation, ReplaceKernels,
+    SanitiseTransformation, SanitiseUnusedRoutineTransformation,
+)
+from loki.transformations.single_column import SCCSmallKernelsPipeline
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='module', name='horizontal')
+def fixture_horizontal():
+    return Dimension(
+        name='horizontal', size='klon', index='jrof',
+        lower=('kst', 'kidia', 'bnds%kidia'),
+        upper=('kend', 'kfdia', 'bnds%kfdia', 'klon')
+    )
+
+
+@pytest.fixture(scope='module', name='block_dim')
+def fixture_block_dim():
+    return Dimension(
+        name='block_dim',
+        size='ngpblks',
+        index=('ibl', 'bnds%kbl')
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared Fortran module fragments
+# ---------------------------------------------------------------------------
+
+FCODE_BNDS_TYPE_MOD = """
+module bnds_type_mod
+  implicit none
+  type bnds_type
+    integer :: kidia
+    integer :: kfdia
+    integer :: kbl
+    integer :: kstglo
+  end type bnds_type
+end module bnds_type_mod
+""".strip()
+
+FCODE_OPTS_TYPE_MOD = """
+module opts_type_mod
+  implicit none
+  type opts_type
+    integer :: klon
+    integer :: kflevg
+    integer :: kgpcomp
+  end type opts_type
+end module opts_type_mod
+""".strip()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline helpers
+# ---------------------------------------------------------------------------
+
+def _parse_modules(frontend, tmp_path):
+    """Parse and return the shared type modules."""
+    bnds_mod = Module.from_source(
+        FCODE_BNDS_TYPE_MOD, frontend=frontend, xmods=[tmp_path]
+    )
+    opts_mod = Module.from_source(
+        FCODE_OPTS_TYPE_MOD, frontend=frontend, xmods=[tmp_path]
+    )
+    return [bnds_mod, opts_mod]
+
+
+def _apply_pipeline(pipeline, items_in_order, sgraph):
+    """
+    Apply all transformations in the pipeline to the given items,
+    respecting ``reverse_traversal`` ordering.
+    """
+    for transform in pipeline.transformations:
+        order = items_in_order
+        if getattr(transform, 'reverse_traversal', False):
+            order = list(reversed(items_in_order))
+        for routine, role, item, targets in order:
+            transform.apply(
+                routine, role=role, item=item,
+                targets=targets, sub_sgraph=sgraph
+            )
+
+
+def _build_scc_stack_pipeline(horizontal, block_dim):
+    """Build the full SCC stack pipeline, excluding packaging transforms."""
+    replace_map = {
+        'verdisint': {
+            'routine': 'verdisint_gpu_opt',
+            'ignore': True,
+            'args': {
+                'kst': {'position': 1},
+                'ldacc': '.true.',
+                'kend': {
+                    'map_to': 'kend_in',
+                    'placeholders': {
+                        'geom_total': 'ydgeometry',
+                        'geom_dim': 'ydgeometry',
+                    },
+                    'expr': 'MOD({geom_total}%YRGEM%NGPTOT, {geom_dim}%YRDIM%NPROMA)',
+                },
+                'ydgeometry': {
+                    'map_to': 'kgpblks',
+                    'member': 'YRDIM%NGPBLKS',
+                },
+            },
+        }
+    }
+    pipeline = Pipeline()
+    pipeline.append(SanitiseTransformation(
+        resolve_associate_mappings=True, resolve_sequence_association=False
+    ))
+    pipeline.append(InlineTransformation(
+        inline_internals=True, inline_marked=True, remove_dead_code=True,
+        allowed_aliases='JROF', resolve_sequence_association=False
+    ))
+    pipeline.append(RemoveCodeTransformation(
+        remove_marked_regions=True, remove_dead_code=False,
+        call_names=('dr_hook', 'abor1'),
+        intrinsic_names=('write(nulout', 'write(nulerr'),
+        kernel_only=True, remove_unused_args=True
+    ))
+    pipeline.append(BlockViewToFieldViewTransformation(
+        horizontal=horizontal, global_gfl_ptr=False
+    ))
+    pipeline.append(InjectBlockIndexTransformation(block_dim=block_dim))
+    pipeline.append(DataOffloadDeepcopyAnalysis())
+    pipeline.append(DataOffloadDeepcopyTransformation(mode='offload'))
+    pipeline.extend(SCCSmallKernelsPipeline(
+        horizontal=horizontal, block_dim=block_dim, directive='openacc',
+        check_bounds=False, trim_vector_sections=True,
+        privatise_derived_types=True, remove_unused_vars=True
+    ))
+    pipeline.append(ReplaceKernels(replace_kernels_map=replace_map))
+    pipeline.append(SanitiseUnusedRoutineTransformation(
+        routines=('verdisint',), stub_kind='error_stop'
+    ))
+    return pipeline
+
+
+def _build_and_apply_2level(
+        driver_source, kernel_source, horizontal, block_dim,
+        driver_name, kernel_name, driver_item_name, kernel_item_name):
+    """Build 2-level call tree, apply pipeline, return (driver, kernel)."""
+    pipeline = SCCSmallKernelsPipeline(
+        horizontal=horizontal, block_dim=block_dim, directive='openacc'
+    )
+    driver = driver_source[driver_name]
+    kernel = kernel_source[kernel_name]
+    driver.enrich(kernel)
+
+    d_item = ProcedureItem(name=driver_item_name, source=driver_source)
+    k_item = ProcedureItem(name=kernel_item_name, source=kernel_source)
+    sgraph = SGraph.from_dict({d_item: [k_item]})
+
+    items = [
+        (driver, 'driver', d_item, [kernel_name]),
+        (kernel, 'kernel', k_item, []),
+    ]
+    _apply_pipeline(pipeline, items, sgraph)
+    return driver, kernel
+
+
+def _build_and_apply_3level(
+        driver_source, mid_source, sub_source,
+        horizontal, block_dim,
+        driver_name, mid_name, sub_name,
+        driver_item_name, mid_item_name, sub_item_name,
+        mid_targets=None):
+    """Build 3-level call tree, apply pipeline, return (driver, mid, sub)."""
+    pipeline = SCCSmallKernelsPipeline(
+        horizontal=horizontal, block_dim=block_dim, directive='openacc'
+    )
+    driver = driver_source[driver_name]
+    mid = mid_source[mid_name]
+    sub = sub_source[sub_name]
+    driver.enrich(mid)
+    mid.enrich(sub)
+
+    d_item = ProcedureItem(name=driver_item_name, source=driver_source)
+    m_item = ProcedureItem(name=mid_item_name, source=mid_source)
+    s_item = ProcedureItem(name=sub_item_name, source=sub_source)
+    sgraph = SGraph.from_dict({d_item: [m_item], m_item: [s_item]})
+
+    if mid_targets is None:
+        mid_targets = [sub_name]
+    items = [
+        (driver, 'driver', d_item, [mid_name]),
+        (mid, 'kernel', m_item, mid_targets),
+        (sub, 'kernel', s_item, []),
+    ]
+    _apply_pipeline(pipeline, items, sgraph)
+    return driver, mid, sub
+
+
+def _build_and_apply_4level(
+        driver_source, mid_source, sub_source, leaf_source,
+        horizontal, block_dim,
+        driver_name, mid_name, sub_name, leaf_name,
+        driver_item_name, mid_item_name, sub_item_name, leaf_item_name,
+        mid_targets=None, sub_targets=None):
+    """Build 4-level call tree, apply pipeline, return routines."""
+    pipeline = SCCSmallKernelsPipeline(
+        horizontal=horizontal, block_dim=block_dim, directive='openacc'
+    )
+    driver = driver_source[driver_name]
+    mid = mid_source[mid_name]
+    sub = sub_source[sub_name]
+    leaf = leaf_source[leaf_name]
+    driver.enrich(mid)
+    mid.enrich(sub)
+    sub.enrich(leaf)
+
+    d_item = ProcedureItem(name=driver_item_name, source=driver_source)
+    m_item = ProcedureItem(name=mid_item_name, source=mid_source)
+    s_item = ProcedureItem(name=sub_item_name, source=sub_source)
+    l_item = ProcedureItem(name=leaf_item_name, source=leaf_source)
+    sgraph = SGraph.from_dict({d_item: [m_item], m_item: [s_item], s_item: [l_item]})
+
+    if mid_targets is None:
+        mid_targets = [sub_name]
+    if sub_targets is None:
+        sub_targets = [leaf_name]
+    items = [
+        (driver, 'driver', d_item, [mid_name]),
+        (mid, 'kernel', m_item, mid_targets),
+        (sub, 'kernel', s_item, sub_targets),
+        (leaf, 'kernel', l_item, []),
+    ]
+    _apply_pipeline(pipeline, items, sgraph)
+    return driver, mid, sub, leaf
+
+
+def _build_and_apply_4level_full_pipeline(
+        driver_source, mid_source, sub_source, leaf_source,
+        horizontal, block_dim,
+        driver_name, mid_name, sub_name, leaf_name,
+        driver_item_name, mid_item_name, sub_item_name, leaf_item_name,
+        mid_targets=None, sub_targets=None):
+    """Build a 4-level call tree, apply the full SCC stack pipeline, and return routines."""
+    pipeline = _build_scc_stack_pipeline(horizontal, block_dim)
+    driver = driver_source[driver_name]
+    mid = mid_source[mid_name]
+    sub = sub_source[sub_name]
+    leaf = leaf_source[leaf_name]
+    driver.enrich(mid)
+    mid.enrich(sub)
+    sub.enrich(leaf)
+
+    d_item = ProcedureItem(name=driver_item_name, source=driver_source)
+    m_item = ProcedureItem(name=mid_item_name, source=mid_source)
+    s_item = ProcedureItem(name=sub_item_name, source=sub_source)
+    l_item = ProcedureItem(name=leaf_item_name, source=leaf_source)
+    sgraph = SGraph.from_dict({d_item: [m_item], m_item: [s_item], s_item: [l_item]})
+
+    if mid_targets is None:
+        mid_targets = [sub_name]
+    if sub_targets is None:
+        sub_targets = [leaf_name]
+    items = [
+        (driver, 'driver', d_item, [mid_name]),
+        (mid, 'kernel', m_item, mid_targets),
+        (sub, 'kernel', s_item, sub_targets),
+        (leaf, 'kernel', l_item, []),
+    ]
+    _apply_pipeline(pipeline, items, sgraph)
+    return driver, mid, sub, leaf
+
+
+def _has_block_loop(routine, block_dim):
+    """Return True if ``routine`` contains a loop over a block_dim index."""
+    for loop in FindNodes(Loop).visit(routine.body):
+        var = str(loop.variable).lower().replace('local_', '')
+        if var in [idx.lower() for idx in block_dim.indices]:
+            return True
+    return False
+
+
+def _get_block_loops(routine, block_dim):
+    """Return all loops whose variable matches a block_dim index."""
+    result = []
+    for loop in FindNodes(Loop).visit(routine.body):
+        var = str(loop.variable).lower().replace('local_', '')
+        if var in [idx.lower() for idx in block_dim.indices]:
+            result.append(loop)
+    return result
+
+
+def _routine_var_names(routine):
+    """Return set of lower-cased variable names from routine."""
+    return {v.name.lower() for v in routine.variables}
+
+
+def _find_calls_by_name(routine, callee_name):
+    """Find all CallStatements in routine.body matching callee_name."""
+    return [c for c in FindNodes(CallStatement).visit(routine.body)
+            if callee_name.lower() in str(c.name).lower()]
+
+
+# ===================================================================
+# Group 1: Top-level driver
+# ===================================================================
+
+FCODE_TOP_DRIVER = """
+module top_driver_mod
+  implicit none
+contains
+  subroutine top_driver(ngpblks, bnds, opts, t, q)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    #include "nested_driver.intfb.h"
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: t(:,:,:)
+    real, intent(inout) :: q(:,:,:)
+    integer :: ibl
+
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+
+      !$loki small-kernels
+      call nested_driver(opts%klon, opts%kflevg, bnds, opts, t(:,:,ibl), q(:,:,ibl))
+    end do
+  end subroutine top_driver
+end module top_driver_mod
+""".strip()
+
+FCODE_NESTED_DRIVER = """
+subroutine nested_driver(klon, klev, bnds, opts, t, q)
+  use bnds_type_mod, only: bnds_type
+  use opts_type_mod, only: opts_type
+  implicit none
+  #include "leaf_kernel.intfb.h"
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  type(opts_type), intent(in) :: opts
+  real, intent(inout) :: t(klon, klev)
+  real, intent(inout) :: q(klon, klev)
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      t(jrof, jk) = t(jrof, jk) + 1.0
+    end do
+  end do
+
+  !$loki small-kernels
+  call leaf_kernel(klon, klev, bnds, opts, t, q)
+end subroutine nested_driver
+""".strip()
+
+FCODE_LEAF_KERNEL = """
+subroutine leaf_kernel(klon, klev, bnds, opts, t, q)
+  use bnds_type_mod, only: bnds_type
+  use opts_type_mod, only: opts_type
+  implicit none
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  type(opts_type), intent(in) :: opts
+  real, intent(inout) :: t(klon, klev)
+  real, intent(inout) :: q(klon, klev)
+  integer :: jrof, jk
+  real :: ztmp(klon, klev)
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      ztmp(jrof, jk) = t(jrof, jk) * 2.0
+      q(jrof, jk) = ztmp(jrof, jk) + 1.0
+    end do
+  end do
+end subroutine leaf_kernel
+""".strip()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_top_driver_pool_allocator_removed(frontend, horizontal, block_dim, tmp_path):
+    """
+    Top-level driver: after the pipeline, the
+    driver must NOT have ISTSZ/ZSTACK/ALLOCATE/DEALLOCATE — pool
+    allocator infrastructure is moved down into nested kernels.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_TOP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_NESTED_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    driver, _, _ = _build_and_apply_3level(
+        driver_src, mid_src, sub_src, horizontal, block_dim,
+        'top_driver', 'nested_driver', 'leaf_kernel',
+        'top_driver_mod#top_driver', '#nested_driver', '#leaf_kernel'
+    )
+
+    var_names = _routine_var_names(driver)
+    assert 'istsz' not in var_names
+    assert 'zstack' not in var_names
+
+    allocs = FindNodes(Allocation).visit(driver.body)
+    deallocs = FindNodes(Deallocation).visit(driver.body)
+    assert not any('zstack' in str(a).lower() for a in allocs)
+    assert not any('zstack' in str(d).lower() for d in deallocs)
+
+
+# ===================================================================
+# Group 2: Nested driver
+# ===================================================================
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_nested_driver_gets_block_loop(frontend, horizontal, block_dim, tmp_path):
+    """
+    Nested driver kernel: after the pipeline, the
+    nested driver must have a block-dimension loop with
+    ``!$acc parallel loop gang``.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_TOP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_NESTED_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, nested, _ = _build_and_apply_3level(
+        driver_src, mid_src, sub_src, horizontal, block_dim,
+        'top_driver', 'nested_driver', 'leaf_kernel',
+        'top_driver_mod#top_driver', '#nested_driver', '#leaf_kernel'
+    )
+
+    assert _has_block_loop(nested, block_dim), (
+        f"Nested driver should have a block-dimension loop.\n"
+        f"Code:\n{fgen(nested)}"
+    )
+
+    # Check for !$acc parallel loop gang pragma on or near the block loop
+    code_lower = fgen(nested).lower()
+    assert 'acc parallel loop gang' in code_lower, (
+        f"Nested driver block loop should have !$acc parallel loop gang.\n"
+        f"Code:\n{fgen(nested)}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_nested_driver_gets_stack_args(frontend, horizontal, block_dim, tmp_path):
+    """
+    Nested driver kernel: in the per-driver-loop
+    pool allocator, the nested driver receives stack args (YDSTACK_L)
+    from the top-level driver and forwards them via YLSTACK_L.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_TOP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_NESTED_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, nested, _ = _build_and_apply_3level(
+        driver_src, mid_src, sub_src, horizontal, block_dim,
+        'top_driver', 'nested_driver', 'leaf_kernel',
+        'top_driver_mod#top_driver', '#nested_driver', '#leaf_kernel'
+    )
+
+    var_names = _routine_var_names(nested)
+    # Nested driver receives stack args from parent (not its own ISTSZ/ZSTACK)
+    assert 'ydstack_l' in var_names or 'ylstack_l' in var_names, (
+        f"Nested driver should have YDSTACK_L or YLSTACK_L.\n"
+        f"Vars: {sorted(var_names)}\nCode:\n{fgen(nested)}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_nested_driver_local_copies(frontend, horizontal, block_dim, tmp_path):
+    """
+    Nested driver: block loop must contain local
+    copies (``local_bnds``, ``local_ibl``, etc.) and these must
+    appear in the ``private(...)`` clause.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_TOP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_NESTED_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, nested, _ = _build_and_apply_3level(
+        driver_src, mid_src, sub_src, horizontal, block_dim,
+        'top_driver', 'nested_driver', 'leaf_kernel',
+        'top_driver_mod#top_driver', '#nested_driver', '#leaf_kernel'
+    )
+
+    code = fgen(nested)
+    code_lower = code.lower()
+
+    # Should have at least one local_ variable
+    assert 'local_' in code_lower, (
+        f"Nested driver should have local_ copies.\nCode:\n{code}"
+    )
+
+    # Check for private clause containing local_ variables
+    private_match = re.search(r'private\(([^)]+)\)', code_lower)
+    assert private_match, (
+        f"Nested driver should have a private(...) clause.\nCode:\n{code}"
+    )
+    private_vars = private_match.group(1)
+    assert 'local_' in private_vars, (
+        f"private(...) clause should contain local_ variables.\n"
+        f"private clause: {private_vars}\nCode:\n{code}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_nested_driver_passes_kwargs(frontend, horizontal, block_dim, tmp_path):
+    """
+    Nested driver: calls to leaf kernels must include
+    BNDS and OPTS as keyword arguments after the pipeline.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_TOP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_NESTED_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, nested, _ = _build_and_apply_3level(
+        driver_src, mid_src, sub_src, horizontal, block_dim,
+        'top_driver', 'nested_driver', 'leaf_kernel',
+        'top_driver_mod#top_driver', '#nested_driver', '#leaf_kernel'
+    )
+
+    calls = _find_calls_by_name(nested, 'leaf_kernel')
+    assert calls, f"Nested driver should still call leaf_kernel.\nCode:\n{fgen(nested)}"
+
+    for call in calls:
+        kwarg_names = [kw[0].lower() for kw in (call.kwarguments or ())]
+        arg_strs = [str(a).lower() for a in call.arguments]
+        all_args = kwarg_names + arg_strs
+        # BNDS may be passed as positional (local_bnds) or kwarg
+        has_bnds = any('bnds' in a for a in all_args)
+        assert has_bnds, (
+            f"Call to leaf_kernel should pass BNDS (positional or kwarg).\n"
+            f"Args: {arg_strs}\nKwargs: {kwarg_names}\n"
+            f"Call: {fgen(call)}\nCode:\n{fgen(nested)}"
+        )
+
+
+# ===================================================================
+# Group 3: Leaf kernel
+# ===================================================================
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_leaf_kernel_parallel_regions(frontend, horizontal, block_dim, tmp_path):
+    """
+    Leaf kernel: after the pipeline, the leaf
+    kernel must have ``!$acc parallel loop gang`` regions with local
+    copies of block indices.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_TOP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_NESTED_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, _, leaf = _build_and_apply_3level(
+        driver_src, mid_src, sub_src, horizontal, block_dim,
+        'top_driver', 'nested_driver', 'leaf_kernel',
+        'top_driver_mod#top_driver', '#nested_driver', '#leaf_kernel'
+    )
+
+    code = fgen(leaf)
+    code_lower = code.lower()
+
+    # Leaf kernel should have block loop(s) with acc parallel loop gang
+    assert _has_block_loop(leaf, block_dim), (
+        f"Leaf kernel should have a block-dimension loop.\nCode:\n{code}"
+    )
+    assert 'acc parallel loop gang' in code_lower, (
+        f"Leaf kernel should have !$acc parallel loop gang.\nCode:\n{code}"
+    )
+
+    # Should have local_ copies
+    assert 'local_' in code_lower, (
+        f"Leaf kernel should have local_ copies of block indices.\n"
+        f"Code:\n{code}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_leaf_kernel_temp_promotion(frontend, horizontal, block_dim, tmp_path):
+    """
+    Leaf kernel: local temporary arrays must get
+    ``!$acc enter data create`` / ``!$acc exit data delete`` (or
+    ``!$loki`` equivalents) after promotion.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_TOP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_NESTED_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, _, leaf = _build_and_apply_3level(
+        driver_src, mid_src, sub_src, horizontal, block_dim,
+        'top_driver', 'nested_driver', 'leaf_kernel',
+        'top_driver_mod#top_driver', '#nested_driver', '#leaf_kernel'
+    )
+
+    code = fgen(leaf)
+    code_lower = code.lower()
+
+    # Check for data management pragmas for ztmp
+    has_enter_data = ('acc enter data' in code_lower or
+                      'loki unstructured-data' in code_lower)
+    # ztmp should be promoted and have data directives
+    # (The pool allocator may convert it to Cray pointer instead;
+    # either approach is valid)
+    all_pragmas = FindNodes(Pragma).visit(leaf.body)
+    cray_ptrs = FindNodes(Intrinsic).visit(leaf.spec)
+    has_cray = any('ztmp' in i.text.lower() for i in cray_ptrs
+                    if 'pointer' in i.text.lower())
+
+    assert has_enter_data or has_cray, (
+        f"Leaf kernel's ztmp should either have !$acc enter data create\n"
+        f"or be pool-allocated via Cray pointer.\n"
+        f"Pragmas: {[fgen(p) for p in all_pragmas]}\n"
+        f"Cray pointers: {[i.text for i in cray_ptrs]}\n"
+        f"Code:\n{code}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_leaf_kernel_acc_routine_removed(frontend, horizontal, block_dim, tmp_path):
+    """
+    Leaf kernel that gets ``!$acc parallel loop gang`` regions must
+    NOT have ``!$acc routine seq`` — it now owns parallel regions.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_TOP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_NESTED_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, _, leaf = _build_and_apply_3level(
+        driver_src, mid_src, sub_src, horizontal, block_dim,
+        'top_driver', 'nested_driver', 'leaf_kernel',
+        'top_driver_mod#top_driver', '#nested_driver', '#leaf_kernel'
+    )
+
+    code = fgen(leaf)
+    code_lower = code.lower()
+
+    # If it has acc parallel loop gang, it must NOT have acc routine seq
+    if 'acc parallel loop gang' in code_lower:
+        assert 'acc routine seq' not in code_lower, (
+            f"Leaf kernel with !$acc parallel loop gang should NOT\n"
+            f"have !$acc routine seq.\nCode:\n{code}"
+        )
+
+
+# ===================================================================
+# Group 4: Thin wrapper
+# ===================================================================
+
+FCODE_WRAPPER_DRIVER = """
+module wrapper_driver_mod
+  implicit none
+contains
+  subroutine wrapper_driver(ngpblks, bnds, opts, phi, pt)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    #include "thin_wrapper.intfb.h"
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: phi(:,:,:)
+    real, intent(in) :: pt(:,:,:)
+    integer :: ibl
+
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+
+      !$loki small-kernels
+      call thin_wrapper(opts%klon, opts%kflevg, bnds%kidia, bnds%kfdia, phi(:,:,ibl), pt(:,:,ibl))
+    end do
+  end subroutine wrapper_driver
+end module wrapper_driver_mod
+""".strip()
+
+FCODE_THIN_WRAPPER = """
+subroutine thin_wrapper(klon, klev, kst, kend, phi, pt)
+  implicit none
+  #include "inner_compute.intfb.h"
+  integer, intent(in) :: klon, klev, kst, kend
+  real, intent(inout) :: phi(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+
+  !$loki small-kernels
+  call inner_compute(klon, klev, kst, kend, phi, pt)
+end subroutine thin_wrapper
+""".strip()
+
+FCODE_INNER_COMPUTE = """
+subroutine inner_compute(klon, klev, kst, kend, phi, pt)
+  implicit none
+  integer, intent(in) :: klon, klev, kst, kend
+  real, intent(inout) :: phi(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+  real :: ztmp(klon)
+  integer :: jrof, jk
+
+  do jrof = kst, kend
+    ztmp(jrof) = 0.0
+  end do
+
+  do jk = 1, klev
+    do jrof = kst, kend
+      ztmp(jrof) = ztmp(jrof) + pt(jrof, jk)
+    end do
+  end do
+
+  do jk = 1, klev
+    do jrof = kst, kend
+      phi(jrof, jk) = phi(jrof, jk) + ztmp(jrof)
+    end do
+  end do
+end subroutine inner_compute
+""".strip()
+
+FCODE_DEEP_DRIVER = """
+module deep_driver_mod
+  implicit none
+contains
+  subroutine deep_driver(ngpblks, bnds, opts, phi, pt)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: phi(:,:,:)
+    real, intent(in) :: pt(:,:,:)
+    integer :: ibl
+
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+
+      !$loki small-kernels
+      call mid_kernel(opts%klon, opts%kflevg, bnds, opts, phi(:,:,ibl), pt(:,:,ibl))
+    end do
+  end subroutine deep_driver
+end module deep_driver_mod
+""".strip()
+
+FCODE_MID_KERNEL = """
+subroutine mid_kernel(klon, klev, bnds, opts, phi, pt)
+  use bnds_type_mod, only: bnds_type
+  use opts_type_mod, only: opts_type
+  implicit none
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  type(opts_type), intent(in) :: opts
+  real, intent(inout) :: phi(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+
+  !$loki small-kernels
+  call sub_kernel(klon, klev, bnds, opts, phi, pt)
+end subroutine mid_kernel
+""".strip()
+
+FCODE_SUB_KERNEL = """
+subroutine sub_kernel(klon, klev, bnds, opts, phi, pt)
+  use bnds_type_mod, only: bnds_type
+  use opts_type_mod, only: opts_type
+  implicit none
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  type(opts_type), intent(in) :: opts
+  real, intent(inout) :: phi(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+  real :: zsum(klon, klev)
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      zsum(jrof, jk) = pt(jrof, jk) + 1.0
+    end do
+  end do
+
+  zsum(bnds%kidia:bnds%kfdia, 1) = 0.0
+
+  !$loki small-kernels
+  call leaf_kernel_deep(klon, klev, bnds, opts, phi, zsum)
+
+  do jk = klev, 1, -1
+    do jrof = bnds%kidia, bnds%kfdia
+      phi(jrof, jk) = phi(jrof, jk) + zsum(jrof, jk)
+    end do
+  end do
+end subroutine sub_kernel
+""".strip()
+
+FCODE_LEAF_KERNEL_DEEP = """
+subroutine leaf_kernel_deep(klon, klev, bnds, opts, phi, zsum)
+  use bnds_type_mod, only: bnds_type
+  use opts_type_mod, only: opts_type
+  implicit none
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  type(opts_type), intent(in) :: opts
+  real, intent(inout) :: phi(klon, klev)
+  real, intent(in) :: zsum(klon, klev)
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      phi(jrof, jk) = phi(jrof, jk) + zsum(jrof, jk)
+    end do
+  end do
+end subroutine leaf_kernel_deep
+""".strip()
+
+FCODE_CONDITIONAL_ACC_PROLOGUE_SUB_KERNEL = """
+subroutine conditional_acc_prologue_sub_kernel(klon, klev, kst, kend, lvertfe, mode_intg, phi, phif, pt, pr, plnpr)
+  implicit none
+  integer, intent(in) :: klon, klev, kst, kend
+  logical, intent(in) :: lvertfe, mode_intg
+  real, intent(inout) :: phi(klon, klev + 1)
+  real, intent(out) :: phif(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+  real, intent(in) :: pr(klon, klev)
+  real, intent(in) :: plnpr(klon, klev)
+  real :: zphi(klon, klev + 2)
+  character(len=4) :: mode_flag
+  integer :: jrof, jk
+
+  !$acc data present(phi, phif, pt, pr, plnpr)
+  !$acc enter data create(zphi)
+
+  mode_flag = 'IBOT'
+  if (mode_intg) mode_flag = 'INTG'
+
+  if (lvertfe) then
+
+    do jk = 1, klev
+      do jrof = kst, kend
+        zphi(jrof, jk + 1) = -pr(jrof, jk) * pt(jrof, jk) * plnpr(jrof, jk)
+      end do
+    end do
+
+    zphi(kst:kend, 1) = 0.0
+    zphi(kst:kend, klev + 2) = 0.0
+
+    !$loki small-kernels
+    call conditional_acc_prologue_leaf_kernel(klon, klev, kst, kend, zphi, phif, pedge=phi(:, klev + 1), mode_flag=mode_flag)
+
+    do jk = klev, 1, -1
+      do jrof = kst, kend
+        phi(jrof, jk) = phi(jrof, jk + 1) + pr(jrof, jk) * pt(jrof, jk) * plnpr(jrof, jk)
+      end do
+    end do
+  else
+    do jk = klev, 1, -1
+      do jrof = kst, kend
+        phi(jrof, jk) = phi(jrof, jk + 1) + pr(jrof, jk) * pt(jrof, jk) * plnpr(jrof, jk)
+        phif(jrof, jk) = phi(jrof, jk + 1) + pr(jrof, jk) * pt(jrof, jk)
+      end do
+    end do
+  end if
+  !$acc exit data delete(zphi)
+  !$acc end data
+end subroutine conditional_acc_prologue_sub_kernel
+""".strip()
+
+
+FCODE_CONDITIONAL_ACC_PROLOGUE_MID_KERNEL = """
+subroutine conditional_acc_prologue_mid_kernel(klon, klev, kst, kend, lvertfe, mode_intg, phi, phif, pt, pr, plnpr)
+  implicit none
+  integer, intent(in) :: klon, klev, kst, kend
+  logical, intent(in) :: lvertfe, mode_intg
+  real, intent(inout) :: phi(klon, klev + 1)
+  real, intent(out) :: phif(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+  real, intent(in) :: pr(klon, klev)
+  real, intent(in) :: plnpr(klon, klev)
+
+  !$loki small-kernels
+  call conditional_acc_prologue_sub_kernel(klon, klev, kst, kend, lvertfe, mode_intg, phi, phif, pt, pr, plnpr)
+end subroutine conditional_acc_prologue_mid_kernel
+""".strip()
+
+
+FCODE_CONDITIONAL_ACC_PROLOGUE_DRIVER = """
+module conditional_acc_prologue_driver_mod
+  implicit none
+contains
+  subroutine conditional_acc_prologue_driver(ngpblks, bnds, opts, lvertfe, mode_intg, phi, phif, pt, pr, plnpr)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    logical, intent(in) :: lvertfe, mode_intg
+    real, intent(inout) :: phi(:,:,:)
+    real, intent(out) :: phif(:,:,:)
+    real, intent(in) :: pt(:,:,:)
+    real, intent(in) :: pr(:,:,:)
+    real, intent(in) :: plnpr(:,:,:)
+    integer :: ibl
+
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+
+      !$loki small-kernels
+      call conditional_acc_prologue_mid_kernel(opts%klon, opts%kflevg, bnds%kidia, bnds%kfdia, lvertfe, mode_intg, &
+        & phi(:,:,ibl), phif(:,:,ibl), pt(:,:,ibl), pr(:,:,ibl), plnpr(:,:,ibl))
+    end do
+  end subroutine conditional_acc_prologue_driver
+end module conditional_acc_prologue_driver_mod
+""".strip()
+
+
+FCODE_CONDITIONAL_ACC_PROLOGUE_LEAF_KERNEL = """
+subroutine conditional_acc_prologue_leaf_kernel(klon, klev, kst, kend, zphi, phif, pedge, mode_flag)
+  implicit none
+  integer, intent(in) :: klon, klev, kst, kend
+  real, intent(in) :: zphi(klon, klev + 2)
+  real, intent(out) :: phif(klon, klev)
+  real, intent(in) :: pedge(klon)
+  character(len=*), intent(in) :: mode_flag
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = kst, kend
+      phif(jrof, jk) = zphi(jrof, jk + 1) + pedge(jrof)
+      if (mode_flag == 'INTG') phif(jrof, jk) = phif(jrof, jk) + 1.0
+    end do
+  end do
+end subroutine conditional_acc_prologue_leaf_kernel
+""".strip()
+
+FCODE_EXPLICIT_ACC_DATA_DRIVER = """
+module explicit_acc_data_driver_mod
+  implicit none
+contains
+  subroutine explicit_acc_data_driver(ngpblks, bnds, opts, lvertfe, phi, phif, pt, pr, plnpr)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    logical, intent(in) :: lvertfe
+    real, intent(inout) :: phi(:,:,:)
+    real, intent(out) :: phif(:,:,:)
+    real, intent(in) :: pt(:,:,:)
+    real, intent(in) :: pr(:,:,:)
+    real, intent(in) :: plnpr(:,:,:)
+    integer :: ibl
+
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+
+      !$loki small-kernels
+      call explicit_acc_data_mid_kernel(opts%klon, opts%kflevg, bnds%kidia, bnds%kfdia, lvertfe, phi(:,:,ibl), phif(:,:,ibl), pt(:,:,ibl), pr(:,:,ibl), plnpr(:,:,ibl))
+    end do
+  end subroutine explicit_acc_data_driver
+end module explicit_acc_data_driver_mod
+""".strip()
+
+FCODE_EXPLICIT_ACC_DATA_MID_KERNEL = """
+subroutine explicit_acc_data_mid_kernel(klon, klev, kst, kend, lvertfe, phi, phif, pt, pr, plnpr)
+  implicit none
+  integer, intent(in) :: klon, klev, kst, kend
+  logical, intent(in) :: lvertfe
+  real, intent(inout) :: phi(klon, klev + 1)
+  real, intent(out) :: phif(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+  real, intent(in) :: pr(klon, klev)
+  real, intent(in) :: plnpr(klon, klev)
+
+  !$loki small-kernels
+  call explicit_acc_data_sub_kernel(klon, klev, kst, kend, lvertfe, phi, phif, pt, pr, plnpr)
+end subroutine explicit_acc_data_mid_kernel
+""".strip()
+
+FCODE_EXPLICIT_ACC_DATA_SUB_KERNEL = """
+subroutine explicit_acc_data_sub_kernel(klon, klev, kst, kend, lvertfe, phi, phif, pt, pr, plnpr)
+  implicit none
+  integer, intent(in) :: klon, klev, kst, kend
+  logical, intent(in) :: lvertfe
+  real, intent(inout) :: phi(klon, klev + 1)
+  real, intent(out) :: phif(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+  real, intent(in) :: pr(klon, klev)
+  real, intent(in) :: plnpr(klon, klev)
+  real :: zphi(klon, 0:klev + 1)
+  integer :: jrof, jk
+
+  !$acc data present(phi, phif, pt, pr, plnpr)
+  !$acc enter data create(zphi)
+  if (lvertfe) then
+    do jk = 1, klev
+      do jrof = kst, kend
+        zphi(jrof, jk) = -pr(jrof, jk) * pt(jrof, jk) * plnpr(jrof, jk)
+      end do
+    end do
+
+    zphi(kst:kend, 0) = 0.0
+    zphi(kst:kend, klev + 1) = 0.0
+
+    !$loki small-kernels
+    call explicit_acc_data_leaf_kernel(klon, klev, kst, kend, zphi, phif, pedge=phi(:, klev + 1))
+
+    do jk = klev, 1, -1
+      do jrof = kst, kend
+        phi(jrof, jk) = phi(jrof, jk + 1) + pr(jrof, jk) * pt(jrof, jk) * plnpr(jrof, jk)
+      end do
+    end do
+  else
+    do jk = klev, 1, -1
+      do jrof = kst, kend
+        phi(jrof, jk) = phi(jrof, jk + 1) + pr(jrof, jk) * pt(jrof, jk) * plnpr(jrof, jk)
+        phif(jrof, jk) = phi(jrof, jk + 1) + pr(jrof, jk) * pt(jrof, jk)
+      end do
+    end do
+  end if
+  !$acc exit data delete(zphi)
+  !$acc end data
+end subroutine explicit_acc_data_sub_kernel
+""".strip()
+
+
+
+FCODE_EXPLICIT_ACC_DATA_LEAF_KERNEL = """
+subroutine explicit_acc_data_leaf_kernel(klon, klev, kst, kend, zphi, phif, pedge)
+  implicit none
+  integer, intent(in) :: klon, klev, kst, kend
+  real, intent(in) :: zphi(klon, 0:klev + 1)
+  real, intent(out) :: phif(klon, klev)
+  real, intent(in) :: pedge(klon)
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = kst, kend
+      phif(jrof, jk) = zphi(jrof, jk) + pedge(jrof)
+    end do
+  end do
+end subroutine explicit_acc_data_leaf_kernel
+""".strip()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_thin_wrapper_no_block_loop(frontend, horizontal, block_dim, tmp_path):
+    """
+    Thin wrapper kernel: must NOT have a block loop.
+    The block loop belongs inside the inner kernel, not in the wrapper.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_WRAPPER_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    wrapper_src = Sourcefile.from_source(
+        FCODE_THIN_WRAPPER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    inner_src = Sourcefile.from_source(
+        FCODE_INNER_COMPUTE, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, wrapper, inner = _build_and_apply_3level(
+        driver_src, wrapper_src, inner_src, horizontal, block_dim,
+        'wrapper_driver', 'thin_wrapper', 'inner_compute',
+        'wrapper_driver_mod#wrapper_driver', '#thin_wrapper', '#inner_compute'
+    )
+
+    # Wrapper must NOT have a block loop
+    assert not _has_block_loop(wrapper, block_dim), (
+        f"Thin wrapper should NOT have a block loop.\n"
+        f"Code:\n{fgen(wrapper)}"
+    )
+
+    # Wrapper must still call inner_compute
+    calls = _find_calls_by_name(wrapper, 'inner_compute')
+    assert calls, (
+        f"Wrapper should still call inner_compute.\nCode:\n{fgen(wrapper)}"
+    )
+
+    # Inner kernel MUST have a block loop
+    assert _has_block_loop(inner, block_dim), (
+        f"Inner kernel should have a block-dimension loop.\n"
+        f"Code:\n{fgen(inner)}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_block_section_propagates_through_intermediate_kernel(
+        frontend, horizontal, block_dim, tmp_path):
+    """
+    A kernel with horizontal work around a ``!$loki small-kernels`` call
+    must still propagate block-section processing to its leaf callee.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_DEEP_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_MID_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_SUB_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    leaf_src = Sourcefile.from_source(
+        FCODE_LEAF_KERNEL_DEEP, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, _, sub, leaf = _build_and_apply_4level(
+        driver_src, mid_src, sub_src, leaf_src, horizontal, block_dim,
+        'deep_driver', 'mid_kernel', 'sub_kernel', 'leaf_kernel_deep',
+        'deep_driver_mod#deep_driver', '#mid_kernel', '#sub_kernel', '#leaf_kernel_deep'
+    )
+
+    assert _has_block_loop(sub, block_dim), (
+        f"Intermediate kernel should have a block-dimension loop.\nCode:\n{fgen(sub)}"
+    )
+    assert _has_block_loop(leaf, block_dim), (
+        f"Leaf kernel should inherit block-section processing through the "
+        f"intermediate kernel.\nCode:\n{fgen(leaf)}"
+    )
+
+    calls = _find_calls_by_name(sub, 'leaf_kernel_deep')
+    assert calls, (
+        f"Intermediate kernel should still call leaf_kernel_deep.\n"
+        f"Code:\n{fgen(sub)}"
+    )
+    assert 'acc parallel loop gang' in fgen(leaf).lower(), (
+        f"Leaf kernel should own a parallel block loop after propagation.\n"
+        f"Code:\n{fgen(leaf)}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_real_pipeline_conditional_acc_prologue_outside_first_block_loop(
+        frontend, horizontal, block_dim, tmp_path):
+    """
+    In the first conditional branch, ``!$acc enter data create`` and the
+    mode-flag setup must stay outside
+    the first inserted block loop.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_CONDITIONAL_ACC_PROLOGUE_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_CONDITIONAL_ACC_PROLOGUE_MID_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_CONDITIONAL_ACC_PROLOGUE_SUB_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    leaf_src = Sourcefile.from_source(
+        FCODE_CONDITIONAL_ACC_PROLOGUE_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, _, sub, _ = _build_and_apply_4level_full_pipeline(
+        driver_src, mid_src, sub_src, leaf_src, horizontal, block_dim,
+        'conditional_acc_prologue_driver', 'conditional_acc_prologue_mid_kernel',
+        'conditional_acc_prologue_sub_kernel', 'conditional_acc_prologue_leaf_kernel',
+        'conditional_acc_prologue_driver_mod#conditional_acc_prologue_driver',
+        '#conditional_acc_prologue_mid_kernel', '#conditional_acc_prologue_sub_kernel',
+        '#conditional_acc_prologue_leaf_kernel'
+    )
+
+    block_loops = _get_block_loops(sub, block_dim)
+    assert block_loops, f"Expected block loop in transformed sub-kernel.\nCode:\n{fgen(sub)}"
+    first_loop = block_loops[0]
+
+    pragmas = FindNodes(Pragma).visit(first_loop.body)
+    assignments = FindNodes(Assignment).visit(first_loop.body)
+    enter_data_inside = [
+        p for p in pragmas
+        if p.keyword.lower() == 'acc'
+        and 'enter' in p.content.lower()
+        and 'data' in p.content.lower()
+        and 'create' in p.content.lower()
+    ]
+    mode_assigns_inside = [a for a in assignments if a.lhs == 'mode_flag']
+
+    assert not enter_data_inside, (
+        f"Conditional prologue reproducer: !$acc enter data create(...) should stay outside the first block loop.\n"
+        f"Found inside first block loop: {[fgen(p) for p in enter_data_inside]}\n"
+        f"First block loop:\n{fgen(first_loop)}\n\nFull sub-kernel:\n{fgen(sub)}"
+    )
+    assert not mode_assigns_inside, (
+        f"Conditional prologue reproducer: mode-flag setup should stay outside the first block loop.\n"
+        f"Found inside first block loop: {[fgen(a) for a in mode_assigns_inside]}\n"
+        f"First block loop:\n{fgen(first_loop)}\n\nFull sub-kernel:\n{fgen(sub)}"
+    )
+
+
+# ===================================================================
+# Group 5: Vector and stack propagation
+# ===================================================================
+
+FCODE_VEC_DRIVER = """
+module vec_driver_mod
+  implicit none
+contains
+  subroutine vec_driver(ngpblks, bnds, opts, t, q)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    #include "vec_kernel.intfb.h"
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: t(:,:,:)
+    real, intent(inout) :: q(:,:,:)
+    integer :: ibl
+
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+
+      !$loki small-kernels
+      call vec_kernel(opts%klon, opts%kflevg, bnds, t(:,:,ibl), q(:,:,ibl))
+    end do
+  end subroutine vec_driver
+end module vec_driver_mod
+""".strip()
+
+# Vector kernel: simple kernel called with !$loki small-kernels.
+# It should get !$acc routine seq or vector annotation, but not its own
+# pool allocator.
+FCODE_VEC_KERNEL = """
+subroutine vec_kernel(klon, klev, bnds, t, q)
+  use bnds_type_mod, only: bnds_type
+  implicit none
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  real, intent(inout) :: t(klon, klev)
+  real, intent(inout) :: q(klon, klev)
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      t(jrof, jk) = t(jrof, jk) * 2.0
+      q(jrof, jk) = t(jrof, jk) + 1.0
+    end do
+  end do
+end subroutine vec_kernel
+""".strip()
+
+# Stack-propagation pattern: caller -> callee where callee has
+# local temporaries that get pool-allocated.
+FCODE_STACK_CALLER = """
+subroutine stack_caller(klon, klev, bnds, opts, pfield)
+  use bnds_type_mod, only: bnds_type
+  use opts_type_mod, only: opts_type
+  implicit none
+  #include "stack_callee.intfb.h"
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  type(opts_type), intent(in) :: opts
+  real, intent(inout) :: pfield(klon, klev)
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      pfield(jrof, jk) = pfield(jrof, jk) + 1.0
+    end do
+  end do
+
+  !$loki small-kernels
+  call stack_callee(klon, klev, bnds, opts, pfield)
+end subroutine stack_caller
+""".strip()
+
+FCODE_STACK_DRIVER = """
+module stack_driver_mod
+  implicit none
+contains
+  subroutine stack_driver(ngpblks, bnds, opts, pfield)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    #include "stack_caller.intfb.h"
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: pfield(:,:,:)
+    integer :: ibl
+
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+
+      !$loki small-kernels
+      call stack_caller(opts%klon, opts%kflevg, bnds, opts, pfield(:,:,ibl))
+    end do
+  end subroutine stack_driver
+end module stack_driver_mod
+""".strip()
+
+FCODE_STACK_CALLEE = """
+subroutine stack_callee(klon, klev, bnds, opts, pfield)
+  use bnds_type_mod, only: bnds_type
+  use opts_type_mod, only: opts_type
+  implicit none
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  type(opts_type), intent(in) :: opts
+  real, intent(inout) :: pfield(klon, klev)
+  real :: ztmp1(klon, klev)
+  real :: ztmp2(klon)
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      ztmp1(jrof, jk) = pfield(jrof, jk) * 2.0
+    end do
+  end do
+  do jrof = bnds%kidia, bnds%kfdia
+    ztmp2(jrof) = 0.0
+  end do
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      ztmp2(jrof) = ztmp2(jrof) + ztmp1(jrof, jk)
+    end do
+  end do
+  do jrof = bnds%kidia, bnds%kfdia
+    pfield(jrof, 1) = ztmp2(jrof)
+  end do
+end subroutine stack_callee
+""".strip()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_vector_kernel_no_pool_allocator(frontend, horizontal, block_dim, tmp_path):
+    """
+    Simple leaf kernel: a kernel without sub-calls
+    should NOT get ISTSZ/ZSTACK at the kernel level.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_VEC_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    kernel_src = Sourcefile.from_source(
+        FCODE_VEC_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, vec_kernel = _build_and_apply_2level(
+        driver_src, kernel_src, horizontal, block_dim,
+        'vec_driver', 'vec_kernel',
+        'vec_driver_mod#vec_driver', '#vec_kernel'
+    )
+
+    var_names = _routine_var_names(vec_kernel)
+    assert 'istsz' not in var_names, (
+        f"Vector kernel should NOT have ISTSZ.\nVars: {sorted(var_names)}\n"
+        f"Code:\n{fgen(vec_kernel)}"
+    )
+    assert 'zstack' not in var_names, (
+        f"Vector kernel should NOT have ZSTACK.\nVars: {sorted(var_names)}\n"
+        f"Code:\n{fgen(vec_kernel)}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_vector_kernel_acc_routine(frontend, horizontal, block_dim, tmp_path):
+    """
+    Leaf kernel called with ``!$loki small-kernels``: should get
+    ``!$acc routine seq`` or ``!$acc routine vector`` annotation.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_VEC_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    kernel_src = Sourcefile.from_source(
+        FCODE_VEC_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, vec_kernel = _build_and_apply_2level(
+        driver_src, kernel_src, horizontal, block_dim,
+        'vec_driver', 'vec_kernel',
+        'vec_driver_mod#vec_driver', '#vec_kernel'
+    )
+
+    code_lower = fgen(vec_kernel).lower()
+    has_acc_routine = ('acc routine' in code_lower or
+                       'acc parallel loop gang' in code_lower)
+    assert has_acc_routine, (
+        f"Kernel should have !$acc routine or !$acc parallel loop gang.\n"
+        f"Code:\n{fgen(vec_kernel)}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_stack_arg_propagated_to_callee(frontend, horizontal, block_dim, tmp_path):
+    """
+    Stack arg propagation: callee kernel with local
+    temporaries must get YDSTACK_L in its argument list, and the
+    caller's call must pass it.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_STACK_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    caller_src = Sourcefile.from_source(
+        FCODE_STACK_CALLER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    callee_src = Sourcefile.from_source(
+        FCODE_STACK_CALLEE, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, caller, callee = _build_and_apply_3level(
+        driver_src, caller_src, callee_src, horizontal, block_dim,
+        'stack_driver', 'stack_caller', 'stack_callee',
+        'stack_driver_mod#stack_driver', '#stack_caller', '#stack_callee'
+    )
+
+    # Callee should have stack arg (YDSTACK_L)
+    callee_arg_names = [str(a).lower() for a in callee.arguments]
+    has_stack = any('stack' in a for a in callee_arg_names)
+    assert has_stack, (
+        f"Callee should have YDSTACK_L in args.\n"
+        f"Args: {callee_arg_names}\nCode:\n{fgen(callee)}"
+    )
+
+    # Caller's call to callee must pass stack arg
+    calls = _find_calls_by_name(caller, 'stack_callee')
+    assert calls, f"Caller should call stack_callee.\nCode:\n{fgen(caller)}"
+    for call in calls:
+        kwarg_names = [kw[0].lower() for kw in (call.kwarguments or ())]
+        arg_strs = [str(a).lower() for a in call.arguments]
+        assert any('stack' in kw for kw in kwarg_names) or \
+               any('stack' in a for a in arg_strs), (
+            f"Call to stack_callee must pass YDSTACK_L.\n"
+            f"Kwargs: {kwarg_names}\nArgs: {arg_strs}\n"
+            f"Call: {fgen(call)}\nCode:\n{fgen(caller)}"
+        )
+
+
+# ===================================================================
+# Group 6: Multi-driver-loop
+# ===================================================================
+
+FCODE_MULTI_DRIVER = """
+module multi_driver_mod
+  implicit none
+contains
+  subroutine multi_driver(ngpblks, bnds, opts, pfield)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    #include "kernel_a.intfb.h"
+    #include "kernel_b.intfb.h"
+    #include "kernel_c.intfb.h"
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: pfield(:,:,:)
+    integer :: ibl
+
+    ! Loop 1: kernel_a WITH !$loki small-kernels
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+      !$loki small-kernels
+      call kernel_a(opts%klon, opts%kflevg, bnds, opts, pfield(:,:,ibl))
+    end do
+
+    ! Loop 2: kernel_b WITH !$loki small-kernels
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+      !$loki small-kernels
+      call kernel_b(opts%klon, opts%kflevg, bnds, opts, pfield(:,:,ibl))
+    end do
+
+    ! Loop 3: kernel_c WITH !$loki small-kernels
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+      !$loki small-kernels
+      call kernel_c(opts%klon, opts%kflevg, bnds, opts, pfield(:,:,ibl))
+    end do
+  end subroutine multi_driver
+end module multi_driver_mod
+""".strip()
+
+FCODE_KERNEL_A = """
+module kernel_a_mod
+  implicit none
+contains
+  subroutine kernel_a(klon, klev, bnds, opts, pfield)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    integer, intent(in) :: klon, klev
+    type(bnds_type), intent(in) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: pfield(klon, klev)
+    real :: ztmp_a(klon, klev)
+    integer :: jrof, jk
+    do jk = 1, klev
+      do jrof = bnds%kidia, bnds%kfdia
+        ztmp_a(jrof, jk) = pfield(jrof, jk) * 2.0
+      end do
+    end do
+    do jk = 1, klev
+      do jrof = bnds%kidia, bnds%kfdia
+        pfield(jrof, jk) = ztmp_a(jrof, jk)
+      end do
+    end do
+  end subroutine kernel_a
+end module kernel_a_mod
+""".strip()
+
+FCODE_KERNEL_B = """
+module kernel_b_mod
+  implicit none
+contains
+  subroutine kernel_b(klon, klev, bnds, opts, pfield)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    integer, intent(in) :: klon, klev
+    type(bnds_type), intent(in) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: pfield(klon, klev)
+    integer :: jrof, jk
+    do jk = 1, klev
+      do jrof = bnds%kidia, bnds%kfdia
+        pfield(jrof, jk) = pfield(jrof, jk) + 1.0
+      end do
+    end do
+  end subroutine kernel_b
+end module kernel_b_mod
+""".strip()
+
+FCODE_KERNEL_C = """
+module kernel_c_mod
+  implicit none
+contains
+  subroutine kernel_c(klon, klev, bnds, opts, pfield)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    integer, intent(in) :: klon, klev
+    type(bnds_type), intent(in) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: pfield(klon, klev)
+    real :: ztmp_c(klon, klev)
+    integer :: jrof, jk
+    do jk = 1, klev
+      do jrof = bnds%kidia, bnds%kfdia
+        ztmp_c(jrof, jk) = pfield(jrof, jk) * 3.0
+      end do
+    end do
+    do jk = 1, klev
+      do jrof = bnds%kidia, bnds%kfdia
+        pfield(jrof, jk) = ztmp_c(jrof, jk)
+      end do
+    end do
+  end subroutine kernel_c
+end module kernel_c_mod
+""".strip()
+
+
+def _build_and_apply_multi_driver(
+        driver_source, kernel_sources, horizontal, block_dim,  # pylint: disable=unused-argument
+        driver_name, kernel_names, driver_item_name, kernel_item_names,
+        kernel_source_objs):
+    """
+    Build multi-kernel call tree. Only the driver gets 'driver' role;
+    kernels get 'kernel' role. All go through the pipeline.
+    """
+    pipeline = SCCSmallKernelsPipeline(
+        horizontal=horizontal, block_dim=block_dim, directive='openacc'
+    )
+    driver = driver_source[driver_name]
+    kernels = [src[name] for src, name in zip(kernel_source_objs, kernel_names)]
+    for k in kernels:
+        driver.enrich(k)
+
+    d_item = ProcedureItem(name=driver_item_name, source=driver_source)
+    k_items = [ProcedureItem(name=iname, source=src)
+               for iname, src in zip(kernel_item_names, kernel_source_objs)]
+    sgraph = SGraph.from_dict({d_item: k_items})
+
+    items = [(driver, 'driver', d_item, list(kernel_names))]
+    for k, ki in zip(kernels, k_items):
+        items.append((k, 'kernel', ki, []))
+    _apply_pipeline(pipeline, items, sgraph)
+    return driver, kernels
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+@pytest.mark.xfail(reason=(
+    'Multi-driver-loop pattern requires mixing SK and standard SCC pipelines. '
+    'All-SK multi-loop drivers hoist block loops into kernels, removing '
+    'ISTSZ/ZSTACK from the driver.'
+))
+def test_multi_driver_loop_max_istsz(frontend, horizontal, block_dim, tmp_path):
+    """
+    Driver with multiple block loops:
+    ISTSZ must be aggregated via MAX across all driver loops, and
+    ZSTACK must be allocated.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_MULTI_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    ka_src = Sourcefile.from_source(
+        FCODE_KERNEL_A, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    kb_src = Sourcefile.from_source(
+        FCODE_KERNEL_B, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    kc_src = Sourcefile.from_source(
+        FCODE_KERNEL_C, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    driver, _ = _build_and_apply_multi_driver(
+        driver_src,
+        [ka_src, kb_src, kc_src],
+        horizontal, block_dim,
+        'multi_driver',
+        ['kernel_a', 'kernel_b', 'kernel_c'],
+        'multi_driver_mod#multi_driver',
+        ['kernel_a_mod#kernel_a', 'kernel_b_mod#kernel_b', 'kernel_c_mod#kernel_c'],
+        [ka_src, kb_src, kc_src]
+    )
+
+    var_names = _routine_var_names(driver)
+    assert 'istsz' in var_names, (
+        f"Driver must have ISTSZ.\nVars: {sorted(var_names)}\n"
+        f"Code:\n{fgen(driver)}"
+    )
+
+    allocs = FindNodes(Allocation).visit(driver.body)
+    assert any('zstack' in str(a).lower() for a in allocs), (
+        f"Driver must ALLOCATE ZSTACK.\n"
+        f"Allocations: {[fgen(a) for a in allocs]}\n"
+        f"Code:\n{fgen(driver)}"
+    )
+
+    # ISTSZ should use MAX (aggregating across loops)
+    assigns = FindNodes(Assignment).visit(driver.body)
+    istsz_assigns = [a for a in assigns if str(a.lhs).lower() == 'istsz']
+    assert istsz_assigns, f"Driver must have ISTSZ assignment.\nCode:\n{fgen(driver)}"
+
+    istsz_rhs = str(istsz_assigns[0].rhs).lower()
+    assert 'max' in istsz_rhs, (
+        f"ISTSZ should use MAX to aggregate stack sizes.\n"
+        f"ISTSZ RHS: {istsz_rhs}\nCode:\n{fgen(driver)}"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+@pytest.mark.xfail(reason=(
+    'Multi-driver-loop pattern requires mixing SK and standard SCC pipelines.'
+))
+def test_multi_driver_loop_loc_assigns(frontend, horizontal, block_dim, tmp_path):
+    """
+    Driver with multiple block loops: each loop with stack-needing
+    calls must have ``YLSTACK_L = LOC(ZSTACK(...))`` inside.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_MULTI_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    ka_src = Sourcefile.from_source(
+        FCODE_KERNEL_A, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    kb_src = Sourcefile.from_source(
+        FCODE_KERNEL_B, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    kc_src = Sourcefile.from_source(
+        FCODE_KERNEL_C, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    driver, _ = _build_and_apply_multi_driver(
+        driver_src,
+        [ka_src, kb_src, kc_src],
+        horizontal, block_dim,
+        'multi_driver',
+        ['kernel_a', 'kernel_b', 'kernel_c'],
+        'multi_driver_mod#multi_driver',
+        ['kernel_a_mod#kernel_a', 'kernel_b_mod#kernel_b', 'kernel_c_mod#kernel_c'],
+        [ka_src, kb_src, kc_src]
+    )
+
+    # Find LOC(ZSTACK) assignments inside driver loops
+    driver_loops = FindNodes(Loop).visit(driver.body)
+    loc_count = 0
+    for dl in driver_loops:
+        loop_assigns = FindNodes(Assignment).visit(dl.body)
+        loc_assigns = [a for a in loop_assigns
+                       if 'ylstack_l' in str(a.lhs).lower()
+                       and 'loc' in str(a.rhs).lower()
+                       and 'zstack' in str(a.rhs).lower()]
+        loc_count += len(loc_assigns)
+
+    # At least loops 1 and 3 need LOC assigns (kernel_a and kernel_c
+    # have pool-allocated temporaries)
+    assert loc_count >= 2, (
+        f"At least 2 driver loops must have YLSTACK_L = LOC(ZSTACK(...)).\n"
+        f"Found {loc_count}.\nCode:\n{fgen(driver)}"
+    )
+
+
+# ===================================================================
+# Group 7: Edge cases
+# ===================================================================
+
+FCODE_PRIV_DRIVER = """
+module priv_driver_mod
+  implicit none
+  type dim_type
+    integer :: nproma
+    integer :: nflevg
+    integer :: ngpblks
+  end type dim_type
+
+  type gem_type
+    real :: rmu0
+  end type gem_type
+
+  type geometry_type
+    type(dim_type) :: yrdim
+    type(gem_type) :: yrgem
+  end type geometry_type
+contains
+  subroutine priv_driver(ydgeometry, bnds, opts, t, q)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    #include "priv_kernel.intfb.h"
+    type(geometry_type), intent(in) :: ydgeometry
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(inout) :: t(:,:,:)
+    real, intent(inout) :: q(:,:,:)
+    integer :: ibl
+
+    do ibl = 1, ydgeometry%yrdim%ngpblks
+      bnds%kbl = ibl
+      bnds%kidia = 1
+      bnds%kfdia = ydgeometry%yrdim%nproma
+
+      !$loki small-kernels
+      call priv_kernel(ydgeometry%yrdim%nproma, ydgeometry%yrdim%nflevg, &
+        & ydgeometry%yrdim%ngpblks, bnds, t(:,:,ibl), q(:,:,ibl))
+    end do
+  end subroutine priv_driver
+end module priv_driver_mod
+""".strip()
+
+FCODE_PRIV_KERNEL = """
+subroutine priv_kernel(klon, klev, ngpblks, bnds, t, q)
+  use bnds_type_mod, only: bnds_type
+  implicit none
+  integer, intent(in) :: klon, klev, ngpblks
+  type(bnds_type), intent(in) :: bnds
+  real, intent(inout) :: t(klon, klev)
+  real, intent(inout) :: q(klon, klev)
+  integer :: jrof, jk
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      t(jrof, jk) = t(jrof, jk) + 1.0
+      q(jrof, jk) = t(jrof, jk) * 2.0
+    end do
+  end do
+end subroutine priv_kernel
+""".strip()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_derived_type_args_not_privatised(frontend, horizontal, block_dim, tmp_path):
+    """
+    Derived-type argument components (e.g. YDGEOMETRY%YRDIM) must NOT
+    appear in the ``private(...)`` clause of ``!$acc parallel loop gang``.
+    Only truly local variables should be privatised.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_PRIV_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    kernel_src = Sourcefile.from_source(
+        FCODE_PRIV_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    driver, _ = _build_and_apply_2level(
+        driver_src, kernel_src, horizontal, block_dim,
+        'priv_driver', 'priv_kernel',
+        'priv_driver_mod#priv_driver', '#priv_kernel'
+    )
+
+    code = fgen(driver)
+    private_matches = re.findall(r'private\(([^)]+)\)', code, re.IGNORECASE)
+
+    for match in private_matches:
+        privates = [p.strip().lower() for p in match.split(',')]
+        for priv in privates:
+            assert 'ydgeometry' not in priv, (
+                f"YDGEOMETRY component '{priv}' should NOT be in\n"
+                f"private() clause.\nprivate({match})\nCode:\n{code}"
+            )
+
+
+FCODE_ACC_EXIT_DRIVER = """
+module acc_exit_driver_mod
+  implicit none
+contains
+  subroutine acc_exit_driver(ngpblks, bnds, opts, pd, pt, psp)
+    use bnds_type_mod, only: bnds_type
+    use opts_type_mod, only: opts_type
+    implicit none
+    #include "acc_exit_kernel.intfb.h"
+    integer, intent(in) :: ngpblks
+    type(bnds_type), intent(inout) :: bnds
+    type(opts_type), intent(in) :: opts
+    real, intent(out) :: pd(:,:,:)
+    real, intent(in) :: pt(:,:,:)
+    real, intent(in) :: psp(:,:)
+    integer :: ibl
+
+    do ibl = 1, ngpblks
+      bnds%kbl = ibl
+      bnds%kstglo = 1 + (ibl - 1) * opts%klon
+      bnds%kidia = 1
+      bnds%kfdia = min(opts%klon, opts%kgpcomp - bnds%kstglo + 1)
+
+      !$loki small-kernels
+      call acc_exit_kernel(opts%klon, opts%kflevg, bnds, opts, pd(:,:,ibl), pt(:,:,ibl), psp(:,ibl))
+    end do
+  end subroutine acc_exit_driver
+end module acc_exit_driver_mod
+""".strip()
+
+FCODE_ACC_EXIT_KERNEL = """
+subroutine acc_exit_kernel(klon, klev, bnds, opts, pd, pt, psp)
+  use bnds_type_mod, only: bnds_type
+  use opts_type_mod, only: opts_type
+  implicit none
+  integer, intent(in) :: klon, klev
+  type(bnds_type), intent(in) :: bnds
+  type(opts_type), intent(in) :: opts
+  real, intent(out) :: pd(klon, klev)
+  real, intent(in) :: pt(klon, klev)
+  real, intent(in) :: psp(klon)
+  real :: ztmp(klon, 0:klev+1)
+  real :: zout(klon, klev)
+  integer :: jrof, jk
+
+  !$acc enter data create(ztmp, zout)
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      ztmp(jrof, jk) = pt(jrof, jk) * 2.0
+    end do
+  end do
+
+  do jrof = bnds%kidia, bnds%kfdia
+    ztmp(jrof, 0) = 0.0
+    ztmp(jrof, klev + 1) = 0.0
+  end do
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      zout(jrof, jk) = ztmp(jrof, jk) + psp(jrof)
+    end do
+  end do
+
+  do jk = 1, klev
+    do jrof = bnds%kidia, bnds%kfdia
+      pd(jrof, jk) = zout(jrof, jk)
+    end do
+  end do
+
+  !$acc exit data delete(ztmp, zout)
+end subroutine acc_exit_kernel
+""".strip()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+@pytest.mark.xfail(reason='Minimal SCC helper still sweeps explicit raw ACC enter/exit pragmas into block loops')
+def test_acc_exit_data_outside_block_loop(frontend, horizontal, block_dim, tmp_path):
+    """
+    ``!$acc enter/exit data`` directives must remain outside the block
+    loop, not be swept inside by extract_block_sections.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_ACC_EXIT_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    kernel_src = Sourcefile.from_source(
+        FCODE_ACC_EXIT_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, kernel = _build_and_apply_2level(
+        driver_src, kernel_src, horizontal, block_dim,
+        'acc_exit_driver', 'acc_exit_kernel',
+        'acc_exit_driver_mod#acc_exit_driver', '#acc_exit_kernel'
+    )
+
+    # Kernel should have a block loop
+    block_loops = _get_block_loops(kernel, block_dim)
+    assert block_loops, (
+        f"Kernel should have a block loop.\nCode:\n{fgen(kernel)}"
+    )
+
+    # Check that !$acc enter/exit data are NOT inside the block loop
+    for bl in block_loops:
+        block_pragmas = FindNodes(Pragma).visit(bl.body)
+        enter_inside = [p for p in block_pragmas
+                        if p.keyword.lower() == 'acc'
+                        and 'enter' in p.content.lower()
+                        and 'data' in p.content.lower()
+                        and 'create' in p.content.lower()]
+        exit_inside = [p for p in block_pragmas
+                       if p.keyword.lower() == 'acc'
+                       and 'exit' in p.content.lower()
+                       and 'data' in p.content.lower()
+                       and 'delete' in p.content.lower()]
+
+        assert not enter_inside, (
+            f"!$acc enter data must NOT be inside block loop.\n"
+            f"Found: {[fgen(p) for p in enter_inside]}\nCode:\n{fgen(kernel)}"
+        )
+        assert not exit_inside, (
+            f"!$acc exit data must NOT be inside block loop.\n"
+            f"Found: {[fgen(p) for p in exit_inside]}\nCode:\n{fgen(kernel)}"
+        )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    xfail=[(OMNI, 'OMNI fails to import undefined module.')]))
+def test_real_pipeline_explicit_acc_data_regions_not_duplicated(
+        frontend, horizontal, block_dim, tmp_path):
+    """
+    The real scc-stack pipeline must not duplicate explicit ACC data regions.
+
+    This reproduces the explicit-data-managed shape where a kernel already contains
+    explicit ``!$acc data`` and ``!$acc enter/exit data`` pragmas before SCC
+    annotation and pragma-model lowering are applied.
+    """
+    defs = _parse_modules(frontend, tmp_path)
+    driver_src = Sourcefile.from_source(
+        FCODE_EXPLICIT_ACC_DATA_DRIVER, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    mid_src = Sourcefile.from_source(
+        FCODE_EXPLICIT_ACC_DATA_MID_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    sub_src = Sourcefile.from_source(
+        FCODE_EXPLICIT_ACC_DATA_SUB_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+    leaf_src = Sourcefile.from_source(
+        FCODE_EXPLICIT_ACC_DATA_LEAF_KERNEL, frontend=frontend, definitions=defs, xmods=[tmp_path]
+    )
+
+    _, _, sub, _ = _build_and_apply_4level_full_pipeline(
+        driver_src, mid_src, sub_src, leaf_src,
+        horizontal, block_dim,
+        'explicit_acc_data_driver', 'explicit_acc_data_mid_kernel',
+        'explicit_acc_data_sub_kernel', 'explicit_acc_data_leaf_kernel',
+        'explicit_acc_data_driver_mod#explicit_acc_data_driver', '#explicit_acc_data_mid_kernel',
+        '#explicit_acc_data_sub_kernel', '#explicit_acc_data_leaf_kernel'
+    )
+
+    acc_pragmas = [p for p in FindNodes(Pragma).visit(sub.body) if p.keyword.lower() == 'acc']
+    acc_data = [p for p in acc_pragmas if p.content.lower().startswith('data ')]
+    acc_end_data = [p for p in acc_pragmas if p.content.lower() == 'end data']
+    acc_enter_data = [p for p in acc_pragmas if p.content.lower().startswith('enter data')]
+    acc_exit_data = [p for p in acc_pragmas if p.content.lower().startswith('exit data')]
+
+    assert len(acc_data) == 1, f"Expected exactly one ACC data region.\nCode:\n{fgen(sub)}"
+    assert len(acc_end_data) == 1, f"Expected exactly one ACC end data pragma.\nCode:\n{fgen(sub)}"
+    assert len(acc_enter_data) == 1, f"Expected exactly one ACC enter data pragma.\nCode:\n{fgen(sub)}"
+    assert len(acc_exit_data) == 1, f"Expected exactly one ACC exit data pragma.\nCode:\n{fgen(sub)}"

--- a/loki/transformations/temporaries/__init__.py
+++ b/loki/transformations/temporaries/__init__.py
@@ -14,3 +14,4 @@ from loki.transformations.temporaries.hoist_variables import * # noqa
 from loki.transformations.temporaries.pool_allocator import * # noqa
 from loki.transformations.temporaries.stack_allocator import * # noqa
 from loki.transformations.temporaries.raw_stack_allocator import * # noqa
+from loki.transformations.temporaries.pool_allocator_per_drv_loop import * # noqa

--- a/loki/transformations/temporaries/pool_allocator.py
+++ b/loki/transformations/temporaries/pool_allocator.py
@@ -381,8 +381,11 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         )
 
     def _get_stack_alloc(self, routine, stack_storage, stack_size_var, block_size): # pylint: disable=unused-argument
+        stack_size = InlineCall(
+            function=Variable(name='MAX'), parameters=(stack_size_var, IntLiteral(1)), kw_parameters=()
+        )
         stack_alloc = Allocation(variables=(stack_storage.clone(dimensions=(  # pylint: disable=no-member
-            stack_size_var, block_size)),))
+            stack_size, block_size)),))
         return stack_alloc
 
     def _get_stack_dealloc(self, routine, stack_storage, stack_size_var, block_size): # pylint: disable=unused-argument
@@ -440,6 +443,11 @@ class TemporariesPoolAllocatorTransformation(Transformation):
 
         variables_append = []  # New variables to declare in the routine
 
+        existing_acc_data_vars = {
+            p.content.lower() for p in FindNodes(Pragma).visit(routine.body)
+            if p.keyword.lower() == 'acc' and 'data' in p.content.lower()
+        }
+
         if self.stack_size_name in variable_map:
             # Use an existing stack size declaration
             stack_size_var = routine.variable_map[self.stack_size_name]
@@ -473,15 +481,30 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             )
             variables_append += [stack_storage]
 
-            block_size = routine.resolve_typebound_var(self.block_dim.size, routine.symbol_map)
+            block_size = None
+            for _size in self.block_dim.sizes:
+                try:
+                    block_size = routine.resolve_typebound_var(_size, routine.symbol_map)
+                    break
+                except (KeyError, AttributeError):
+                    continue
+            if block_size is None:
+                raise RuntimeError(
+                    f'{self.__class__.__name__}: Could not resolve any block dimension size '
+                    f'({self.block_dim.sizes}) in {routine.name}'
+                )
             stack_alloc = self._get_stack_alloc(routine, stack_storage, stack_size_var, block_size)
             stack_dealloc = self._get_stack_dealloc(routine, stack_storage, stack_size_var, block_size)
 
             body_prepend += [stack_alloc]
             pragma_data_start = self._get_pragma_start(routine, stack_storage)
-            body_prepend += [pragma_data_start]
             pragma_data_end = self._get_pragma_end(routine, stack_storage)
-            body_append += [pragma_data_end]
+
+            stack_name = stack_storage.name.lower()  # pylint: disable=no-member
+            explicit_acc_management = any(stack_name in content for content in existing_acc_data_vars)
+            if not explicit_acc_management:
+                body_prepend += [pragma_data_start]
+                body_append += [pragma_data_end]
             if stack_dealloc is not None:
                 body_append += [stack_dealloc]
 
@@ -507,7 +530,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             return True
         return False
 
-    def _determine_stack_size(self, routine, successors, local_stack_size=None, item=None):
+    def _determine_stack_size(self, routine, successors, local_stack_size=None, item=None, drv_loop=None):
         """
         Utility routine to determine the stack size required for the given :data:`routine`,
         including calls to subroutines
@@ -522,6 +545,10 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             The stack size required for temporaries in :data:`routine`
         item : :any:`Item`
             Scheduler work item corresponding to routine.
+        drv_loop : :any:`Loop`, optional
+            If provided, only consider calls within this specific loop when
+            collecting successor stack sizes. When ``None``, the entire
+            routine body is searched (original behaviour).
 
         Returns
         -------
@@ -548,8 +575,9 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         # Collect stack sizes for successors
         # Note that we need to translate the names of variables used in the expressions to the
         # local names according to the call signature
+        section = drv_loop.body if drv_loop is not None else routine.body
         stack_sizes = []
-        for call in FindNodes(CallStatement).visit(routine.body):
+        for call in FindNodes(CallStatement).visit(section):
             if call.name in successor_map and self._key in successor_map[call.name].trafo_data:
                 successor_stack_size = successor_map[call.name].trafo_data[self._key]['stack_size']
                 # Replace any occurence of routine arguments in the stack size expression
@@ -730,6 +758,54 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             if not var.type.pointer or var.type.allocatable
         ]
 
+        # Filter out temporaries that are already managed explicitly by data
+        # pragmas in the routine body. Pool-allocating them would rewrite them
+        # as Cray-pointer aliases and can break subsequent device data handling.
+        explicit_data_vars = set()
+        for pragma in FindNodes(Pragma).visit(routine.body):
+            keyword = pragma.keyword.lower()
+            content = pragma.content.lower()
+            parameters = None
+
+            if keyword == 'acc':
+                if 'enter' in content and 'data' in content:
+                    parameters = get_pragma_parameters(
+                        pragma, starts_with='enter data', only_loki_pragmas=False
+                    )
+                elif 'exit' in content and 'data' in content:
+                    parameters = get_pragma_parameters(
+                        pragma, starts_with='exit data', only_loki_pragmas=False
+                    )
+            elif keyword == 'loki' and 'unstructured-data' in content:
+                if content.startswith('exit unstructured-data'):
+                    parameters = get_pragma_parameters(
+                        pragma, starts_with='exit unstructured-data', only_loki_pragmas=False
+                    )
+                else:
+                    parameters = get_pragma_parameters(
+                        pragma, starts_with='unstructured-data', only_loki_pragmas=False
+                    )
+
+            if not parameters:
+                continue
+
+            parameters = {
+                key: ', '.join(as_tuple(value)) for key, value in parameters.items()
+            }
+            for category in ('create', 'delete'):
+                values = parameters.get(category, '')
+                if not values:
+                    continue
+                for entry in values.split(','):
+                    entry = entry.strip()
+                    if entry:
+                        explicit_data_vars.add(entry.lower())
+
+        temporary_arrays = [
+            var for var in temporary_arrays
+            if var.name.lower() not in explicit_data_vars
+        ]
+
         # Create stack argument and local stack var
         stack_var = self._get_local_stack_var(routine)
         stack_var_end = self._get_local_stack_var_end(routine) if self.check_bounds else None
@@ -901,9 +977,16 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         if loop_map:
             routine.body = Transformer(loop_map).visit(routine.body)
 
-    def inject_pool_allocator_into_calls(self, routine, targets, ignore, driver=False):
+    def inject_pool_allocator_into_calls(self, routine, targets, ignore, driver=False, drv_loop=None):
         """
         Add the pool allocator argument into subroutine calls
+
+        Parameters
+        ----------
+        drv_loop : :any:`Loop`, optional
+            If provided, only inject into calls within this specific loop.
+            When ``None``, all calls in the routine body are considered
+            (original behaviour).
         """
         call_map = {}
 
@@ -928,7 +1011,8 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             dimensions = as_tuple(stack_storage_var_dim)
             new_kwarguments += ((stack_storage_var.name, stack_storage_var.clone(dimensions=dimensions)),)
 
-        for call in FindNodes(CallStatement).visit(routine.body):
+        section = drv_loop.body if drv_loop is not None else routine.body
+        for call in FindNodes(CallStatement).visit(section):
             if call.name in targets or call.routine.name.lower() in ignore:
                # If call is declared via an explicit interface, the ProcedureSymbol corresponding to the call is the
                # interface block rather than the Subroutine itself. This means we have to update the interface block

--- a/loki/transformations/temporaries/pool_allocator_per_drv_loop.py
+++ b/loki/transformations/temporaries/pool_allocator_per_drv_loop.py
@@ -1,0 +1,343 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Pool allocator variant that operates per driver loop.
+
+This module provides :any:`TemporariesPoolAllocatorPerDrvLoopTransformation`,
+a subclass of :any:`TemporariesPoolAllocatorTransformation` that creates
+independent pool allocator infrastructure for each driver loop in a routine.
+
+This is required by the small-kernels pipeline where multiple independent
+driver loops may exist in a single routine, each calling different kernels
+with different temporary allocation requirements.
+"""
+
+from loki.expression import (
+    IntLiteral, InlineCall, Literal, Variable, Sum, Product,
+    Cast
+)
+from loki.ir import (
+    FindNodes, Transformer, Assignment,
+    Loop, pragmas_attached
+)
+from loki.logging import warning, debug
+from loki.tools import as_tuple
+
+from loki.transformations.temporaries.pool_allocator import TemporariesPoolAllocatorTransformation
+from loki.transformations.utilities import find_driver_loops
+
+
+__all__ = ['TemporariesPoolAllocatorPerDrvLoopTransformation']
+
+
+class TemporariesPoolAllocatorPerDrvLoopTransformation(TemporariesPoolAllocatorTransformation):
+    """
+    Pool allocator transformation that creates one stack per driver loop.
+
+    Unlike the parent :any:`TemporariesPoolAllocatorTransformation` which
+    creates a single pool allocator per driver routine, this variant
+    identifies all driver loops (via :func:`find_driver_loops`) and injects
+    independent stack pointer initialisation into each one.
+
+    For "nested driver" kernels (those with ``LowerBlockIndex`` trafo_data),
+    driver loops are also identified and processed, enabling pool allocation
+    within kernel-level block loops created by
+    ``SCCBlockSectionToLoopTransformation``.
+
+    The aggregate stack size across all driver loops is used for the single
+    ``ALLOCATE(ZSTACK(ISTSZ, nb))`` statement, wrapped in ``MAX(..., 1)``
+    to prevent zero-sized allocations.
+
+    Parameters
+    ----------
+    Same as :any:`TemporariesPoolAllocatorTransformation`.
+
+    Notes
+    -----
+    ``check_bounds`` defaults to ``True``, providing runtime safety against
+    zero-sized or overflowing stack allocations.
+    """
+
+    # Reuse the parent's trafo_data key so that successor stack sizes
+    # stored by the parent's kernel-side logic are visible to this
+    # transformation's driver-side logic.
+    _key = 'TemporariesPoolAllocatorTransformation'
+
+    def transform_subroutine(self, routine, **kwargs):
+        """
+        Dispatch pool allocator logic per driver loop.
+
+        For kernels, temporaries are replaced with Cray-pointer stack
+        allocations (delegated to the parent's
+        :meth:`apply_pool_allocator_to_temporaries`). For drivers and
+        "nested driver" kernels (those with ``LowerBlockIndex``
+        trafo_data), each driver loop gets its own stack pointer
+        initialisation.
+        """
+        role = kwargs['role']
+        item = kwargs.get('item', None)
+        ignore = item.ignore if item else ()
+        targets = as_tuple(kwargs.get('targets', None))
+
+        if item:
+            item.trafo_data[self._key] = {'kind_imports': {}}
+
+        self.import_c_sizeof(routine)
+        self.import_real64(routine)
+
+        sub_sgraph = kwargs.get('sub_sgraph', None)
+        successors = as_tuple(sub_sgraph.successors(item)) if sub_sgraph is not None else ()
+
+        with pragmas_attached(routine, Loop):
+            # Determine driver loops: for drivers always, for kernels
+            # only when they have LowerBlockIndex trafo_data (nested drivers)
+            if role == 'driver' or (item and 'LowerBlockIndex' in item.trafo_data):
+                driver_loops = find_driver_loops(section=routine.body, targets=targets)
+            else:
+                driver_loops = []
+
+            if role == 'kernel':
+                stack_size = self.apply_pool_allocator_to_temporaries(routine, item=item)
+                if item:
+                    stack_size = self._determine_stack_size(
+                        routine, successors, stack_size, item=item
+                    )
+                    item.trafo_data[self._key]['stack_size'] = stack_size
+            elif item:
+                stack_size = self._determine_stack_size(routine, successors, item=item)
+                item.trafo_data[self._key]['stack_size'] = stack_size
+
+            if item:
+                self.import_allocation_types(routine, item)
+
+            if driver_loops:
+                self.add_driver_imports(routine)
+
+                # Compute per-loop stack sizes and aggregate with MAX
+                per_loop_sizes = [
+                    self._determine_stack_size(
+                        routine, successors, item=item, drv_loop=drv_loop
+                    )
+                    for drv_loop in driver_loops
+                ]
+                aggregate_stack_size = self._aggregate_stack_sizes(per_loop_sizes)
+
+                # Inject pool allocator into each driver loop
+                drv_loop_map = {}
+                for drv_loop in driver_loops:
+                    drv_loop_map[drv_loop] = self._create_pool_allocator_in_drv_loop(
+                        routine, aggregate_stack_size, drv_loop
+                    )
+
+                if drv_loop_map:
+                    routine.body = Transformer(drv_loop_map).visit(routine.body)
+
+            # Inject stack arguments into all targeted calls in the routine
+            self.inject_pool_allocator_into_calls(
+                routine, targets, ignore, driver=(role == 'driver')
+            )
+
+    def get_block_index(self, routine, variable_map):
+        """
+        Resolve the block index, including ``local_``-prefixed variants.
+
+        ``SCCBlockSectionToLoopTransformation`` creates block-dimension
+        variables with a ``local_`` prefix. This override checks for both
+        the original name and the prefixed form.
+        """
+        # Try standard resolution first
+        block_index = super().get_block_index(routine, variable_map)
+        if block_index is not None:
+            return block_index
+
+        # Try with local_ prefix
+        local_index = f'local_{self.block_dim.index}'
+        if local_index.lower() in {k.lower() for k in variable_map}:
+            return variable_map.get(local_index, None)
+
+        # Try local_ prefix on compound indices
+        for index in self.block_dim.indices:
+            local_name = f'local_{index.split("%", maxsplit=1)[0]}'
+            if local_name.lower() in {k.lower() for k in variable_map}:
+                return routine.resolve_typebound_var(
+                    f'local_{index}', variable_map
+                )
+
+        return None
+
+    @staticmethod
+    def _aggregate_stack_sizes(sizes):
+        """
+        Combine per-loop stack-size expressions into a single aggregate.
+
+        Unwraps nested ``MAX(...)`` calls, removes zero literals and
+        duplicates, then returns ``Literal(0)`` (all zero), a single
+        expression, or ``MAX(...)`` of all unique non-zero expressions.
+
+        Parameters
+        ----------
+        sizes : list of :any:`Expression`
+            Per-loop stack-size expressions.
+
+        Returns
+        -------
+        :any:`Expression`
+            The aggregated stack size (maximum across all inputs).
+        """
+        flat = []
+        for s in sizes:
+            if isinstance(s, InlineCall) and s.function == 'MAX':
+                flat.extend(s.parameters)
+            else:
+                flat.append(s)
+
+        seen = set()
+        non_zero = []
+        for s in flat:
+            if isinstance(s, (Literal, IntLiteral)) and int(s) == 0:
+                continue
+            key = str(s)
+            if key not in seen:
+                seen.add(key)
+                non_zero.append(s)
+
+        if not non_zero:
+            return Literal(0)
+        if len(non_zero) == 1:
+            return non_zero[0]
+        return InlineCall(
+            function=Variable(name='MAX'),
+            parameters=as_tuple(non_zero),
+            kw_parameters=()
+        )
+
+    def _create_pool_allocator_in_drv_loop(self, routine, stack_size, drv_loop):
+        """
+        Inject pool allocator stack pointer initialisation into a driver loop.
+
+        This creates the ``ISTSZ``/``ZSTACK`` variables (on first call) and
+        inserts ``YLSTACK_L = LOC(ZSTACK(1, block_index))`` and the
+        corresponding end-pointer assignment into the loop body.
+
+        Parameters
+        ----------
+        routine : :any:`Subroutine`
+            The driver routine.
+        stack_size : :any:`Expression`
+            The aggregate stack size expression.
+        drv_loop : :any:`Loop`
+            The driver loop to inject into.
+
+        Returns
+        -------
+        :any:`Loop`
+            The modified driver loop with stack pointer assignments.
+        """
+        stack_storage, stack_size_var = self._get_stack_storage_and_size_var(routine, stack_size)
+        stack_ptr = self._get_stack_ptr(routine)
+        stack_end = self._get_stack_end(routine)
+
+        # Find position for stack pointer assignment
+        assignments = FindNodes(Assignment).visit(drv_loop.body)
+        block_index = self.get_block_index(routine, routine.variable_map)
+        if block_index is None:
+            warning(
+                f'{self.__class__.__name__}: '
+                f'Could not resolve block index in {routine.name}; '
+                f'no stack pointer assignment inserted!'
+            )
+            return drv_loop
+
+        # Build set of block-dim index names (including local_ prefix)
+        block_indices = set()
+        for idx in self.block_dim.indices:
+            block_indices.add(idx.lower())
+            block_indices.add(f'local_{idx}'.lower())
+            if '%' in idx:
+                block_indices.add(idx.split('%')[-1].lower())
+                block_indices.add(f'local_{idx.split("%")[-1]}'.lower())
+
+        if drv_loop.variable == block_index or str(drv_loop.variable).lower() == str(block_index).lower():
+            # Block variable is the loop variable
+            assign_pos = -1
+        else:
+            # Look for the exact assignment that defines the resolved block index
+            assign_pos = None
+            for assignment in assignments:
+                if assignment.lhs == block_index or str(assignment.lhs).lower() == str(block_index).lower():
+                    assert assignment in drv_loop.body
+                    assign_pos = drv_loop.body.index(assignment)
+                    break
+
+            # Fall back to broad block-index matching only if the exact symbol
+            # is not found directly in the top-level loop body.
+            if assign_pos is None:
+                for assignment in assignments:
+                    if str(assignment.lhs).lower() in block_indices:
+                        assert assignment in drv_loop.body
+                        assign_pos = drv_loop.body.index(assignment)
+                        break
+
+            if assign_pos is None:
+                warning(
+                    f'{self.__class__.__name__}: '
+                    f'Could not find a block dimension for loop with variable '
+                    f'{drv_loop.variable} and bounds {drv_loop.bounds} in '
+                    f'{routine.name}; no stack pointer assignment inserted!'
+                )
+                return drv_loop
+
+        # Check for existing pointer assignment
+        stack_ptr_name = f'{self.stack_local_var_name}_{self.stack_ptr_name}'
+        if any(str(a.lhs).lower() == stack_ptr_name.lower() for a in assignments):
+            debug(
+                f'{self.__class__.__name__}: '
+                f'Stack pointer already exists within loop with variable '
+                f'{drv_loop.variable} in {routine.name}; skipping.'
+            )
+            return drv_loop
+
+        # Build pointer assignment
+        if self.cray_ptr_loc_rhs:
+            ptr_assignment = Assignment(lhs=stack_ptr, rhs=IntLiteral(1))
+        else:
+            ptr_assignment = Assignment(
+                lhs=stack_ptr, rhs=InlineCall(
+                    function=Variable(name='LOC'),
+                    parameters=(
+                        stack_storage.clone(
+                            dimensions=(Literal(1), block_index)
+                        ),
+                    ),
+                    kw_parameters=None
+                )
+            )
+
+        # Build stack end assignment
+        new_assignments = (ptr_assignment,)
+        if self.check_bounds:
+            _kind = routine.imported_symbol_map.get('REAL64')
+            if self.cray_ptr_loc_rhs:
+                stack_incr = Assignment(
+                    lhs=stack_end, rhs=Sum((stack_ptr, stack_size_var))
+                )
+            else:
+                _real_size_bytes = Cast(name='REAL', expression=Literal(1), kind=_kind)
+                _real_size_bytes = InlineCall(
+                    Variable(name='C_SIZEOF'),
+                    parameters=as_tuple(_real_size_bytes)
+                )
+                stack_incr = Assignment(
+                    lhs=stack_end,
+                    rhs=Sum((stack_ptr, Product((stack_size_var, _real_size_bytes))))
+                )
+            new_assignments += (stack_incr,)
+
+        return drv_loop.clone(
+            body=drv_loop.body[:assign_pos + 1] + new_assignments + drv_loop.body[assign_pos + 1:]
+        )

--- a/loki/transformations/temporaries/tests/test_pool_allocator.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator.py
@@ -58,7 +58,7 @@ def check_stack_created_in_driver(
 
     # Is there an allocation and deallocation for the stack storage?
     allocations = FindNodes(ir.Allocation).visit(driver.body)
-    assert len(allocations) == 1 and 'zstack(istsz,nb)' in allocations[0].variables
+    assert len(allocations) == 1 and 'zstack(max(istsz, 1),nb)' in allocations[0].variables
     deallocations = FindNodes(ir.Deallocation).visit(driver.body)
     assert len(deallocations) == 1 and 'zstack' in deallocations[0].variables
 
@@ -130,7 +130,7 @@ def test_pool_allocator_temporaries(tmp_path, frontend, generate_driver_stack, b
 
         istsz = {stack_size_str}
 
-        {'ALLOCATE(ZSTACK(ISTSZ, nb))' if trafo == TemporariesPoolAllocatorTransformation else 'CALL ECSTACK%GET_STACK_PTR(ZSTACK, ISTSZ, nb)'}
+        {'ALLOCATE(ZSTACK(MAX(ISTSZ, 1), nb))' if trafo == TemporariesPoolAllocatorTransformation else 'CALL ECSTACK%GET_STACK_PTR(ZSTACK, ISTSZ, nb)'}
     """
     if cray_ptr_loc_rhs:
         fcode_stack_assign = """
@@ -826,6 +826,45 @@ end module kernel_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_pool_allocator_skips_explicit_acc_managed_temporary(frontend, block_dim, horizontal):
+    fcode = """
+subroutine kernel(start, end, klon, klev, nb, field)
+    implicit none
+    integer, intent(in) :: start, end, klon, klev, nb
+    real, intent(inout) :: field(klon, klev, nb)
+    real :: work(klon, nb)
+    integer :: jl, jk
+
+    !$acc enter data create(work)
+    do jk=1,klev
+        do jl=start,end
+            work(jl, 1) = field(jl, jk, 1)
+        end do
+    end do
+    !$acc exit data delete(work)
+end subroutine kernel
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    trafo = TemporariesPoolAllocatorTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=False
+    )
+
+    stack_size = trafo.apply_pool_allocator_to_temporaries(routine)
+
+    pointers = [
+        intrinsic.text.split(',')[1].replace(')', '').replace(' ', '')
+        for intrinsic in FindNodes(Intrinsic).visit(routine.spec)
+        if 'pointer' in intrinsic.text.lower()
+    ]
+    assignments = FindNodes(Assignment).visit(routine.body)
+
+    assert 'work' not in pointers
+    assert all('ip_work' not in assignment.lhs for assignment in assignments)
+    assert stack_size == 0
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('directive', [False, 'openmp', 'openacc'])
 @pytest.mark.parametrize('cray_ptr_loc_rhs', [False, True])
 def test_pool_allocator_temporaries_kernel_nested(tmp_path, frontend, block_dim, directive, cray_ptr_loc_rhs):
@@ -1451,3 +1490,38 @@ end subroutine driver
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
 
     assert transformation.get_block_index(routine, routine.variable_map) == 'geom%blk_dim%ib'
+
+
+def test_pool_allocator_resolves_second_block_size_expression():
+    """Use the first resolvable block-size expression when the first one is absent."""
+    fcode = """
+subroutine driver(ydgeo)
+  use iso_fortran_env, only: real64
+  implicit none
+  type dim_type
+    integer :: ngpblks
+  end type dim_type
+  type geo_type
+    type(dim_type) :: yrdim
+  end type geo_type
+  type(geo_type), intent(in) :: ydgeo
+end subroutine driver
+    """.strip()
+
+    routine = Subroutine.from_source(fcode)
+    block_dim = Dimension(
+        name='block_dim',
+        size=('ydgeometry%yrdim%ngpblks', 'ydgeo%yrdim%ngpblks'),
+        index='ibl'
+    )
+    transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
+
+    stack_storage, stack_size_var = transformation._get_stack_storage_and_size_var(
+        routine, parse_expr('0')
+    )
+
+    assert stack_size_var == 'istsz'
+    assert stack_storage == 'zstack(:, :)'
+    allocations = FindNodes(ir.Allocation).visit(routine.body)
+    assert len(allocations) == 1
+    assert allocations[0].variables[0] == 'zstack(max(istsz, 1), ydgeo%yrdim%ngpblks)'

--- a/loki/transformations/temporaries/tests/test_pool_allocator.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator.py
@@ -1234,7 +1234,9 @@ def test_pool_allocator_more_call_checks(tmp_path, frontend, block_dim, caplog, 
         }
     }
     scheduler = Scheduler(
-        paths=[tmp_path], config=SchedulerConfig.from_dict(config), frontend=frontend, xmods=[tmp_path]
+        paths=[tmp_path], config=SchedulerConfig.from_dict(config),
+        seed_routines=['kernel'],
+        frontend=frontend, xmods=[tmp_path]
     )
 
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim, horizontal=horizontal,

--- a/loki/transformations/temporaries/tests/test_pool_allocator.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator.py
@@ -5,6 +5,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+# pylint: disable=too-many-lines
+
 import pytest
 
 from loki.expression.parser import parse_expr
@@ -854,10 +856,10 @@ end subroutine kernel
 
     pointers = [
         intrinsic.text.split(',')[1].replace(')', '').replace(' ', '')
-        for intrinsic in FindNodes(Intrinsic).visit(routine.spec)
+        for intrinsic in FindNodes(ir.GenericStmt).visit(routine.spec)
         if 'pointer' in intrinsic.text.lower()
     ]
-    assignments = FindNodes(Assignment).visit(routine.body)
+    assignments = FindNodes(ir.Assignment).visit(routine.body)
 
     assert 'work' not in pointers
     assert all('ip_work' not in assignment.lhs for assignment in assignments)
@@ -1465,7 +1467,8 @@ end module kernel_mod
 
     # check stack size allocation
     allocations = FindNodes(ir.Allocation).visit(driver.body)
-    assert len(allocations) == 1 and 'zstack(istsz,geom%blk_dim%nb)' in allocations[0].variables
+    assert len(allocations) == 1
+    assert allocations[0].variables[0] == 'zstack(max(istsz, 1), geom%blk_dim%nb)'
 
     # check that array size was imported to the driver
     assert 'n' in driver.imported_symbols

--- a/loki/transformations/temporaries/tests/test_pool_allocator_per_drv_loop.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator_per_drv_loop.py
@@ -15,7 +15,7 @@ from loki import Dimension, Subroutine
 from loki.batch import ProcedureItem
 from loki.expression import IntLiteral, InlineCall, Literal, Variable
 from loki.frontend import available_frontends, OMNI
-from loki.ir import FindNodes, Assignment, CallStatement, Loop, Intrinsic
+from loki.ir import nodes as ir, FindNodes
 
 from loki.transformations.temporaries import TemporariesPoolAllocatorPerDrvLoopTransformation
 
@@ -117,10 +117,10 @@ end subroutine driver
     assert driver.variable_map['zstack'].type.allocatable
 
     # Verify: stack pointer assignment inside driver loop
-    loops = FindNodes(Loop).visit(driver.body)
+    loops = FindNodes(ir.Loop).visit(driver.body)
     driver_loop = [l for l in loops if l.variable == 'b']
     assert len(driver_loop) == 1
-    assignments = FindNodes(Assignment).visit(driver_loop[0].body)
+    assignments = FindNodes(ir.Assignment).visit(driver_loop[0].body)
     stack_ptr_assigns = [a for a in assignments if 'ylstack_l' in str(a.lhs).lower()]
     assert len(stack_ptr_assigns) >= 1
 
@@ -129,7 +129,7 @@ end subroutine driver
     assert 'ydstack_u' in kernel.variable_map
 
     # Verify: kernel call has stack kwargs
-    calls = FindNodes(CallStatement).visit(driver.body)
+    calls = FindNodes(ir.CallStatement).visit(driver.body)
     kernel_calls = [c for c in calls if c.name == 'kernel']
     assert len(kernel_calls) == 1
     kwarg_names = [kw[0].lower() for kw in kernel_calls[0].kwarguments]
@@ -137,7 +137,7 @@ end subroutine driver
     assert 'ydstack_u' in kwarg_names
 
     # Verify: Cray pointers in kernel
-    intrinsics = FindNodes(Intrinsic).visit(kernel.spec)
+    intrinsics = FindNodes(ir.GenericStmt).visit(kernel.spec)
     pointer_decls = [i for i in intrinsics if 'POINTER' in i.text]
     assert len(pointer_decls) == 2  # tmp1 and tmp2
 
@@ -209,9 +209,9 @@ end subroutine driver_loc
         sub_sgraph=sgraph
     )
 
-    loops = FindNodes(Loop).visit(driver.body)
+    loops = FindNodes(ir.Loop).visit(driver.body)
     driver_loop = [loop for loop in loops if loop.variable == 'jkglo'][0]
-    assignments = [node for node in driver_loop.body if isinstance(node, Assignment)]
+    assignments = [node for node in driver_loop.body if isinstance(node, ir.Assignment)]
 
     ibl_assign_pos = next(
         idx for idx, assignment in enumerate(assignments)
@@ -337,17 +337,17 @@ end subroutine driver
     assert 'zstack' in driver.variable_map
 
     # Verify: both driver loops have stack pointer assignments
-    loops = FindNodes(Loop).visit(driver.body)
+    loops = FindNodes(ir.Loop).visit(driver.body)
     driver_loops = [l for l in loops if l.variable == 'b']
     assert len(driver_loops) == 2
 
     for loop in driver_loops:
-        assignments = FindNodes(Assignment).visit(loop.body)
+        assignments = FindNodes(ir.Assignment).visit(loop.body)
         stack_assigns = [a for a in assignments if 'ylstack_l' in str(a.lhs).lower()]
         assert len(stack_assigns) >= 1
 
     # Verify: both kernel calls have stack kwargs
-    calls = FindNodes(CallStatement).visit(driver.body)
+    calls = FindNodes(ir.CallStatement).visit(driver.body)
     for call in calls:
         kwarg_names = [kw[0].lower() for kw in call.kwarguments]
         assert 'ydstack_l' in kwarg_names
@@ -452,7 +452,7 @@ end subroutine driver
     )
 
     # The ISTSZ assignment should use MAX of the two sizes
-    assignments = FindNodes(Assignment).visit(driver.body)
+    assignments = FindNodes(ir.Assignment).visit(driver.body)
     istsz_assigns = [a for a in assignments if str(a.lhs).lower() == 'istsz']
     assert len(istsz_assigns) == 1
     # The RHS should be a MAX(...) call since both loops have different sizes
@@ -535,10 +535,10 @@ end subroutine outer_kernel
     assert 'zstack' in outer.variable_map
 
     # Verify: stack pointer assignment in driver loop
-    loops = FindNodes(Loop).visit(outer.body)
+    loops = FindNodes(ir.Loop).visit(outer.body)
     block_loops = [l for l in loops if l.variable == 'b']
     assert len(block_loops) == 1
-    assignments = FindNodes(Assignment).visit(block_loops[0].body)
+    assignments = FindNodes(ir.Assignment).visit(block_loops[0].body)
     stack_assigns = [a for a in assignments if 'ylstack_l' in str(a.lhs).lower()]
     assert len(stack_assigns) >= 1
 
@@ -692,16 +692,16 @@ end subroutine driver_loc
     assert kernel_zstack.type.intent == 'inout'
 
     # Verify: driver stack pointer uses integer 1 (not LOC)
-    loops = FindNodes(Loop).visit(driver.body)
+    loops = FindNodes(ir.Loop).visit(driver.body)
     driver_loop = [l for l in loops if l.variable == 'b'][0]
-    assignments = FindNodes(Assignment).visit(driver_loop.body)
+    assignments = FindNodes(ir.Assignment).visit(driver_loop.body)
     stack_ptr_assigns = [a for a in assignments if 'ylstack_l' in str(a.lhs).lower()]
     assert len(stack_ptr_assigns) >= 1
     # In cray_ptr_loc_rhs mode, YLSTACK_L = 1
     assert stack_ptr_assigns[0].rhs == 1
 
     # Verify: kernel call has ZSTACK kwarg
-    calls = FindNodes(CallStatement).visit(driver.body)
+    calls = FindNodes(ir.CallStatement).visit(driver.body)
     kernel_calls = [c for c in calls if c.name == 'kernel_loc']
     assert len(kernel_calls) == 1
     kwarg_names = [kw[0].lower() for kw in kernel_calls[0].kwarguments]
@@ -709,6 +709,6 @@ end subroutine driver_loc
     assert 'ydstack_l' in kwarg_names
 
     # Verify: kernel uses LOC(ZSTACK(...)) for pointer assignment
-    kernel_assigns = FindNodes(Assignment).visit(kernel.body)
+    kernel_assigns = FindNodes(ir.Assignment).visit(kernel.body)
     loc_assigns = [a for a in kernel_assigns if 'LOC' in str(a.rhs)]
     assert len(loc_assigns) >= 1

--- a/loki/transformations/temporaries/tests/test_pool_allocator_per_drv_loop.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator_per_drv_loop.py
@@ -1,0 +1,714 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Tests for :any:`TemporariesPoolAllocatorPerDrvLoopTransformation`.
+"""
+
+import pytest
+
+from loki import Dimension, Subroutine
+from loki.batch import ProcedureItem
+from loki.expression import IntLiteral, InlineCall, Literal, Variable
+from loki.frontend import available_frontends, OMNI
+from loki.ir import FindNodes, Assignment, CallStatement, Loop, Intrinsic
+
+from loki.transformations.temporaries import TemporariesPoolAllocatorPerDrvLoopTransformation
+
+
+@pytest.fixture(scope='module', name='block_dim')
+def fixture_block_dim():
+    return Dimension(name='block_dim', size='nb', index='b', aliases=('nb',))
+
+
+@pytest.fixture(scope='module', name='horizontal')
+def fixture_horizontal():
+    return Dimension(
+        name='horizontal', size='nlon', index='jl',
+        bounds=('start', 'end'), aliases=('klon', 'columns')
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_per_drv_loop_single_loop(tmp_path, frontend, block_dim, horizontal):
+    """
+    Test basic per-driver-loop pool allocator with a single driver loop
+    calling one kernel with temporaries.
+    """
+    fcode_kernel = """
+subroutine kernel(nlon, nz, start, end, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, start, end
+  real, intent(inout) :: field1(nlon, nz)
+  real :: tmp1(nlon, nz)
+  real :: tmp2(nlon)
+  integer :: jl, jk
+
+  do jk = 1, nz
+    do jl = start, end
+      tmp1(jl, jk) = field1(jl, jk) * 2.0
+    end do
+  end do
+  do jl = start, end
+    tmp2(jl) = tmp1(jl, 1)
+    field1(jl, 1) = tmp2(jl)
+  end do
+end subroutine kernel
+    """.strip()
+
+    fcode_driver = """
+subroutine driver(nlon, nz, nb, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, nb
+  real, intent(inout) :: field1(nlon, nz, nb)
+  integer :: b
+
+  !$loki driver-loop
+  do b = 1, nb
+    call kernel(nlon, nz, 1, nlon, field1(:,:,b))
+  end do
+end subroutine driver
+    """.strip()
+
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend, xmods=[tmp_path])
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend, xmods=[tmp_path])
+
+    driver.enrich(kernel)
+
+    transformation = TemporariesPoolAllocatorPerDrvLoopTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=True
+    )
+
+    # Create mock items
+    kernel_item = ProcedureItem(name='#kernel', source=kernel, config={'role': 'kernel'})
+    driver_item = ProcedureItem(name='#driver', source=driver, config={'role': 'driver'})
+
+    class MockSGraph:
+        def successors(self, item):
+            if item is driver_item:
+                return (kernel_item,)
+            return ()
+
+    sgraph = MockSGraph()
+
+    # Transform kernel first (reverse traversal)
+    transformation.transform_subroutine(
+        kernel, role='kernel', item=kernel_item, targets=('kernel',),
+        sub_sgraph=sgraph
+    )
+
+    # Transform driver
+    transformation.transform_subroutine(
+        driver, role='driver', item=driver_item, targets=('kernel',),
+        sub_sgraph=sgraph
+    )
+
+    # Verify: ISTSZ variable created
+    assert 'istsz' in driver.variable_map
+
+    # Verify: ZSTACK variable created (allocatable)
+    assert 'zstack' in driver.variable_map
+    assert driver.variable_map['zstack'].type.allocatable
+
+    # Verify: stack pointer assignment inside driver loop
+    loops = FindNodes(Loop).visit(driver.body)
+    driver_loop = [l for l in loops if l.variable == 'b']
+    assert len(driver_loop) == 1
+    assignments = FindNodes(Assignment).visit(driver_loop[0].body)
+    stack_ptr_assigns = [a for a in assignments if 'ylstack_l' in str(a.lhs).lower()]
+    assert len(stack_ptr_assigns) >= 1
+
+    # Verify: kernel has stack arguments
+    assert 'ydstack_l' in kernel.variable_map
+    assert 'ydstack_u' in kernel.variable_map
+
+    # Verify: kernel call has stack kwargs
+    calls = FindNodes(CallStatement).visit(driver.body)
+    kernel_calls = [c for c in calls if c.name == 'kernel']
+    assert len(kernel_calls) == 1
+    kwarg_names = [kw[0].lower() for kw in kernel_calls[0].kwarguments]
+    assert 'ydstack_l' in kwarg_names
+    assert 'ydstack_u' in kwarg_names
+
+    # Verify: Cray pointers in kernel
+    intrinsics = FindNodes(Intrinsic).visit(kernel.spec)
+    pointer_decls = [i for i in intrinsics if 'POINTER' in i.text]
+    assert len(pointer_decls) == 2  # tmp1 and tmp2
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_per_drv_loop_stack_pointer_inserted_after_resolved_block_index(
+        tmp_path, frontend, horizontal):
+    block_dim = Dimension(name='block_dim', size='nb', index=('ibl', 'bnds%kbl'))
+
+    fcode_kernel = """
+subroutine kernel_loc(nlon, nz, start, end, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, start, end
+  real, intent(inout) :: field1(nlon, nz)
+  real :: tmp1(nlon)
+  integer :: jl
+
+  do jl = start, end
+    tmp1(jl) = field1(jl, 1)
+    field1(jl, 1) = tmp1(jl)
+  end do
+end subroutine kernel_loc
+    """.strip()
+
+    fcode_driver = """
+subroutine driver_loc(nlon, nz, nproma, nb, kgpcomp, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, nproma, nb, kgpcomp
+  real, intent(inout) :: field1(nlon, nz, nb)
+  integer :: jkglo, kst, kend, ibl
+
+  !$loki driver-loop
+  do jkglo = 1, kgpcomp, nproma
+    kst = 1
+    kend = min(nproma, kgpcomp - jkglo + 1)
+    ibl = (jkglo - 1) / nproma + 1
+    call kernel_loc(nlon, nz, kst, kend, field1(:,:,ibl))
+  end do
+end subroutine driver_loc
+    """.strip()
+
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend, xmods=[tmp_path])
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend, xmods=[tmp_path])
+    driver.enrich(kernel)
+
+    transformation = TemporariesPoolAllocatorPerDrvLoopTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=True
+    )
+
+    kernel_item = ProcedureItem(name='#kernel_loc', source=kernel, config={'role': 'kernel'})
+    driver_item = ProcedureItem(name='#driver_loc', source=driver, config={'role': 'driver'})
+
+    class MockSGraph:
+        def successors(self, item):
+            if item is driver_item:
+                return (kernel_item,)
+            return ()
+
+    sgraph = MockSGraph()
+
+    transformation.transform_subroutine(
+        kernel, role='kernel', item=kernel_item, targets=('kernel_loc',),
+        sub_sgraph=sgraph
+    )
+    transformation.transform_subroutine(
+        driver, role='driver', item=driver_item, targets=('kernel_loc',),
+        sub_sgraph=sgraph
+    )
+
+    loops = FindNodes(Loop).visit(driver.body)
+    driver_loop = [loop for loop in loops if loop.variable == 'jkglo'][0]
+    assignments = [node for node in driver_loop.body if isinstance(node, Assignment)]
+
+    ibl_assign_pos = next(
+        idx for idx, assignment in enumerate(assignments)
+        if assignment.lhs == 'ibl'
+    )
+    stack_assign_pos = next(
+        idx for idx, assignment in enumerate(assignments)
+        if assignment.lhs == 'ylstack_l'
+    )
+
+    assert stack_assign_pos > ibl_assign_pos
+    assert 'loc(zstack(1, ibl))' in str(assignments[stack_assign_pos].rhs).lower()
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_per_drv_loop_multiple_loops(tmp_path, frontend, block_dim, horizontal):
+    """
+    Test per-driver-loop pool allocator with multiple independent driver
+    loops calling different kernels.
+    """
+    fcode_kernel1 = """
+subroutine kernel1(nlon, nz, start, end, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, start, end
+  real, intent(inout) :: field1(nlon, nz)
+  real :: tmp1(nlon, nz)
+  integer :: jl, jk
+
+  do jk = 1, nz
+    do jl = start, end
+      tmp1(jl, jk) = field1(jl, jk) * 2.0
+      field1(jl, jk) = tmp1(jl, jk)
+    end do
+  end do
+end subroutine kernel1
+    """.strip()
+
+    fcode_kernel2 = """
+subroutine kernel2(nlon, nz, start, end, field2)
+  implicit none
+  integer, intent(in) :: nlon, nz, start, end
+  real, intent(inout) :: field2(nlon, nz)
+  real :: tmp2(nlon, nz)
+  real :: tmp3(nlon)
+  integer :: jl, jk
+
+  do jk = 1, nz
+    do jl = start, end
+      tmp2(jl, jk) = field2(jl, jk) + 1.0
+      field2(jl, jk) = tmp2(jl, jk)
+    end do
+  end do
+  do jl = start, end
+    tmp3(jl) = field2(jl, 1)
+    field2(jl, 1) = tmp3(jl)
+  end do
+end subroutine kernel2
+    """.strip()
+
+    fcode_driver = """
+subroutine driver(nlon, nz, nb, field1, field2)
+  implicit none
+  integer, intent(in) :: nlon, nz, nb
+  real, intent(inout) :: field1(nlon, nz, nb)
+  real, intent(inout) :: field2(nlon, nz, nb)
+  integer :: b
+
+  !$loki driver-loop
+  do b = 1, nb
+    call kernel1(nlon, nz, 1, nlon, field1(:,:,b))
+  end do
+
+  !$loki driver-loop
+  do b = 1, nb
+    call kernel2(nlon, nz, 1, nlon, field2(:,:,b))
+  end do
+end subroutine driver
+    """.strip()
+
+    kernel1 = Subroutine.from_source(fcode_kernel1, frontend=frontend, xmods=[tmp_path])
+    kernel2 = Subroutine.from_source(fcode_kernel2, frontend=frontend, xmods=[tmp_path])
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend, xmods=[tmp_path])
+
+    driver.enrich(kernel1)
+    driver.enrich(kernel2)
+
+    transformation = TemporariesPoolAllocatorPerDrvLoopTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=True
+    )
+
+    kernel1_item = ProcedureItem(name='#kernel1', source=kernel1, config={'role': 'kernel'})
+    kernel2_item = ProcedureItem(name='#kernel2', source=kernel2, config={'role': 'kernel'})
+    driver_item = ProcedureItem(name='#driver', source=driver, config={'role': 'driver'})
+
+    class MockSGraph:
+        def successors(self, item):
+            if item is driver_item:
+                return (kernel1_item, kernel2_item)
+            return ()
+
+    sgraph = MockSGraph()
+
+    # Transform kernels first
+    transformation.transform_subroutine(
+        kernel1, role='kernel', item=kernel1_item, targets=('kernel1',),
+        sub_sgraph=sgraph
+    )
+    transformation.transform_subroutine(
+        kernel2, role='kernel', item=kernel2_item, targets=('kernel2',),
+        sub_sgraph=sgraph
+    )
+
+    # Transform driver
+    transformation.transform_subroutine(
+        driver, role='driver', item=driver_item, targets=('kernel1', 'kernel2'),
+        sub_sgraph=sgraph
+    )
+
+    # Verify: single ISTSZ and ZSTACK
+    assert 'istsz' in driver.variable_map
+    assert 'zstack' in driver.variable_map
+
+    # Verify: both driver loops have stack pointer assignments
+    loops = FindNodes(Loop).visit(driver.body)
+    driver_loops = [l for l in loops if l.variable == 'b']
+    assert len(driver_loops) == 2
+
+    for loop in driver_loops:
+        assignments = FindNodes(Assignment).visit(loop.body)
+        stack_assigns = [a for a in assignments if 'ylstack_l' in str(a.lhs).lower()]
+        assert len(stack_assigns) >= 1
+
+    # Verify: both kernel calls have stack kwargs
+    calls = FindNodes(CallStatement).visit(driver.body)
+    for call in calls:
+        kwarg_names = [kw[0].lower() for kw in call.kwarguments]
+        assert 'ydstack_l' in kwarg_names
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_per_drv_loop_aggregate_stack_size(tmp_path, frontend, block_dim, horizontal):
+    """
+    Test that aggregate stack size uses MAX when loops call different kernels
+    with different temporary sizes.
+    """
+    # kernel1 has one tmp(nlon, nz) -> size = nlon*nz*sizeof(real)
+    fcode_kernel1 = """
+subroutine kernel_big(nlon, nz, start, end, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, start, end
+  real, intent(inout) :: field1(nlon, nz)
+  real :: tmp_large(nlon, nz)
+  integer :: jl, jk
+
+  do jk = 1, nz
+    do jl = start, end
+      tmp_large(jl, jk) = field1(jl, jk)
+      field1(jl, jk) = tmp_large(jl, jk)
+    end do
+  end do
+end subroutine kernel_big
+    """.strip()
+
+    # kernel2 has one tmp(nlon) -> smaller size
+    fcode_kernel2 = """
+subroutine kernel_small(nlon, nz, start, end, field2)
+  implicit none
+  integer, intent(in) :: nlon, nz, start, end
+  real, intent(inout) :: field2(nlon, nz)
+  real :: tmp_small(nlon)
+  integer :: jl
+
+  do jl = start, end
+    tmp_small(jl) = field2(jl, 1)
+    field2(jl, 1) = tmp_small(jl)
+  end do
+end subroutine kernel_small
+    """.strip()
+
+    fcode_driver = """
+subroutine driver(nlon, nz, nb, field1, field2)
+  implicit none
+  integer, intent(in) :: nlon, nz, nb
+  real, intent(inout) :: field1(nlon, nz, nb)
+  real, intent(inout) :: field2(nlon, nz, nb)
+  integer :: b
+
+  !$loki driver-loop
+  do b = 1, nb
+    call kernel_big(nlon, nz, 1, nlon, field1(:,:,b))
+  end do
+
+  !$loki driver-loop
+  do b = 1, nb
+    call kernel_small(nlon, nz, 1, nlon, field2(:,:,b))
+  end do
+end subroutine driver
+    """.strip()
+
+    kernel_big = Subroutine.from_source(fcode_kernel1, frontend=frontend, xmods=[tmp_path])
+    kernel_small = Subroutine.from_source(fcode_kernel2, frontend=frontend, xmods=[tmp_path])
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend, xmods=[tmp_path])
+
+    driver.enrich(kernel_big)
+    driver.enrich(kernel_small)
+
+    transformation = TemporariesPoolAllocatorPerDrvLoopTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=True
+    )
+
+    kernel_big_item = ProcedureItem(name='#kernel_big', source=kernel_big, config={'role': 'kernel'})
+    kernel_small_item = ProcedureItem(name='#kernel_small', source=kernel_small, config={'role': 'kernel'})
+    driver_item = ProcedureItem(name='#driver', source=driver, config={'role': 'driver'})
+
+    class MockSGraph:
+        def successors(self, item):
+            if item is driver_item:
+                return (kernel_big_item, kernel_small_item)
+            return ()
+
+    sgraph = MockSGraph()
+
+    transformation.transform_subroutine(
+        kernel_big, role='kernel', item=kernel_big_item, targets=('kernel_big',),
+        sub_sgraph=sgraph
+    )
+    transformation.transform_subroutine(
+        kernel_small, role='kernel', item=kernel_small_item, targets=('kernel_small',),
+        sub_sgraph=sgraph
+    )
+    transformation.transform_subroutine(
+        driver, role='driver', item=driver_item, targets=('kernel_big', 'kernel_small'),
+        sub_sgraph=sgraph
+    )
+
+    # The ISTSZ assignment should use MAX of the two sizes
+    assignments = FindNodes(Assignment).visit(driver.body)
+    istsz_assigns = [a for a in assignments if str(a.lhs).lower() == 'istsz']
+    assert len(istsz_assigns) == 1
+    # The RHS should be a MAX(...) call since both loops have different sizes
+    rhs = istsz_assigns[0].rhs
+    assert isinstance(rhs, InlineCall) and rhs.function == 'MAX'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_per_drv_loop_nested_driver_kernel(tmp_path, frontend, block_dim, horizontal):
+    """
+    Test that a kernel with LowerBlockIndex trafo_data (nested driver)
+    also gets pool allocator infrastructure in its block loops.
+    """
+    fcode_inner = """
+subroutine inner_kernel(nlon, nz, start, end, field)
+  implicit none
+  integer, intent(in) :: nlon, nz, start, end
+  real, intent(inout) :: field(nlon, nz)
+  real :: work(nlon, nz)
+  integer :: jl, jk
+
+  do jk = 1, nz
+    do jl = start, end
+      work(jl, jk) = field(jl, jk) * 3.0
+      field(jl, jk) = work(jl, jk)
+    end do
+  end do
+end subroutine inner_kernel
+    """.strip()
+
+    fcode_outer = """
+subroutine outer_kernel(nlon, nz, nb, start, end, field)
+  implicit none
+  integer, intent(in) :: nlon, nz, nb, start, end
+  real, intent(inout) :: field(nlon, nz, nb)
+  integer :: b
+
+  !$loki driver-loop
+  do b = 1, nb
+    call inner_kernel(nlon, nz, start, end, field(:,:,b))
+  end do
+end subroutine outer_kernel
+    """.strip()
+
+    inner = Subroutine.from_source(fcode_inner, frontend=frontend, xmods=[tmp_path])
+    outer = Subroutine.from_source(fcode_outer, frontend=frontend, xmods=[tmp_path])
+
+    outer.enrich(inner)
+
+    transformation = TemporariesPoolAllocatorPerDrvLoopTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=True
+    )
+
+    inner_item = ProcedureItem(name='#inner_kernel', source=inner, config={'role': 'kernel'})
+    outer_item = ProcedureItem(name='#outer_kernel', source=outer, config={'role': 'kernel'})
+    # Simulate LowerBlockIndex trafo_data presence
+    outer_item.trafo_data['LowerBlockIndex'] = {'driver_loop': None}
+
+    class MockSGraph:
+        def successors(self, item):
+            if item is outer_item:
+                return (inner_item,)
+            return ()
+
+    sgraph = MockSGraph()
+
+    transformation.transform_subroutine(
+        inner, role='kernel', item=inner_item, targets=('inner_kernel',),
+        sub_sgraph=sgraph
+    )
+    transformation.transform_subroutine(
+        outer, role='kernel', item=outer_item, targets=('inner_kernel',),
+        sub_sgraph=sgraph
+    )
+
+    # Verify: outer kernel has pool allocator infrastructure
+    assert 'istsz' in outer.variable_map
+    assert 'zstack' in outer.variable_map
+
+    # Verify: stack pointer assignment in driver loop
+    loops = FindNodes(Loop).visit(outer.body)
+    block_loops = [l for l in loops if l.variable == 'b']
+    assert len(block_loops) == 1
+    assignments = FindNodes(Assignment).visit(block_loops[0].body)
+    stack_assigns = [a for a in assignments if 'ylstack_l' in str(a.lhs).lower()]
+    assert len(stack_assigns) >= 1
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_per_drv_loop_local_prefix_block_index(tmp_path, frontend, horizontal):
+    """
+    Test that get_block_index resolves local_-prefixed block indices
+    created by SCCBlockSectionToLoopTransformation.
+    """
+    block_dim = Dimension(name='block_dim', size='nb', index='jkglo', aliases=('nb',))
+
+    fcode_kernel = """
+subroutine nested_drv(nlon, nz, nb, start, end, field)
+  implicit none
+  integer, intent(in) :: nlon, nz, nb, start, end
+  real, intent(inout) :: field(nlon, nz, nb)
+  integer :: local_jkglo
+
+  !$loki driver-loop
+  do local_jkglo = 1, nb
+    ! body
+  end do
+end subroutine nested_drv
+    """.strip()
+
+    routine = Subroutine.from_source(fcode_kernel, frontend=frontend, xmods=[tmp_path])
+
+    transformation = TemporariesPoolAllocatorPerDrvLoopTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=True
+    )
+
+    # Test get_block_index resolves local_ prefix
+    block_index = transformation.get_block_index(routine, routine.variable_map)
+    assert block_index is not None
+    assert str(block_index).lower() == 'local_jkglo'
+
+
+def test_aggregate_stack_sizes_unit():
+    """
+    Unit test for _aggregate_stack_sizes static method.
+    """
+    aggregate = TemporariesPoolAllocatorPerDrvLoopTransformation._aggregate_stack_sizes
+
+    # All zeros
+    result = aggregate([Literal(0), Literal(0)])
+    assert int(result) == 0
+
+    # Single non-zero
+    expr = IntLiteral(42)
+    result = aggregate([Literal(0), expr])
+    assert result is expr
+
+    # Multiple non-zero -> MAX
+    expr1 = IntLiteral(10)
+    expr2 = IntLiteral(20)
+    result = aggregate([expr1, expr2])
+    assert isinstance(result, InlineCall) and result.function == 'MAX'
+    assert len(result.parameters) == 2
+
+    # Deduplication
+    result = aggregate([expr1, expr1])
+    assert result is expr1  # Only one unique value
+
+    # Unwraps nested MAX
+    inner_max = InlineCall(
+        function=Variable(name='MAX'),
+        parameters=(IntLiteral(5), IntLiteral(15)),
+        kw_parameters=()
+    )
+    result = aggregate([inner_max, IntLiteral(25)])
+    assert isinstance(result, InlineCall) and result.function == 'MAX'
+    assert len(result.parameters) == 3  # 5, 15, 25 flattened
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI parser not reliably available')]
+))
+def test_per_drv_loop_cray_ptr_loc_rhs(tmp_path, frontend, block_dim, horizontal):
+    """
+    Test per-driver-loop pool allocator with cray_ptr_loc_rhs=True mode,
+    where the stack array is passed directly and LOC() calls happen in kernels.
+    """
+    fcode_kernel = """
+subroutine kernel_loc(nlon, nz, start, end, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, start, end
+  real, intent(inout) :: field1(nlon, nz)
+  real :: tmp1(nlon, nz)
+  integer :: jl, jk
+
+  do jk = 1, nz
+    do jl = start, end
+      tmp1(jl, jk) = field1(jl, jk) * 2.0
+      field1(jl, jk) = tmp1(jl, jk)
+    end do
+  end do
+end subroutine kernel_loc
+    """.strip()
+
+    fcode_driver = """
+subroutine driver_loc(nlon, nz, nb, field1)
+  implicit none
+  integer, intent(in) :: nlon, nz, nb
+  real, intent(inout) :: field1(nlon, nz, nb)
+  integer :: b
+
+  !$loki driver-loop
+  do b = 1, nb
+    call kernel_loc(nlon, nz, 1, nlon, field1(:,:,b))
+  end do
+end subroutine driver_loc
+    """.strip()
+
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend, xmods=[tmp_path])
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend, xmods=[tmp_path])
+
+    driver.enrich(kernel)
+
+    transformation = TemporariesPoolAllocatorPerDrvLoopTransformation(
+        block_dim=block_dim, horizontal=horizontal, check_bounds=True,
+        cray_ptr_loc_rhs=True
+    )
+
+    kernel_item = ProcedureItem(name='#kernel_loc', source=kernel, config={'role': 'kernel'})
+    driver_item = ProcedureItem(name='#driver_loc', source=driver, config={'role': 'driver'})
+
+    class MockSGraph:
+        def successors(self, item):
+            if item is driver_item:
+                return (kernel_item,)
+            return ()
+
+    sgraph = MockSGraph()
+
+    transformation.transform_subroutine(
+        kernel, role='kernel', item=kernel_item, targets=('kernel_loc',),
+        sub_sgraph=sgraph
+    )
+    transformation.transform_subroutine(
+        driver, role='driver', item=driver_item, targets=('kernel_loc',),
+        sub_sgraph=sgraph
+    )
+
+    # Verify: kernel has ZSTACK argument (contiguous real array)
+    assert 'zstack' in kernel.variable_map
+    kernel_zstack = kernel.variable_map['zstack']
+    assert kernel_zstack.type.contiguous
+    assert kernel_zstack.type.intent == 'inout'
+
+    # Verify: driver stack pointer uses integer 1 (not LOC)
+    loops = FindNodes(Loop).visit(driver.body)
+    driver_loop = [l for l in loops if l.variable == 'b'][0]
+    assignments = FindNodes(Assignment).visit(driver_loop.body)
+    stack_ptr_assigns = [a for a in assignments if 'ylstack_l' in str(a.lhs).lower()]
+    assert len(stack_ptr_assigns) >= 1
+    # In cray_ptr_loc_rhs mode, YLSTACK_L = 1
+    assert stack_ptr_assigns[0].rhs == 1
+
+    # Verify: kernel call has ZSTACK kwarg
+    calls = FindNodes(CallStatement).visit(driver.body)
+    kernel_calls = [c for c in calls if c.name == 'kernel_loc']
+    assert len(kernel_calls) == 1
+    kwarg_names = [kw[0].lower() for kw in kernel_calls[0].kwarguments]
+    assert 'zstack' in kwarg_names
+    assert 'ydstack_l' in kwarg_names
+
+    # Verify: kernel uses LOC(ZSTACK(...)) for pointer assignment
+    kernel_assigns = FindNodes(Assignment).visit(kernel.body)
+    loc_assigns = [a for a in kernel_assigns if 'LOC' in str(a.rhs)]
+    assert len(loc_assigns) >= 1

--- a/loki/transformations/tests/test_dependency.py
+++ b/loki/transformations/tests/test_dependency.py
@@ -657,9 +657,11 @@ def test_dependency_duplicate_subgraph(tmp_path, frontend, suffix, module_suffix
 
     transformed_items = {name.split('#')[0] if name.split('#')[0] else name[1:]
                          for name in expected_items if not name.endswith(f'{suffix}')}
+    transformed_items -= {'compute_3_mod'}
     assert plan_dict['LOKI_SOURCES_TO_TRANSFORM'] == transformed_items
     assert plan_dict['LOKI_SOURCES_TO_REMOVE'] == transformed_items
     appended_items = {name.split('#')[0] if name.split('#')[0] else name[1:] for name in expected_items}
+    appended_items -= {'compute_3_mod'}
     appended_items = {f'{name}.idem' for name in appended_items}
     assert plan_dict['LOKI_SOURCES_TO_APPEND'] == appended_items
 

--- a/loki/transformations/tests/test_lower_block_index_sk.py
+++ b/loki/transformations/tests/test_lower_block_index_sk.py
@@ -1,0 +1,853 @@
+# (C) Copyright 2018- ECMWF.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Tests for :any:`LowerBlockIndexSKTransformation` and the extended
+:any:`InjectBlockIndexTransformation.get_block_index` with ``loop=`` parameter.
+"""
+
+import pytest
+
+from loki import Dimension, Module, Subroutine
+from loki.expression import symbols as sym
+from loki.frontend import available_frontends, OMNI
+from loki.ir import nodes as ir, FindNodes, pragmas_attached
+from loki.transformations.block_index_transformations import InjectBlockIndexTransformation
+from loki.transformations.block_index_transformations_sk import LowerBlockIndexSKTransformation
+
+
+@pytest.fixture
+def block_dim():
+    return Dimension(
+        name='block_dim', size='nb', index='ibl',
+        bounds=('1', 'nb'),
+        aliases=('bnds%kbl', 'jkglo'),
+    )
+
+
+@pytest.fixture
+def horizontal():
+    return Dimension(
+        name='horizontal', size='nproma', index='jl',
+        bounds=('1', 'nproma'),
+    )
+
+
+# -------------------------------------------------------------------
+# Fortran fixtures
+# -------------------------------------------------------------------
+
+FCODE_TYPE_MOD = """
+module type_mod
+  implicit none
+  type :: bnds_type
+    integer :: kidia
+    integer :: kfdia
+    integer :: kbl
+  end type bnds_type
+  type :: geom_type
+    integer :: ngpblks
+  end type geom_type
+end module type_mod
+"""
+
+FCODE_PARKIND = """
+module parkind1
+  implicit none
+  integer, parameter :: jpim = selected_int_kind(9)
+  integer, parameter :: jprb = selected_real_kind(13, 300)
+end module parkind1
+"""
+
+
+def _make_item(routine, role='kernel', targets=(), config=None):
+    """Create a minimal ProcedureItem-like mock for testing."""
+
+    class _MockItem:
+        def __init__(self, routine, role, targets, config):
+            self.routine = routine
+            self.role = role
+            self.targets = targets
+            self.local_name = routine.name.lower()
+            self.trafo_data = {}
+            self.config = config or {}
+
+    return _MockItem(routine, role, targets, config)
+
+
+def _build_sgraph(items):
+    """Build a minimal successor map from a list of items."""
+
+    class _MockSGraph:
+        def __init__(self, items):
+            self._map = {items[i]: [items[i+1]] for i in range(len(items)-1)}
+            if items:
+                self._map.setdefault(items[-1], [])
+
+        def successors(self, item):
+            return self._map.get(item, [])
+
+    return _MockSGraph(items)
+
+
+# -------------------------------------------------------------------
+# Tests
+# -------------------------------------------------------------------
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_driver_passes_relevant_vars(frontend, block_dim):
+    """
+    Verify that LowerBlockIndexSKTransformation passes driver-loop header
+    variables as new arguments to the callee.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field, ydbnds)
+  use type_mod, only: bnds_type
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  type(bnds_type), intent(in) :: ydbnds
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  integer :: jl, jk
+
+  do jk = 1, nlev
+    do jl = 1, nproma
+      field(jl, jk) = 0.0
+    end do
+  end do
+end subroutine kernel
+"""
+    type_mod = Module.from_source(FCODE_TYPE_MOD, frontend=frontend)
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend, definitions=[type_mod])
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend, definitions=[type_mod])
+
+    driver.enrich(kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # Check that nb was added as kwarg to the call
+    calls = FindNodes(ir.CallStatement).visit(driver.body)
+    assert len(calls) == 1
+    call = calls[0]
+    kwarg_names = [k for k, _ in call.kwarguments]
+    assert 'nb' in [str(k).lower() for k in kwarg_names]
+
+    # Check that nb is now in kernel arguments
+    kernel_arg_names = [a.name.lower() for a in kernel.arguments]
+    assert 'nb' in kernel_arg_names
+
+    # Check trafo_data was propagated
+    assert 'LowerBlockIndex' in kernel_item.trafo_data
+    assert 'relevant_vars' in kernel_item.trafo_data['LowerBlockIndex']
+    assert 'driver_loop' in kernel_item.trafo_data['LowerBlockIndex']
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_kernel_propagates_to_sub_kernel(frontend, block_dim):
+    """
+    Verify recursive propagation: driver -> kernel -> sub_kernel.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+
+  !$loki small-kernels
+  call sub_kernel(nproma, nlev, field)
+end subroutine kernel
+"""
+    fcode_sub_kernel = """
+subroutine sub_kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  field(1, 1) = 1.0
+end subroutine sub_kernel
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
+    sub_kernel = Subroutine.from_source(fcode_sub_kernel, frontend=frontend)
+
+    driver.enrich(kernel)
+    kernel.enrich(sub_kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=('sub_kernel',))
+    sub_kernel_item = _make_item(sub_kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item, sub_kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+
+    # Process driver first
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # Now process kernel (it should propagate to sub_kernel)
+    trafo.transform_subroutine(
+        kernel, role='kernel', targets=('sub_kernel',),
+        item=kernel_item, sub_sgraph=sgraph
+    )
+
+    # Verify sub_kernel got trafo_data
+    assert 'LowerBlockIndex' in sub_kernel_item.trafo_data
+    assert 'relevant_vars' in sub_kernel_item.trafo_data['LowerBlockIndex']
+
+    # Verify nb was added to sub_kernel arguments
+    sub_kernel_arg_names = [a.name.lower() for a in sub_kernel.arguments]
+    assert 'nb' in sub_kernel_arg_names
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_promotes_local_arrays(frontend, block_dim):
+    """
+    Verify that callee-local arrays are promoted with the block dimension.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  real :: tmp(nproma, nlev)
+  integer :: jl, jk
+
+  do jk = 1, nlev
+    do jl = 1, nproma
+      tmp(jl, jk) = field(jl, jk) * 2.0
+      field(jl, jk) = tmp(jl, jk)
+    end do
+  end do
+end subroutine kernel
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
+    driver.enrich(kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # Check tmp was promoted to 3D (nproma, nlev, nb)
+    tmp_var = kernel.variable_map.get('tmp')
+    assert tmp_var is not None
+    assert len(tmp_var.shape) == 3
+    assert tmp_var.shape[-1] == 'nb'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_injects_unstructured_data_pragmas(frontend, block_dim):
+    """
+    Verify that !$loki unstructured-data create/delete pragmas are injected.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  real :: work(nproma)
+  integer :: jl, jk
+
+  do jk = 1, nlev
+    do jl = 1, nproma
+      work(jl) = field(jl, jk)
+      field(jl, jk) = work(jl) + 1.0
+    end do
+  end do
+end subroutine kernel
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
+    driver.enrich(kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # Check pragmas in kernel body
+    pragmas = FindNodes(ir.Pragma).visit(kernel.body)
+    create_pragmas = [p for p in pragmas if 'unstructured-data create' in p.content]
+    delete_pragmas = [p for p in pragmas if 'unstructured-data delete' in p.content]
+    assert len(create_pragmas) == 1
+    assert len(delete_pragmas) == 1
+    assert 'work' in create_pragmas[0].content
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_does_not_duplicate_existing_loki_unstructured_data_pragmas(frontend, block_dim):
+    """
+    Verify that existing generic ``!$loki unstructured-data`` pragmas
+    suppress duplicate injection before ``PragmaModel`` lowering.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  real :: work(nproma)
+  integer :: jl, jk
+
+  !$loki unstructured-data create(work)
+  do jk = 1, nlev
+    do jl = 1, nproma
+      work(jl) = field(jl, jk)
+      field(jl, jk) = work(jl) + 1.0
+    end do
+  end do
+  !$loki exit unstructured-data delete(work)
+end subroutine kernel
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
+    driver.enrich(kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    pragmas = FindNodes(ir.Pragma).visit(kernel.body)
+    create_pragmas = [p for p in pragmas if 'unstructured-data create' in p.content]
+    delete_pragmas = [p for p in pragmas if 'unstructured-data delete' in p.content]
+    assert len(create_pragmas) == 1
+    assert len(delete_pragmas) == 1
+    assert create_pragmas[0].content == 'unstructured-data create(work)'
+    assert delete_pragmas[0].content == 'exit unstructured-data delete(work)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_replaces_block_index_with_range(frontend, block_dim):
+    """
+    Verify that block-index subscripts in call arguments are replaced
+    with range indices (:).
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  field(1, 1) = 0.0
+end subroutine kernel
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
+    driver.enrich(kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # The call argument field(:,:,ibl) should become field(:,:,:)
+    calls = FindNodes(ir.CallStatement).visit(driver.body)
+    call = calls[0]
+    field_arg = call.arguments[2]  # third positional arg
+    assert all(isinstance(d, sym.RangeIndex) for d in field_arg.dimensions)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_imports_derived_types_and_kinds(frontend, block_dim):
+    """
+    Verify that derived-type and kind-parameter imports are propagated
+    to the callee when new arguments with those types are added.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field, ydbnds)
+  use type_mod, only: bnds_type
+  use parkind1, only: jpim
+  implicit none
+  integer(kind=jpim), intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  type(bnds_type), intent(in) :: ydbnds
+  integer :: ibl, kidia, kfdia
+  kidia = ydbnds%kidia
+  kfdia = ydbnds%kfdia
+
+  do ibl = 1, nb
+    kidia = ydbnds%kidia
+    kfdia = ydbnds%kfdia
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  field(1, 1) = 0.0
+end subroutine kernel
+"""
+    type_mod = Module.from_source(FCODE_TYPE_MOD, frontend=frontend)
+    parkind = Module.from_source(FCODE_PARKIND, frontend=frontend)
+    driver = Subroutine.from_source(
+        fcode_driver, frontend=frontend, definitions=[type_mod, parkind]
+    )
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend, definitions=[type_mod, parkind])
+    driver.enrich(kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # Check that kernel now imports from type_mod or parkind1
+    kernel_imports = list(kernel.imports)
+    imported_names = set()
+    for imp in kernel_imports:
+        for s in imp.symbols:
+            imported_names.add(s.name.lower())
+
+    # ydbnds has type bnds_type -> should propagate the import
+    # (only if ydbnds was passed as new arg — depends on dtype matching)
+    # At minimum, check that some import was added
+    kernel_arg_names = [a.name.lower() for a in kernel.arguments]
+    # kidia and kfdia are scalars used in the loop header assignments
+    # They should be passed (or their parent ydbnds via dtype match)
+    assert any(name in kernel_arg_names for name in ('kidia', 'kfdia', 'ydbnds'))
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_only_processes_pragma_annotated_calls(frontend, block_dim):
+    """
+    Verify that calls without the !$loki small-kernels pragma are not
+    modified by the transformation.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: ibl
+
+  do ibl = 1, nb
+    call regular_kernel(nproma, nlev, field(:,:,ibl))
+    !$loki small-kernels
+    call sk_kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_regular = """
+subroutine regular_kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  field(1,1) = 0.0
+end subroutine regular_kernel
+"""
+    fcode_sk = """
+subroutine sk_kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  field(1,1) = 0.0
+end subroutine sk_kernel
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    regular = Subroutine.from_source(fcode_regular, frontend=frontend)
+    sk = Subroutine.from_source(fcode_sk, frontend=frontend)
+    driver.enrich(regular)
+    driver.enrich(sk)
+
+    regular_item = _make_item(regular, role='kernel', targets=())
+    sk_item = _make_item(sk, role='kernel', targets=())
+    driver_item = _make_item(driver, role='driver', targets=('regular_kernel', 'sk_kernel'))
+
+    class _MockSGraph:
+        def successors(self, item):
+            if item is driver_item:
+                return [regular_item, sk_item]
+            return []
+
+    sgraph = _MockSGraph()
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('regular_kernel', 'sk_kernel'),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # regular_kernel should be unchanged (still 2 args)
+    assert len(regular.arguments) == 3  # nproma, nlev, field
+
+    # sk_kernel should have gained nb as argument
+    sk_arg_names = [a.name.lower() for a in sk.arguments]
+    assert 'nb' in sk_arg_names
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_inject_block_index_per_loop(frontend, block_dim):
+    """
+    Verify InjectBlockIndexTransformation.get_block_index resolves
+    block-index aliases from loop-body assignments.
+    """
+    fcode = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: jkglo, ibl
+
+  do jkglo = 1, nb
+    ibl = jkglo
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    trafo = InjectBlockIndexTransformation(block_dim=block_dim)
+
+    variable_map = routine.variable_map
+    # Without loop context, should find ibl directly
+    result = trafo.get_block_index(routine, variable_map)
+    assert result == 'ibl'
+
+    # With loop context providing assignment ibl = jkglo, should still resolve
+    with pragmas_attached(routine, ir.Loop):
+        loops = FindNodes(ir.Loop).visit(routine.body)
+        assert len(loops) == 1
+        result_with_loop = trafo.get_block_index(routine, variable_map, loop=loops[0])
+        assert result_with_loop == 'ibl'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_dtype_matching_kwargs(frontend, block_dim):
+    """
+    Verify that when a derived-type member variable (e.g. ``ydbnds%kidia``)
+    appears in the driver loop header, its root parent (``ydbnds``) is
+    matched by dtype to an existing callee argument (``ydcpg_bnds``) and
+    passed as a keyword argument using the callee's argument name.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field, ydbnds)
+  use type_mod, only: bnds_type
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  type(bnds_type), intent(in) :: ydbnds
+  integer :: ibl, kidia
+
+  do ibl = 1, nb
+    kidia = ydbnds%kidia
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field, ydcpg_bnds)
+  use type_mod, only: bnds_type
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  type(bnds_type), intent(in) :: ydcpg_bnds
+  field(1, 1) = 0.0
+end subroutine kernel
+"""
+    type_mod = Module.from_source(FCODE_TYPE_MOD, frontend=frontend)
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend, definitions=[type_mod])
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend, definitions=[type_mod])
+    driver.enrich(kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # ydbnds is NOT passed in the original call, but ydbnds%kidia appears
+    # in the loop body. The root parent ydbnds has dtype bnds_type which
+    # matches the callee's ydcpg_bnds argument — so ydbnds should be passed
+    # as a kwarg with key 'ydcpg_bnds' (the callee's arg name).
+    calls = FindNodes(ir.CallStatement).visit(driver.body)
+    call = calls[0]
+    kwarg_dict = {str(k).lower(): v for k, v in call.kwarguments}
+
+    # ydbnds passed as kwarg matching callee's ydcpg_bnds by dtype
+    assert 'ydcpg_bnds' in kwarg_dict
+    assert kwarg_dict['ydcpg_bnds'] == 'ydbnds'
+
+    # ydbnds should NOT appear as a new positional argument in the kernel
+    kernel_arg_names = [a.name.lower() for a in kernel.arguments]
+    assert 'ydbnds' not in kernel_arg_names
+    assert 'ydcpg_bnds' in kernel_arg_names  # existing arg kept
+    assert 'nb' in kernel_arg_names  # nb added as new arg
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_argument_dims_updated(frontend, block_dim):
+    """
+    Verify that callee argument array declarations are promoted from
+    2D to 3D when the call-site argument has higher rank.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  field(1, 1) = 0.0
+end subroutine kernel
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend)
+    driver.enrich(kernel)
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # field in kernel should now be 3D: (nproma, nlev, nb)
+    field_var = kernel.variable_map['field']
+    assert len(field_var.shape) == 3
+    assert field_var.shape[-1] == 'nb'
+
+    # Verify dimensions match shape
+    assert len(field_var.dimensions) == 3
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_new_derived_dummy_declared_before_bounds_use(frontend):
+    """
+    Verify that newly-added derived-type dummies are declared before any
+    existing dummy-array declarations whose bounds are updated to use them.
+    """
+    fcode_type_mod = """
+module type_mod
+  implicit none
+  type :: yrdim_type
+    integer :: ngpblks
+  end type yrdim_type
+  type :: geometry
+    type(yrdim_type) :: yrdim
+  end type geometry
+end module type_mod
+"""
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, geom, field)
+  use type_mod, only: geometry
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  type(geometry), intent(in) :: geom
+  real, intent(inout) :: field(nproma, nlev, geom%yrdim%ngpblks)
+  integer :: ibl, jkglo
+
+  do ibl = 1, nb
+    jkglo = geom%yrdim%ngpblks
+    !$loki small-kernels
+    call kernel(nproma, nlev, field(:, :, ibl))
+  end do
+end subroutine driver
+"""
+    fcode_kernel = """
+subroutine kernel(nproma, nlev, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev
+  real, intent(inout) :: field(nproma, nlev)
+  field(1, 1) = 0.0
+end subroutine kernel
+"""
+    type_mod = Module.from_source(fcode_type_mod, frontend=frontend)
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend, definitions=[type_mod])
+    kernel = Subroutine.from_source(fcode_kernel, frontend=frontend, definitions=[type_mod])
+    driver.enrich(kernel)
+
+    geom_block_dim = Dimension(
+        name='block_dim', size='geom%yrdim%ngpblks', index='ibl',
+        bounds=('1', 'geom%yrdim%ngpblks'), aliases=('jkglo',)
+    )
+
+    driver_item = _make_item(driver, role='driver', targets=('kernel',))
+    kernel_item = _make_item(kernel, role='kernel', targets=())
+    sgraph = _build_sgraph([driver_item, kernel_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=geom_block_dim)
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    decls = [decl for decl in FindNodes(ir.VariableDeclaration).visit(kernel.spec) if len(decl.symbols) == 1]
+    decl_pos = {decl.symbols[0].name.lower(): idx for idx, decl in enumerate(decls)}
+
+    assert 'geom' in [arg.name.lower() for arg in kernel.arguments]
+    assert kernel.variable_map['field'].shape[-1] == 'geom%yrdim%ngpblks'
+    assert decl_pos['geom'] < decl_pos['field']
+
+
+@pytest.mark.parametrize('frontend', available_frontends(xfail=[(OMNI, 'OMNI cannot import undefined modules')]))
+def test_sk_deferred_call_skipped(frontend, block_dim):
+    """
+    Verify that un-enriched (DEFERRED) calls are skipped gracefully
+    with a warning, and the routine is not modified.
+    """
+    fcode_driver = """
+subroutine driver(nproma, nlev, nb, field)
+  implicit none
+  integer, intent(in) :: nproma, nlev, nb
+  real, intent(inout) :: field(nproma, nlev, nb)
+  integer :: ibl
+
+  do ibl = 1, nb
+    !$loki small-kernels
+    call unknown_kernel(nproma, nlev, field(:,:,ibl))
+  end do
+end subroutine driver
+"""
+    driver = Subroutine.from_source(fcode_driver, frontend=frontend)
+    # Do NOT enrich — call remains DEFERRED
+
+    driver_item = _make_item(driver, role='driver', targets=('unknown_kernel',))
+    sgraph = _build_sgraph([driver_item])
+
+    trafo = LowerBlockIndexSKTransformation(block_dim=block_dim)
+    # Should not raise — just warn and skip
+    trafo.transform_subroutine(
+        driver, role='driver', targets=('unknown_kernel',),
+        item=driver_item, sub_sgraph=sgraph
+    )
+
+    # Driver should be unchanged — call still has original arguments
+    calls = FindNodes(ir.CallStatement).visit(driver.body)
+    assert len(calls) == 1
+    assert len(calls[0].arguments) == 3  # nproma, nlev, field(:,:,ibl)

--- a/loki/transformations/tests/test_lower_block_index_sk.py
+++ b/loki/transformations/tests/test_lower_block_index_sk.py
@@ -10,6 +10,8 @@ Tests for :any:`LowerBlockIndexSKTransformation` and the extended
 :any:`InjectBlockIndexTransformation.get_block_index` with ``loop=`` parameter.
 """
 
+# pylint: disable=redefined-outer-name
+
 import pytest
 
 from loki import Dimension, Module, Subroutine


### PR DESCRIPTION
### Description

New pipeline to generate "small kernels": 

* via `!$loki small-kernels` pragma annotated to calls
* the block loop can be lowered to kernels (in order to expose the parallelism there)
  * this obviously alters the amount and size of kernels and also the offload (to some extent)
* moreover, this allows to replace parts of the code/routines to be replaced with other manually optimised variants and being called from host

**Therefore, this enables e.g., to replace a deeply-buried dgemm call that is necessarily implemented in a naive way to instead use cublas and call a optimised GPU dgemm version from host**.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 