### PR TITLE
Scheduler handling of seed routines

### DIFF
--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -160,6 +160,27 @@ class Scheduler:
     # TODO: Should be user-definable!
     source_suffixes = ['.f90', '.F90', '.f', '.F']
 
+    @staticmethod
+    def _get_implicit_seeds(config):
+        """
+        Derive implicit seed routines from the scheduler config.
+
+        By default, only driver routines and routines explicitly marked with
+        ``seed_routine = true`` become graph roots.
+        """
+        implicit_seeds = tuple(
+            name.lower() for name in config.routines
+            if config.create_item_config(name).get('role') == 'driver'
+            or config.create_item_config(name).get('seed_routine', False)
+        )
+        if not implicit_seeds:
+            raise RuntimeError(
+                'No seed routines provided and no implicit seeds found in the scheduler config. '
+                'Set `seed_routines`, mark routines with `role = "driver"`, or set '
+                '`seed_routine = true`.'
+            )
+        return implicit_seeds
+
     def __init__(self, paths, config=None, seed_routines=None, preprocess=False,
                  includes=None, defines=None, definitions=None, xmods=None,
                  omni_includes=None, full_parse=True, frontend=FP, output_dir=None):
@@ -175,10 +196,8 @@ class Scheduler:
 
         # Build-related arguments to pass to the sources
         self.paths = [Path(p) for p in as_tuple(paths)]
-        self.seeds = tuple(
-            seed.lower()
-            for seed in as_tuple(seed_routines) or self.config.routines.keys()
-        )
+        self.seeds = tuple(seed.lower() for seed in as_tuple(seed_routines)) if seed_routines else \
+            self._get_implicit_seeds(self.config)
 
         # Accumulate all build arguments to pass to `Sourcefile` constructors
         self.build_args = {

--- a/loki/batch/scheduler.py
+++ b/loki/batch/scheduler.py
@@ -174,11 +174,13 @@ class Scheduler:
             or config.create_item_config(name).get('seed_routine', False)
         )
         if not implicit_seeds:
-            raise RuntimeError(
-                'No seed routines provided and no implicit seeds found in the scheduler config. '
-                'Set `seed_routines`, mark routines with `role = "driver"`, or set '
-                '`seed_routine = true`.'
-            )
+            implicit_seeds = tuple(seed.lower() for seed in config.routines.keys())
+            warning("[Loki]: "
+                "Using implicit or unspecified seed routines is deprecated and will be removed in a future release. "
+                "Currently, no seed routines were provided and none were discovered in the scheduler config. "
+                "Please update your configuration by setting `seed_routines`, "
+                "marking routines with `role = \"driver\"`, "
+                "or setting `seed_routine = true`.")
         return implicit_seeds
 
     def __init__(self, paths, config=None, seed_routines=None, preprocess=False,
@@ -196,8 +198,12 @@ class Scheduler:
 
         # Build-related arguments to pass to the sources
         self.paths = [Path(p) for p in as_tuple(paths)]
-        self.seeds = tuple(seed.lower() for seed in as_tuple(seed_routines)) if seed_routines else \
-            self._get_implicit_seeds(self.config)
+        if seed_routines:
+            info('Initializing Scheduler graph from list of seed routines provided in the config')
+            self.seeds = tuple(seed.lower() for seed in as_tuple(seed_routines))
+        else:
+            info('Initializing Scheduler graph from driver routines')
+            self.seeds = self._get_implicit_seeds(self.config)
 
         # Accumulate all build arguments to pass to `Sourcefile` constructors
         self.build_args = {

--- a/loki/batch/sgraph.py
+++ b/loki/batch/sgraph.py
@@ -210,9 +210,13 @@ class SGraph:
         if new_items:
             self.add_nodes(new_items)
 
-        # propagate 'lib' attribute (the compile unit the item belongs to)
+        # Propagate the parent lib unless the child has an explicit routine-level
+        # library override in the scheduler config.
         for new_item in new_items:
-            new_item.config['lib'] = item.config.get('lib', None)
+            keys = config.match_item_keys(new_item.name, config.routines)
+            has_explicit_lib = any('lib' in config.routines[key] for key in keys)
+            if not has_explicit_lib:
+                new_item.config['lib'] = item.config.get('lib', None)
 
         # Careful not to include cycles (from recursive TypeDefs)
         self.add_edges((item, item_) for item_ in dependencies if not item == item_)

--- a/loki/batch/tests/test_scheduler_config.py
+++ b/loki/batch/tests/test_scheduler_config.py
@@ -824,7 +824,6 @@ def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_sch
             'subroutine_3_loki_m1_mod#subroutine_3_loki_m1',
             'nested_subroutine_1_loki_m1_mod#nested_subroutine_1_loki_m1',
             'nested_subroutine_3_loki_m1_mod#nested_subroutine_3_loki_m1',
-            'nested_subroutine_3_mod#nested_subroutine_3',
         },
         'm2': {
             'driver_2_mod#driver_2',
@@ -890,7 +889,7 @@ def test_scheduler_multi_modes(testdir, tmp_path, multi_modes_config, reinit_sch
         'driver_0_mod.m1', 'driver_1_mod.m1', 'driver_2_mod.m2', 'driver_3_mod.m3',
         'driver_4_mod.m3', 'nested_subroutine_1_loki_m1_mod.m1',
         'nested_subroutine_1_loki_m3_mod.m3', 'nested_subroutine_2_loki_m2_mod.m2',
-        'nested_subroutine_3_mod.m1', 'nested_subroutine_3_loki_m1_mod.m1',
+        'nested_subroutine_3_loki_m1_mod.m1',
         'nested_subroutine_3_loki_m2_mod.m2', 'nested_subroutine_3_loki_m3_mod.m3',
         'subroutine_1_loki_m1_mod.m1', 'subroutine_2_loki_m2_mod.m2',
         'subroutine_3_loki_m1_mod.m1', 'subroutine_3_loki_m3_mod.m3'
@@ -1059,3 +1058,320 @@ end module test_multi_modes_kernel2
             item_imports = item_ir.imports
             imported_modules = {imp.module for imp in item_imports}
             assert imported_modules == imports
+
+
+def _write_shared_kernel_multi_mode_sources(src_dir):
+    """
+    Create a minimal multi-mode graph with two drivers sharing one kernel that
+    calls a downstream leaf.
+    """
+    fcode_driver_small = """
+subroutine driver_small
+    use shared_kernel_mod, only: shared_kernel
+    implicit none
+    call shared_kernel
+end subroutine driver_small
+    """.strip()
+
+    fcode_driver_stack = """
+subroutine driver_stack
+    use shared_kernel_mod, only: shared_kernel
+    implicit none
+    call shared_kernel
+end subroutine driver_stack
+    """.strip()
+
+    fcode_shared_kernel = """
+module shared_kernel_mod
+implicit none
+contains
+subroutine shared_kernel
+    use leaf_mod, only: leaf
+    call leaf
+end subroutine shared_kernel
+end module shared_kernel_mod
+    """.strip()
+
+    fcode_leaf = """
+module leaf_mod
+implicit none
+contains
+subroutine leaf
+end subroutine leaf
+end module leaf_mod
+    """.strip()
+
+    (src_dir/'driver_small.F90').write_text(fcode_driver_small)
+    (src_dir/'driver_stack.F90').write_text(fcode_driver_stack)
+    (src_dir/'shared_kernel_mod.F90').write_text(fcode_shared_kernel)
+    (src_dir/'leaf_mod.F90').write_text(fcode_leaf)
+
+
+def _shared_kernel_multi_mode_config():
+    return SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm_small', 'replicate': True},
+        'routines': {
+            'driver_small': {'role': 'driver', 'mode': 'm_small', 'replicate': False},
+            'driver_stack': {'role': 'driver', 'mode': 'm_stack', 'replicate': False},
+        },
+        'transformations': {
+            'IdemSmall': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'IdemStack': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+        },
+        'pipelines': {
+            'm_small': {'transformations': {'IdemSmall'}},
+            'm_stack': {'transformations': {'IdemStack'}},
+        },
+    })
+
+
+def _shared_kernel_multi_mode_override_config():
+    return SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm_small', 'replicate': True},
+        'routines': {
+            'driver_small': {'role': 'driver', 'mode': 'm_small', 'replicate': False},
+            'driver_stack': {'role': 'driver', 'mode': 'm_stack', 'replicate': False},
+            'shared_kernel': {'role': 'kernel'},
+            'leaf': {'role': 'kernel'},
+        },
+        'transformations': {
+            'IdemSmall': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'IdemStack': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+        },
+        'pipelines': {
+            'm_small': {'transformations': {'IdemSmall'}},
+            'm_stack': {'transformations': {'IdemStack'}},
+        },
+    })
+
+
+def _shared_kernel_multi_mode_seed_override_config():
+    return SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False, 'mode': 'm_small', 'replicate': True},
+        'routines': {
+            'driver_small': {'role': 'driver', 'mode': 'm_small', 'replicate': False},
+            'driver_stack': {'role': 'driver', 'mode': 'm_stack', 'replicate': False},
+            'shared_kernel': {'role': 'kernel', 'seed_routine': True},
+            'leaf': {'role': 'kernel', 'seed_routine': True},
+        },
+        'transformations': {
+            'IdemSmall': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+            'IdemStack': {'classname': 'IdemTransformation', 'module': 'loki.transformations'},
+        },
+        'pipelines': {
+            'm_small': {'transformations': {'IdemSmall'}},
+            'm_stack': {'transformations': {'IdemStack'}},
+        },
+    })
+
+
+def test_scheduler_multi_modes_shared_kernel_plan_variants(tmp_path):
+    """
+    Document current multi-mode planning behaviour for a shared kernel.
+
+    Without explicit per-routine config entries, the original shared kernel is
+    replaced entirely by renamed per-mode variants.
+    """
+    scheduler_config = _shared_kernel_multi_mode_config()
+
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    out_dir = tmp_path/'output'
+    out_dir.mkdir()
+
+    scheduler = Scheduler(paths=src_dir, config=scheduler_config, xmods=[tmp_path], output_dir=out_dir)
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.process(scheduler_config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.process(FileWriteTransformation(), proc_strategy=ProcessingStrategy.PLAN)
+
+    plan_trafo = CMakePlanTransformation(rootpath=src_dir)
+    scheduler.process(transformation=plan_trafo, proc_strategy=ProcessingStrategy.PLAN)
+    planfile = tmp_path/'planfile'
+    plan_trafo.write_plan(planfile)
+
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+    plan_dict = {k: v.split() for k, v in plan_pattern.findall(planfile.read_text())}
+    append_stems = [Path(s).stem for s in plan_dict['LOKI_SOURCES_TO_APPEND']]
+
+    assert len(plan_dict['LOKI_SOURCES_TO_APPEND']) == len(set(plan_dict['LOKI_SOURCES_TO_APPEND']))
+
+    assert 'shared_kernel_mod.m_small' not in append_stems
+    assert append_stems.count('shared_kernel_loki_m_small_mod.m_small') == 1
+    assert append_stems.count('shared_kernel_loki_m_stack_mod.m_stack') == 1
+
+    assert 'leaf_mod.m_small' not in append_stems
+    assert append_stems.count('leaf_loki_m_small_mod.m_small') == 1
+    assert append_stems.count('leaf_loki_m_stack_mod.m_stack') == 1
+
+
+def test_scheduler_multi_modes_shared_kernel_plan_variants_with_routine_override(tmp_path):
+    """
+    Explicit per-routine config entries change the current behaviour: the
+    original shared kernel remains and same-mode clones are emitted in addition.
+    """
+    scheduler_config = _shared_kernel_multi_mode_override_config()
+
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    out_dir = tmp_path/'output'
+    out_dir.mkdir()
+
+    scheduler = Scheduler(
+        paths=src_dir, config=scheduler_config,
+        seed_routines=['driver_small', 'driver_stack', 'shared_kernel', 'leaf'],
+        xmods=[tmp_path], output_dir=out_dir
+    )
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.process(scheduler_config.pipelines, proc_strategy=ProcessingStrategy.PLAN)
+    scheduler.process(FileWriteTransformation(), proc_strategy=ProcessingStrategy.PLAN)
+
+    plan_trafo = CMakePlanTransformation(rootpath=src_dir)
+    scheduler.process(transformation=plan_trafo, proc_strategy=ProcessingStrategy.PLAN)
+    planfile = tmp_path/'planfile'
+    plan_trafo.write_plan(planfile)
+
+    plan_pattern = re.compile(r'set\(\s*(\w+)\s*(.*?)\s*\)', re.DOTALL)
+    plan_dict = {k: v.split() for k, v in plan_pattern.findall(planfile.read_text())}
+    append_stems = [Path(s).stem for s in plan_dict['LOKI_SOURCES_TO_APPEND']]
+
+    assert len(plan_dict['LOKI_SOURCES_TO_APPEND']) == len(set(plan_dict['LOKI_SOURCES_TO_APPEND']))
+
+    # This matches the semantic duplication pattern seen in the real-world case.
+    assert append_stems.count('shared_kernel_mod.m_small') == 1
+    assert append_stems.count('shared_kernel_loki_m_small_mod.m_small') == 1
+    assert append_stems.count('shared_kernel_loki_m_stack_mod.m_stack') == 1
+
+    assert append_stems.count('leaf_mod.m_small') == 1
+    assert append_stems.count('leaf_loki_m_small_mod.m_small') == 1
+    assert append_stems.count('leaf_loki_m_stack_mod.m_stack') == 1
+
+
+def test_scheduler_multi_modes_shared_kernel_call_import_rewrite_consistency(tmp_path):
+    """
+    Document how call and import rewrites currently behave for shared kernels.
+
+    Both drivers are rewired to mode-specific clones, while the original shared
+    kernel and leaf remain in the scheduler with their original call/import chain.
+    """
+    scheduler_config = _shared_kernel_multi_mode_override_config()
+
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    out_dir = tmp_path/'output'
+    out_dir.mkdir()
+
+    scheduler = Scheduler(
+        paths=src_dir, config=scheduler_config,
+        seed_routines=['driver_small', 'driver_stack', 'shared_kernel', 'leaf'],
+        xmods=[tmp_path], output_dir=out_dir
+    )
+    scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.DEFAULT)
+    scheduler.process(scheduler_config.pipelines, proc_strategy=ProcessingStrategy.DEFAULT)
+
+    expected_items = {
+        '#driver_small',
+        '#driver_stack',
+        'shared_kernel_mod#shared_kernel',
+        'shared_kernel_loki_m_small_mod#shared_kernel_loki_m_small',
+        'shared_kernel_loki_m_stack_mod#shared_kernel_loki_m_stack',
+        'leaf_mod#leaf',
+        'leaf_loki_m_small_mod#leaf_loki_m_small',
+        'leaf_loki_m_stack_mod#leaf_loki_m_stack',
+    }
+    assert expected_items <= {item.name for item in scheduler.items}
+
+    def calls_for(item_name):
+        routine = scheduler[item_name].ir
+        return tuple(str(call.name).lower() for call in FindNodes(ir.CallStatement).visit(routine.body))
+
+    def imports_for(item_name):
+        routine = scheduler[item_name].ir
+        return {imp.module.lower() for imp in routine.imports}
+
+    assert calls_for('#driver_small') == ('shared_kernel_loki_m_small',)
+    assert imports_for('#driver_small') == {'shared_kernel_loki_m_small_mod'}
+
+    assert calls_for('#driver_stack') == ('shared_kernel_loki_m_stack',)
+    assert imports_for('#driver_stack') == {'shared_kernel_loki_m_stack_mod'}
+
+    assert calls_for('shared_kernel_loki_m_small_mod#shared_kernel_loki_m_small') == ('leaf_loki_m_small',)
+    assert imports_for('shared_kernel_loki_m_small_mod#shared_kernel_loki_m_small') == {'leaf_loki_m_small_mod'}
+
+    assert calls_for('shared_kernel_loki_m_stack_mod#shared_kernel_loki_m_stack') == ('leaf_loki_m_stack',)
+    assert imports_for('shared_kernel_loki_m_stack_mod#shared_kernel_loki_m_stack') == {'leaf_loki_m_stack_mod'}
+
+    # The original shared kernel remains active with the original import/call chain.
+    assert calls_for('shared_kernel_mod#shared_kernel') == ('leaf',)
+    assert imports_for('shared_kernel_mod#shared_kernel') == {'leaf_mod'}
+
+
+def test_scheduler_multi_modes_explicit_routine_entries_do_not_become_seeds(tmp_path):
+    """
+    Explicit routine config entries alone do not become scheduler seeds when
+    seed_routines is not provided.
+    """
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    no_override_scheduler = Scheduler(
+        paths=src_dir, config=_shared_kernel_multi_mode_config(),
+        xmods=[tmp_path], output_dir=tmp_path/'out-no-override'
+    )
+    override_scheduler = Scheduler(
+        paths=src_dir, config=_shared_kernel_multi_mode_override_config(), xmods=[tmp_path],
+        output_dir=tmp_path/'out-override'
+    )
+
+    assert no_override_scheduler.seeds == ('driver_small', 'driver_stack')
+    assert override_scheduler.seeds == ('driver_small', 'driver_stack')
+
+    no_override_scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.DEFAULT)
+    override_scheduler.propagate_and_separate_modes(proc_strategy=ProcessingStrategy.DEFAULT)
+
+    assert 'shared_kernel_mod#shared_kernel' not in {item.name for item in no_override_scheduler.items}
+    assert 'shared_kernel_mod#shared_kernel' not in {item.name for item in override_scheduler.items}
+
+
+def test_scheduler_implicit_seeds_include_seed_routine_entries(tmp_path):
+    """
+    Non-driver routines explicitly marked with ``seed_routine = true`` are added
+    to the implicit seed set alongside driver routines.
+    """
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    scheduler = Scheduler(
+        paths=src_dir, config=_shared_kernel_multi_mode_seed_override_config(),
+        xmods=[tmp_path], output_dir=tmp_path/'output'
+    )
+
+    assert scheduler.seeds == ('driver_small', 'driver_stack', 'shared_kernel', 'leaf')
+
+
+def test_scheduler_requires_implicit_seed_or_explicit_seed_routines(tmp_path):
+    """
+    When no explicit seeds are provided, the scheduler requires at least one
+    implicit seed via a driver role or ``seed_routine = true``.
+    """
+    src_dir = tmp_path/'sources'
+    src_dir.mkdir()
+    _write_shared_kernel_multi_mode_sources(src_dir)
+
+    config = SchedulerConfig.from_dict({
+        'default': {'role': 'kernel', 'expand': True, 'strict': False},
+        'routines': {
+            'shared_kernel': {'role': 'kernel'},
+            'leaf': {'role': 'kernel'},
+        },
+    })
+
+    with pytest.raises(RuntimeError, match='No seed routines provided and no implicit seeds found'):
+        Scheduler(paths=src_dir, config=config, xmods=[tmp_path], output_dir=tmp_path/'output')

--- a/loki/batch/tests/test_scheduler_config.py
+++ b/loki/batch/tests/test_scheduler_config.py
@@ -13,6 +13,7 @@ from subprocess import CalledProcessError
 
 import pytest
 
+from loki.logging import WARNING
 from loki import Array, Dimension, FindNodes, Literal, Sourcefile
 from loki.batch import Pipeline, ProcessingStrategy, Scheduler, SchedulerConfig, Transformation
 from loki.frontend import HAVE_FP, HAVE_OMNI, OMNI, available_frontends
@@ -1356,7 +1357,7 @@ def test_scheduler_implicit_seeds_include_seed_routine_entries(tmp_path):
     assert scheduler.seeds == ('driver_small', 'driver_stack', 'shared_kernel', 'leaf')
 
 
-def test_scheduler_requires_implicit_seed_or_explicit_seed_routines(tmp_path):
+def test_scheduler_requires_implicit_seed_or_explicit_seed_routines(tmp_path, caplog):
     """
     When no explicit seeds are provided, the scheduler requires at least one
     implicit seed via a driver role or ``seed_routine = true``.
@@ -1373,5 +1374,12 @@ def test_scheduler_requires_implicit_seed_or_explicit_seed_routines(tmp_path):
         },
     })
 
-    with pytest.raises(RuntimeError, match='No seed routines provided and no implicit seeds found'):
-        Scheduler(paths=src_dir, config=config, xmods=[tmp_path], output_dir=tmp_path/'output')
+    caplog.set_level(WARNING)
+
+    # Once deprecated:
+    # with pytest.raises(RuntimeError, match='No seed routines provided and no implicit seeds found'):
+    scheduler = Scheduler(paths=src_dir, config=config, xmods=[tmp_path], output_dir=tmp_path/'output')
+    # however, rn for backwards compability only expect warning and old behaviour
+    assert set(scheduler.seeds) == {'shared_kernel', 'leaf'}
+    assert len(caplog.records) == 1
+    assert "Using implicit or unspecified seed routines is deprecated and will" in caplog.records[0].message

--- a/loki/batch/tests/test_scheduler_processing.py
+++ b/loki/batch/tests/test_scheduler_processing.py
@@ -232,6 +232,7 @@ def test_scheduler_dependencies_ignore(tmp_path, testdir, preprocess, frontend):
 
     schedulerB = Scheduler(
         paths=projB, includes=projB/'include', config=configB,
+        seed_routines=['ext_driver'],
         frontend=frontend, preprocess=preprocess, xmods=[tmp_path]
     )
 
@@ -288,10 +289,10 @@ def test_scheduler_dependencies_ignore(tmp_path, testdir, preprocess, frontend):
         # Apply dependency injection transformation and ensure only the root driver is not transformed
         schedulerA.process(transformation)
 
-    assert schedulerA.items[0].source.all_subroutines[0].name == 'driverB'
-    assert schedulerA.items[1].source.all_subroutines[0].name == 'kernelB_test'
-    assert schedulerA.items[4].source.all_subroutines[0].name == 'compute_l1_test'
-    assert schedulerA.items[5].source.all_subroutines[0].name == 'compute_l2_test'
+    assert schedulerA['driverb_mod#driverb'].source.all_subroutines[0].name == 'driverB'
+    assert schedulerA['kernelb_test_mod#kernelb_test'].source.all_subroutines[0].name == 'kernelB_test'
+    assert schedulerA['compute_l1_test_mod#compute_l1_test'].source.all_subroutines[0].name == 'compute_l1_test'
+    assert schedulerA['compute_l2_test_mod#compute_l2_test'].source.all_subroutines[0].name == 'compute_l2_test'
 
     # Note that 'ext_driver' and 'ext_kernel' are no longer part of the dependency graph because the
     # renaming makes it impossible to discover the non-transformed routines

--- a/loki/lint/tests/test_linter.py
+++ b/loki/lint/tests/test_linter.py
@@ -512,7 +512,7 @@ def test_linter_lint_files_scheduler(testdir, rules, routines, files):
             'expand': True,
             'strict': True,
         },
-        'routines': {'other_routine': {}}
+        'routines': {'other_routine': {'seed_routine': True}}
     }},
     {'include': ['linter_lint_files_fix.F90']}
 ])
@@ -584,7 +584,7 @@ end subroutine OTHER_ROUTINE
             'expand': True,
             'strict': True
         },
-        'routines': {'other_routine': {}}
+        'routines': {'other_routine': {'seed_routine': True}}
     }},
     {'include': ['*.F90']}
 ])

--- a/loki/transformations/build_system/tests/test_file_write.py
+++ b/loki/transformations/build_system/tests/test_file_write.py
@@ -269,7 +269,9 @@ end subroutine d
         },
         'routines': {
             'b_mod': {'replicate': False},
-            'not_c': {'replicate': False},
+            # either keep this seed routine or remove the have_non_replicate_conflict in
+            # the caplog assertion below
+            'not_c': {'replicate': False, 'seed_routine': True},
             'd': {'role': 'driver', 'replicate': False},
         }
     })

--- a/loki/transformations/inline/tests/test_inline_transformation.py
+++ b/loki/transformations/inline/tests/test_inline_transformation.py
@@ -487,6 +487,7 @@ end module innermost_mod
 
     scheduler = Scheduler(
         paths=[tmp_path], config=SchedulerConfig.from_dict(config),
+        seed_routines=['outermost'],
         frontend=frontend, xmods=[tmp_path]
     )
 

--- a/loki/transformations/temporaries/tests/test_pool_allocator.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator.py
@@ -1193,7 +1193,9 @@ def test_pool_allocator_more_call_checks(tmp_path, frontend, block_dim, caplog, 
         }
     }
     scheduler = Scheduler(
-        paths=[tmp_path], config=SchedulerConfig.from_dict(config), frontend=frontend, xmods=[tmp_path]
+        paths=[tmp_path], config=SchedulerConfig.from_dict(config),
+        seed_routines=['kernel'],
+        frontend=frontend, xmods=[tmp_path]
     )
 
     transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim, horizontal=horizontal,

--- a/loki/transformations/tests/test_dependency.py
+++ b/loki/transformations/tests/test_dependency.py
@@ -657,9 +657,11 @@ def test_dependency_duplicate_subgraph(tmp_path, frontend, suffix, module_suffix
 
     transformed_items = {name.split('#')[0] if name.split('#')[0] else name[1:]
                          for name in expected_items if not name.endswith(f'{suffix}')}
+    transformed_items -= {'compute_3_mod'}
     assert plan_dict['LOKI_SOURCES_TO_TRANSFORM'] == transformed_items
     assert plan_dict['LOKI_SOURCES_TO_REMOVE'] == transformed_items
     appended_items = {name.split('#')[0] if name.split('#')[0] else name[1:] for name in expected_items}
+    appended_items -= {'compute_3_mod'}
     appended_items = {f'{name}.idem' for name in appended_items}
     assert plan_dict['LOKI_SOURCES_TO_APPEND'] == appended_items
 


### PR DESCRIPTION
### Description

This pull request introduces several improvements to the scheduler's handling of seed routines and multi-mode planning, alongside updates to tests to reflect the new logic. The main changes ensure that implicit seeds are correctly inferred from the configuration, requiring at least one driver or routine marked with `seed_routine = true`, and that explicit routine entries alone do not become seeds unless marked or provided. Test cases and assertions have been updated to document and verify the new behaviors, especially for multi-mode and shared kernel scenarios.

### Scheduler seed routine logic and multi-mode planning

* Added `_get_implicit_seeds` static method to `Scheduler` to derive seed routines from the config, defaulting to routines with `role = 'driver'` or `seed_routine = true`, and raising an error if none are found. (`loki/batch/scheduler.py`)
* Updated `Scheduler.__init__` to use the new implicit seed logic when `seed_routines` is not provided. (`loki/batch/scheduler.py`)
* Added comprehensive tests for multi-mode planning and shared kernel behavior, including new helper functions and test cases to document and verify routine selection, plan file generation, and call/import rewrites. (`loki/batch/tests/test_scheduler_config.py`)
* Ensured that explicit routine entries in the config do not become seeds unless marked with `seed_routine = true` or specified in `seed_routines`. (`loki/batch/tests/test_scheduler_config.py`)

### Attribute propagation and dependency handling

* Improved propagation of the `lib` attribute in the scheduler's dependency graph, so child routines only inherit the parent's library unless they have an explicit override. (`loki/batch/sgraph.py`)

### Test updates and consistency

* Updated and added tests to use the new seed routine logic, ensuring correct routine selection and plan consistency in various transformation, linting, and build scenarios. This includes passing `seed_routines` explicitly where needed and marking routines with `seed_routine = true` in test configs. [[1]](diffhunk://#diff-9d0b832c88c1e413fedcd6ae7b80d7134f622d381993bdea06dd3d8439768889R490) [[2]](diffhunk://#diff-a999af48b93ac47f0c05921f255e19c790f6e7fd1a22a9927a6addf758d93400L1195-R1197) [[3]](diffhunk://#diff-812f3ad989b8ca17c314162292fd78847e34e5dd810d41603882339d66a3de76R235) [[4]](diffhunk://#diff-99686d8aa1d59b5b7109fde85cfcf15dd5b4ee9255215d4748d91a88669da7b1L515-R515) [[5]](diffhunk://#diff-99686d8aa1d59b5b7109fde85cfcf15dd5b4ee9255215d4748d91a88669da7b1L587-R587) [[6]](diffhunk://#diff-769ca0b4b448441e2ba4c099b7492416d4c72ae238880f19aacdc8488bfc376fL272-R274)

### Minor test and assertion corrections

* Adjusted test assertions to access scheduler items by name rather than index, and made minor corrections to expected results in plan file and dependency tests. [[1]](diffhunk://#diff-812f3ad989b8ca17c314162292fd78847e34e5dd810d41603882339d66a3de76L291-R295) [[2]](diffhunk://#diff-21642120a43170785a63e36d1a42cf8972aec83febda51ce8105536fd9b0e978R660-R664) [[3]](diffhunk://#diff-9ab4f0e7b1dd8ae49f97393292b89e4e4c70e19938dbdada4d4a36690fa9ba18L827) [[4]](diffhunk://#diff-9ab4f0e7b1dd8ae49f97393292b89e4e4c70e19938dbdada4d4a36690fa9ba18L893-R892)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 