### PR TITLE
Add optional error codes to `StopStmt`

### DIFF
--- a/loki/frontend/fparser.py
+++ b/loki/frontend/fparser.py
@@ -3502,7 +3502,7 @@ class FParser2IR(GenericVisitor):
         return ir.ExitStmt(o.items[1], **kwargs)
 
     def visit_Stop_Stmt(self, o, **kwargs):
-        return ir.StopStmt(**kwargs)
+        return ir.StopStmt(o.items[1], **kwargs)
 
     def visit_Print_Stmt(self, o, **kwargs):
         children = [self.visit(c, **kwargs) for c in o.children]

--- a/loki/frontend/omni.py
+++ b/loki/frontend/omni.py
@@ -1480,7 +1480,7 @@ class OMNI2IR(GenericVisitor):
         return ir.GotoStmt(text=label, source=kwargs['source'])
 
     def visit_FstopStatement(self, o, **kwargs):
-        return ir.StopStmt(**kwargs)
+        return ir.StopStmt(o.attrib.get('code'), **kwargs)
 
     def visit_statementLabel(self, o, **kwargs):
         return ir.Comment('__STATEMENT_LABEL__', label=o.attrib['label_name'], source=kwargs['source'])

--- a/loki/ir/nodes/stmt_nodes.py
+++ b/loki/ir/nodes/stmt_nodes.py
@@ -293,21 +293,24 @@ class StopStmt(GenericStmt):
 
     Parameters
     ----------
+    text : str, optional
+        The optional error code (integer or character) returned on stopping.
     **kwargs : optional
         Other parameters that are passed on to the parent class constructor.
     """
 
     keyword = 'STOP'
 
-    text: Optional[None] = None
+    text: Optional[Union[Expression, str]] = ''
 
-    def __post_init__(self):
-        super().__post_init__()
-        if not self.text is None:
-            raise ValidationError('[Loki] StopStmt takes no constructor arguments')
+    @field_validator('text', mode='before')
+    @classmethod
+    def ensure_literal(cls, value):
+        from loki.expression import symbols as sym  # pylint: disable=import-outside-toplevel
+        return sym.Literal(value) if value else ''
 
     def __repr__(self):
-        return 'Stop::'
+        return f'Stop::{self.text if self.text else ""}'
 
 
 @dataclass_strict(frozen=True)

--- a/loki/ir/nodes/tests/test_nodes.py
+++ b/loki/ir/nodes/tests/test_nodes.py
@@ -558,8 +558,8 @@ def test_stmt_nodes(n, i):
         ir.ContinueStmt(n)
 
     assert fgen(ir.StopStmt()) == 'STOP'
-    with pytest.raises(ValidationError):
-        ir.StopStmt(n)
+    assert fgen(ir.StopStmt(1)) == 'STOP 1'
+    assert fgen(ir.StopStmt("'all done'")) == "STOP 'all done'"
 
     assert fgen(ir.ExitStmt()) == 'EXIT'
     assert fgen(ir.ExitStmt(1)) == 'EXIT 1'

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -633,7 +633,7 @@ class RemoveCallsTransformer(Transformer):
     def visit_GenericStmt(self, o, **kwargs):
         """ Match and remove :any:`GenericStmt` nodes against name patterns """
         if self.intrinsic_names:
-            if any(str(c).lower() in o.text.lower() for c in self.intrinsic_names):
+            if any(str(c).lower() in str(o.text).lower() for c in self.intrinsic_names):
                 return None
 
         rebuilt = tuple(self.visit(i, **kwargs) for i in o.children)

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -8,7 +8,7 @@
 import shutil
 import pytest
 
-from loki import Subroutine, Module, Sourcefile, gettempdir
+from loki import Subroutine, Module, Sourcefile, gettempdir, fgen
 from loki.batch import Scheduler, SchedulerConfig
 from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes, FindInlineCalls
@@ -577,6 +577,9 @@ subroutine never_gonna_give(dave)
 
     if (lhook) call dr_hook('never_gonna_give',1,zhook_handle)
 
+    stop
+    stop 1
+
 end subroutine
     """
 
@@ -606,10 +609,17 @@ end subroutine
     conditionals = FindNodes(ir.Conditional).visit(routine.body)
     assert len(conditionals) == (4 if frontend == OMNI else 0)
 
-    # Check that all intrinsic calls to WRITE have been removed
+    # Check that all intrinsic calls to WRITE have been removed, while
+    # the PRINT and STOP statements survive (StopStmt is a GenericStmt)
     intrinsics = FindNodes(ir.GenericStmt).visit(routine.body)
-    assert len(intrinsics) == 1
+    assert len(intrinsics) == 3
     assert 'never gonna let you down' in intrinsics[0].text
+
+    # Ensure STOP statements survive, both with and without an error code
+    stops = FindNodes(ir.StopStmt).visit(routine.body)
+    assert len(stops) == 2
+    assert fgen(stops[0]) == 'STOP'
+    assert fgen(stops[1]) == 'STOP 1'
 
     # Check that the repsective imports have also been stripped
     imports = FindNodes(ir.Import).visit(routine.spec)


### PR DESCRIPTION
A small PR that adds optional error codes to stop statements, and a matching small fix to the `RemoveCodeTransformation` to stringify them as necessary.
 