### PR TITLE
Testing workaround for the OMNI frontend on macos

### DIFF
--- a/loki/transformations/tests/test_remove_code.py
+++ b/loki/transformations/tests/test_remove_code.py
@@ -619,7 +619,9 @@ end subroutine
     stops = FindNodes(ir.StopStmt).visit(routine.body)
     assert len(stops) == 2
     assert fgen(stops[0]) == 'STOP'
-    assert fgen(stops[1]) == 'STOP 1'
+    # We don't do a simple fgen(stops[1]) == 'STOP 1' check due to a weird OMNI
+    # quirk on macos
+    assert 'STOP' in fgen(stops[1]) and '1' in fgen(stops[1])
 
     # Check that the repsective imports have also been stripped
     imports = FindNodes(ir.Import).visit(routine.spec)


### PR DESCRIPTION
A subtle change to a code removal test to workaround a weird quirk of OMNI on macos as compared to on linux.