### PR TITLE
Transformations: Isolated CI JIT test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,18 @@ pylint --rcfile .pylintrc <relevant paths>
 For broader validation, keep using the same activated environment and local `.pylintrc`.
 
 
+## Commit Message Style
+
+When creating commits in this repository:
+
+- Use a sub-package or area marker in the subject, followed by a colon.
+- Keep the subject concise and imperative, for example:
+  `JIT: Add isolated JIT execution helper`
+  `Transformations: Isolate parametrise JIT test execution`
+- Wrap commit body lines like Python docstrings, preferably around 72 characters.
+- Use the body to explain why the change is needed and what behavior it protects.
+
+
 ## Loki Test Assertions
 
 When editing or adding tests, prefer assertions that match Loki's native IR and expression semantics rather than assertions that depend on rendered source formatting.
@@ -63,4 +75,3 @@ When editing test imports, keep `loki.*` import lines ordered alphabetically by 
   - Avoid: `(str(loop.variable), str(loop.bounds.start), str(loop.bounds.stop), ... )`
 - Use stringification only when the test is explicitly about rendered output, pretty-printing, or a node type that does not compare reliably through Loki's native equality support.
 - If stringification is still necessary in a structural test, keep it narrowly scoped and document why.
-

--- a/loki/jit_build/jit.py
+++ b/loki/jit_build/jit.py
@@ -24,7 +24,7 @@ from loki.subroutine import Subroutine
 from loki.tools import as_tuple, gettempdir, filehash
 
 
-__all__ = ['jit_compile', 'jit_compile_lib', 'run_isolated', 'clean_test']
+__all__ = ['jit_compile', 'jit_compile_and_run', 'jit_compile_lib', 'run_isolated', 'clean_test']
 
 
 _f90wrap_kind_map = Path(__file__).parent.parent/'tests/kind_map'
@@ -90,6 +90,64 @@ def run_isolated(target, *args, multiprocessing_context='fork', exit_after_resul
     if kind == 'result':
         return payload
     return None
+
+
+def _jit_compile_and_run(source, args, kwargs, filepath, objname):
+    """
+    JIT-compile ``source`` and execute the selected entry point.
+    """
+    function = jit_compile(source, filepath=filepath, objname=objname)
+    result = function(*args, **kwargs)
+    return result, args, kwargs
+
+
+def _copy_back_arguments(original, updated):
+    """
+    Copy updated array-like argument values back into the caller objects.
+    """
+    for original_value, updated_value in zip(original, updated):
+        if hasattr(original_value, '__setitem__') and hasattr(original_value, 'shape'):
+            original_value[...] = updated_value
+
+
+def jit_compile_and_run(source, *args, filepath=None, objname=None, isolated=False,
+                        multiprocessing_context='fork', exit_after_result=False, **kwargs):
+    """
+    JIT-compile a source item and execute the selected entry point.
+
+    The complete compile, load, and execution cycle can optionally run in a
+    short-lived subprocess to isolate native extension module state from the
+    parent test process.
+
+    Parameters
+    ----------
+    source : :any:`Sourcefile` or :any:`Module` or :any:`Subroutine`
+        The item to compile and load.
+    *args : tuple
+        Positional arguments passed to the compiled entry point.
+    filepath : str or :any:`Path`, optional
+        Path of the source file to write.
+    objname : str, optional
+        Name of the compiled object to execute.
+    isolated : bool, optional
+        Run the compile-and-execute cycle via :any:`run_isolated` when enabled.
+    multiprocessing_context : str, optional
+        Multiprocessing start method used for isolated execution.
+    exit_after_result : bool, optional
+        Exit the isolated child immediately after reporting the result.
+    **kwargs : dict
+        Keyword arguments passed to the compiled entry point.
+    """
+    if isolated:
+        result, updated_args, updated_kwargs = run_isolated(
+            _jit_compile_and_run, source, args, kwargs, filepath, objname,
+            multiprocessing_context=multiprocessing_context, exit_after_result=exit_after_result
+        )
+        _copy_back_arguments(args, updated_args)
+        _copy_back_arguments(kwargs.values(), updated_kwargs.values())
+        return result
+    result, _, _ = _jit_compile_and_run(source, args, kwargs, filepath, objname)
+    return result
 
 
 def jit_compile(source, filepath=None, objname=None):

--- a/loki/jit_build/jit.py
+++ b/loki/jit_build/jit.py
@@ -44,7 +44,8 @@ def _run_isolated_worker(conn, target, args, kwargs, exit_after_result):
         os._exit(0)  # pylint: disable=protected-access
 
 
-def run_isolated(target, *args, multiprocessing_context='fork', exit_after_result=False, **kwargs):
+def run_isolated(target, *args, multiprocessing_context='fork', exit_after_result=False,
+                 timeout=None, **kwargs):
     """
     Execute ``target`` in a short-lived subprocess and return its result.
 
@@ -66,6 +67,8 @@ def run_isolated(target, *args, multiprocessing_context='fork', exit_after_resul
         Exit the child process immediately after reporting the result, bypassing
         interpreter shutdown. This is useful for native extension tests where
         finalizers can crash after successful execution.
+    timeout : int or float, optional
+        Maximum time in seconds to wait for the isolated child process.
     """
     ctx = get_context(multiprocessing_context)
     parent_conn, child_conn = ctx.Pipe(duplex=False)
@@ -74,7 +77,13 @@ def run_isolated(target, *args, multiprocessing_context='fork', exit_after_resul
     )
     process.start()
     child_conn.close()
-    process.join()
+    process.join(timeout=timeout)
+
+    if process.is_alive():
+        process.terminate()
+        process.join()
+        parent_conn.close()
+        raise RuntimeError(f'Isolated process timed out after {timeout} seconds')
 
     try:
         has_payload = parent_conn.poll()
@@ -110,8 +119,9 @@ def _copy_back_arguments(original, updated):
             original_value[...] = updated_value
 
 
-def jit_compile_and_run(source, *args, filepath=None, objname=None, isolated=False,
-                        multiprocessing_context='fork', exit_after_result=False, **kwargs):
+def jit_compile_and_run(source, *args, filepath=None, objname=None, isolated=True,
+                        multiprocessing_context='fork', exit_after_result=False,
+                        timeout=10, **kwargs):
     """
     JIT-compile a source item and execute the selected entry point.
 
@@ -128,20 +138,26 @@ def jit_compile_and_run(source, *args, filepath=None, objname=None, isolated=Fal
     filepath : str or :any:`Path`, optional
         Path of the source file to write.
     objname : str, optional
-        Name of the compiled object to execute.
+        Name of the compiled object to execute. Defaults to ``source.name``
+        when available.
     isolated : bool, optional
-        Run the compile-and-execute cycle via :any:`run_isolated` when enabled.
+        Run the compile-and-execute cycle via :any:`run_isolated` when enabled
+        (default: ``True``).
     multiprocessing_context : str, optional
         Multiprocessing start method used for isolated execution.
     exit_after_result : bool, optional
         Exit the isolated child immediately after reporting the result.
+    timeout : int or float, optional
+        Maximum time in seconds to wait for isolated execution (default: 10).
     **kwargs : dict
         Keyword arguments passed to the compiled entry point.
     """
+    objname = objname or getattr(source, 'name', None)
     if isolated:
         result, updated_args, updated_kwargs = run_isolated(
             _jit_compile_and_run, source, args, kwargs, filepath, objname,
-            multiprocessing_context=multiprocessing_context, exit_after_result=exit_after_result
+            multiprocessing_context=multiprocessing_context, exit_after_result=exit_after_result,
+            timeout=timeout
         )
         _copy_back_arguments(args, updated_args)
         _copy_back_arguments(kwargs.values(), updated_kwargs.values())

--- a/loki/jit_build/jit.py
+++ b/loki/jit_build/jit.py
@@ -98,7 +98,7 @@ def run_isolated(target, *args, multiprocessing_context='fork', exit_after_resul
         raise RuntimeError(f'Isolated process failed with exit code {process.exitcode}')
     if kind == 'result':
         return payload
-    return None
+    raise RuntimeError('Unexpected return form child process - something has gone terribly wrong!')
 
 
 def _jit_compile_and_run(source, args, kwargs, filepath, objname):

--- a/loki/jit_build/jit.py
+++ b/loki/jit_build/jit.py
@@ -127,7 +127,7 @@ def jit_compile_and_run(source, *args, filepath=None, objname=None, isolated=Tru
 
     The complete compile, load, and execution cycle can optionally run in a
     short-lived subprocess to isolate native extension module state from the
-    parent test process.
+    parent test process. See :any:`run_isolated` for available options for arguments.
 
     Parameters
     ----------

--- a/loki/jit_build/jit.py
+++ b/loki/jit_build/jit.py
@@ -8,6 +8,9 @@
 Utilities to facilitate Just-in-Time compilation for testing purposes.
 """
 from pathlib import Path
+from multiprocessing import get_context
+from queue import Empty
+import traceback
 
 from loki.backend import fgen
 from loki.jit_build.builder import Builder
@@ -21,10 +24,50 @@ from loki.subroutine import Subroutine
 from loki.tools import as_tuple, gettempdir, filehash
 
 
-__all__ = ['jit_compile', 'jit_compile_lib', 'clean_test']
+__all__ = ['jit_compile', 'jit_compile_lib', 'run_isolated', 'clean_test']
 
 
 _f90wrap_kind_map = Path(__file__).parent.parent/'tests/kind_map'
+
+
+def _run_isolated_worker(queue, target, args, kwargs):
+    """
+    Execute a callable in a subprocess and report the outcome through a queue.
+    """
+    try:
+        queue.put(('result', target(*args, **kwargs)))
+    except Exception:  # pylint: disable=broad-exception-caught
+        queue.put(('exception', traceback.format_exc()))
+
+
+def run_isolated(target, *args, **kwargs):
+    """
+    Execute ``target`` in a short-lived subprocess and return its result.
+
+    This is useful for tests that JIT-compile and import native extension modules,
+    where unloading all linked Fortran/Python wrapper state from the current process
+    is not reliable. Python exceptions raised by ``target`` are re-raised as
+    :any:`RuntimeError` with the child traceback; native crashes or explicit
+    non-zero exits are reported via the child process exit code.
+    """
+    ctx = get_context('fork')
+    queue = ctx.Queue()
+    process = ctx.Process(target=_run_isolated_worker, args=(queue, target, args, kwargs))
+    process.start()
+    process.join()
+
+    try:
+        kind, payload = queue.get_nowait()
+    except Empty:
+        kind = payload = None
+
+    if kind == 'exception':
+        raise RuntimeError(payload)
+    if process.exitcode != 0:
+        raise RuntimeError(f'Isolated process failed with exit code {process.exitcode}')
+    if kind == 'result':
+        return payload
+    return None
 
 
 def jit_compile(source, filepath=None, objname=None):

--- a/loki/jit_build/jit.py
+++ b/loki/jit_build/jit.py
@@ -9,7 +9,7 @@ Utilities to facilitate Just-in-Time compilation for testing purposes.
 """
 from pathlib import Path
 from multiprocessing import get_context
-from queue import Empty
+import os
 import traceback
 
 from loki.backend import fgen
@@ -30,17 +30,21 @@ __all__ = ['jit_compile', 'jit_compile_lib', 'run_isolated', 'clean_test']
 _f90wrap_kind_map = Path(__file__).parent.parent/'tests/kind_map'
 
 
-def _run_isolated_worker(queue, target, args, kwargs):
+def _run_isolated_worker(conn, target, args, kwargs, exit_after_result):
     """
     Execute a callable in a subprocess and report the outcome through a queue.
     """
     try:
-        queue.put(('result', target(*args, **kwargs)))
+        conn.send(('result', target(*args, **kwargs)))
     except Exception:  # pylint: disable=broad-exception-caught
-        queue.put(('exception', traceback.format_exc()))
+        conn.send(('exception', traceback.format_exc()))
+    finally:
+        conn.close()
+    if exit_after_result:
+        os._exit(0)  # pylint: disable=protected-access
 
 
-def run_isolated(target, *args, **kwargs):
+def run_isolated(target, *args, multiprocessing_context='fork', exit_after_result=False, **kwargs):
     """
     Execute ``target`` in a short-lived subprocess and return its result.
 
@@ -49,17 +53,35 @@ def run_isolated(target, *args, **kwargs):
     is not reliable. Python exceptions raised by ``target`` are re-raised as
     :any:`RuntimeError` with the child traceback; native crashes or explicit
     non-zero exits are reported via the child process exit code.
+
+    Parameters
+    ----------
+    target : callable
+        The callable to execute in the child process.
+    multiprocessing_context : str, optional
+        Multiprocessing start method. Use ``'fork'`` for low-overhead isolation
+        when inherited process state is safe, or ``'spawn'`` when the child must
+        start without inherited native extension modules.
+    exit_after_result : bool, optional
+        Exit the child process immediately after reporting the result, bypassing
+        interpreter shutdown. This is useful for native extension tests where
+        finalizers can crash after successful execution.
     """
-    ctx = get_context('fork')
-    queue = ctx.Queue()
-    process = ctx.Process(target=_run_isolated_worker, args=(queue, target, args, kwargs))
+    ctx = get_context(multiprocessing_context)
+    parent_conn, child_conn = ctx.Pipe(duplex=False)
+    process = ctx.Process(
+        target=_run_isolated_worker, args=(child_conn, target, args, kwargs, exit_after_result)
+    )
     process.start()
+    child_conn.close()
     process.join()
 
     try:
-        kind, payload = queue.get_nowait()
-    except Empty:
+        has_payload = parent_conn.poll()
+        kind, payload = parent_conn.recv() if has_payload else (None, None)
+    except EOFError:
         kind = payload = None
+    parent_conn.close()
 
     if kind == 'exception':
         raise RuntimeError(payload)

--- a/loki/jit_build/tests/test_build.py
+++ b/loki/jit_build/tests/test_build.py
@@ -8,8 +8,10 @@
 from pathlib import Path
 import os
 import pytest
+import numpy as np
 
-from loki.jit_build import Obj, Lib, Builder, run_isolated
+from loki import Subroutine
+from loki.jit_build import Obj, Lib, Builder, run_isolated, jit_compile_and_run
 from loki.jit_build.compiler import  (
     Compiler, GNUCompiler, NvidiaCompiler, get_compiler_from_env,
     _default_compiler
@@ -87,6 +89,51 @@ def test_run_isolated_nonzero_exit():
     with pytest.raises(RuntimeError) as excinfo:
         run_isolated(_isolated_exit, 7)
     assert 'exit code 7' in str(excinfo.value)
+
+
+def test_jit_compile_and_run_in_process(tmp_path):
+    """
+    Test that jit_compile_and_run executes compiled sources in-process by default.
+    """
+    source = """
+subroutine fill_array(a, n)
+  integer, intent(inout) :: a(n)
+  integer, intent(in) :: n
+  integer :: j
+  do j=1,n
+    a(j) = j
+  end do
+end subroutine fill_array
+"""
+    routine = Subroutine.from_source(source)
+    n = 5
+    a = np.zeros(shape=(n,), dtype=np.int32)
+    jit_compile_and_run(routine, filepath=tmp_path/'fill_array.F90', objname='fill_array', a=a, n=n)
+    assert np.all(a == range(1, n+1))
+
+
+def test_jit_compile_and_run_isolated(tmp_path):
+    """
+    Test that jit_compile_and_run can isolate compile-and-execute cycles.
+    """
+    source = """
+subroutine fill_array(a, n)
+  integer, intent(inout) :: a(n)
+  integer, intent(in) :: n
+  integer :: j
+  do j=1,n
+    a(j) = j
+  end do
+end subroutine fill_array
+"""
+    routine = Subroutine.from_source(source)
+    n = 5
+    a = np.zeros(shape=(n,), dtype=np.int32)
+    result = jit_compile_and_run(
+        routine, filepath=tmp_path/'fill_array_isolated.F90', objname='fill_array', isolated=True, a=a, n=n
+    )
+    assert result is None
+    assert np.all(a == range(1, n+1))
 
 
 def test_build_clean(builder):

--- a/loki/jit_build/tests/test_build.py
+++ b/loki/jit_build/tests/test_build.py
@@ -64,6 +64,13 @@ def test_run_isolated_process_side_effect(tmp_path):
     assert path.read_text() == 'child process wrote this'
 
 
+def test_run_isolated_exit_after_result():
+    """
+    Test that run_isolated can bypass child interpreter shutdown after success.
+    """
+    assert run_isolated(_isolated_add, 2, 5, exit_after_result=True) == 7
+
+
 def test_run_isolated_exception():
     """
     Test that run_isolated reports Python exceptions from the child process.

--- a/loki/jit_build/tests/test_build.py
+++ b/loki/jit_build/tests/test_build.py
@@ -7,6 +7,7 @@
 
 from pathlib import Path
 import os
+import time
 import pytest
 import numpy as np
 
@@ -50,6 +51,10 @@ def _isolated_exit(status):
     os._exit(status)  # pylint: disable=protected-access
 
 
+def _isolated_sleep(seconds):
+    time.sleep(seconds)
+
+
 def test_run_isolated_returns_result():
     """
     Test that run_isolated returns picklable target results.
@@ -91,9 +96,18 @@ def test_run_isolated_nonzero_exit():
     assert 'exit code 7' in str(excinfo.value)
 
 
+def test_run_isolated_timeout():
+    """
+    Test that run_isolated terminates child processes that exceed a timeout.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        run_isolated(_isolated_sleep, 5, timeout=0.1)
+    assert 'timed out after 0.1 seconds' in str(excinfo.value)
+
+
 def test_jit_compile_and_run_in_process(tmp_path):
     """
-    Test that jit_compile_and_run executes compiled sources in-process by default.
+    Test that jit_compile_and_run supports explicit in-process execution.
     """
     source = """
 subroutine fill_array(a, n)
@@ -108,13 +122,13 @@ end subroutine fill_array
     routine = Subroutine.from_source(source)
     n = 5
     a = np.zeros(shape=(n,), dtype=np.int32)
-    jit_compile_and_run(routine, filepath=tmp_path/'fill_array.F90', objname='fill_array', a=a, n=n)
+    jit_compile_and_run(routine, filepath=tmp_path/'fill_array.F90', isolated=False, a=a, n=n)
     assert np.all(a == range(1, n+1))
 
 
 def test_jit_compile_and_run_isolated(tmp_path):
     """
-    Test that jit_compile_and_run can isolate compile-and-execute cycles.
+    Test that jit_compile_and_run isolates compile-and-execute cycles by default.
     """
     source = """
 subroutine fill_array(a, n)
@@ -130,7 +144,7 @@ end subroutine fill_array
     n = 5
     a = np.zeros(shape=(n,), dtype=np.int32)
     result = jit_compile_and_run(
-        routine, filepath=tmp_path/'fill_array_isolated.F90', objname='fill_array', isolated=True, a=a, n=n
+        routine, filepath=tmp_path/'fill_array_isolated.F90', a=a, n=n
     )
     assert result is None
     assert np.all(a == range(1, n+1))

--- a/loki/jit_build/tests/test_build.py
+++ b/loki/jit_build/tests/test_build.py
@@ -6,9 +6,10 @@
 # nor does it submit to any jurisdiction.
 
 from pathlib import Path
+import os
 import pytest
 
-from loki.jit_build import Obj, Lib, Builder
+from loki.jit_build import Obj, Lib, Builder, run_isolated
 from loki.jit_build.compiler import  (
     Compiler, GNUCompiler, NvidiaCompiler, get_compiler_from_env,
     _default_compiler
@@ -29,6 +30,56 @@ def fixture_builder(here, tmp_path):
 @pytest.fixture(scope='module', name='testdir')
 def fixture_testdir(here):
     return here.parent.parent/'tests'
+
+
+def _isolated_add(a, b):
+    return a + b
+
+
+def _isolated_write_file(path):
+    Path(path).write_text('child process wrote this')
+
+
+def _isolated_raise():
+    raise ValueError('isolated failure')
+
+
+def _isolated_exit(status):
+    os._exit(status)  # pylint: disable=protected-access
+
+
+def test_run_isolated_returns_result():
+    """
+    Test that run_isolated returns picklable target results.
+    """
+    assert run_isolated(_isolated_add, 2, 5) == 7
+
+
+def test_run_isolated_process_side_effect(tmp_path):
+    """
+    Test that run_isolated executes the target in a child process.
+    """
+    path = tmp_path/'isolated.txt'
+    assert run_isolated(_isolated_write_file, path) is None
+    assert path.read_text() == 'child process wrote this'
+
+
+def test_run_isolated_exception():
+    """
+    Test that run_isolated reports Python exceptions from the child process.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        run_isolated(_isolated_raise)
+    assert 'ValueError: isolated failure' in str(excinfo.value)
+
+
+def test_run_isolated_nonzero_exit():
+    """
+    Test that run_isolated reports child process crashes or explicit exits.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        run_isolated(_isolated_exit, 7)
+    assert 'exit code 7' in str(excinfo.value)
 
 
 def test_build_clean(builder):

--- a/loki/transformations/array_indexing/tests/test_array_demote.py
+++ b/loki/transformations/array_indexing/tests/test_array_demote.py
@@ -9,7 +9,7 @@ import pytest
 import numpy as np
 
 from loki import Subroutine
-from loki.jit_build import jit_compile
+from loki.jit_build import jit_compile_and_run
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends
 
@@ -59,14 +59,12 @@ end subroutine transform_demote_variables
 
     # Test the original implementation
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
     n = 3
     m = 2
     scalar = np.array(0)
     vector = np.zeros(shape=(n,), order='F', dtype=np.int32)
     matrix = np.zeros(shape=(n, n), order='F', dtype=np.int32)
-    function(scalar, vector, matrix, n, m)
+    jit_compile_and_run(routine, scalar, vector, matrix, n, m, filepath=filepath)
 
     assert scalar == 3
     assert np.all(vector == np.arange(1, n + 1)*2)
@@ -87,14 +85,12 @@ end subroutine transform_demote_variables
 
     # Test promoted routine
     demoted_filepath = tmp_path/(f'{routine.name}_demoted_{frontend}.f90')
-    demoted_function = jit_compile(routine, filepath=demoted_filepath, objname=routine.name)
-
     n = 3
     m = 2
     scalar = np.array(0)
     vector = np.zeros(shape=(n,), order='F', dtype=np.int32)
     matrix = np.zeros(shape=(n, n), order='F', dtype=np.int32)
-    demoted_function(scalar, vector, matrix, n, m)
+    jit_compile_and_run(routine, scalar, vector, matrix, n, m, filepath=demoted_filepath)
 
     assert scalar == 3
     assert np.all(vector == np.arange(1, n + 1)*2)
@@ -134,8 +130,6 @@ end subroutine transform_demote_dimension_arguments
 
     # Test the original implementation
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
     assert isinstance(routine.variable_map['vec1'], sym.Array)
     assert routine.variable_map['vec1'].shape == (routine.variable_map['n'],)
     assert isinstance(routine.variable_map['vec2'], sym.Array)
@@ -148,7 +142,7 @@ end subroutine transform_demote_dimension_arguments
     vec1 = np.zeros(shape=(n,), order='F', dtype=np.int32) + 3
     vec2 = np.zeros(shape=(n,), order='F', dtype=np.int32) + 2
     matrix = np.zeros(shape=(n, m), order='F', dtype=np.int32) + 1
-    function(vec1, vec2, matrix, n, m)
+    jit_compile_and_run(routine, vec1, vec2, matrix, n, m, filepath=filepath)
 
     assert np.all(vec1 == 3) and np.sum(vec1) == 9
     assert np.all(vec2 == 2) and np.sum(vec2) == 6
@@ -164,14 +158,12 @@ end subroutine transform_demote_dimension_arguments
 
     # Test promoted routine
     demoted_filepath = tmp_path/(f'{routine.name}_demoted_{frontend}.f90')
-    demoted_function = jit_compile(routine, filepath=demoted_filepath, objname=routine.name)
-
     n = 3
     m = 2
     vec1 = np.array(3)
     vec2 = np.zeros(shape=(n,), order='F', dtype=np.int32) + 2
     matrix = np.zeros(shape=(m, ), order='F', dtype=np.int32) + 1
-    demoted_function(vec1, vec2, matrix, n, m)
+    jit_compile_and_run(routine, vec1, vec2, matrix, n, m, filepath=demoted_filepath)
 
     assert vec1 == 3
     assert np.all(vec2 == 2) and np.sum(vec2) == 6

--- a/loki/transformations/array_indexing/tests/test_array_indexing.py
+++ b/loki/transformations/array_indexing/tests/test_array_indexing.py
@@ -10,7 +10,7 @@ import pytest
 import numpy as np
 
 from loki import Module, Subroutine, fgen
-from loki.jit_build import jit_compile, jit_compile_lib, clean_test, Builder, Obj
+from loki.jit_build import jit_compile, jit_compile_and_run, jit_compile_lib, clean_test, Builder, Obj
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes, FindVariables
@@ -215,9 +215,8 @@ def test_transform_flatten_arrays(tmp_path, frontend, builder, start_index):
     # Test the original implementation
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{start_index}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
     orig_x1, orig_x2, orig_x3, orig_x4 = init_arguments(l1, l2, l3, l4)
-    function(orig_x1, orig_x2, orig_x3, orig_x4, l1, l2, l3, l4)
+    jit_compile_and_run(routine, orig_x1, orig_x2, orig_x3, orig_x4, l1, l2, l3, l4, filepath=filepath)
     clean_test(filepath)
 
     # Test flattening order='F'
@@ -225,9 +224,8 @@ def test_transform_flatten_arrays(tmp_path, frontend, builder, start_index):
     normalize_array_shape_and_access(f_routine)
     flatten_arrays(routine=f_routine, order='F', start_index=1)
     filepath = tmp_path/(f'{f_routine.name}_{start_index}_flattened_F_{frontend}.f90')
-    function = jit_compile(f_routine, filepath=filepath, objname=routine.name)
     f_x1, f_x2, f_x3, f_x4 = init_arguments(l1, l2, l3, l4, flattened=True)
-    function(f_x1, f_x2, f_x3, f_x4, l1, l2, l3, l4)
+    jit_compile_and_run(f_routine, f_x1, f_x2, f_x3, f_x4, l1, l2, l3, l4, filepath=filepath)
     validate_routine(f_routine)
     clean_test(filepath)
 
@@ -242,9 +240,8 @@ def test_transform_flatten_arrays(tmp_path, frontend, builder, start_index):
     invert_array_indices(c_routine)
     flatten_arrays(routine=c_routine, order='C', start_index=1)
     filepath = tmp_path/(f'{c_routine.name}_{start_index}_flattened_C_{frontend}.f90')
-    function = jit_compile(c_routine, filepath=filepath, objname=routine.name)
     c_x1, c_x2, c_x3, c_x4 = init_arguments(l1, l2, l3, l4, flattened=True)
-    function(c_x1, c_x2, c_x3, c_x4, l1, l2, l3, l4)
+    jit_compile_and_run(c_routine, c_x1, c_x2, c_x3, c_x4, l1, l2, l3, l4, filepath=filepath)
     validate_routine(c_routine)
     clean_test(filepath)
 

--- a/loki/transformations/array_indexing/tests/test_array_promote.py
+++ b/loki/transformations/array_indexing/tests/test_array_promote.py
@@ -9,7 +9,7 @@ import pytest
 import numpy as np
 
 from loki import Subroutine
-from loki.jit_build import jit_compile
+from loki.jit_build import jit_compile_and_run
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends
 
@@ -38,8 +38,7 @@ end subroutine transform_promote_variable_scalar
 
     # Test the original implementation
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-    ret = function()
+    ret = jit_compile_and_run(routine, filepath=filepath)
     assert ret == 55
 
     # Apply and test the transformation
@@ -49,8 +48,7 @@ end subroutine transform_promote_variable_scalar
     assert routine.variable_map['tmp'].shape == (sym.Literal(10),)
 
     promoted_filepath = tmp_path/(f'{routine.name}_promoted_{frontend}.f90')
-    promoted_function = jit_compile(routine, filepath=promoted_filepath, objname=routine.name)
-    ret = promoted_function()
+    ret = jit_compile_and_run(routine, filepath=promoted_filepath)
     assert ret == 55
 
 
@@ -92,12 +90,10 @@ end subroutine transform_promote_variables
 
     # Test the original implementation
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
     n = 10
     scalar = np.array(0)
     vector = np.zeros(shape=(n,), order='F', dtype=np.int32)
-    function(scalar, vector, n)
+    jit_compile_and_run(routine, scalar, vector, n, filepath=filepath)
     assert scalar == n*n
     assert np.all(vector == np.array(list(range(1, 2*n+1, 2)), order='F', dtype=np.int32) + n + 1)
 
@@ -132,11 +128,9 @@ end subroutine transform_promote_variables
 
     # Test promoted routine
     promoted_filepath = tmp_path/(f'{routine.name}_promoted_{frontend}.f90')
-    promoted_function = jit_compile(routine, filepath=promoted_filepath, objname=routine.name)
-
     scalar = np.array(0)
     vector = np.zeros(shape=(n,), order='F', dtype=np.int32)
-    promoted_function(scalar, vector, n)
+    jit_compile_and_run(routine, scalar, vector, n, filepath=promoted_filepath)
     assert scalar == n*(n+1)//2
     assert np.all(vector[:-1] == np.array(list(range(n + 1, 2*n)), order='F', dtype=np.int32))
     assert vector[-1] == 3*n

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 
 from loki import Module, Subroutine, Dimension
-from loki.jit_build import jit_compile, jit_compile_lib, Builder, Obj
+from loki.jit_build import jit_compile_and_run, jit_compile_lib, Builder, Obj
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes, FindVariables
@@ -70,8 +70,7 @@ end subroutine transform_resolve_vector_notation
     ret2 = np.zeros(shape=(3, 5), order='F', dtype=np.int32)
 
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-    function(ret1, ret2)
+    jit_compile_and_run(routine, ret1, ret2, filepath=filepath)
 
     assert np.all(ret1 == 11)
     assert np.all(ret2 == 42)
@@ -133,8 +132,6 @@ end subroutine transform_resolve_vector_notation_common_loops
     routine = Subroutine.from_source(fcode, frontend=frontend)
     # Test the original implementation
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
     n = 3
     m = 2
     l = 3
@@ -144,7 +141,8 @@ end subroutine transform_resolve_vector_notation_common_loops
     vector = np.zeros(shape=(n,), order='F', dtype=np.int32)
     vector_2 = np.zeros(shape=(n,), order='F', dtype=np.int32)
     matrix = np.zeros(shape=(n, n), order='F', dtype=np.int32)
-    function(scalar, vector, vector_2, matrix, n, m, l, kidia, kfdia)
+    jit_compile_and_run(routine, scalar, vector, vector_2, matrix, n, m, l, kidia, kfdia,
+                        filepath=filepath)
 
     assert scalar == 3
     assert np.all(vector == np.arange(1, n + 1)*2)
@@ -200,8 +198,6 @@ end subroutine transform_resolve_vector_notation_common_loops
 
     # Test promoted routine
     resolved_filepath = tmp_path/(f'{routine.name}_resolved_{frontend}.f90')
-    resolved_function = jit_compile(routine, filepath=resolved_filepath, objname=routine.name)
-
     n = 3
     m = 2
     l = 3
@@ -211,7 +207,8 @@ end subroutine transform_resolve_vector_notation_common_loops
     vector = np.zeros(shape=(n,), order='F', dtype=np.int32)
     vector_2 = np.zeros(shape=(n,), order='F', dtype=np.int32)
     matrix = np.zeros(shape=(n, n), order='F', dtype=np.int32)
-    resolved_function(scalar, vector, vector_2, matrix, n, m, l, kidia, kfdia)
+    jit_compile_and_run(routine, scalar, vector, vector_2, matrix, n, m, l, kidia, kfdia,
+                        filepath=resolved_filepath)
 
     assert scalar == 3
     assert np.all(vector == np.arange(1, n + 1)*2)

--- a/loki/transformations/inline/tests/test_constants.py
+++ b/loki/transformations/inline/tests/test_constants.py
@@ -9,7 +9,7 @@ import pytest
 import numpy as np
 
 from loki import Module, Subroutine
-from loki.jit_build import jit_compile_lib, Builder, Obj, jit_compile, clean_test
+from loki.jit_build import jit_compile_lib, Builder, Obj, jit_compile_and_run, clean_test
 from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
 from loki.expression import symbols as sym, parse_expr
@@ -222,19 +222,19 @@ end subroutine kernel
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
     # test original function
     a, b = np.array(1, dtype=np.int32), np.array(2, dtype=np.int32)
-    function(a=a, b=b)
+    jit_compile_and_run(routine, filepath=filepath, a=a, b=b)
     assert a == 15
 
     inline_constant_parameters(routine=routine, external_only=False)
 
     transf_filepath = tmp_path/(f'{routine.name}_transf_{frontend}.f90')
-    transf_function = jit_compile(routine, filepath=transf_filepath, objname=routine.name)
     # test transformed function
     transf_a, transf_b = np.array(1, dtype=np.int32), np.array(2, dtype=np.int32)
-    transf_function(a=transf_a, b=transf_b)
+    jit_compile_and_run(
+        routine, filepath=transf_filepath, a=transf_a, b=transf_b
+    )
     assert transf_a == 15
 
     # check IR

--- a/loki/transformations/inline/tests/test_procedures.py
+++ b/loki/transformations/inline/tests/test_procedures.py
@@ -9,7 +9,7 @@ import pytest
 import numpy as np
 
 from loki import Module, Subroutine
-from loki.jit_build import jit_compile
+from loki.jit_build import jit_compile_and_run
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI
 from loki.ir import (
@@ -64,11 +64,9 @@ end subroutine member_routines
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
     filepath = tmp_path/(f'ref_transform_inline_member_routines_{frontend}.f90')
-    reference = jit_compile(routine, filepath=filepath, objname='member_routines')
-
     a = np.array([1., 2., 3.], order='F')
     b = np.array([3., 3., 3.], order='F')
-    reference(a, b)
+    jit_compile_and_run(routine, a, b, filepath=filepath)
 
     assert (a == [6., 7., 8.]).all()
     assert (b == [3., 3., 3.]).all()
@@ -83,11 +81,9 @@ end subroutine member_routines
 
     # An verify compiled behaviour
     filepath = tmp_path/(f'transform_inline_member_routines_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='member_routines')
-
     a = np.array([1., 2., 3.], order='F')
     b = np.array([3., 3., 3.], order='F')
-    function(a, b)
+    jit_compile_and_run(routine, a, b, filepath=filepath)
 
     assert (a == [6., 7., 8.]).all()
     assert (b == [3., 3., 3.]).all()
@@ -136,12 +132,10 @@ end subroutine member_functions
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
     filepath = tmp_path/(f'ref_transform_inline_member_functions_{frontend}.f90')
-    reference = jit_compile(routine, filepath=filepath, objname='member_functions')
-
     a = np.array([1., 2., 3.], order='F')
     b = np.array([3., 3., 3.], order='F')
     c = np.array([0., 0., 0.], order='F')
-    reference(a, b, c)
+    jit_compile_and_run(routine, a, b, c, filepath=filepath)
 
     assert (a == [3., 4., 5.]).all()
     assert (b == [3., 3., 3.]).all()
@@ -156,12 +150,10 @@ end subroutine member_functions
 
     # An verify compiled behaviour
     filepath = tmp_path/(f'transform_inline_member_functions_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='member_functions')
-
     a = np.array([1., 2., 3.], order='F')
     b = np.array([3., 3., 3.], order='F')
     c = np.array([0., 0., 0.], order='F')
-    function(a, b, c)
+    jit_compile_and_run(routine, a, b, c, filepath=filepath)
 
     assert (a == [3., 4., 5.]).all()
     assert (b == [3., 3., 3.]).all()

--- a/loki/transformations/tests/test_loop_blocking.py
+++ b/loki/transformations/tests/test_loop_blocking.py
@@ -10,7 +10,7 @@ import pytest
 import numpy as np
 
 from loki import Subroutine
-from loki.jit_build import jit_compile, clean_test
+from loki.jit_build import jit_compile_and_run, clean_test
 from loki.expression import symbols as sym, Array
 from loki.frontend import available_frontends
 from loki.ir import (
@@ -275,12 +275,11 @@ def test_3d_splitting(tmp_path, frontend, block_size, n):
     )
 
     filepath = tmp_path / (f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     a = np.zeros(n, order='F')
     b = np.zeros((2,n), order='F')
     c = np.zeros((2,2,n), order='F')
-    function(a, b, c, n)
+    jit_compile_and_run(routine, a, b, c, n, filepath=filepath)
     a_ref = np.linspace(1, n, n)
     b_ref = np.tile(a_ref, (2, 1))
     c_ref = np.tile(a_ref, (2,2,1))
@@ -415,13 +414,12 @@ end subroutine test_1d_blocking_multi_intent
 
 
     filepath = tmp_path / (f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     a = np.linspace(1, n, n)
     b = np.ones(n, order='F')
     a_ref = np.linspace(1, n, n)
     b_ref = b + a*a
-    function(a, b, n)
+    jit_compile_and_run(routine, a, b, n, filepath=filepath, isolated=False)
     assert np.array_equal(a, a_ref), "a should be equal to a_ref=(1, 2, ..., n)"
     assert np.array_equal(b, b_ref), "b should equal to (2, 5, ..., 1 + n^2)"
     clean_test(filepath)
@@ -474,11 +472,10 @@ def test_2d_blocking(tmp_path, frontend, block_size, n):
                 assert idx not in var.dimensions, "The variable should be blocked and the local variable used"
 
     filepath = tmp_path / (f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     a = np.zeros(n, order='F')
     b = np.zeros((n,n), order='F')
-    function(a, b, n)
+    jit_compile_and_run(routine, a, b, n, filepath=filepath, isolated=False)
     a_ref = np.linspace(1, n, n)
     b_ref = np.tile(a_ref, (n,1))
     assert np.array_equal(a, a_ref), "a should be equal to a_ref=(1, 2, ..., n)"
@@ -534,13 +531,12 @@ def test_3d_blocking(tmp_path, frontend, block_size, n):
                 assert idx not in var.dimensions, "The variable should be blocked and the local variable used"
 
     filepath = tmp_path / (f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
 
     a = np.zeros(n, order='F')
     b = np.zeros((2,n), order='F')
     c = np.zeros((2,2,n), order='F')
-    function(a, b, c, n)
+    jit_compile_and_run(routine, a, b, c, n, filepath=filepath)
     a_ref = np.linspace(1, n, n)
     b_ref = np.tile(a_ref, (2, 1))
     c_ref = np.tile(a_ref, (2,2,1))

--- a/loki/transformations/tests/test_parametrise.py
+++ b/loki/transformations/tests/test_parametrise.py
@@ -13,7 +13,7 @@ import pytest
 import numpy as np
 
 from loki import Scheduler, fgen, Subroutine
-from loki.jit_build import jit_compile
+from loki.jit_build import jit_compile, run_isolated
 from loki.expression import symbols as sym, parse_expr
 from loki.frontend import available_frontends
 from loki.ir import nodes as ir, FindNodes
@@ -56,7 +56,7 @@ def fixture_config():
     }
 
 
-def compile_and_test(scheduler, tmp_path, a=5, b=1):
+def _compile_and_test(scheduler, tmp_path, a, b):
     """
     Compile the source code and call the driver function in order to test the results for correctness.
     """
@@ -83,6 +83,16 @@ def compile_and_test(scheduler, tmp_path, a=5, b=1):
             assert (c == 11).all()
         else:
             assert False, f'Unknown driver name {item.local_name}'
+
+
+def compile_and_test(scheduler, tmp_path, a=5, b=1):
+    """
+    Run JIT compilation and execution in a short-lived subprocess.
+    """
+    try:
+        run_isolated(_compile_and_test, scheduler, tmp_path, a, b)
+    except RuntimeError as exc:
+        pytest.fail(str(exc))
 
 
 def check_arguments_and_parameter(scheduler, subroutine_arguments, call_arguments, parameter_variables):

--- a/loki/transformations/tests/test_parametrise.py
+++ b/loki/transformations/tests/test_parametrise.py
@@ -56,14 +56,10 @@ def fixture_config():
     }
 
 
-def _compile_and_test(scheduler, tmp_path, a, b):
+def _compile_and_test(path_source_map, driver_path_map, tmp_path, a, b):
     """
     Compile the source code and call the driver function in order to test the results for correctness.
     """
-    # Pick out the source files to compile
-    driver_path_map = {item: item.source.path.stem for item in scheduler.items if 'driver' in item.name}
-    path_source_map = {item.source.path.stem: item.source for item in driver_path_map}
-
     # Compile each file only once
     path_module_map = {
         stem: jit_compile(source, filepath=tmp_path/f'{stem}.F90', objname=stem)
@@ -71,26 +67,31 @@ def _compile_and_test(scheduler, tmp_path, a, b):
     }
 
     # Run and validate each driver
-    for item, stem in driver_path_map.items():
+    for driver_name, stem in driver_path_map:
         c = np.zeros((a, b), dtype=np.int32, order='F')
         d = np.zeros((b,), dtype=np.int32, order='F')
-        if item.local_name == 'driver':
+        if driver_name == 'driver':
             path_module_map[stem].driver(a, b, c, d)
             assert (c == 11).all()
             assert (d == 42).all()
-        elif item.local_name == 'another_driver':
+        elif driver_name == 'another_driver':
             path_module_map[stem].another_driver(a, b, c)
             assert (c == 11).all()
         else:
-            assert False, f'Unknown driver name {item.local_name}'
+            assert False, f'Unknown driver name {driver_name}'
 
 
 def compile_and_test(scheduler, tmp_path, a=5, b=1):
     """
     Run JIT compilation and execution in a short-lived subprocess.
     """
+    driver_path_map = [(item.local_name, item.source.path.stem) for item in scheduler.items if 'driver' in item.name]
+    path_source_map = {item.source.path.stem: fgen(item.source) for item in scheduler.items if 'driver' in item.name}
     try:
-        run_isolated(_compile_and_test, scheduler, tmp_path, a, b)
+        run_isolated(
+            _compile_and_test, path_source_map, driver_path_map, tmp_path, a, b,
+            multiprocessing_context='spawn', exit_after_result=True
+        )
     except RuntimeError as exc:
         pytest.fail(str(exc))
 

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -1056,6 +1056,7 @@ end subroutine transform_loop_fission_promote_read_after_write
 def test_transform_loop_fission_promote_multiple_read_after_write(tmp_path, frontend):
     fcode = """
 subroutine transform_loop_fission_promote_mult_r_a_w(a, b, klon, klev, nclv)
+  implicit none
   integer, intent(inout) :: a(klon, klev), b(klon, klev, nclv)
   integer, intent(in) :: klon, klev, nclv
   integer :: jm, jk, jl, zsupsat(klon), zqxn(nclv, klon)
@@ -1085,10 +1086,10 @@ end subroutine transform_loop_fission_promote_mult_r_a_w
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
 
     # Test the reference solution
-    klon, klev, nclv = 32, 100, 5
+    klon, klev, nclv = 16, 37, 5
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev, nclv), order='F', dtype=np.int32)
-    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, nclv=nclv, filepath=filepath, isolated=False)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, nclv=nclv, filepath=filepath)
     assert np.all(a == np.array([[jl] * klev for jl in range(1, klon+1)], order='F'))
     assert np.all(b == np.array([[[jl + jm for jm in range(1, nclv+1)]] * klev
                                 for jl in range(1, klon+1)], order='F'))
@@ -1109,11 +1110,11 @@ end subroutine transform_loop_fission_promote_mult_r_a_w
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
 
     # Test transformation
-    klon, klev, nclv = 32, 100, 5
+    klon, klev, nclv = 16, 37, 5
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev, nclv), order='F', dtype=np.int32)
     jit_compile_and_run(
-        routine, a=a, b=b, klon=klon, klev=klev, nclv=nclv, filepath=fissioned_filepath, isolated=False
+        routine, a=a, b=b, klon=klon, klev=klev, nclv=nclv, filepath=fissioned_filepath
     )
     assert np.all(a == np.array([[jl] * klev for jl in range(1, klon+1)], order='F'))
     assert np.all(b == np.array([[[jl + jm for jm in range(1, nclv+1)]] * klev

--- a/loki/transformations/tests/test_transform_loop.py
+++ b/loki/transformations/tests/test_transform_loop.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 
 from loki import Subroutine
-from loki.jit_build import jit_compile, clean_test
+from loki.jit_build import jit_compile_and_run, clean_test
 from loki.frontend import available_frontends
 from loki.ir import (
     is_loki_pragma, pragmas_attached, FindNodes, Loop, Conditional,
@@ -618,13 +618,12 @@ end subroutine transform_loop_fuse_collapse_range
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     # Test the reference solution
     klon, klev = 32, 100
     a = np.zeros(shape=(klon, klev+1), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon+1, klev), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, filepath=filepath)
     assert np.all(a == np.array([list(range(1, klev+2))] * klon, order='F'))
     assert np.all(b[..., 14:] == np.array([[jl + jk for jk in range(15, klev+1)]
                                            for jl in range(1, klon+2)], order='F'))
@@ -640,13 +639,12 @@ end subroutine transform_loop_fuse_collapse_range
     assert len(FindNodes(Conditional).visit(routine.body)) == 2
 
     fused_filepath = tmp_path/(f'{routine.name}_fused_{frontend}.f90')
-    fused_function = jit_compile(routine, filepath=fused_filepath, objname=routine.name)
 
     # Test transformation
     klon, klev = 32, 100
     a = np.zeros(shape=(klon, klev+1), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon+1, klev), order='F', dtype=np.int32)
-    fused_function(a=a, b=b, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, filepath=fused_filepath)
     assert np.all(a == np.array([list(range(1, klev+2))] * klon, order='F'))
     assert np.all(b[..., 14:] == np.array([[jl + jk for jk in range(15, klev+1)]
                                            for jl in range(1, klon+2)], order='F'))
@@ -827,13 +825,12 @@ end subroutine transform_loop_fission_promote
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     # Test the reference solution
     n = 100
     a = np.zeros(shape=(n,), dtype=np.int32)
     b = np.zeros(shape=(n,), dtype=np.int32)
-    function(a=a, b=b, n=n)
+    jit_compile_and_run(routine, a=a, b=b, n=n, filepath=filepath)
     assert np.all(a == range(1,n+1))
     assert np.all(b == range(n, 0, -1))
 
@@ -849,13 +846,12 @@ end subroutine transform_loop_fission_promote
     assert routine.variable_map['tmp'].shape == ('n',)
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
 
     # Test transformation
     n = 100
     a = np.zeros(shape=(n,), dtype=np.int32)
     b = np.zeros(shape=(n,), dtype=np.int32)
-    fissioned_function(a=a, b=b, n=n)
+    jit_compile_and_run(routine, a=a, b=b, n=n, filepath=fissioned_filepath)
     assert np.all(a == range(1,n+1))
     assert np.all(b == range(n, 0, -1))
 
@@ -1024,12 +1020,11 @@ end subroutine transform_loop_fission_promote_read_after_write
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     # Test the reference solution
     klon, klev = 32, 100
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    function(a=a, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, klon=klon, klev=klev, filepath=filepath)
     assert np.all(a == np.array([[jl + jk for jk in range(1, klev+1)]
                                 for jl in range(1, klon+1)], order='F'))
 
@@ -1045,12 +1040,11 @@ end subroutine transform_loop_fission_promote_read_after_write
     assert routine.variable_map['tmp'].shape == ('klev',)
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
 
     # Test transformation
     klon, klev = 32, 100
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    fissioned_function(a=a, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, klon=klon, klev=klev, filepath=fissioned_filepath)
     assert np.all(a == np.array([[jl + jk for jk in range(1, klev+1)]
                                 for jl in range(1, klon+1)], order='F'))
 
@@ -1089,13 +1083,12 @@ end subroutine transform_loop_fission_promote_mult_r_a_w
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     # Test the reference solution
     klon, klev, nclv = 32, 100, 5
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev, nclv), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev, nclv=nclv)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, nclv=nclv, filepath=filepath, isolated=False)
     assert np.all(a == np.array([[jl] * klev for jl in range(1, klon+1)], order='F'))
     assert np.all(b == np.array([[[jl + jm for jm in range(1, nclv+1)]] * klev
                                 for jl in range(1, klon+1)], order='F'))
@@ -1114,13 +1107,14 @@ end subroutine transform_loop_fission_promote_mult_r_a_w
     assert routine.variable_map['zqxn'].shape == ('nclv', 'klon', 'klev')
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
 
     # Test transformation
     klon, klev, nclv = 32, 100, 5
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev, nclv), order='F', dtype=np.int32)
-    fissioned_function(a=a, b=b, klon=klon, klev=klev, nclv=nclv)
+    jit_compile_and_run(
+        routine, a=a, b=b, klon=klon, klev=klev, nclv=nclv, filepath=fissioned_filepath, isolated=False
+    )
     assert np.all(a == np.array([[jl] * klev for jl in range(1, klon+1)], order='F'))
     assert np.all(b == np.array([[[jl + jm for jm in range(1, nclv+1)]] * klev
                                 for jl in range(1, klon+1)], order='F'))
@@ -1156,13 +1150,12 @@ end subroutine transform_loop_fusion_fission
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     # Test the reference solution
     klon, klev = 32, 100
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, filepath=filepath)
     assert np.all(a == np.array([list(range(1, klev+1))] * klon, order='F'))
     assert np.all(b == np.array([[jl + jk for jk in range(1, klev+1)]
                                 for jl in range(1, klon+1)], order='F'))
@@ -1181,13 +1174,12 @@ end subroutine transform_loop_fusion_fission
     assert routine.variable_map['zsupsat'].shape == ('klon', 'klev')
 
     fissioned_filepath = tmp_path/(f'{routine.name}_fissioned_{frontend}.f90')
-    fissioned_function = jit_compile(routine, filepath=fissioned_filepath, objname=routine.name)
 
     # Test transformation
     klon, klev = 32, 100
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    fissioned_function(a=a, b=b, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, filepath=fissioned_filepath)
     assert np.all(a == np.array([list(range(1, klev+1))] * klon, order='F'))
     assert np.all(b == np.array([[jl + jk for jk in range(1, klev+1)]
                                 for jl in range(1, klon+1)], order='F'))
@@ -1394,11 +1386,10 @@ end subroutine test_transform_loop_unroll_nested_counters
  """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path / f'{routine.name}_{frontend}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
 
     # Test the reference solution
     s = np.array(0)
-    function(s=s)
+    jit_compile_and_run(routine, s=s, filepath=filepath)
     tuples = [a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 11)) if b <= a]
     assert s == sum(tuples)
 
@@ -1409,11 +1400,10 @@ end subroutine test_transform_loop_unroll_nested_counters
            len(FindNodes(Assignment).visit(routine.body)) == len(tuples)
 
     unrolled_filepath = tmp_path / f'{routine.name}_unrolled_{frontend}.f90'
-    unrolled_function = jit_compile(routine, filepath=unrolled_filepath, objname=routine.name)
 
     # Test transformation
     s = np.array(0)
-    unrolled_function(s=s)
+    jit_compile_and_run(routine, s=s, filepath=unrolled_filepath)
     assert s == sum(a + b + 1 for (a, b) in itertools.product(range(1, 11), range(1, 11)) if b <= a)
 
     clean_test(filepath)

--- a/loki/transformations/tests/test_transform_region.py
+++ b/loki/transformations/tests/test_transform_region.py
@@ -9,7 +9,7 @@ import pytest
 import numpy as np
 
 from loki import Subroutine, FindNodes, Loop
-from loki.jit_build import jit_compile
+from loki.jit_build import jit_compile_and_run
 from loki.expression import symbols as sym
 from loki.ir import Assignment
 from loki.frontend import available_frontends
@@ -99,7 +99,6 @@ end subroutine transform_region_hoist_inlined_pragma
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
     klon, klev = 32, 100
     ref_a = np.array([[jl + 1] * klev for jl in range(klon)], order='F')
     ref_b = np.array([[jk + 1 for jk in range(klev)] for _ in range(klon)], order='F')
@@ -107,7 +106,7 @@ end subroutine transform_region_hoist_inlined_pragma
     # Test the reference solution
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, filepath=filepath)
     assert np.all(a == ref_a)
     assert np.all(b == ref_b)
 
@@ -123,13 +122,12 @@ end subroutine transform_region_hoist_inlined_pragma
     assert loop_variables(routine.body) == ['jk', 'jl', 'jk', 'jl', 'jk', 'jl']
 
     hoisted_filepath = tmp_path/(f'{routine.name}_hoisted_{frontend}.f90')
-    hoisted_function = jit_compile(routine, filepath=hoisted_filepath, objname=routine.name)
 
     # Test transformation
     klon, klev = 32, 100
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    hoisted_function(a=a, b=b, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, filepath=hoisted_filepath)
     assert np.all(a == ref_a)
     assert np.all(b == ref_b)
 
@@ -282,7 +280,6 @@ end subroutine transform_region_hoist_promote
 """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'{routine.name}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
     klon, klev = 32, 100
     ref_a = np.array([[jl + 1] * klev for jl in range(klon)], order='F')
     ref_b = np.array([[jk + 1 for jk in range(klev)] for _ in range(klon)], order='F')
@@ -290,7 +287,7 @@ end subroutine transform_region_hoist_promote
     # Test the reference solution
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    function(a=a, b=b, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, filepath=filepath)
     assert np.all(a == ref_a)
     assert np.all(b == ref_b)
 
@@ -312,12 +309,11 @@ end subroutine transform_region_hoist_promote
     assert b_tmp.type.shape[0] == 'klev'
 
     hoisted_filepath = tmp_path/(f'{routine.name}_hoisted_{frontend}.f90')
-    hoisted_function = jit_compile(routine, filepath=hoisted_filepath, objname=routine.name)
 
     # Test transformation
     klon, klev = 32, 100
     a = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
     b = np.zeros(shape=(klon, klev), order='F', dtype=np.int32)
-    hoisted_function(a=a, b=b, klon=klon, klev=klev)
+    jit_compile_and_run(routine, a=a, b=b, klon=klon, klev=klev, filepath=hoisted_filepath)
     assert np.all(a == ref_a)
     assert np.all(b == ref_b)

--- a/loki/transformations/transpile/tests/test_sdfg.py
+++ b/loki/transformations/transpile/tests/test_sdfg.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 from loki import Subroutine
-from loki.jit_build import jit_compile
+from loki.jit_build import jit_compile_and_run
 from loki.frontend import available_frontends
 
 from loki.transformations.transpile import FortranPythonTransformation
@@ -74,14 +74,12 @@ end subroutine routine_copy
 
     # Test the reference solution
     filepath = tmp_path/(f'routine_copy_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='routine_copy')
-
     n = 64
     x_ref = np.array(range(n), dtype=np.float64)
     x = np.zeros(n, dtype=np.float64)
     x[:] = x_ref[:]
     y = np.zeros(n, dtype=np.float64)
-    function(n=n, x=x, y=y)
+    jit_compile_and_run(routine, n=n, x=x, y=y, filepath=filepath)
     assert all(x_ref == y)
 
     # Create and compile the SDFG
@@ -118,13 +116,11 @@ end subroutine routine_axpy_scalar
 
     # Test the reference solution
     filepath = tmp_path/(f'sdfg_routine_axpy_scalar_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='routine_axpy_scalar')
-
     a = np.float64(23)
     x = np.float64(42)
     x_out = np.array([x], dtype=np.float64)
     y = np.float64(5)
-    function(a=a, x=x_out, y=y)
+    jit_compile_and_run(routine, a=a, x=x_out, y=y, filepath=filepath)
     assert x_out == a * x + y
 
     # Create and compile the SDFG
@@ -163,13 +159,13 @@ end subroutine routine_copy_stream
 
     # Test the reference solution
     filepath = tmp_path/(f'sdfg_routine_copy_stream_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='routine_copy_stream')
-
     length = 32
     alpha = np.array([7], dtype=np.int32)
     vector_in = np.array(range(length), order='F', dtype=np.int32)
     vector_out = np.zeros(length, order='F', dtype=np.int32)
-    function(length=length, alpha=alpha, vector_in=vector_in, vector_out=vector_out)
+    jit_compile_and_run(
+        routine, length=length, alpha=alpha, vector_in=vector_in, vector_out=vector_out, filepath=filepath
+    )
     assert np.all(vector_out == np.array(range(length)) + alpha)
 
     # Create and compile the SDFG
@@ -212,8 +208,6 @@ end subroutine routine_fixed_loop
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'sdfg_routine_fixed_loop_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='routine_fixed_loop')
-
     # Test the reference solution
     n, m = 6, 4
     scalar = np.array([2.0], dtype=np.float64)
@@ -222,7 +216,10 @@ end subroutine routine_fixed_loop
     tensor_out = np.zeros(shape=(m, n), order='F')
     ref_vector = vector + np.array(list(range(n)), dtype=np.float64) + 1.
     ref_tensor = np.transpose(tensor)
-    function(scalar=scalar, vector=vector, vector_out=vector, tensor=tensor, tensor_out=tensor_out)
+    jit_compile_and_run(
+        routine, scalar=scalar, vector=vector, vector_out=vector, tensor=tensor, tensor_out=tensor_out,
+        filepath=filepath
+    )
     assert np.all(vector == ref_vector)
     assert np.all(tensor_out == ref_tensor)
 
@@ -266,13 +263,11 @@ end subroutine routine_loop_carried_dependency
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'sdfg_routine_loop_carried_dependency_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='routine_loop_carried_dependency')
-
     # Test the reference solution
     n = 32
     vector = np.zeros(shape=(n,), order='F') + 3.
     ref_vector = np.array(list(itertools.accumulate(vector)))
-    function(vector=vector)
+    jit_compile_and_run(routine, vector=vector, filepath=filepath)
     assert np.all(vector == ref_vector)
 
     # Create and compile the SDFG
@@ -336,8 +331,6 @@ end subroutine routine_moving_average
     """
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'sdfg_routine_moving_average_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='routine_moving_average')
-
     # Create random input data
     n = 32
     data_in = np.array(np.random.rand(n), order='F')
@@ -350,7 +343,7 @@ end subroutine routine_moving_average
 
     # Test the Fortran kernel
     data_out = np.zeros(shape=(n,), order='F')
-    function(length=n, data_in=data_in, data_out=data_out)
+    jit_compile_and_run(routine, length=n, data_in=data_in, data_out=data_out, filepath=filepath)
     assert np.all(data_out[1:-1] == expected[1:-1])
 
     # Create and compile the SDFG

--- a/loki/transformations/transpile/tests/test_transpile.py
+++ b/loki/transformations/transpile/tests/test_transpile.py
@@ -9,7 +9,7 @@ import pytest
 import numpy as np
 
 from loki import Subroutine, Module, cgen, cppgen, cudagen, FindNodes
-from loki.jit_build import jit_compile, jit_compile_lib, clean_test, Builder, Obj
+from loki.jit_build import jit_compile, jit_compile_and_run, jit_compile_lib, clean_test, Builder, Obj
 import loki.expression.symbols as sym
 from loki.frontend import available_frontends
 from loki import ir
@@ -127,13 +127,11 @@ end subroutine simple_loops
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'simple_loops{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='simple_loops')
-
     n, m = 3, 4
     scalar = 2.0
     vector = np.zeros(shape=(n,), order='F') + 3.
     tensor = np.zeros(shape=(n, m), order='F') + 4.
-    function(n, m, scalar, vector, tensor)
+    jit_compile_and_run(routine, n, m, scalar, vector, tensor, filepath=filepath)
 
     assert np.all(vector == 8.)
     assert np.all(tensor == [[11., 21., 31., 41.],
@@ -231,8 +229,7 @@ end subroutine transpile_arguments
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'transpile_arguments{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transpile_arguments')
-    a, b, c = function(n, array, array_io, a_io, b_io, c_io)
+    a, b, c = jit_compile_and_run(routine, n, array, array_io, a_io, b_io, c_io, filepath=filepath)
 
     assert np.all(array == 3.) and array.size == n
     assert np.all(array_io == 6.)
@@ -557,13 +554,11 @@ end subroutine transp_vect
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'transp_vect{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transp_vect')
-
     n, m = 3, 4
     scalar = 2.0
     v1 = np.zeros(shape=(n,), order='F')
     v2 = np.zeros(shape=(n,), order='F')
-    function(n, m, scalar, v1, v2)
+    jit_compile_and_run(routine, n, m, scalar, v1, v2, filepath=filepath)
 
     assert np.all(v1 == 3.)
     assert v2[0] == 1. and np.all(v2[1:] == 4.)
@@ -617,11 +612,11 @@ end subroutine transpile_intrinsics
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'transpile_intrinsics{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transpile_intrinsics')
-
     # Test the reference solution
     v1, v2, v3, v4 = 2., 4., 1., 5.
-    vmin, vmax, vabs, vmin_nested, vmax_nested = function(v1, v2, v3, v4)
+    vmin, vmax, vabs, vmin_nested, vmax_nested = jit_compile_and_run(
+        routine, v1, v2, v3, v4, filepath=filepath
+    )
     assert vmin == 2. and vmax == 4. and vabs == 2.
     assert vmin_nested == 1. and vmax_nested == 5.
 
@@ -678,8 +673,6 @@ end subroutine transp_loop_ind
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/(f'transp_loop_ind{"_c_ptr" if use_c_ptr else ""}_{frontend}.f90')
-    function = jit_compile(routine, filepath=filepath, objname='transp_loop_ind')
-
     # Test the reference solution
     n = 6
     cidx, fidx = 3, 4
@@ -687,7 +680,7 @@ end subroutine transp_loop_ind
     mask2 = np.zeros(shape=(n,), order='F', dtype=np.int32)
     mask3 = np.zeros(shape=(n,), order='F', dtype=np.float64)
 
-    function(n=n, idx=fidx, mask1=mask1, mask2=mask2, mask3=mask3)
+    jit_compile_and_run(routine, n=n, idx=fidx, mask1=mask1, mask2=mask2, mask3=mask3, filepath=filepath)
     assert np.all(mask1[:cidx-1] == 1)
     assert mask1[cidx] == 2
     assert np.all(mask1[cidx+1:] == 0)
@@ -1028,12 +1021,10 @@ end subroutine transpile_expressions
     # Generate reference code, compile run and verify
     routine = Subroutine.from_source(fcode, frontend=frontend)
     filepath = tmp_path/f'{routine.name}{"_c_ptr" if use_c_ptr else ""}_{frontend!s}.f90'
-    function = jit_compile(routine, filepath=filepath, objname=routine.name)
-
     n = 10
     scalar = 2.0
     vector = np.zeros(shape=(n,), order='F')
-    function(n, scalar, vector)
+    jit_compile_and_run(routine, n, scalar, vector, filepath=filepath)
 
     assert np.all(vector == [i * scalar for i in range(1, n+1)])
 


### PR DESCRIPTION
### Description

This PR aims to address a long-standing issue with racy failure in the transformation test base. In particular, `test_parametrise.py` creates multiple variations of the same module procedures with varying signatures and no renaming for the various test variations, leading to a racy situation where the assignment of two subsequent variants in the same thread can cause symbol aliasing and thus trigger mem corruption and sigsevs. To prevent this, simple de-aliasing techniques are not sufficient, as the compiled fortran symbols are still loaded dynamically into the Python runtime within the same process.

To fix this, this PR adds a small `run_isolated` utility that executes a helper method in a short-lived child process, allowing the `compile-and-check` utility in the problematic test to be forced onto a separate process and thus avoid dynamic symbol aliasing.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 