### PR TITLE
Also apply `RemoveCode` to driver loop bodies

### DIFF
--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -11,17 +11,22 @@ section and to perform Dead Code Elimination.
 """
 
 import operator as op
+from fnmatch import fnmatchcase
 from itertools import chain
 
 from loki.analyse import dataflow_analysis_attached
 from loki.batch import Transformation
 from loki.expression import simplify, symbols as sym, symbolic_op
-from loki.ir import nodes as ir, Transformer, FindNodes, FindVariables, FindInlineCalls, SubstituteExpressions
+from loki.ir import (
+    nodes as ir, Transformer, FindNodes, FindVariables, FindInlineCalls,
+    SubstituteExpressions, pragmas_attached
+)
 from loki.ir.pragma_utils import (
     is_loki_pragma, pragma_regions_attached, get_pragma_parameters
 )
 from loki.program_unit import ProgramUnit
 from loki.tools import flatten, as_tuple, OrderedSet
+from loki.transformations.utilities import find_driver_loops
 __all__ = [
     'RemoveCodeTransformation',
     'do_remove_dead_code', 'RemoveDeadCodeTransformer',
@@ -67,8 +72,8 @@ class RemoveCodeTransformation(Transformation):
         Use :any:`simplify` when branch pruning in during
         :meth:`remove_dead_code`.
     call_names : list of str
-        List of subroutine names against which to match
-        :any:`CallStatement` nodes during :meth:`remove_calls`.
+        List of subroutine names or glob-style name patterns against which
+        to match :any:`CallStatement` nodes during :meth:`remove_calls`.
     intrinsic_names : list of str
         List of module names against which to match :any:`GenericStmt`
         nodes during :meth:`remove_calls`.
@@ -77,7 +82,8 @@ class RemoveCodeTransformation(Transformation):
         objects during :meth:`remove_calls`; default: ``True``
     kernel_only : boolean
         Only apply the configured removal to subroutines marked as
-        "kernel"; default: ``False``
+        "kernel" and to driver-loop bodies in routines marked as
+        "driver"; default: ``False``
     remove_unused_args : boolean
         Remove unused dummy arguments from routines.
     remove_unused_vars : boolean
@@ -123,12 +129,25 @@ class RemoveCodeTransformation(Transformation):
 
     def transform_subroutine(self, routine, **kwargs):
 
-        if kwargs.get('role') == 'kernel' or not self.kernel_only:
+        role = kwargs.get('role')
+
+        if role == 'driver' and self.kernel_only:
+            # Apply named node removal to driver loops, while preserving the
+            # non-transformed setup/teardown parts of driver routines.
+            if self.call_names:
+                with pragmas_attached(routine, ir.Loop):
+                    driver_loops = find_driver_loops(section=routine.body, targets=kwargs.get('targets', ()))
+                    for loop in driver_loops:
+                        do_remove_calls(
+                            body=loop, call_names=self.call_names, remove_imports=False
+                        )
+
+        if role == 'kernel' or not self.kernel_only:
             # Apply named node removal to strip specific calls
             if self.call_names or self.intrinsic_names:
                 do_remove_calls(
-                    routine, call_names=self.call_names,
-                    intrinsic_names=self.intrinsic_names,
+                    body=routine.body, spec=routine.spec,
+                    call_names=self.call_names, intrinsic_names=self.intrinsic_names,
                     remove_imports=self.remove_imports
                 )
 
@@ -540,19 +559,26 @@ class RemoveRegionTransformer(Transformer):
 
 
 def do_remove_calls(
-        routine, call_names=None, intrinsic_names=None, remove_imports=True
+        body, spec=None, call_names=None, intrinsic_names=None,
+        remove_imports=True
 ):
     """
     Utility routine to remove all :any:`CallStatement` nodes
-    to specific named subroutines in a :any:`Subroutine`.
+    matching specific named subroutines or glob-style name patterns in a
+    given IR body.
 
     For more information, see :any:`RemoveCallsTransformer`.
 
     Parameters
     ----------
+    body : :any:`Node` or tuple of :any:`Node`
+        Body section to transform in-place.
+    spec : :any:`Node` or tuple of :any:`Node`, optional
+        Spec section to transform in-place when ``remove_imports`` is
+        enabled.
     call_names : list of str
-        List of subroutine names against which to match
-        :any:`CallStatement` nodes.
+        List of subroutine names or glob-style name patterns against which
+        to match :any:`CallStatement` nodes.
     intrinsic_names : list of str
         List of module names against which to match :any:`GenericStmt`
         nodes.
@@ -563,16 +589,18 @@ def do_remove_calls(
 
     transformer = RemoveCallsTransformer(
         call_names=call_names, intrinsic_names=intrinsic_names,
-        remove_imports=remove_imports
+        remove_imports=remove_imports, inplace=True
     )
-    routine.spec = transformer.visit(routine.spec)
-    routine.body = transformer.visit(routine.body)
+    if remove_imports and spec:
+        transformer.visit(spec)
+    if body:
+        transformer.visit(body)
 
 
 class RemoveCallsTransformer(Transformer):
     """
     A :any:`Transformer` that removes all :any:`CallStatement` nodes
-    to specific named subroutines.
+    matching specific named subroutines or glob-style name patterns.
 
     This :any:`Transformer` will by default also remove the enclosing
     inline-conditional when encountering calls of the form ```if
@@ -590,8 +618,8 @@ class RemoveCallsTransformer(Transformer):
     Parameters
     ----------
     call_names : list of str
-        List of subroutine names against which to match
-        :any:`CallStatement` nodes.
+        List of subroutine names or glob-style name patterns against which
+        to match :any:`CallStatement` nodes.
     intrinsic_names : list of str
         List of module names against which to match :any:`GenericStmt`
         nodes.
@@ -606,13 +634,18 @@ class RemoveCallsTransformer(Transformer):
     ):
         super().__init__(**kwargs)
 
-        self.call_names = as_tuple(call_names)
+        self.call_names = tuple(str(name).lower() for name in as_tuple(call_names))
         self.intrinsic_names = as_tuple(intrinsic_names)
         self.remove_imports = remove_imports
 
+    def matches_call_name(self, name):
+        """Return ``True`` if ``name`` matches any configured call name pattern."""
+        name = str(name).lower()
+        return any(fnmatchcase(name, pattern) for pattern in self.call_names)
+
     def visit_CallStatement(self, o, **kwargs):
         """ Match and remove :any:`CallStatement` nodes against name patterns """
-        if o.name in self.call_names:
+        if self.matches_call_name(o.name):
             return None
 
         rebuilt = tuple(self.visit(i, **kwargs) for i in o.children)
@@ -642,9 +675,9 @@ class RemoveCallsTransformer(Transformer):
     def visit_Import(self, o, **kwargs):
         """ Remove the symbol of any named calls from Import nodes """
 
-        symbols_found = any(s in self.call_names for s in o.symbols)
+        symbols_found = any(self.matches_call_name(s) for s in o.symbols)
         if self.remove_imports and symbols_found:
-            new_symbols = tuple(s for s in o.symbols if s not in self.call_names)
+            new_symbols = tuple(s for s in o.symbols if not self.matches_call_name(s))
             return o.clone(symbols=new_symbols) if new_symbols else None
 
         rebuilt = tuple(self.visit(i, **kwargs) for i in o.children)

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -128,6 +128,26 @@ class RemoveCodeTransformation(Transformation):
         self.remove_unused_vars = remove_unused_vars
         self.remove_only_arrays = remove_only_arrays
 
+    def _apply_to_ir(self, internal_node, scope, spec=None, remove_imports=False):
+        """
+        Internal utility to apply code removal transformations.
+        """
+
+        if self.call_names or self.intrinsic_names:
+            do_remove_calls(
+                body=internal_node, spec=spec,
+                call_names=self.call_names, intrinsic_names=self.intrinsic_names,
+                remove_imports=remove_imports
+            )
+        if self.remove_marked_regions:
+            do_remove_marked_regions(
+                body=internal_node, scope=scope,
+                mark_with_comment=self.mark_with_comment,
+                replacement_call=self.replacement_call,
+                replacement_msg=self.replacement_msg,
+                replacement_module=self.replacement_module
+            )
+
     def transform_subroutine(self, routine, **kwargs):
 
         role = kwargs.get('role')
@@ -139,37 +159,12 @@ class RemoveCodeTransformation(Transformation):
                 with pragmas_attached(routine, ir.Loop):
                     driver_loops = find_driver_loops(section=routine.body, targets=kwargs.get('targets', ()))
                     for loop in driver_loops:
-                        if self.call_names:
-                            do_remove_calls(
-                                body=loop, call_names=self.call_names, remove_imports=False
-                            )
-                        if self.remove_marked_regions:
-                            do_remove_marked_regions(
-                                body=loop, scope=routine,
-                                mark_with_comment=self.mark_with_comment,
-                                replacement_call=self.replacement_call,
-                                replacement_msg=self.replacement_msg,
-                                replacement_module=self.replacement_module
-                            )
+                        self._apply_to_ir(loop, scope=routine, remove_imports=False)
 
         if role == 'kernel' or not self.kernel_only:
             # Apply named node removal to strip specific calls
-            if self.call_names or self.intrinsic_names:
-                do_remove_calls(
-                    body=routine.body, spec=routine.spec,
-                    call_names=self.call_names, intrinsic_names=self.intrinsic_names,
-                    remove_imports=self.remove_imports
-                )
-
-            # Apply marked region removal
-            if self.remove_marked_regions:
-                do_remove_marked_regions(
-                    body=routine.body, scope=routine,
-                    mark_with_comment=self.mark_with_comment,
-                    replacement_call=self.replacement_call,
-                    replacement_msg=self.replacement_msg,
-                    replacement_module=self.replacement_module
-                )
+            self._apply_to_ir(routine.body, scope=routine, spec=routine.spec,
+                              remove_imports=self.remove_imports)
 
             # Apply Dead Code Elimination
             if self.remove_dead_code:

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -22,7 +22,8 @@ from loki.ir import (
     SubstituteExpressions, pragmas_attached
 )
 from loki.ir.pragma_utils import (
-    is_loki_pragma, pragma_regions_attached, get_pragma_parameters
+    is_loki_pragma, attach_pragma_regions, detach_pragma_regions,
+    get_pragma_parameters
 )
 from loki.program_unit import ProgramUnit
 from loki.tools import flatten, as_tuple, OrderedSet
@@ -132,15 +133,24 @@ class RemoveCodeTransformation(Transformation):
         role = kwargs.get('role')
 
         if role == 'driver' and self.kernel_only:
-            # Apply named node removal to driver loops, while preserving the
+            # Apply code removal to driver loops, while preserving the
             # non-transformed setup/teardown parts of driver routines.
-            if self.call_names:
+            if self.call_names or self.remove_marked_regions:
                 with pragmas_attached(routine, ir.Loop):
                     driver_loops = find_driver_loops(section=routine.body, targets=kwargs.get('targets', ()))
                     for loop in driver_loops:
-                        do_remove_calls(
-                            body=loop, call_names=self.call_names, remove_imports=False
-                        )
+                        if self.call_names:
+                            do_remove_calls(
+                                body=loop, call_names=self.call_names, remove_imports=False
+                            )
+                        if self.remove_marked_regions:
+                            do_remove_marked_regions(
+                                body=loop, scope=routine,
+                                mark_with_comment=self.mark_with_comment,
+                                replacement_call=self.replacement_call,
+                                replacement_msg=self.replacement_msg,
+                                replacement_module=self.replacement_module
+                            )
 
         if role == 'kernel' or not self.kernel_only:
             # Apply named node removal to strip specific calls
@@ -154,7 +164,8 @@ class RemoveCodeTransformation(Transformation):
             # Apply marked region removal
             if self.remove_marked_regions:
                 do_remove_marked_regions(
-                    routine, mark_with_comment=self.mark_with_comment,
+                    body=routine.body, scope=routine,
+                    mark_with_comment=self.mark_with_comment,
                     replacement_call=self.replacement_call,
                     replacement_msg=self.replacement_msg,
                     replacement_module=self.replacement_module
@@ -428,12 +439,12 @@ class RemoveDeadCodeTransformer(Transformer):
 
 
 def do_remove_marked_regions(
-        routine, mark_with_comment=True, replacement_call=None,
+        body, scope=None, mark_with_comment=True, replacement_call=None,
         replacement_msg=None, replacement_module=None
 ):
     """
     Utility routine to remove code regions marked with
-    ``!$loki remove`` pragmas from a subroutine's body.
+    ``!$loki remove`` pragmas from a given IR body.
 
     Optionally, any removed region might be marked with a
     comment and/or a simple single-argument "abort" call. For this,
@@ -445,8 +456,11 @@ def do_remove_marked_regions(
 
     Parameters
     ----------
-    routine : :any:`Subroutine`
-        The subroutine to which to apply dead code elimination.
+    body : :any:`Node`
+        The IR node whose body should be searched for marked regions.
+    scope : :any:`Subroutine`, optional
+        The surrounding subroutine scope to use for replacement calls and
+        optional replacement imports.
     mark_with_comment : boolean
         Flag to trigger the insertion of a marker comment when
         removing a region; default: ``True``.
@@ -467,22 +481,26 @@ def do_remove_marked_regions(
         mark_with_comment=mark_with_comment,
         replacement_call=replacement_call,
         replacement_msg=replacement_msg,
+        inplace=True
     )
 
-    with pragma_regions_attached(routine, keyword='loki'):
-        routine.body = transformer.visit(routine.body, scope=routine)
+    attach_pragma_regions(body, keyword='loki')
+    try:
+        transformer.visit(body, scope=scope)
+    finally:
+        detach_pragma_regions(body)
 
-    if transformer.replacement_done and replacement_module:
+    if scope and transformer.replacement_done and replacement_module:
         # Get newly inject procedure symbol for the replacement call
-        callsym = sym.ProcedureSymbol(replacement_call, scope=routine)
+        callsym = sym.ProcedureSymbol(replacement_call, scope=scope)
 
         # Inject import of replacement module if it does not exist
-        import_map = {i.module: i for i in routine.imports}
+        import_map = {i.module: i for i in scope.imports}
         if imprt := import_map.get(replacement_module):
             if not any(s == replacement_call for s in imprt.symbols):
                 imprt._update(symbols=imprt.symbols + (callsym,))
         else:
-            routine.spec.prepend(ir.Import(
+            scope.spec.prepend(ir.Import(
                 module=f'{replacement_module}', symbols=(callsym,), c_import=False)
             )
 
@@ -537,7 +555,7 @@ class RemoveRegionTransformer(Transformer):
             if self.mark_with_comment:
                 replacement.append(ir.Comment(text='! [Loki] Removed content of pragma-marked region!'))
 
-            if self.replacement_call and not bypass:
+            if self.replacement_call and not bypass and kwargs.get('scope'):
                 # Get the outer scope, to avoid picking associates
                 routine = kwargs['scope']
                 while not isinstance(routine, ProgramUnit):

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -135,13 +135,13 @@ class RemoveCodeTransformation(Transformation):
 
         if self.call_names or self.intrinsic_names:
             do_remove_calls(
-                body=internal_node, spec=spec,
+                internal_node=internal_node, spec=spec,
                 call_names=self.call_names, intrinsic_names=self.intrinsic_names,
                 remove_imports=remove_imports
             )
         if self.remove_marked_regions:
             do_remove_marked_regions(
-                body=internal_node, scope=scope,
+                internal_node=internal_node, scope=scope,
                 mark_with_comment=self.mark_with_comment,
                 replacement_call=self.replacement_call,
                 replacement_msg=self.replacement_msg,
@@ -434,12 +434,12 @@ class RemoveDeadCodeTransformer(Transformer):
 
 
 def do_remove_marked_regions(
-        body, scope=None, mark_with_comment=True, replacement_call=None,
+        internal_node, scope=None, mark_with_comment=True, replacement_call=None,
         replacement_msg=None, replacement_module=None
 ):
     """
     Utility routine to remove code regions marked with
-    ``!$loki remove`` pragmas from a given IR body.
+    ``!$loki remove`` pragmas from a given :any:`InternalNode`.
 
     Optionally, any removed region might be marked with a
     comment and/or a simple single-argument "abort" call. For this,
@@ -451,7 +451,7 @@ def do_remove_marked_regions(
 
     Parameters
     ----------
-    body : :any:`Node`
+    internal_node : :any:`InternalNode`
         The IR node whose body should be searched for marked regions.
     scope : :any:`Subroutine`, optional
         The surrounding subroutine scope to use for replacement calls and
@@ -479,11 +479,11 @@ def do_remove_marked_regions(
         inplace=True
     )
 
-    attach_pragma_regions(body, keyword='loki')
+    attach_pragma_regions(internal_node, keyword='loki')
     try:
-        transformer.visit(body, scope=scope)
+        transformer.visit(internal_node, scope=scope)
     finally:
-        detach_pragma_regions(body)
+        detach_pragma_regions(internal_node)
 
     if scope and transformer.replacement_done and replacement_module:
         # Get newly inject procedure symbol for the replacement call
@@ -572,20 +572,20 @@ class RemoveRegionTransformer(Transformer):
 
 
 def do_remove_calls(
-        body, spec=None, call_names=None, intrinsic_names=None,
+        internal_node, spec=None, call_names=None, intrinsic_names=None,
         remove_imports=True
 ):
     """
     Utility routine to remove all :any:`CallStatement` nodes
     matching specific named subroutines or glob-style name patterns in a
-    given IR body.
+    given :any:`InternalNode`.
 
     For more information, see :any:`RemoveCallsTransformer`.
 
     Parameters
     ----------
-    body : :any:`Node` or tuple of :any:`Node`
-        Body section to transform in-place.
+    internal_node : :any:`Node` or tuple of :any:`Node`
+        :any:`InternalNode` to transform in-place.
     spec : :any:`Node` or tuple of :any:`Node`, optional
         Spec section to transform in-place when ``remove_imports`` is
         enabled.
@@ -606,8 +606,8 @@ def do_remove_calls(
     )
     if remove_imports and spec:
         transformer.visit(spec)
-    if body:
-        transformer.visit(body)
+    if internal_node:
+        transformer.visit(internal_node)
 
 
 class RemoveCallsTransformer(Transformer):

--- a/loki/transformations/remove_code.py
+++ b/loki/transformations/remove_code.py
@@ -22,8 +22,7 @@ from loki.ir import (
     SubstituteExpressions, pragmas_attached
 )
 from loki.ir.pragma_utils import (
-    is_loki_pragma, attach_pragma_regions, detach_pragma_regions,
-    get_pragma_parameters
+    is_loki_pragma, pragma_regions_attached, get_pragma_parameters
 )
 from loki.program_unit import ProgramUnit
 from loki.tools import flatten, as_tuple, OrderedSet
@@ -479,11 +478,8 @@ def do_remove_marked_regions(
         inplace=True
     )
 
-    attach_pragma_regions(internal_node, keyword='loki')
-    try:
+    with pragma_regions_attached(internal_node, keyword='loki'):
         transformer.visit(internal_node, scope=scope)
-    finally:
-        detach_pragma_regions(internal_node)
 
     if scope and transformer.replacement_done and replacement_module:
         # Get newly inject procedure symbol for the replacement call

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -593,7 +593,8 @@ end subroutine
     # Note that OMNI enforces keyword-arg passing for intrinsic
     # call to ``write``, so we match both conventions.
     do_remove_calls(
-        routine, call_names=('ABOR1', 'DR_HOOK'),
+        body=routine.body, spec=routine.spec,
+        call_names=('ABOR1', 'DR_HOOK'),
         intrinsic_names=('WRITE(NULOUT', 'write(unit=nulout'),
         remove_imports=remove_imports
     )
@@ -633,6 +634,78 @@ end subroutine
         assert imports[0].symbols == ('lhook', 'dr_hook')
         assert imports[1].module == 'abor1_mod'
         assert imports[1].symbols == ('abor1',)
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full type definitions for derived types')]
+))
+def test_remove_calls_glob_patterns(frontend):
+    """Test removal of calls matched by glob-style call name patterns."""
+
+    fcode = """
+subroutine driver(n, state)
+    implicit none
+    type state_type
+      integer :: value
+    end type state_type
+    integer, intent(in) :: n
+    type(state_type), intent(inout) :: state
+
+    call state%update_view(n)
+    call state%other_call(n)
+end subroutine driver
+    """
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    do_remove_calls(body=routine.body, call_names=('*%update_view',), remove_imports=False)
+
+    call_names = [str(call.name).lower() for call in FindNodes(ir.CallStatement).visit(routine.body)]
+    assert call_names == ['state%other_call']
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI needs full type definitions for derived types')]
+))
+def test_remove_code_transformation_driver_loop_calls(frontend):
+    """Test kernel-only call removal also applies to driver-loop bodies."""
+
+    fcode = """
+subroutine driver(n, state)
+    implicit none
+    type state_type
+      integer :: value
+    end type state_type
+    integer, intent(in) :: n
+    type(state_type), intent(inout) :: state
+    integer :: ibl
+
+    call state%update_view(0)
+
+    !$loki driver-loop
+    do ibl=1, n
+      call state%update_view(ibl)
+      if (ibl > 1) call state%update_view(ibl - 1)
+      call kernel(ibl)
+    end do
+
+    call state%update_view(n + 1)
+end subroutine driver
+    """
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    transformation = RemoveCodeTransformation(
+        call_names=('*%update_view',), kernel_only=True,
+        remove_marked_regions=False
+    )
+    transformation.apply(routine, role='driver', targets=('kernel',))
+
+    call_names = [str(call.name).lower() for call in FindNodes(ir.CallStatement).visit(routine.body)]
+    assert call_names.count('state%update_view') == 2
+    assert 'kernel' in call_names
+
+    loop = FindNodes(ir.Loop).visit(routine.body)[0]
+    loop_call_names = [str(call.name).lower() for call in FindNodes(ir.CallStatement).visit(loop.body)]
+    assert loop_call_names == ['kernel']
 
 
 @pytest.mark.parametrize('frontend', available_frontends(

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -480,12 +480,13 @@ end subroutine test_remove_code
 
     if replace_with_abort:
         do_remove_marked_regions(
-            body=routine.body, scope=routine, mark_with_comment=mark_with_comment,
+            internal_node=routine.body, scope=routine, mark_with_comment=mark_with_comment,
             replacement_call='ABOR1', replacement_module='ABOR1_MOD',
             replacement_msg='Unsupported code path in {}',
         )
     else:
-        do_remove_marked_regions(body=routine.body, scope=routine, mark_with_comment=mark_with_comment)
+        do_remove_marked_regions(internal_node=routine.body, scope=routine,
+                                 mark_with_comment=mark_with_comment)
 
     assigns = FindNodes(ir.Assignment).visit(routine.body)
     assert len(assigns) == 3
@@ -593,7 +594,7 @@ end subroutine
     # Note that OMNI enforces keyword-arg passing for intrinsic
     # call to ``write``, so we match both conventions.
     do_remove_calls(
-        body=routine.body, spec=routine.spec,
+        internal_node=routine.body, spec=routine.spec,
         call_names=('ABOR1', 'DR_HOOK'),
         intrinsic_names=('WRITE(NULOUT', 'write(unit=nulout'),
         remove_imports=remove_imports
@@ -657,7 +658,7 @@ end subroutine driver
     """
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
-    do_remove_calls(body=routine.body, call_names=('*%update_view',), remove_imports=False)
+    do_remove_calls(internal_node=routine.body, call_names=('*%update_view',), remove_imports=False)
 
     call_names = [str(call.name).lower() for call in FindNodes(ir.CallStatement).visit(routine.body)]
     assert call_names == ['state%other_call']

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -694,6 +694,8 @@ subroutine driver(n, state)
       !$loki end remove
       if (ibl > 1) call state%update_view(ibl - 1)
       call kernel(ibl)
+      write(nulout,*) "I should be deleted."
+      write(*,*) "But please keep me."
     end do
 
     call state%update_view(n + 1)
@@ -702,7 +704,7 @@ end subroutine driver
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
     transformation = RemoveCodeTransformation(
-        call_names=('*%update_view',), kernel_only=True
+        call_names=('*%update_view',), intrinsic_names=('write(nulout',), kernel_only=True
     )
     transformation.apply(routine, role='driver', targets=('kernel',))
 
@@ -715,6 +717,10 @@ end subroutine driver
     loop = FindNodes(ir.Loop).visit(routine.body)[0]
     loop_call_names = [str(call.name).lower() for call in FindNodes(ir.CallStatement).visit(loop.body)]
     assert loop_call_names == ['kernel']
+
+    writes = FindNodes(ir.GenericStmt).visit(loop.body)
+    assert len(writes) == 1
+    assert 'please keep me' in writes[0].text
 
 
 @pytest.mark.parametrize('frontend', available_frontends(

--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -480,12 +480,12 @@ end subroutine test_remove_code
 
     if replace_with_abort:
         do_remove_marked_regions(
-            routine, mark_with_comment=mark_with_comment,
+            body=routine.body, scope=routine, mark_with_comment=mark_with_comment,
             replacement_call='ABOR1', replacement_module='ABOR1_MOD',
             replacement_msg='Unsupported code path in {}',
         )
     else:
-        do_remove_marked_regions(routine, mark_with_comment=mark_with_comment)
+        do_remove_marked_regions(body=routine.body, scope=routine, mark_with_comment=mark_with_comment)
 
     assigns = FindNodes(ir.Assignment).visit(routine.body)
     assert len(assigns) == 3
@@ -681,9 +681,16 @@ subroutine driver(n, state)
 
     call state%update_view(0)
 
+    !$loki remove
+    call should_stay_outside()
+    !$loki end remove
+
     !$loki driver-loop
     do ibl=1, n
       call state%update_view(ibl)
+      !$loki remove
+      call should_be_removed()
+      !$loki end remove
       if (ibl > 1) call state%update_view(ibl - 1)
       call kernel(ibl)
     end do
@@ -694,13 +701,14 @@ end subroutine driver
 
     routine = Subroutine.from_source(fcode, frontend=frontend)
     transformation = RemoveCodeTransformation(
-        call_names=('*%update_view',), kernel_only=True,
-        remove_marked_regions=False
+        call_names=('*%update_view',), kernel_only=True
     )
     transformation.apply(routine, role='driver', targets=('kernel',))
 
     call_names = [str(call.name).lower() for call in FindNodes(ir.CallStatement).visit(routine.body)]
     assert call_names.count('state%update_view') == 2
+    assert 'should_stay_outside' in call_names
+    assert 'should_be_removed' not in call_names
     assert 'kernel' in call_names
 
     loop = FindNodes(ir.Loop).visit(routine.body)[0]


### PR DESCRIPTION
This PR updes the `RemoveCode` trafo to also operate on driver loop bodies if `kernel_only=True`. I still kept the option name as is, but I'm happy to update it to `kernel_and_driver_loop_only`, but this will be a non-backwards compatible change.

`do_remove_calls` is also updated so that pattern-matching is applied to the specified `call_names`, rather than removing only those calls that match exactly. 