### PR TITLE
Optionally remove OpenMP loops in deepcopy trafo

### DIFF
--- a/loki/transformations/data_offload/offload.py
+++ b/loki/transformations/data_offload/offload.py
@@ -13,7 +13,33 @@ from loki.ir import (
 )
 from loki.logging import warning, error
 from loki.tools import as_tuple
-__all__ = ['DataOffloadTransformation']
+__all__ = ['do_remove_openmp_pragmas', 'DataOffloadTransformation']
+
+
+def do_remove_openmp_pragmas(routine, regions):
+    """
+    Remove existing OpenMP pragmas from the given pragma regions.
+
+    Parameters
+    ----------
+    routine : `Subroutine`
+        Subroutine whose body will be updated.
+    regions : `PragmaRegion` or tuple of `PragmaRegion`
+        Region(s) from which OpenMP pragmas should be removed.
+    """
+    pragma_map = {}
+    for loki_region in as_tuple(regions):
+        for pragma in FindNodes(Pragma).visit(loki_region.body):
+            if pragma.keyword.lower() == 'omp':
+                pragma_map[pragma] = None
+        for omp_region in FindNodes(PragmaRegion).visit(loki_region):
+            if omp_region.pragma.keyword.lower() == 'omp':
+                pragma_map[omp_region.pragma] = None
+                if omp_region.pragma_post:
+                    pragma_map[omp_region.pragma_post] = None
+
+    if pragma_map:
+        routine.body = Transformer(pragma_map).visit(routine.body)
 
 
 class DataOffloadTransformation(Transformation):
@@ -200,19 +226,11 @@ class DataOffloadTransformation(Transformation):
             List of subroutines that are to be considered as part of
             the transformation call tree.
         """
-        pragma_map = {}
+        active_regions = []
         with pragma_regions_attached(routine):
             for region in FindNodes(PragmaRegion).visit(routine.body):
                 # Only work on active `!$loki data` regions
-                if not self._is_active_loki_data_region(region, targets):
-                    continue
+                if self._is_active_loki_data_region(region, targets):
+                    active_regions.append(region)
 
-                for p in FindNodes(Pragma).visit(routine.body):
-                    if p.keyword.lower() == 'omp':
-                        pragma_map[p] = None
-                for r in FindNodes(PragmaRegion).visit(region):
-                    if r.pragma.keyword.lower() == 'omp':
-                        pragma_map[r.pragma] = None
-                        pragma_map[r.pragma_post] = None
-
-        routine.body = Transformer(pragma_map).visit(routine.body)
+        do_remove_openmp_pragmas(routine, active_regions)

--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -34,6 +34,7 @@ from loki.transformations.field_api import (
         FieldAPIAccessorType
 )
 from loki.transformations.utilities import find_driver_loops, get_integer_variable
+from loki.transformations.data_offload.offload import do_remove_openmp_pragmas
 
 __all__ = ['DataOffloadDeepcopyAnalysis', 'DataOffloadDeepcopyTransformation']
 
@@ -449,8 +450,9 @@ class DataOffloadDeepcopyTransformation(Transformation):
     _key = 'DataOffloadDeepcopyAnalysis'
     field_array_match_pattern = re.compile('^field_[0-9][a-z][a-z]_array')
 
-    def __init__(self, mode):
+    def __init__(self, mode, remove_openmp=False):
         self.mode = mode
+        self.remove_openmp = remove_openmp
 
     def transform_subroutine(self, routine, **kwargs):
 
@@ -465,6 +467,17 @@ class DataOffloadDeepcopyTransformation(Transformation):
         targets = kwargs['targets']
 
         if role == 'driver':
+            if self.remove_openmp:
+                data_regions = []
+                with pragma_regions_attached(routine):
+                    for region in FindNodes(ir.PragmaRegion).visit(routine.body):
+                        if not is_loki_pragma(region.pragma, starts_with='data'):
+                            continue
+                        with pragmas_attached(routine, ir.Loop):
+                            driver_loops = find_driver_loops(region.body, targets)
+                        if driver_loops:
+                            data_regions.append(region)
+                do_remove_openmp_pragmas(routine, data_regions)
             self.process_driver(routine, item.trafo_data[self._key]['analysis'],
                                 item.trafo_data[self._key]['typedef_configs'], targets)
 

--- a/loki/transformations/data_offload/tests/test_offload.py
+++ b/loki/transformations/data_offload/tests/test_offload.py
@@ -15,7 +15,9 @@ from loki.ir import (
     pragma_regions_attached, get_pragma_parameters
 )
 
-from loki.transformations import DataOffloadTransformation, PragmaModelTransformation
+from loki.transformations import (
+    DataOffloadTransformation, PragmaModelTransformation, do_remove_openmp_pragmas
+)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -189,6 +191,57 @@ def test_data_offload_region_complex_remove_openmp(frontend):
     assert 'copyin( a )' in transformed
     assert 'copy( b, c )' in transformed
     assert '!$omp' not in transformed
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_do_remove_openmp_pragmas_driver_loop_region(frontend):
+    """
+    Test removing OpenMP pragmas from an explicitly selected ``!$loki data``
+    region with a pragma-marked driver loop but no target kernel call.
+    """
+
+    fcode_driver = """
+  SUBROUTINE driver_routine(ngptot, nproma, arr)
+    INTEGER, INTENT(IN) :: ngptot, nproma
+    REAL, INTENT(INOUT) :: arr(ngptot)
+    INTEGER :: jkglo, ibl
+
+    !$loki data
+    !$omp parallel do private(ibl)
+    !$loki driver-loop
+    do jkglo=1, ngptot, nproma
+      ibl = (jkglo - 1)/nproma + 1
+      arr(jkglo) = real(ibl)
+    end do
+    !$omp end parallel do
+    !$loki end data
+  END SUBROUTINE driver_routine
+"""
+    driver = Sourcefile.from_source(fcode_driver, frontend=frontend)['driver_routine']
+
+    with pragma_regions_attached(driver):
+        data_regions = [
+            region for region in FindNodes(PragmaRegion).visit(driver.body)
+            if region.pragma.keyword.lower() == 'loki' and 'data' in region.pragma.content.lower()
+        ]
+        assert len(data_regions) == 1
+
+    do_remove_openmp_pragmas(driver, data_regions)
+
+    pragmas = FindNodes(Pragma).visit(driver.body)
+    assert not any(p.keyword.lower() == 'omp' for p in pragmas)
+    assert any(p.keyword.lower() == 'loki' and 'driver-loop' in p.content.lower() for p in pragmas)
+
+    with pragma_regions_attached(driver):
+        regions = FindNodes(PragmaRegion).visit(driver.body)
+        assert len(regions) == 1
+        loops = FindNodes(Loop).visit(regions[0])
+        assert len(loops) == 1
+        assert loops[0].variable == 'jkglo'
+
+    transformed = driver.to_fortran().lower()
+    assert '!$omp' not in transformed
+    assert '!$loki data' in transformed
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -1017,6 +1017,49 @@ def test_offload_deepcopy_simple_driver(frontend, config, deepcopy_code, tmp_pat
     check_other_variable_type('offload', conds, calls, pragmas, driver)
 
 
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('remove_openmp', [False, True])
+def test_offload_deepcopy_transformation_remove_openmp_guard(frontend, remove_openmp):
+    """Test that deepcopy OpenMP removal is guarded by the constructor option."""
+
+    fcode_driver = """
+  SUBROUTINE driver_routine(ngptot, nproma, arr)
+    INTEGER, INTENT(IN) :: ngptot, nproma
+    REAL, INTENT(INOUT) :: arr(ngptot)
+    INTEGER :: jkglo, ibl
+
+    !$loki data
+    !$omp parallel do private(ibl)
+    !$loki driver-loop
+    do jkglo=1, ngptot, nproma
+      ibl = (jkglo - 1)/nproma + 1
+      arr(jkglo) = real(ibl)
+    end do
+    !$omp end parallel do
+    !$loki end data
+  END SUBROUTINE driver_routine
+"""
+    source = Sourcefile.from_source(fcode_driver, frontend=frontend)
+    item = Item(name='#driver_routine', source=source)
+    driver = item.ir
+
+    class NoOpDeepcopyTransformation(DataOffloadDeepcopyTransformation):
+        """Skip deepcopy generation to test only the OpenMP cleanup gate."""
+
+        def process_driver(self, routine, analyses, typedef_configs, targets):  # pylint: disable=unused-argument
+            pass
+
+    transformation = NoOpDeepcopyTransformation(mode='offload', remove_openmp=remove_openmp)
+    item.trafo_data[transformation._key] = {'analysis': {}, 'typedef_configs': {}}
+
+    transformation.transform_subroutine(driver, item=item, role='driver', targets=())
+
+    omp_pragmas = [
+        pragma for pragma in FindNodes(ir.Pragma).visit(driver.body) if pragma.keyword.lower() == 'omp'
+    ]
+    assert bool(omp_pragmas) is not remove_openmp
+
+
 def test_deepcopy_dataflow_analysis_ignore_calls_skips_unenriched_call():
     scope = Scope()
     _name = 'ABOR1_ACC'


### PR DESCRIPTION
This PR enables the optional removal of OpenMP directives in the deepcopy trafo.
 