### PR TITLE
DeepcopyDataflowAnalysis: make sure disabled calls do not cause issues

### DIFF
--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -7,6 +7,7 @@
 
 from collections import defaultdict
 from pathlib import Path
+import fnmatch
 
 import re
 try:
@@ -125,18 +126,29 @@ class DeepcopyDataflowAnalysis(DataflowAnalysis):
     the dataflow analysis of the child :any:`Subroutine` and ignoring the intents altogether.
     """
 
-    def __init__(self, successor_map, include_literal_kinds=False):
+    def __init__(self, successor_map, ignore_calls=(), include_literal_kinds=False):
         super().__init__(include_literal_kinds=include_literal_kinds)
         self.successor_map = successor_map
+        self.ignore_calls = tuple(name.lower() for name in ignore_calls)
+
+    def is_ignored_call(self, call):
+        """Return ``True`` if the call matches the configured ignored-call patterns."""
+
+        name = str(call.name).lower()
+        return any(fnmatch.fnmatch(name, pattern) for pattern in self.ignore_calls)
 
     def resolve_call_effects(self, call, *, attacher, **kwargs):
-        if not call.routine:
-            msg = f'[Loki::DataOffloadDeepcopyAnalysis] Cannot apply transformation without enriching calls: {call}.'
-            raise RuntimeError(msg)
 
+        # this already captures disabled/blocked/ignored calls
         child = self.successor_map.get(call, None)
         if not child:
             return None
+
+        if not call.routine:
+            if self.is_ignored_call(call):
+                return None
+            msg = f'[Loki::DataOffloadDeepcopyAnalysis] Cannot apply transformation without enriching calls: {call}.'
+            raise RuntimeError(msg)
 
         # remap root variable names to current scope
         arg_map = get_sanitised_arg_map(call.arg_map)
@@ -195,6 +207,8 @@ class DataOffloadDeepcopyAnalysis(Transformation):
        routine.name_dataoffload_analysis.yaml. For drivers, the files are named
        driver_target-name_offload_analysis.yaml, where "target-name" is the name of the first target
        routine in a given driver loop.
+    ignore_calls : list/tuple
+       Specify a list of routines/calls to be ignored for the analysis (on top of ignored scheduler items).
     """
 
     _key = 'DataOffloadDeepcopyAnalysis'
@@ -207,10 +221,13 @@ class DataOffloadDeepcopyAnalysis(Transformation):
     # therefore be processed.
     process_ignored_items = True
 
-    def __init__(self, output_analysis=False):
+    def __init__(self, output_analysis=False, ignore_calls=None):
         self.output_analysis = output_analysis
+        self.ignore_calls = as_tuple(ignore_calls)
 
     def transform_subroutine(self, routine, **kwargs):
+
+        item = kwargs.get('item')
 
         if not (item := kwargs.pop('item', None)):
             msg = f'[Loki::DataOffloadDeepcopyAnalysis] Cannot apply transformation without item: {routine}.'
@@ -332,7 +349,8 @@ class DataOffloadDeepcopyAnalysis(Transformation):
             warning(f'[Loki::DataOffloadDeepcopyAnalysis] Pointer associations found in {routine_name}')
 
         dataflow_analysis = DeepcopyDataflowAnalysis(
-            successor_map=successor_map, include_literal_kinds=False
+            successor_map=successor_map, ignore_calls=self.ignore_calls,
+            include_literal_kinds=False
         )
         with dfa_attached(scope_node, dfa=dataflow_analysis):
 
@@ -440,7 +458,7 @@ class DataOffloadDeepcopyTransformation(Transformation):
             msg = '[Loki::DataOffloadDeepcopyTransformation] can only be applied by the Scheduler.'
             raise RuntimeError(msg)
 
-        if not item.trafo_data[self._key]:
+        if not item.trafo_data.get(self._key):
             raise RuntimeError(f'[Loki::DataOffloadDeepcopyTransformation] item missing analysis: {item.name}.')
 
         role = kwargs['role']

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -10,20 +10,25 @@ import pytest
 import yaml
 
 from loki.backend import fgen
+from loki.sourcefile import Sourcefile
+from loki.batch.item import Item
 from loki.batch import Scheduler
 from loki.ir import (
     nodes as ir, FindNodes, is_loki_pragma, pragma_regions_attached, get_pragma_parameters,
     pragmas_attached
 )
 from loki.expression import Variable, RangeIndex, IntLiteral
+from loki.expression import symbols as sym
 from loki.frontend import available_frontends
 from loki.logging import log_levels
 from loki.subroutine import Subroutine
 from loki.tools import gettempdir, flatten, as_tuple
 from loki.transformations import (
-        DataOffloadDeepcopyAnalysis, DataOffloadDeepcopyTransformation, find_driver_loops
+        DataOffloadDeepcopyAnalysis, DataOffloadDeepcopyTransformation, RemoveCodeTransformation,
+        find_driver_loops
 )
-from loki.types import BasicType, DerivedType, SymbolAttributes, Scope
+from loki.transformations.data_offload.offload_deepcopy import DeepcopyDataflowAnalysis
+from loki.types import BasicType, DerivedType, SymbolAttributes, Scope, ProcedureType
 
 
 @pytest.fixture(scope='module', name='deepcopy_code')
@@ -354,6 +359,62 @@ def fixture_expected_analysis():
         },
         'ij': 'write'
     }
+
+
+@pytest.fixture(scope='module', name='deepcopy_abort_code')
+def fixture_deepcopy_abort_code():
+    fcode = {
+        'kernel': (
+            """
+module kernel_mod
+contains
+subroutine kernel(flag, a)
+  logical, intent(in) :: flag
+  real, intent(inout) :: a(:)
+
+  if (flag) then
+    !$loki remove
+    a(:) = 0.
+    !$loki end remove
+  endif
+end subroutine kernel
+end module kernel_mod
+            """.strip()
+        ),
+        'driver': (
+            """
+module driver_mod
+contains
+subroutine driver(ngpblks, flag, a)
+  use kernel_mod, only : kernel
+  integer, intent(in) :: ngpblks
+  logical, intent(in) :: flag
+  real, intent(inout) :: a(:,:)
+  integer :: ibl
+
+!$loki data
+!$loki driver-loop
+  do ibl = 1, ngpblks
+    call kernel(flag, a(:, ibl))
+  enddo
+!$loki end data
+
+end subroutine driver
+end module driver_mod
+            """.strip()
+        )
+    }
+
+    workdir = gettempdir()/'test_offload_deepcopy_abort'
+    if workdir.exists():
+        rmtree(workdir)
+    workdir.mkdir()
+    for name, code in fcode.items():
+        (workdir/f'{name}.F90').write_text(code)
+
+    yield workdir
+
+    rmtree(workdir)
 
 
 @pytest.fixture(scope='function', name='config')
@@ -954,3 +1015,108 @@ def test_offload_deepcopy_simple_driver(frontend, config, deepcopy_code, tmp_pat
     # filter out target calls, as we only need to check generated boilerplate
     calls = [call for call in calls if not call.name.name.lower() in driver_item.targets]
     check_other_variable_type('offload', conds, calls, pragmas, driver)
+
+
+def test_deepcopy_dataflow_analysis_ignore_calls_skips_unenriched_call():
+    scope = Scope()
+    _name = 'ABOR1_ACC'
+    _type = SymbolAttributes(dtype=ProcedureType(_name))
+    name = sym.ProcedureSymbol(name=_name, type=_type, scope=scope)
+    call = ir.CallStatement(name=name, arguments=())
+
+    analysis = DeepcopyDataflowAnalysis(
+        successor_map={call: object()},
+        ignore_calls=('ABOR1*',)
+    )
+
+    assert analysis.resolve_call_effects(call, attacher=None) is None
+
+
+def test_deepcopy_dataflow_analysis_unenriched_call_raises():
+    scope = Scope()
+    _name = 'ABOR1_ACC'
+    _type = SymbolAttributes(dtype=ProcedureType(_name))
+    name = sym.ProcedureSymbol(name=_name, type=_type, scope=scope)
+    call = ir.CallStatement(name=name, arguments=())
+
+    analysis = DeepcopyDataflowAnalysis(successor_map={call: object()})
+
+    with pytest.raises(
+        RuntimeError,
+        match=r'\[Loki::DataOffloadDeepcopyAnalysis\] Cannot apply transformation without enriching calls:'
+    ):
+        analysis.resolve_call_effects(call, attacher=None)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_offload_deepcopy_analysis_transform_subroutine_without_item_raises(frontend):
+    routine = Subroutine.from_source('subroutine test_routine()\nend subroutine test_routine', frontend=frontend)
+
+    transformation = DataOffloadDeepcopyAnalysis()
+
+    with pytest.raises(
+        RuntimeError,
+        match=r'\[Loki::DataOffloadDeepcopyAnalysis\] Cannot apply transformation without item:'
+    ):
+        transformation.transform_subroutine(routine, role='driver', targets=(), sub_sgraph=None)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_offload_deepcopy_transformation_transform_subroutine_without_item_raises(frontend):
+    routine = Subroutine.from_source('subroutine test_routine()\nend subroutine test_routine', frontend=frontend)
+
+    transformation = DataOffloadDeepcopyTransformation(mode='offload')
+
+    with pytest.raises(
+        RuntimeError,
+        match=r'\[Loki::DataOffloadDeepcopyTransformation\] can only be applied by the Scheduler\.'
+    ):
+        transformation.transform_subroutine(routine, role='driver', targets=())
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_offload_deepcopy_transformation_transform_subroutine_without_analysis_raises(frontend):
+    source = Sourcefile.from_source('subroutine test_routine()\nend subroutine test_routine', frontend=frontend)
+    item = Item(name='#test_routine', source=source)
+    routine = item.ir
+
+    transformation = DataOffloadDeepcopyTransformation(mode='offload')
+
+    with pytest.raises(
+        RuntimeError,
+        match=r'\[Loki::DataOffloadDeepcopyTransformation\] item missing analysis: #test_routine\.'
+    ):
+        transformation.transform_subroutine(routine, item=item, role='driver', targets=())
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_offload_deepcopy_analysis_skips_unresolved_replacement_calls_without_successors(
+        frontend, config, deepcopy_abort_code, tmp_path
+):
+    """Ensure unresolved replacement calls without successors do not break deepcopy analysis."""
+
+    config['routines'] = {
+        'driver': {'role': 'driver'},
+    }
+
+    scheduler = Scheduler(
+        paths=deepcopy_abort_code, config=config, frontend=frontend, xmods=[tmp_path],
+        output_dir=tmp_path, preprocess=True
+    )
+
+    scheduler.process(transformation=RemoveCodeTransformation(
+        remove_marked_regions=True,
+        replacement_call='ABOR1_ACC',
+        replacement_msg='Reached removed GPU-unsupported-path in {}'
+    ))
+
+    kernel = scheduler['kernel_mod#kernel'].ir
+    kernel_calls = FindNodes(ir.CallStatement).visit(kernel.body)
+    assert any(call.name.name.lower() == 'abor1_acc' for call in kernel_calls)
+
+    transformation = DataOffloadDeepcopyAnalysis()
+    scheduler.process(transformation=transformation)
+
+    driver_item = scheduler['driver_mod#driver']
+    analysis = driver_item.trafo_data[transformation._key]['analysis']
+    assert analysis


### PR DESCRIPTION
### Description

This pull request adds support for disabling certain calls from being processed during the data offload deepcopy analysis, based on configurable pattern matching. The main changes introduce a mechanism to skip analysis for calls (such as error handler replacements) that match user-specified patterns, and include a new test to validate this behavior.

### Dataflow Analysis Configuration

* The `DeepcopyDataflowAnalysis` class now accepts a `disabled_calls` argument, allowing users to specify call name patterns (using wildcards) that should be ignored during analysis. The logic for checking if a call is disabled is encapsulated in the new `is_disabled_call` method, which uses `fnmatch` for pattern matching.

* The `DataOffloadDeepcopyAnalysis` transformation class is updated to extract disabled call patterns from the transformation item configuration and pass them to the dataflow analysis. [[1]](diffhunk://#diff-b63370d9c121347cd187f4b5c6784cc46d6ba8532f2942e1e2cba811289d75d3R224-R230) [[2]](diffhunk://#diff-b63370d9c121347cd187f4b5c6784cc46d6ba8532f2942e1e2cba811289d75d3L335-R352)

### Test Enhancements

* A new test fixture, `deepcopy_abort_code`, is added to provide source code and setup for testing the disabled call functionality.

* A new test, `test_offload_deepcopy_analysis_ignores_unresolved_abor1_replacement`, is added to verify that calls matching the disabled pattern (e.g., `ABOR1*`) are ignored by the analysis, ensuring that replacement error handler calls are not processed.

### Dependency and Import Updates

* The `fnmatch` module is imported to support pattern-based matching of call names.
* The test imports are updated to include `RemoveCodeTransformation`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 