### PR TITLE
CMake: Fix venv reconfigure and add reconfiguration test

### DIFF
--- a/cmake/loki_python_macros.cmake
+++ b/cmake/loki_python_macros.cmake
@@ -131,10 +131,15 @@ function( loki_create_python_venv )
     set( Python3_FIND_VIRTUALENV STANDARD )
     find_package( Python3 ${_PAR_PYTHON_VERSION} COMPONENTS Interpreter REQUIRED )
 
-    # Ensure the activate script is writable in case the venv exists already
-    if( EXISTS "${VENV_PATH}/bin/activate" )
-        file( CHMOD "${VENV_PATH}/bin/activate" FILE_PERMISSIONS OWNER_READ OWNER_WRITE )
-    endif()
+    # Ensure the activate scripts are writable in case the venv exists already
+    file( GLOB activate_SCRIPTS "${VENV_PATH}/bin/activate*" )
+    file( GLOB Activate_SCRIPTS "${VENV_PATH}/bin/Activate*" )
+    foreach( _SCRIPT ${activate_SCRIPTS} ${Activate_SCRIPTS} )
+        if( EXISTS "${_SCRIPT}" )
+            message( STATUS "Making activate script ${_SCRIPT} writable" )
+            file( CHMOD "${_SCRIPT}" FILE_PERMISSIONS OWNER_READ OWNER_WRITE )
+        endif()
+    endforeach()
 
     # Create a virtualenv
     message( STATUS "Create Python virtual environment ${VENV_PATH}" )

--- a/loki/tests/test_cmake.py
+++ b/loki/tests/test_cmake.py
@@ -190,6 +190,11 @@ def fixture_loki_install(here, tmp_dir, ecbuild, loki_artifacts_and_env, silent,
 
     yield builddir, installdir
 
+    if builddir.exists():
+        shutil.rmtree(builddir)
+    if installdir.exists():
+        shutil.rmtree(installdir)
+
 
 @contextmanager
 def clean_builddir(builddir):
@@ -242,11 +247,6 @@ loki_transform_plan(
 
     yield projdir
 
-    filepath.unlink()
-    (projdir/'loki').unlink()
-    shutil.rmtree(projdir/'projA', ignore_errors=True)
-    shutil.rmtree(projdir/'projB', ignore_errors=True)
-
 
 def test_cmake_plan(tmp_dir, config, cmake_project, loki_install, ecbuild, silent):
     """
@@ -297,4 +297,11 @@ def test_cmake_plan(tmp_dir, config, cmake_project, loki_install, ecbuild, silen
                 f'{name}.idem' for name in expected_files
             }
 
-        shutil.rmtree(loki_root)
+
+def test_cmake_reconfigure(loki_install):
+    """
+    Verify that CMake reconfiguration works (e.g., doesn't throw up errors when recreating the ifsbench venv).
+    """
+    build_dir, _ = loki_install
+    # This will throw an exception if execution fails
+    execute(['cmake', str(build_dir)])


### PR DESCRIPTION

### Description

Make all activate scripts writable (not just the main one) before recreating a venv, preventing permission errors on reconfiguration.

Add test_cmake_reconfigure to verify CMake reconfiguration succeeds. Clean up fixture_loki_install teardown to remove stale build/install directories between parametrized runs, which previously caused pip install failures when transitioning from populate to non-populate mode.

Remove redundant manual cleanup from cmake_project fixture and test_cmake_plan that is now handled by fixture teardown and the module-scoped tmp_dir cleanup.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 