### PR TITLE
Unroll array initialisers

### DIFF
--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -940,7 +940,7 @@ end subroutine test_literal_list
         "Unqualifiable ':' should remain a RangeIndex on the LHS"
 
     literal_warnings = [r for r in caplog.records
-                        if 'Literal list on RHS' in r.message
+                        if 'prevents literal-list unrolling' in r.message
                         and 'ResolveVectorNotationTransformer' in r.message]
     assert literal_warnings
     assert any('test_literal_list' in r.message for r in literal_warnings)

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -947,6 +947,53 @@ end subroutine test_literal_list
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_literal_list_unsupported(frontend, caplog):
+    """
+    Only literal-list elements that are scalar variables or literals are
+    unrolled.  Any other element leaves the assignment unchanged, with a
+    warning.
+    """
+    fcode = """
+subroutine test_literal_list_unsupported(arr, brr)
+  implicit none
+  integer, intent(inout) :: arr(3), brr(3)
+  integer :: i
+
+  ! Implied-do array constructor: a LiteralList with a single InlineDo element
+  arr(1:3) = [(i, i=1,3)]
+
+  ! Arithmetic expression elements are not scalar variables or literals
+  brr(1:3) = (/ 2*i, 2*i, 2*i /)
+end subroutine test_literal_list_unsupported
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    caplog.set_level(WARNING)
+    resolve_vector_notation(routine)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    # Both assignments are left unchanged: their LiteralList RHS and qualified
+    # range LHS survive rather than being (wrongly / unsupportedly) unrolled.
+    assert len(assigns) == 2
+    for assign in assigns:
+        assert isinstance(assign.rhs, sym.LiteralList), \
+            "LiteralList RHS should be preserved when it cannot be unrolled"
+        assert any(isinstance(d, sym.RangeIndex) for d in assign.lhs.dimensions), \
+            "The range LHS should remain a RangeIndex"
+
+    arr_assign = next(a for a in assigns if 'arr' in a.lhs.name)
+    assert any(isinstance(el, sym.InlineDo) for el in arr_assign.rhs.elements), \
+        "The InlineDo element should be preserved on the RHS"
+
+    literal_warnings = [r for r in caplog.records
+                        if 'not scalar variables or literals' in r.message
+                        and 'ResolveVectorNotationTransformer' in r.message]
+    # One warning per unsupported assignment.
+    assert len(literal_warnings) == 2
+    assert any('test_literal_list_unsupported' in r.message for r in literal_warnings)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_resolve_vector_notation_broadcast_and_nesting(frontend):
     """
     Test 1D-to-2D broadcasts and nested full-colon resolution,

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -15,6 +15,7 @@ from loki.jit_build import jit_compile_and_run, jit_compile_lib, Builder, Obj
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes, FindVariables
+from loki.logging import WARNING
 
 from loki.transformations.array_indexing.vector_notation import (
     resolve_vector_notation, resolve_vector_dimension,
@@ -447,7 +448,7 @@ subroutine test_extended(klon, klev, ngpblks, nproma)
     ! B1: 2D array zeroing (both dims implicit)
     local_var1(:, :, ibl) = 0
 
-    ! B2: Literal list assignment -- should NOT be resolved
+    ! B2: Literal list assignment -- should be unrolled into scalars
     local_var1(1:2, 1, ibl) = (/ 2.739, 4.043 /)
 
     ! B3: Multi-term RHS with matching ranges
@@ -493,16 +494,27 @@ end subroutine test_extended
                           for a in FindNodes(ir.Assignment).visit(l.body))]
     assert len(b1_jl_loops) >= 1, "Expected jl loop containing local_var1 assignment"
 
-    # B2: Literal list assignment should be unchanged (no loop wrapping)
+    # B2: Literal list assignment should be unrolled into one scalar
+    # assignment per element; no LiteralList should survive, and the
+    # unrolled assignments should not be wrapped in a generated loop.
     generated_loop_bodies = []
     for l in loops:
         if l.variable.name.startswith('i_'):
             generated_loop_bodies.extend(FindNodes(ir.Assignment).visit(l.body))
+    literal_assigns = [a for a in assigns
+                       if hasattr(a.rhs, 'elements') or 'LiteralList' in type(a.rhs).__name__]
+    assert not literal_assigns, "Literal list RHS should have been unrolled"
     b2_assigns = [a for a in assigns
-                  if hasattr(a.rhs, 'elements') or 'LiteralList' in type(a.rhs).__name__]
+                  if str(a.lhs).startswith('local_var1(') and str(a.lhs).endswith('1, ibl)')
+                  and not isinstance(a.rhs, sym.LiteralList)
+                  and str(a.rhs) in ('2.739', '4.043')]
+    assert len(b2_assigns) == 2, \
+        f"Expected 2 unrolled scalar assignments, got {len(b2_assigns)}"
     for b2a in b2_assigns:
         assert b2a not in generated_loop_bodies, \
-            "Literal list assignment should not be inside a generated loop"
+            "Unrolled literal-list assignment should not be inside a generated loop"
+        assert not any(isinstance(d, sym.RangeIndex) for d in b2a.lhs.dimensions), \
+            "Unrolled LHS should not contain a RangeIndex"
 
     # B3: Multi-term RHS arrays should all have loop indices, no RangeIndex left
     b3_assigns = [a for a in assigns
@@ -797,18 +809,13 @@ end subroutine test_ifs_patterns
 def test_resolve_vector_notation_early_exits(frontend, caplog):
     """
     Test that certain patterns are correctly skipped by the resolver:
-    literal list assignments, SUM intrinsic, scalar assignments, and
-    assumed-shape arrays whose LHS ``:`` cannot be qualified.
+    SUM intrinsic, scalar assignments, and assumed-shape arrays whose
+    LHS ``:`` cannot be qualified.
 
-    Also check that the literal-list and unqualified-':' bailouts
-    each emit a warning naming the offending statement and routine,
-    matching the production messages
-    ``[ResolveVectorNotationTransformer] Literal list on RHS of ...``
-    and
+    Also check that the unqualified-':' bailout emits a warning naming
+    the offending statement and routine, matching the production message
     ``[ResolveVectorNotationTransformer] Unqualified ":" on LHS of ...``.
     """
-    from loki.logging import WARNING  # pylint: disable=import-outside-toplevel
-
     fcode = """
 subroutine test_early_exits(n, arr, arr2, scalar, arr_assumed)
   implicit none
@@ -817,9 +824,6 @@ subroutine test_early_exits(n, arr, arr2, scalar, arr_assumed)
   real, intent(inout) :: scalar
   real, intent(inout) :: arr_assumed(:,:)
   real :: total
-
-  ! Skip: literal list assignment
-  arr(1:3) = (/ 1.0, 2.0, 3.0 /)
 
   ! Skip: SUM intrinsic in RHS
   total = sum(arr(1:n))
@@ -839,15 +843,7 @@ end subroutine test_early_exits
     caplog.set_level(WARNING)
     resolve_vector_notation(routine)
 
-    # The literal-list bailout should have emitted a warning identifying
-    # the offending statement.
-    literal_warnings = [r for r in caplog.records
-                        if 'Literal list on RHS' in r.message
-                        and 'ResolveVectorNotationTransformer' in r.message]
-    assert literal_warnings
-    assert any('test_early_exits' in r.message for r in literal_warnings)
-
-    # The unqualified-':' bailout should have emitted a warning too.
+    # The unqualified-':' bailout should have emitted a warning.
     unqualified_warnings = [r for r in caplog.records
                             if 'Unqualified ":"' in r.message
                             and 'ResolveVectorNotationTransformer' in r.message]
@@ -856,16 +852,6 @@ end subroutine test_early_exits
 
     loops = FindNodes(ir.Loop).visit(routine.body)
     assigns = FindNodes(ir.Assignment).visit(routine.body)
-
-    # Literal list assignment should remain unchanged
-    literal_assigns = [a for a in assigns
-                       if hasattr(a.rhs, 'elements') or 'LiteralList' in type(a.rhs).__name__]
-    assert len(literal_assigns) >= 1, "Literal list assignment should still exist"
-    # It should NOT be inside any generated loop
-    for la in literal_assigns:
-        for l in loops:
-            assert la not in FindNodes(ir.Assignment).visit(l.body), \
-                "Literal list assignment should not be inside a generated loop"
 
     # SUM assignment should remain unchanged (total = sum(...))
     sum_assigns = [a for a in assigns if str(a.lhs) == 'total']
@@ -900,6 +886,64 @@ end subroutine test_early_exits
     # LHS should have loop index, not RangeIndex
     assert not any(isinstance(d, sym.RangeIndex) for d in resolved_assigns[0].lhs.dimensions), \
         "Resolved assignment LHS should not have RangeIndex"
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_literal_list(frontend, caplog):
+    """
+    A literal-list RHS assigned to an array section should be *unrolled*
+    into one scalar assignment per element rather than bailing out.
+
+    The exception is an assumed-shape LHS, whose ``:`` has no derivable
+    lower bound: it cannot be unrolled and must be left unchanged with a
+    warning.
+    """
+    fcode = """
+subroutine test_literal_list(arr, brr, crr, n)
+  implicit none
+  integer, intent(in) :: n
+  real, intent(inout) :: arr(n), brr(0:n)
+  real, intent(inout) :: crr(:)
+
+  ! Simple, one-based range
+  arr(1:3) = (/ 1.0, 2.0, 3.0 /)
+
+  ! Shifted (non-one) lower bound
+  brr(2:4) = (/ 4.0, 5.0, 6.0 /)
+
+  ! Assumed-shape LHS: ':' cannot be qualified, so cannot be unrolled
+  crr(:) = (/ 7.0, 8.0, 9.0 /)
+end subroutine test_literal_list
+"""
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    caplog.set_level(WARNING)
+    resolve_vector_notation(routine)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    # The qualified ranges are unrolled into one scalar assignment per element.
+    arr_map = {str(a.lhs): str(a.rhs) for a in assigns
+               if 'arr' in a.lhs.name}
+    assert arr_map == {'arr(1)': '1.0', 'arr(2)': '2.0', 'arr(3)': '3.0'}
+
+    brr_map = {str(a.lhs): str(a.rhs) for a in assigns
+               if 'brr' in a.lhs.name}
+    assert brr_map == {'brr(2)': '4.0', 'brr(3)': '5.0', 'brr(4)': '6.0'}
+
+    # The assumed-shape assignment is left unchanged: its LiteralList RHS and
+    # unqualified ':' LHS survive, and a warning naming the routine is emitted.
+    crr_assigns = [a for a in assigns if 'crr' in a.lhs.name]
+    assert len(crr_assigns) == 1
+    assert isinstance(crr_assigns[0].rhs, sym.LiteralList), \
+        "LiteralList RHS should be preserved when it cannot be unrolled"
+    assert any(isinstance(d, sym.RangeIndex) for d in crr_assigns[0].lhs.dimensions), \
+        "Unqualifiable ':' should remain a RangeIndex on the LHS"
+
+    literal_warnings = [r for r in caplog.records
+                        if 'Literal list on RHS' in r.message
+                        and 'ResolveVectorNotationTransformer' in r.message]
+    assert literal_warnings
+    assert any('test_literal_list' in r.message for r in literal_warnings)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1503,8 +1547,6 @@ def test_resolve_vector_dimension_empty_bounds_warning(frontend, caplog):
     lower/upper bounds are not present in the routine's scope, it should
     emit a warning and leave the routine unchanged.
     """
-    from loki.logging import WARNING  # pylint: disable=import-outside-toplevel
-
     fcode = """
 subroutine test_empty_bounds(n, a)
   implicit none

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -501,8 +501,7 @@ end subroutine test_extended
     for l in loops:
         if l.variable.name.startswith('i_'):
             generated_loop_bodies.extend(FindNodes(ir.Assignment).visit(l.body))
-    literal_assigns = [a for a in assigns
-                       if hasattr(a.rhs, 'elements') or 'LiteralList' in type(a.rhs).__name__]
+    literal_assigns = [a for a in assigns if isinstance(a.rhs, sym.LiteralList)]
     assert not literal_assigns, "Literal list RHS should have been unrolled"
     b2_assigns = [a for a in assigns
                   if str(a.lhs).startswith('local_var1(') and str(a.lhs).endswith('1, ibl)')

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -636,6 +636,17 @@ class ResolveVectorNotationTransformer(Transformer):
             )
             return None
 
+        # Only unroll when every element is a scalar variable or a literal,
+        # so that each element is rank-0 and the RHS element count trivially
+        # matches the LHS range extent without further shape introspection.
+        if not all(isinstance(el, (sym.Scalar, sym._Literal)) for el in stmt.rhs.elements):
+            warning(
+                f'[ResolveVectorNotationTransformer] Literal-list RHS of '
+                f'"{stmt}"{scope_str} has elements that are not scalar '
+                f'variables or literals; literal-list unrolling not supported. '
+            )
+            return None
+
         lhs_array = stmt.lhs
         # A LiteralList RHS is always a rank-1 initialiser (multi-dimensional
         # initialisers require RESHAPE, which Loki treats as an InlineCall, not

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -623,10 +623,17 @@ class ResolveVectorNotationTransformer(Transformer):
         Mixed RHS expressions and bare ``:`` ranges are not supported.
 
         Returns the unrolled scalar assignments, or ``None`` if the assignment
-        cannot be unrolled (so the caller can fall back to warn-and-bail).
+        cannot be unrolled (in which case a warning describing the failure mode
+        has already been emitted).
         """
+        scope_str = f' in routine "{self.scope.name}"' if self.scope is not None else ''
+
         # Only handle a pure literal-list RHS (no mixed expressions).
         if not isinstance(stmt.rhs, sym.LiteralList):
+            warning(
+                f'[ResolveVectorNotationTransformer] Mixed literal-list RHS of '
+                f'"{stmt}"{scope_str} prevents vector notation resolution. '
+            )
             return None
 
         lhs_array = stmt.lhs
@@ -642,6 +649,10 @@ class ResolveVectorNotationTransformer(Transformer):
         # A bare ``:`` (unknown lower bound) cannot be turned into concrete
         # element indices.
         if lower is None:
+            warning(
+                f'[ResolveVectorNotationTransformer] Unqualified ":" on LHS of '
+                f'"{stmt}"{scope_str} prevents literal-list unrolling (shape unknown). '
+            )
             return None
         step_expr = step if step else sym.IntLiteral(1)
 
@@ -693,11 +704,6 @@ class ResolveVectorNotationTransformer(Transformer):
             resolved = self._resolve_literal_list(stmt)
             if resolved:
                 return resolved
-            scope_str = f' in routine "{self.scope.name}"' if self.scope is not None else ''
-            warning(
-                f'[ResolveVectorNotationTransformer] Literal list on RHS of '
-                f'"{stmt}"{scope_str} prevents vector notation resolution. '
-            )
             return stmt
 
         # --- Step 3: Identify range-indexed dimensions ---

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -607,6 +607,55 @@ class ResolveVectorNotationTransformer(Transformer):
 
         return new_index_range_map, pre_stmts, new_vars
 
+    def _resolve_literal_list(self, stmt):
+        """
+        Resolve an assignment whose RHS is a literal list by *unrolling* it
+        into one scalar assignment per element.
+
+        For example ``A(1:3) = (/ 1.0, 2.0, 3.0 /)`` becomes::
+
+            A(1) = 1.0
+            A(2) = 2.0
+            A(3) = 3.0
+
+        Only the simple case of a pure literal-list RHS assigned to an LHS
+        array with a single, explicitly bounded, range dimension is handled.
+        Mixed RHS expressions and bare ``:`` ranges are not supported.
+
+        Returns the unrolled scalar assignments, or ``None`` if the assignment
+        cannot be unrolled (so the caller can fall back to warn-and-bail).
+        """
+        # Only handle a pure literal-list RHS (no mixed expressions).
+        if not isinstance(stmt.rhs, sym.LiteralList):
+            return None
+
+        lhs_array = stmt.lhs
+        # A LiteralList RHS is always a rank-1 initialiser (multi-dimensional
+        # initialisers require RESHAPE, which Loki treats as an InlineCall, not
+        # a LiteralList), so the LHS has exactly one range dimension (though not
+        # necessarily the leading one, e.g. foo(j, 1:3)).
+        range_pos = self._find_range_positions(lhs_array.dimensions)[0]
+        lhs_range = lhs_array.dimensions[range_pos]
+
+        lower = lhs_range.lower
+        step = lhs_range.step
+        # A bare ``:`` (unknown lower bound) cannot be turned into concrete
+        # element indices.
+        if lower is None:
+            return None
+        step_expr = step if step else sym.IntLiteral(1)
+
+        # Emit one scalar assignment per element, with LHS index ``lower + k*step``.
+        assignments = []
+        for k, element in enumerate(stmt.rhs.elements):
+            index = simplify(sym.Sum((lower, sym.Product((sym.IntLiteral(k), step_expr)))))
+            new_dims = list(lhs_array.dimensions)
+            new_dims[range_pos] = index
+            new_lhs = lhs_array.clone(dimensions=as_tuple(new_dims))
+            assignments.append(ir.Assignment(lhs=new_lhs, rhs=element))
+
+        return as_tuple(assignments)
+
     def visit_Assignment(self, stmt, **kwargs):  # pylint: disable=unused-argument
 
         # --- Step 1: Early exits ---
@@ -617,15 +666,6 @@ class ResolveVectorNotationTransformer(Transformer):
 
         # LHS is not an array
         if not isinstance(stmt.lhs, sym.Array):
-            return stmt
-
-        # RHS contains a literal list (e.g., (/ 1.0, 2.0 /))
-        if FindLiteralLists().visit(stmt.rhs):
-            scope_str = f' in routine "{self.scope.name}"' if self.scope is not None else ''
-            warning(
-                f'[ResolveVectorNotationTransformer] Literal list on RHS of '
-                f'"{stmt}"{scope_str} prevents vector notation resolution. '
-            )
             return stmt
 
         create_loops = kwargs.get('create_loops', True)
@@ -644,6 +684,21 @@ class ResolveVectorNotationTransformer(Transformer):
         if self.derive_qualified_ranges:
             shape_mapper = IterationRangeShapeMapper()
             stmt._update(lhs=shape_mapper(stmt.lhs), rhs=shape_mapper(stmt.rhs))
+
+        # --- Resolve literal-list RHS by unrolling ---
+        # This runs after Step 2 so the LHS range has explicit bounds.
+        # Falls back to the previous warn-and-bail behaviour when unrolling is
+        # not possible (mixed RHS, unknown ranges).
+        if FindLiteralLists().visit(stmt.rhs):
+            resolved = self._resolve_literal_list(stmt)
+            if resolved:
+                return resolved
+            scope_str = f' in routine "{self.scope.name}"' if self.scope is not None else ''
+            warning(
+                f'[ResolveVectorNotationTransformer] Literal list on RHS of '
+                f'"{stmt}"{scope_str} prevents vector notation resolution. '
+            )
+            return stmt
 
         # --- Step 3: Identify range-indexed dimensions ---
 


### PR DESCRIPTION
This PR updates the `ResolveVectorNotationTransformation` so that array initialisers are unrolled. 

Some array initialisation statements proved to be very costly in the GPU runs on jupiter. It's hard to determine a priori which ones will bite, so we unroll simple 1D constant bound array initialiasation statements automatically with this PR. A warning is printed for more complex unresolvable ones so that they are easily identifiable and can be addressed in source if necessary.