### PR TITLE
Adapt pool allocator for nested driver loops

### DIFF
--- a/loki/transformations/temporaries/pool_allocator.py
+++ b/loki/transformations/temporaries/pool_allocator.py
@@ -19,13 +19,13 @@ from loki.ir import (
     FindNodes, FindVariables, FindInlineCalls, Transformer, GenericStmt,
     Assignment, Conditional, CallStatement, Import, Allocation,
     Deallocation, Loop, Pragma, Interface, get_pragma_parameters,
-    SubstituteExpressions
+    SubstituteExpressions, pragmas_attached
 )
 from loki.logging import warning, debug
 from loki.tools import as_tuple, OrderedSet
 from loki.types import SymbolAttributes, BasicType, DerivedType
 
-from loki.transformations.utilities import recursive_expression_map_update
+from loki.transformations.utilities import recursive_expression_map_update, find_driver_loops
 
 
 __all__ = ['TemporariesPoolAllocatorTransformation', 'EcstackPoolAllocatorTransformation']
@@ -244,7 +244,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
             if item:
                 # import variable type specifiers used in stack allocations
                 self.import_allocation_types(routine, item)
-            self.create_pool_allocator(routine, stack_size)
+            self.create_pool_allocator(routine, stack_size, targets)
 
         self.inject_pool_allocator_into_calls(routine, targets, ignore, driver=role=='driver')
 
@@ -771,7 +771,21 @@ class TemporariesPoolAllocatorTransformation(Transformation):
 
         return stack_size
 
-    def create_pool_allocator(self, routine, stack_size):
+    @staticmethod
+    def _is_driver_loop_pragma(pragma):
+        """
+        Check whether an attached pragma identifies a driver loop that needs
+        pool allocator stack-pointer initialisation.
+        """
+        keyword = pragma.keyword.lower()
+        content = pragma.content.lower()
+        if 'loop gang' in content or 'teams distribute' in content:
+            return True
+        if keyword == 'omp' and content.startswith(('parallel', 'do')):
+            return True
+        return False
+
+    def create_pool_allocator(self, routine, stack_size, targets):
         """
         Create a pool allocator in the driver
         """
@@ -815,9 +829,20 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         if pragma_map:
             routine.body = Transformer(pragma_map).visit(routine.body)
 
-        # Find first block loop and assign local stack pointers there
+        # Find driver/parallel block loops and assign local stack pointers there
         loop_map = {}
-        for loop in FindNodes(Loop).visit(routine.body):
+        with pragmas_attached(routine, Loop):
+            driver_loops = find_driver_loops(routine.body, targets)
+            annotated_loops = [
+                loop for loop in FindNodes(Loop).visit(routine.body)
+                if any(
+                    self._is_driver_loop_pragma(pragma)
+                    for pragma in as_tuple(loop.pragma)
+                )
+            ]
+            loops = OrderedSet(as_tuple(driver_loops) + as_tuple(annotated_loops))
+
+        for loop in loops:
             assignments = FindNodes(Assignment).visit(loop.body)
             if loop.variable != self.block_dim.index:
                 # Check if block variable is assigned in loop body

--- a/loki/transformations/temporaries/pool_allocator.py
+++ b/loki/transformations/temporaries/pool_allocator.py
@@ -772,17 +772,18 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         return stack_size
 
     @staticmethod
-    def _is_driver_loop_pragma(pragma):
+    def _is_driver_loop(loop):
         """
         Check whether an attached pragma identifies a driver loop that needs
         pool allocator stack-pointer initialisation.
         """
-        keyword = pragma.keyword.lower()
-        content = pragma.content.lower()
-        if 'loop gang' in content or 'teams distribute' in content:
-            return True
-        if keyword == 'omp' and content.startswith(('parallel', 'do')):
-            return True
+        for pragma in as_tuple(loop.pragma):
+            keyword = pragma.keyword.lower()
+            content = pragma.content.lower()
+            if 'loop gang' in content or 'teams distribute' in content:
+                return True
+            if keyword == 'omp' and content.startswith(('parallel', 'do')):
+                return True
         return False
 
     def create_pool_allocator(self, routine, stack_size, targets):
@@ -832,15 +833,7 @@ class TemporariesPoolAllocatorTransformation(Transformation):
         # Find driver/parallel block loops and assign local stack pointers there
         loop_map = {}
         with pragmas_attached(routine, Loop):
-            driver_loops = find_driver_loops(routine.body, targets)
-            annotated_loops = [
-                loop for loop in FindNodes(Loop).visit(routine.body)
-                if any(
-                    self._is_driver_loop_pragma(pragma)
-                    for pragma in as_tuple(loop.pragma)
-                )
-            ]
-            loops = OrderedSet(as_tuple(driver_loops) + as_tuple(annotated_loops))
+            loops = find_driver_loops(routine.body, targets, self._is_driver_loop)
 
         for loop in loops:
             assignments = FindNodes(Assignment).visit(loop.body)

--- a/loki/transformations/temporaries/tests/test_pool_allocator.py
+++ b/loki/transformations/temporaries/tests/test_pool_allocator.py
@@ -8,7 +8,7 @@
 import pytest
 
 from loki.expression.parser import parse_expr
-from loki import Dimension
+from loki import Dimension, Subroutine
 from loki.batch import Scheduler, SchedulerConfig
 from loki.expression import (
         InlineCall, RangeIndex, simplify, Sum,
@@ -87,6 +87,57 @@ def check_stack_created_in_driver(
                     assignments[1].rhs == 'ylstack_l + istsz * c_sizeof(real(1, kind=real64))')
     # Check that stack assignment happens before kernel call
     assert all(loops[0].body.index(a) < loops[0].body.index(first_kernel_call) for a in assignments)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+@pytest.mark.parametrize('loop_pragma, loop_end_pragma, increment', [
+    ('!$omp parallel do private(b)', '!$omp end parallel do', '1.0'),
+    (
+        '!$omp parallel default(shared) private(b)\n    marker = marker + 1\n'
+        '    !$omp do',
+        '!$omp end do\n    !$omp end parallel',
+        'marker'
+    ),
+    ('!$acc parallel loop gang', '!$acc end parallel loop', '1.0'),
+    ('!$omp target teams distribute', '!$omp end target teams distribute', '1.0'),
+])
+def test_pool_allocator_annotated_driver_loops_without_targets(
+        frontend, block_dim, loop_pragma, loop_end_pragma, increment
+):
+    """
+    Parallel loops may already be present without Loki driver-loop annotations.
+    Treat OpenMP CPU, OpenACC gang, and OpenMP target teams loops as annotated
+    driver loops.
+    """
+    fcode = f"""
+subroutine driver(NLON, NB, FIELD, nouter_loop)
+    implicit none
+    integer, intent(in) :: nlon, nb, nouter_loop
+    real, intent(inout) :: field(nlon, nb)
+    integer :: b, marker, it
+
+    marker = 0
+
+    do it=1,nouter_loop
+      {loop_pragma}
+      do b=1,nb
+          field(1,b) = field(1,b) + {increment}
+      end do
+      {loop_end_pragma}
+    enddo
+end subroutine driver
+    """.strip()
+
+    driver = Subroutine.from_source(fcode, frontend=frontend)
+    transformation = TemporariesPoolAllocatorTransformation(block_dim=block_dim)
+    transformation.transform_subroutine(driver, role='driver', targets=())
+
+    loops = FindNodes(ir.Loop).visit(driver.body)
+    assert len(loops) == 2
+
+    assignments = tuple(stmt for stmt in loops[1].body if isinstance(stmt, ir.Assignment))
+    assert assignments[0].lhs == 'ylstack_l'
+    assert assignments[1].lhs == 'ylstack_u'
 
 
 @pytest.mark.parametrize('generate_driver_stack', [True, False])

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -657,7 +657,7 @@ def is_driver_loop(loop, targets):
     return False
 
 
-def find_driver_loops(section, targets):
+def find_driver_loops(section, targets, additional_identifier=None):
     """
     Find and return all driver loops in a given `section`.
 
@@ -676,8 +676,17 @@ def find_driver_loops(section, targets):
     targets : list or string
         List of subroutines that are to be considered as part of
         the transformation call tree.
+    additional_identifier : callable, optional
+        An optional callback that receives a :any:`Loop` and returns
+        ``True`` if it should be treated as a driver loop. This is checked
+        in addition to the pragma and target-call based identification.
     """
     targets = [str(t).lower() for t in as_tuple(targets)]
+
+    def _is_marked_driver_loop(loop):
+        if is_pragma_driver_loop(loop):
+            return True
+        return additional_identifier and additional_identifier(loop)
 
     class FindDriverLoops(Visitor):
         """
@@ -718,7 +727,7 @@ def find_driver_loops(section, targets):
 
         def visit_Loop(self, loop, **kwargs):
             depth = kwargs.pop('depth', 0)
-            if is_pragma_driver_loop(loop):
+            if _is_marked_driver_loop(loop):
                 # Propagate the presence of the pragma only if inside a loop nest
                 self.driver_loops.append(loop)
                 return depth > 0, False, []


### PR DESCRIPTION
This PR adds support to the pool allocator transformation for nested driver loops, i.e. the following pattern:

```
do  nt=1,nouter_loop
   !.. driver loop
    do jkglo=...
    enddo
enddo
```