### PR TITLE
Apply `pragma_regions_attached` context manager to internal nodes too

### DIFF
--- a/loki/ir/pragma_utils.py
+++ b/loki/ir/pragma_utils.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from codetiming import Timer
 
 #from loki.backend.fgen import fgen
-from loki.ir.nodes import VariableDeclaration, Pragma, PragmaRegion
+from loki.ir.nodes import VariableDeclaration, Pragma, PragmaRegion, InternalNode
 from loki.ir.find import FindNodes
 from loki.ir.transformer import Transformer
 from loki.ir.visitor import Visitor
@@ -652,7 +652,7 @@ def detach_pragma_regions(ir):
 
 
 @contextmanager
-def pragma_regions_attached(module_or_routine, keyword=None):
+def pragma_regions_attached(ir_or_internal_node, keyword=None):
     """
     Create a context in which :any:`PragmaRegion` node objects are
     inserted into the IR to define code regions marked by matching
@@ -689,23 +689,29 @@ def pragma_regions_attached(module_or_routine, keyword=None):
 
     Parameters
     ----------
-    module_or_routine : :any:`Module` or :any:`Subroutine` in
-        which :any:`PragmaRegion` objects are to be inserted.
+    ir_or_internal_node : :any:`Module`, :any:`Subroutine` or :any:`InternalNode`
+        in which :any:`PragmaRegion` objects are to be inserted.
     keyword : str, optional
         Limit pragma attachment to pragmas with the given keyword
     """
-    if hasattr(module_or_routine, 'spec'):
-        module_or_routine.spec = attach_pragma_regions(module_or_routine.spec, keyword=keyword)
-    if hasattr(module_or_routine, 'body'):
-        module_or_routine.body = attach_pragma_regions(module_or_routine.body, keyword=keyword)
+    if isinstance(ir_or_internal_node, InternalNode):
+        ir_or_internal_node = attach_pragma_regions(ir_or_internal_node, keyword=keyword)
+    else:
+        if hasattr(ir_or_internal_node, 'spec'):
+            ir_or_internal_node.spec = attach_pragma_regions(ir_or_internal_node.spec, keyword=keyword)
+        if hasattr(ir_or_internal_node, 'body'):
+            ir_or_internal_node.body = attach_pragma_regions(ir_or_internal_node.body, keyword=keyword)
 
     try:
-        yield module_or_routine
+        yield ir_or_internal_node
     finally:
-        if hasattr(module_or_routine, 'spec'):
-            module_or_routine.spec = detach_pragma_regions(module_or_routine.spec)
-        if hasattr(module_or_routine, 'body'):
-            module_or_routine.body = detach_pragma_regions(module_or_routine.body)
+        if isinstance(ir_or_internal_node, InternalNode):
+            ir_or_internal_node = detach_pragma_regions(ir_or_internal_node)
+        else:
+            if hasattr(ir_or_internal_node, 'spec'):
+                ir_or_internal_node.spec = detach_pragma_regions(ir_or_internal_node.spec)
+            if hasattr(ir_or_internal_node, 'body'):
+                ir_or_internal_node.body = detach_pragma_regions(ir_or_internal_node.body)
 
 
 class SubstitutePragmaStrings(Transformer):

--- a/loki/ir/tests/test_pragma_utils.py
+++ b/loki/ir/tests/test_pragma_utils.py
@@ -3,7 +3,7 @@ import pytest
 
 from loki import Module, Subroutine, FindNodes, flatten, pprint, fgen
 from loki.frontend import available_frontends, FP
-from loki.ir import Pragma, Loop, VariableDeclaration, PragmaRegion
+from loki.ir import Pragma, Loop, VariableDeclaration, PragmaRegion, Assignment
 from loki.ir.pragma_utils import (
     is_loki_pragma, get_pragma_parameters, attach_pragmas, detach_pragmas,
     pragmas_attached, pragma_regions_attached, SubstitutePragmaStrings
@@ -462,7 +462,9 @@ subroutine test_tools_pragmas_attached_region (in, out, n)
 
 !$foo bar
   do i=1,n
+!$foo_inner bar
     out(i) = in(i)
+!$foo_inner end bar
   end do
 !$foo end bar
 end subroutine test_tools_pragmas_attached_region
@@ -472,13 +474,13 @@ end subroutine test_tools_pragmas_attached_region
     loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 3
     assert all(loop.pragma is None for loop in loops)
-    assert len(FindNodes(Pragma).visit(routine.body)) == 5
+    assert len(FindNodes(Pragma).visit(routine.body)) == 7
 
     with pragma_regions_attached(routine):
         assert len(FindNodes(Pragma).visit(routine.body)) == 1
-        assert len(FindNodes(PragmaRegion).visit(routine.body)) == 2
-        # Find loops inside regions
         regions = FindNodes(PragmaRegion).visit(routine.body)
+        assert len(regions) == 3
+        # Find loops inside regions
         region_loops = flatten(FindNodes(Loop).visit(r) for r in regions)
         assert len(region_loops) == 2
         assert all(l in loops for l in region_loops)
@@ -486,12 +488,19 @@ end subroutine test_tools_pragmas_attached_region
     # Verify that loops from context are still valid
     assert all(l in loops for l in region_loops)
 
+    # Verify pragma region inside loop body
+    with pragma_regions_attached(loops[2]):
+        regions = FindNodes(PragmaRegion).visit(loops[2].body)
+        assert len(regions) == 1
+        assert len(regions[0].body) == 1
+        assert isinstance(regions[0].body[0], Assignment)
+
     # Ensure that everything is back to where it was
     loops_after = FindNodes(Loop).visit(routine.body)
     assert len(loops_after) == 3
     assert loops_after == loops
     assert all(loop.pragma is None for loop in loops_after)
-    assert len(FindNodes(Pragma).visit(routine.body)) == 5
+    assert len(FindNodes(Pragma).visit(routine.body)) == 7
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
A small PR that updates the `pragma_regions_attached` context manager so it can also be applied to `InternalNode`s.