### PR TITLE
Further improving resolve vector notation

### DIFF
--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -2377,3 +2377,97 @@ end subroutine test_dup_dims
         f"indicating only one loop variable was used for two distinct dimensions; "
         f"expected two distinct loop variables"
     )
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_scalar_plus_range_duplicate(frontend):
+    """
+    Regression test: when a loop variable already appears as a fixed scalar
+    subscript in the same array reference, a range that maps to the same loop
+    variable must get a fresh index variable instead.
+
+    Example:  ``field(i,j,1:n)`` inside ``DO j=1,n`` must NOT produce
+    ``field(i,j,j)`` — the third subscript must be a distinct
+    synthesized loop variable.
+    """
+    fcode = """
+subroutine test_scalar_range_dup(nouter, ninner, field)
+  implicit none
+  integer, intent(in) :: nouter, ninner
+  real, intent(inout) :: field(nouter, ninner, ninner)
+  integer :: i, j
+
+  do i = 1, nouter
+    do j = 1, ninner
+      field(i, j, 1:ninner) = 0.0
+    enddo
+  enddo
+
+end subroutine test_scalar_range_dup
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    resolve_vector_notation(routine)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    # Find the resolved field assignment (no more RangeIndex dimensions)
+    resolved_assigns = [
+        a for a in assigns
+        if isinstance(a.lhs, sym.Array)
+        and 'field' in a.lhs.name.lower()
+        and not any(isinstance(d, sym.RangeIndex) for d in a.lhs.dimensions)
+        and len(a.lhs.dimensions) == 3
+    ]
+    assert len(resolved_assigns) == 1
+
+    assign = resolved_assigns[0]
+    dims = assign.lhs.dimensions
+    # dims[1] should be the original J; dims[2] must be different
+    assert dims[1] == 'j'
+    assert str(dims[2]).lower() != 'j', (
+        f"Third subscript of field is '{dims[2]}' which aliases the existing "
+        f"scalar subscript J; expected a distinct synthesized loop variable"
+    )
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_nested_loop_variable_shadowing(frontend):
+    """
+    Regression test: resolving a range inside an existing loop must not reuse
+    the active outer loop variable for the new inner loop, or scalar references
+    to that outer variable on the RHS become shadowed.
+    """
+    fcode = """
+subroutine test_nested_loop_shadowing(nouter, ninner, work, edge_hi, edge_lo)
+  implicit none
+  integer, intent(in) :: nouter, ninner
+  real, intent(inout) :: work(nouter, ninner)
+  real, intent(in) :: edge_hi(nouter, 0:ninner), edge_lo(nouter, 0:ninner)
+  integer :: i, j
+
+  do i = 1, nouter
+    do j = 1, ninner
+      work(i, 1:ninner) = max(edge_hi(i, j-1), edge_lo(i, 0:ninner-1))
+    enddo
+  enddo
+
+end subroutine test_nested_loop_shadowing
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 3
+
+    outer_j_loop = next(loop for loop in loops if loop.variable == 'j' and loop.bounds == '1:ninner')
+    inner_loops = FindNodes(ir.Loop).visit(outer_j_loop.body)
+    assert len(inner_loops) == 1
+    assert str(inner_loops[0].variable).lower() != 'j'
+
+    assign = FindNodes(ir.Assignment).visit(inner_loops[0].body)[0]
+    lhs_dims = assign.lhs.dimensions
+    assert lhs_dims[1] == inner_loops[0].variable
+
+    rhs_text = str(assign.rhs).replace(' ', '').lower()
+    assert 'edge_hi(i,j-1)' in rhs_text
+    assert f'edge_lo(i,-1+{str(inner_loops[0].variable).lower()})' in rhs_text

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -1958,6 +1958,40 @@ end module test_shifted_multi_mod
             f'[{label}] Expected one frac dim to have +1 offset, got: {frac_dims}'
 
 
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI cannot parse unresolved external function some_func')]
+))
+def test_resolve_vector_notation_unresolved_inline_call_is_conservative(frontend):
+    """
+    Do not scalarize array arguments to unresolved inline calls, even if the
+    LHS uses vector notation.
+    """
+
+    fcode = """
+subroutine test_unresolved_inline(jl, n, lhs, arr)
+  implicit none
+  integer, intent(in) :: jl, n
+  real, intent(inout) :: lhs(n)
+  real, intent(in)    :: arr(n)
+
+  lhs(1:n) = some_func(arr(:), n)
+end subroutine test_unresolved_inline
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    resolve_vector_notation(routine)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    inline_calls = FindInlineCalls().visit(routine.body)
+
+    assert len(assigns) == 1
+    assert not loops
+    assert assigns[0].lhs == 'lhs(1:n)'
+    assert not inline_calls
+    assert assigns[0].rhs == 'some_func(arr(:), n)'
+
+
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_resolve_vector_notation_non_elemental_inline_call_is_conservative(frontend, tmp_path):
     """

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -1536,16 +1536,21 @@ def test_resolve_vector_notation_no_implicit_rhs(frontend):
     Only assignments where all RHS ranges are explicit should be resolved.
     """
     fcode = """
-subroutine test_no_implicit_rhs(start, end, n, a, b, c)
+subroutine test_no_implicit_rhs(start, end, n, a, b, c, scalar)
   implicit none
   integer, intent(in) :: start, end, n
   real, intent(inout) :: a(n), b(n), c(n)
+  real, intent(in) :: scalar
 
   ! RHS uses bare ':' -- should NOT be resolved with resolve_implicit_rhs_ranges=False
   a(start:end) = b(:)
 
   ! Both sides use explicit range -- SHOULD be resolved
   a(start:end) = c(start:end)
+
+  ! Scalar RHS should still resolve
+  a(start:end) = 0.0
+  a(start:end) = scalar
 
 end subroutine test_no_implicit_rhs
     """.strip()
@@ -1556,36 +1561,46 @@ end subroutine test_no_implicit_rhs
     loops = FindNodes(ir.Loop).visit(routine.body)
     assigns = FindNodes(ir.Assignment).visit(routine.body)
 
-    # Exactly one loop should be generated (for the explicit-range assignment only)
-    assert len(loops) == 1, \
-        f"Expected exactly 1 loop (for explicit-range assignment), got {len(loops)}"
+    # Three loops should be generated: explicit-range assignment plus two scalar RHS cases.
+    assert len(loops) == 3, \
+        f"Expected exactly 3 loops (explicit-range + scalar RHS assignments), got {len(loops)}"
 
     # The unresolved assignment (bare RHS ':') should remain as a vector assignment
     unresolved = [a for a in assigns if isinstance(a.lhs, sym.Array)
                   and any(isinstance(d, sym.RangeIndex) for d in a.lhs.dimensions)]
-    assert len(unresolved) >= 1, \
-        "Assignment with bare RHS ':' should remain unresolved (LHS still has RangeIndex)"
+    assert len(unresolved) == 1, \
+        "Only the assignment with bare RHS ':' should remain unresolved"
+    assert 'b(:)' in str(unresolved[0].rhs), \
+        f"Unexpected unresolved assignment: {unresolved[0]}"
 
-    # The resolved loop should contain the explicit-range assignment (c)
-    loop_assigns = FindNodes(ir.Assignment).visit(loops[0].body)
-    assert len(loop_assigns) == 1
-    assert 'c(' in str(loop_assigns[0].rhs), \
-        f"Expected resolved c(...) in loop body, got: {loop_assigns[0].rhs}"
+    # The resolved loops should cover explicit-range and scalar RHS assignments.
+    loop_assigns = [FindNodes(ir.Assignment).visit(loop.body)[0] for loop in loops]
+    rhs_texts = {str(assign.rhs).replace(' ', '') for assign in loop_assigns}
+    assert any('c(' in rhs for rhs in rhs_texts), \
+        f"Expected resolved c(...) assignment, got: {rhs_texts}"
+    assert '0.0' in rhs_texts, f"Expected scalar literal assignment, got: {rhs_texts}"
+    assert 'scalar' in rhs_texts, f"Expected scalar variable assignment, got: {rhs_texts}"
+    assert all(str(assign.lhs) == 'a(jl)' for assign in loop_assigns)
 
     # --- Part 2: range dimension NOT in the first position ---
     # Ensures that qualified-position tracking works when the range
     # dimension sits at a non-leading position in the index tuple.
     fcode2 = """
-subroutine test_no_implicit_rhs_pos(start, end, m, n, a, b, c)
+subroutine test_no_implicit_rhs_pos(start, end, m, n, a, b, c, scalar)
   implicit none
   integer, intent(in) :: start, end, m, n
   real, intent(inout) :: a(m, n), b(m, n), c(m, n)
+  real, intent(in) :: scalar
 
   ! RHS bare ':' in second dim -- should NOT be resolved
   a(1, start:end) = b(1, :)
 
   ! Both sides explicit in second dim -- SHOULD be resolved
   a(1, start:end) = c(1, start:end)
+
+  ! Scalar RHS in second dim should still resolve
+  a(1, start:end) = 0.0
+  a(1, start:end) = scalar
 
 end subroutine test_no_implicit_rhs_pos
     """.strip()
@@ -1596,21 +1611,65 @@ end subroutine test_no_implicit_rhs_pos
     loops2 = FindNodes(ir.Loop).visit(routine2.body)
     assigns2 = FindNodes(ir.Assignment).visit(routine2.body)
 
-    # Exactly one loop for the explicit-range assignment
-    assert len(loops2) == 1, \
-        f"Expected exactly 1 loop, got {len(loops2)}"
+    # Three loops for explicit-range plus two scalar RHS assignments.
+    assert len(loops2) == 3, \
+        f"Expected exactly 3 loops, got {len(loops2)}"
 
     # The unresolved assignment should still have a RangeIndex
     unresolved2 = [a for a in assigns2 if isinstance(a.lhs, sym.Array)
                    and any(isinstance(d, sym.RangeIndex) for d in a.lhs.dimensions)]
-    assert len(unresolved2) >= 1, \
-        "Assignment with bare RHS ':' should remain unresolved"
+    assert len(unresolved2) == 1, \
+        "Only the assignment with bare RHS ':' should remain unresolved"
+    assert 'b(1, :)' in str(unresolved2[0].rhs), \
+        f"Unexpected unresolved assignment: {unresolved2[0]}"
 
-    # The resolved loop body should reference c
-    loop_assigns2 = FindNodes(ir.Assignment).visit(loops2[0].body)
-    assert len(loop_assigns2) == 1
-    assert 'c(' in str(loop_assigns2[0].rhs), \
-        f"Expected resolved c(...) in loop body, got: {loop_assigns2[0].rhs}"
+    # The resolved loop bodies should reference explicit-range and scalar RHS cases.
+    loop_assigns2 = [FindNodes(ir.Assignment).visit(loop.body)[0] for loop in loops2]
+    rhs_texts2 = {str(assign.rhs).replace(' ', '') for assign in loop_assigns2}
+    assert any('c(' in rhs for rhs in rhs_texts2), \
+        f"Expected resolved c(...) assignment, got: {rhs_texts2}"
+    assert '0.0' in rhs_texts2, f"Expected scalar literal assignment, got: {rhs_texts2}"
+    assert 'scalar' in rhs_texts2, f"Expected scalar variable assignment, got: {rhs_texts2}"
+    assert all(str(assign.lhs) == 'a(1, jl)' for assign in loop_assigns2)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_masked_statements_scalar_rhs_with_no_implicit_rhs(frontend):
+    """
+    Scalar RHS masked assignments should still lower when
+    ``resolve_implicit_rhs_ranges=False``.
+    """
+
+    fcode = """
+subroutine test_masked_scalar_rhs(start, end, n, a)
+  implicit none
+  integer, intent(in) :: start, end, n
+  real, intent(inout) :: a(n)
+
+  where (a(start:end) > 0.0)
+    a(start:end) = 0.0
+  end where
+end subroutine test_masked_scalar_rhs
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    dim = Dimension(name='horizontal', index='jl', lower='start', upper='end')
+    resolve_vector_dimension(routine, dimension=dim, resolve_implicit_rhs_ranges=False)
+
+    masked = FindNodes(ir.MaskedStatement).visit(routine.body)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    conds = FindNodes(ir.Conditional).visit(routine.body)
+
+    assert not masked
+    assert len(loops) == 1
+    assert loops[0].variable == 'jl'
+    assert loops[0].bounds == 'start:end'
+    assert len(conds) == 1
+    assert 'a(jl) > 0.0' in str(conds[0].condition)
+
+    loop_assign = FindNodes(ir.Assignment).visit(loops[0].body)[0]
+    assert loop_assign.lhs == 'a(jl)'
+    assert loop_assign.rhs == '0.0'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1977,6 +2036,37 @@ end subroutine test_lower_only_slice
 
     assert len(loops) == 1
     assert loops[0].bounds == '2:n'
+    assert len(assigns) == 1
+    assert assigns[0].lhs == 'out(i_out_0)'
+    assert assigns[0].rhs == 'arr(i_out_0)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_upper_only_slice(frontend):
+    """
+    Upper-only slices such as ``arr(:n-1)`` must be qualified from shape before
+    vector resolution.
+    """
+
+    fcode = """
+subroutine test_upper_only_slice(n, arr, out)
+  implicit none
+  integer, intent(in) :: n
+  real, intent(in) :: arr(n)
+  real, intent(inout) :: out(n)
+
+  out(:n-1) = arr(:n-1)
+end subroutine test_upper_only_slice
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    assert len(loops) == 1
+    assert loops[0].bounds == '1:n - 1'
     assert len(assigns) == 1
     assert assigns[0].lhs == 'out(i_out_0)'
     assert assigns[0].rhs == 'arr(i_out_0)'

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -1865,11 +1865,11 @@ def test_resolve_vector_notation_shifted_range_multi_arg(frontend):
     fcode = """
 module test_shifted_multi_mod
 contains
-  elemental real function beta2alpha(p, x, y)
+  elemental real function shifted_multi_beta2alpha(p, x, y)
     implicit none
     real, intent(in) :: p, x, y
-    beta2alpha = p + x + y
-  end function beta2alpha
+    shifted_multi_beta2alpha = p + x + y
+  end function shifted_multi_beta2alpha
 
   subroutine test_shifted_multi(jcol, kstart, kend, nlev, overlap_alpha, overlap_param, frac)
     implicit none
@@ -1878,7 +1878,7 @@ contains
     real, intent(in)    :: overlap_param(kend, nlev)
     real, intent(in)    :: frac(kend, nlev)
     do jcol = kstart, kend
-      overlap_alpha(jcol,1:nlev-1) = beta2alpha(overlap_param(jcol,:), &
+      overlap_alpha(jcol,1:nlev-1) = shifted_multi_beta2alpha(overlap_param(jcol,:), &
            frac(jcol,1:nlev-1), frac(jcol,2:nlev))
     end do
   end subroutine test_shifted_multi
@@ -1886,13 +1886,15 @@ end module test_shifted_multi_mod
     """.strip()
 
     # --- Approach 1: resolve_vector_dimension + resolve_vector_notation ---
-    routine1 = Sourcefile.from_source(fcode, frontend=frontend)['test_shifted_multi']
+    source1 = Sourcefile.from_source(fcode, frontend=frontend)
+    routine1 = source1['test_shifted_multi']
     dim = Dimension(name='horizontal', index='jcol', lower='kstart', upper='kend')
     resolve_vector_dimension(routine1, dimension=dim, derive_qualified_ranges=True)
     resolve_vector_notation(routine1)
 
     # --- Approach 2: resolve_vector_notation only ---
-    routine2 = Sourcefile.from_source(fcode, frontend=frontend)['test_shifted_multi']
+    source2 = Sourcefile.from_source(fcode, frontend=frontend)
+    routine2 = source2['test_shifted_multi']
     resolve_vector_notation(routine2)
 
     for label, routine in [('pipeline', routine1), ('notation-only', routine2)]:
@@ -1962,7 +1964,7 @@ end subroutine test_non_elemental_inline
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_vector_notation_elemental_inline_mixed_arguments(frontend):
+def test_resolve_vector_notation_elemental_inline_mixed_arguments(frontend, tmp_path):
     """
     Elemental inline calls with mixed argument shapes should resolve only the
     participating vector dimensions and leave scalar/broadcast arguments alone.
@@ -1971,12 +1973,12 @@ def test_resolve_vector_notation_elemental_inline_mixed_arguments(frontend):
     fcode = """
 module test_elemental_inline_mixed_mod
 contains
-  elemental real function beta2alpha(p, x, y, n)
+  elemental real function mixed_beta2alpha(p, x, y, n)
     implicit none
     integer, intent(in) :: n
     real, intent(in) :: p, x, y
-    beta2alpha = p + x + y + n
-  end function beta2alpha
+    mixed_beta2alpha = p + x + y + n
+  end function mixed_beta2alpha
 
   subroutine test_elemental_inline_mixed(jcol, kstart, kend, nlev, overlap_alpha, overlap_param, frac)
     implicit none
@@ -1985,14 +1987,14 @@ contains
     real, intent(in)    :: overlap_param(kend, nlev)
     real, intent(in)    :: frac(kend, nlev)
     do jcol = kstart, kend
-      overlap_alpha(jcol,1:nlev-1) = beta2alpha(overlap_param(jcol,:), &
+      overlap_alpha(jcol,1:nlev-1) = mixed_beta2alpha(overlap_param(jcol,:), &
            frac(jcol,1:nlev-1), frac(jcol,2:nlev), nlev)
     end do
   end subroutine test_elemental_inline_mixed
 end module test_elemental_inline_mixed_mod
     """.strip()
 
-    source = Sourcefile.from_source(fcode, frontend=frontend)
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     routine = source['test_elemental_inline_mixed']
     dim = Dimension(name='horizontal', index='jcol', lower='kstart', upper='kend')
     resolve_vector_dimension(routine, dimension=dim, derive_qualified_ranges=True)
@@ -2021,11 +2023,11 @@ def test_resolve_vector_notation_elemental_inline_unlinked_procedure_type(fronte
     fcode = """
 module test_elemental_inline_unlinked_mod
 contains
-  elemental real function beta2alpha(p, x, y)
+  elemental real function unlinked_beta2alpha(p, x, y)
     implicit none
     real, intent(in) :: p, x, y
-    beta2alpha = p + x + y
-  end function beta2alpha
+    unlinked_beta2alpha = p + x + y
+  end function unlinked_beta2alpha
 
   subroutine test_elemental_inline_unlinked(jcol, kstart, kend, nlev, overlap_alpha, overlap_param, frac)
     implicit none
@@ -2034,7 +2036,7 @@ contains
     real, intent(in)    :: overlap_param(kend, nlev)
     real, intent(in)    :: frac(kend, nlev)
     do jcol = kstart, kend
-      overlap_alpha(jcol,1:nlev-1) = beta2alpha(overlap_param(jcol,:), &
+      overlap_alpha(jcol,1:nlev-1) = unlinked_beta2alpha(overlap_param(jcol,:), &
            frac(jcol,1:nlev-1), frac(jcol,2:nlev))
     end do
   end subroutine test_elemental_inline_unlinked

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -2288,73 +2288,34 @@ end module test_vector_rhs_subscript_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_vector_notation_vector_valued_slice_bounds_are_conservative(frontend, tmp_path):
+def test_resolve_vector_notation_partial_slice_preserves_step(frontend):
     """
-    Do not resolve vector notation when the slice bounds are themselves
-    vector-valued, e.g. ``out(config%band:)``.
+    Lower-only slices with an explicit step must preserve that step when the
+    upper bound is qualified from the array shape.
     """
 
     fcode = """
-module test_vector_slice_bounds_mod
+subroutine test_partial_slice_preserves_step(n, arr, out)
   implicit none
-  type config_type
-    integer :: band(3)
-  end type config_type
-contains
-  subroutine test_vector_slice_bounds(config, arr, out)
-    implicit none
-    type(config_type), intent(in) :: config
-    real, intent(in) :: arr(5)
-    real, intent(out) :: out(5)
+  integer, intent(in) :: n
+  real, intent(in) :: arr(n)
+  real, intent(inout) :: out(n)
 
-    out(config%band:5) = arr(config%band:5)
-  end subroutine test_vector_slice_bounds
-end module test_vector_slice_bounds_mod
+  out(2::2) = arr(2::2)
+end subroutine test_partial_slice_preserves_step
     """.strip()
 
-    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
-    routine = source['test_vector_slice_bounds']
+    routine = Subroutine.from_source(fcode, frontend=frontend)
     resolve_vector_notation(routine)
 
     loops = FindNodes(ir.Loop).visit(routine.body)
     assigns = FindNodes(ir.Assignment).visit(routine.body)
 
-    assert not loops
+    assert len(loops) == 1
+    assert loops[0].bounds == '2:n:2'
     assert len(assigns) == 1
-    assert str(assigns[0].lhs) == 'out(config%band:5)'
-    assert str(assigns[0].rhs) == 'arr(config%band:5)'
-
-
-@pytest.mark.parametrize(
-    'frontend',
-    available_frontends(skip=[(OMNI, 'Hard to force unresolved bound members with OMNI')])
-)
-def test_resolve_vector_notation_unresolved_scalar_bound_warning(frontend, caplog):
-    """
-    Unresolved derived-type members in accepted slice bounds should emit a
-    warning because Loki cannot distinguish scalar from array-valued members.
-    """
-    from loki.logging import WARNING  # pylint: disable=import-outside-toplevel
-
-    fcode = """
-subroutine test_unresolved_scalar_bound_warning(arr, out)
-  implicit none
-  real, intent(in) :: arr(5)
-  real, intent(out) :: out(5)
-
-  out(1:dims%klon) = arr(1:dims%klon)
-end subroutine test_unresolved_scalar_bound_warning
-    """.strip()
-
-    routine = Subroutine.from_source(fcode, frontend=frontend)
-
-    caplog.set_level(WARNING)
-    resolve_vector_notation(routine)
-
-    assert any(
-        'Treating unresolved bound expression as scalar' in record.message
-        for record in caplog.records
-    )
+    assert assigns[0].lhs == 'out(i_out_0)'
+    assert assigns[0].rhs == 'arr(i_out_0)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -10,11 +10,11 @@
 import pytest
 import numpy as np
 
-from loki import Module, Subroutine, Dimension
+from loki import Module, Subroutine, Dimension, Sourcefile
 from loki.jit_build import jit_compile_and_run, jit_compile_lib, Builder, Obj
 from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI
-from loki.ir import nodes as ir, FindNodes, FindVariables
+from loki.ir import nodes as ir, FindNodes, FindVariables, FindInlineCalls
 from loki.logging import WARNING
 
 from loki.transformations.array_indexing.vector_notation import (
@@ -802,6 +802,95 @@ end subroutine test_ifs_patterns
     p8_loops = [l for l in loops if l.variable.name.startswith('i_zremap_')]
     assert len(p8_loops) >= 2, \
         f"Pattern 8: expected 2 nested loops for zremap, got {len(p8_loops)}"
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_masked_statements_nested_condition(frontend):
+    """
+    Resolve sequential WHERE blocks nested inside an outer scalar IF.
+
+    This covers the ecRad-style pattern where the mask contains a mix of
+    scalar and vector terms, such as ``ssa_total > 0.0 .and. od_total(:) > 0.0``.
+    """
+
+    fcode = """
+subroutine test_masked_nested(flag, ncol, od_total, ssa_total, g_total, ssa, g, cloud)
+  implicit none
+  logical, intent(in) :: flag
+  integer, intent(in) :: ncol
+  real, intent(inout) :: ssa_total(ncol), g_total(ncol)
+  real, intent(in) :: od_total(ncol), ssa(ncol), g(ncol), cloud(ncol)
+
+  if (flag) then
+    where (od_total(:) > 0.0)
+      ssa_total = (ssa(:) + cloud(:)) / od_total(:)
+    end where
+    where (ssa_total > 0.0 .and. od_total(:) > 0.0)
+      g_total = (g(:) + cloud(:)) / ssa_total
+    end where
+  end if
+end subroutine test_masked_nested
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    dim = Dimension(name='horizontal', index='jl', lower='1', upper='ncol')
+    resolve_vector_dimension(routine, dimension=dim, derive_qualified_ranges=True)
+
+    conds = FindNodes(ir.Conditional).visit(routine.body)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+
+    outer_cond = next(c for c in conds if c.condition == 'flag')
+    nested_conds = [c for c in FindNodes(ir.Conditional).visit(outer_cond.body) if c.condition != 'flag']
+    assert len(nested_conds) == 2
+    assert len(loops) == 2
+    assert all(loop.variable == 'jl' for loop in loops)
+    assert all(loop.bounds == '1:ncol' for loop in loops)
+
+    first_assign = FindNodes(ir.Assignment).visit(loops[0].body)[0]
+    assert first_assign.lhs == 'ssa_total(jl)'
+    assert first_assign.rhs == '(ssa(jl) + cloud(jl))/od_total(jl)'
+
+    second_assign = FindNodes(ir.Assignment).visit(loops[1].body)[0]
+    assert second_assign.lhs == 'g_total(jl)'
+    assert second_assign.rhs == '(g(jl) + cloud(jl))/ssa_total(jl)'
+
+    second_inner_cond = next(c for c in FindNodes(ir.Conditional).visit(loops[1].body))
+    second_cond = str(second_inner_cond.condition).replace(' ', '').lower()
+    assert 'ssa_total(jl)>0.0' in second_cond
+    assert 'od_total(jl)>0.0' in second_cond
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_masked_statements_fallback_unresolved_rhs(frontend):
+    """
+    Keep unsupported masked statements unchanged when RHS bare ranges are not
+    allowed to resolve.
+    """
+
+    fcode = """
+subroutine test_masked_fallback(start, end, n, a, b)
+  implicit none
+  integer, intent(in) :: start, end, n
+  real, intent(inout) :: a(n), b(n)
+
+  where (a(start:end) > 0.0)
+    a(start:end) = b(:)
+  end where
+end subroutine test_masked_fallback
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    dim = Dimension(name='horizontal', index='jl', lower='start', upper='end')
+    resolve_vector_dimension(routine, dimension=dim, resolve_implicit_rhs_ranges=False)
+
+    masked = FindNodes(ir.MaskedStatement).visit(routine.body)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    conds = FindNodes(ir.Conditional).visit(routine.body)
+
+    assert len(masked) == 1
+    assert not loops
+    assert not conds
+    assert masked[0].conditions[0] == 'a(start:end) > 0.0'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1714,27 +1803,36 @@ def test_resolve_vector_notation_shifted_range_multi_arg(frontend):
     alone must produce ``frac(jcol, 1 + i_...)`` (not ``1 + (1:nlev-1)``).
     """
     fcode = """
-subroutine test_shifted_multi(jcol, kstart, kend, nlev, overlap_alpha, overlap_param, frac)
-  implicit none
-  integer, intent(in) :: kstart, kend, nlev, jcol
-  real, intent(inout) :: overlap_alpha(kend, nlev-1)
-  real, intent(in)    :: overlap_param(kend, nlev)
-  real, intent(in)    :: frac(kend, nlev)
-  do jcol = kstart, kend
-    overlap_alpha(jcol,1:nlev-1) = beta2alpha(overlap_param(jcol,:), &
-         frac(jcol,1:nlev-1), frac(jcol,2:nlev))
-  end do
-end subroutine test_shifted_multi
+module test_shifted_multi_mod
+contains
+  elemental real function beta2alpha(p, x, y)
+    implicit none
+    real, intent(in) :: p, x, y
+    beta2alpha = p + x + y
+  end function beta2alpha
+
+  subroutine test_shifted_multi(jcol, kstart, kend, nlev, overlap_alpha, overlap_param, frac)
+    implicit none
+    integer, intent(in) :: kstart, kend, nlev, jcol
+    real, intent(inout) :: overlap_alpha(kend, nlev-1)
+    real, intent(in)    :: overlap_param(kend, nlev)
+    real, intent(in)    :: frac(kend, nlev)
+    do jcol = kstart, kend
+      overlap_alpha(jcol,1:nlev-1) = beta2alpha(overlap_param(jcol,:), &
+           frac(jcol,1:nlev-1), frac(jcol,2:nlev))
+    end do
+  end subroutine test_shifted_multi
+end module test_shifted_multi_mod
     """.strip()
 
     # --- Approach 1: resolve_vector_dimension + resolve_vector_notation ---
-    routine1 = Subroutine.from_source(fcode, frontend=frontend)
+    routine1 = Sourcefile.from_source(fcode, frontend=frontend)['test_shifted_multi']
     dim = Dimension(name='horizontal', index='jcol', lower='kstart', upper='kend')
     resolve_vector_dimension(routine1, dimension=dim, derive_qualified_ranges=True)
     resolve_vector_notation(routine1)
 
     # --- Approach 2: resolve_vector_notation only ---
-    routine2 = Subroutine.from_source(fcode, frontend=frontend)
+    routine2 = Sourcefile.from_source(fcode, frontend=frontend)['test_shifted_multi']
     resolve_vector_notation(routine2)
 
     for label, routine in [('pipeline', routine1), ('notation-only', routine2)]:
@@ -1766,6 +1864,208 @@ end subroutine test_shifted_multi
         # One frac should be accessed with the plain loop index, the other with +1 offset
         assert any('1+' in d or '+1' in d for d in frac_dims), \
             f'[{label}] Expected one frac dim to have +1 offset, got: {frac_dims}'
+
+
+@pytest.mark.parametrize('frontend', available_frontends(
+    skip=[(OMNI, 'OMNI cannot parse unresolved external function some_func')]
+))
+def test_resolve_vector_notation_non_elemental_inline_call_is_conservative(frontend):
+    """
+    Do not scalarize array actual arguments to unknown/non-elemental inline
+    calls, even if the LHS uses vector notation.
+    """
+
+    fcode = """
+subroutine test_non_elemental_inline(jl, n, lhs, arr)
+  implicit none
+  integer, intent(in) :: jl, n
+  real, intent(inout) :: lhs(n)
+  real, intent(in)    :: arr(n)
+
+  lhs(1:n) = some_func(arr(:), n)
+end subroutine test_non_elemental_inline
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    resolve_vector_notation(routine)
+
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    inline_calls = FindInlineCalls().visit(routine.body)
+
+    assert len(assigns) == 1
+    assert not loops
+    assert str(assigns[0].lhs) == 'lhs(1:n)'
+    assert not inline_calls
+    rhs_text = str(assigns[0].rhs).replace(' ', '')
+    assert rhs_text == 'some_func(arr(:),n)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_elemental_inline_mixed_arguments(frontend):
+    """
+    Elemental inline calls with mixed argument shapes should resolve only the
+    participating vector dimensions and leave scalar/broadcast arguments alone.
+    """
+
+    fcode = """
+module test_elemental_inline_mixed_mod
+contains
+  elemental real function beta2alpha(p, x, y, n)
+    implicit none
+    integer, intent(in) :: n
+    real, intent(in) :: p, x, y
+    beta2alpha = p + x + y + n
+  end function beta2alpha
+
+  subroutine test_elemental_inline_mixed(jcol, kstart, kend, nlev, overlap_alpha, overlap_param, frac)
+    implicit none
+    integer, intent(in) :: kstart, kend, nlev, jcol
+    real, intent(inout) :: overlap_alpha(kend, nlev-1)
+    real, intent(in)    :: overlap_param(kend, nlev)
+    real, intent(in)    :: frac(kend, nlev)
+    do jcol = kstart, kend
+      overlap_alpha(jcol,1:nlev-1) = beta2alpha(overlap_param(jcol,:), &
+           frac(jcol,1:nlev-1), frac(jcol,2:nlev), nlev)
+    end do
+  end subroutine test_elemental_inline_mixed
+end module test_elemental_inline_mixed_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['test_elemental_inline_mixed']
+    dim = Dimension(name='horizontal', index='jcol', lower='kstart', upper='kend')
+    resolve_vector_dimension(routine, dimension=dim, derive_qualified_ranges=True)
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 2
+
+    assign = FindNodes(ir.Assignment).visit(loops[1].body)[0]
+    inline_call = FindInlineCalls().visit(assign.rhs)[0]
+    call_text = str(inline_call).replace(' ', '')
+
+    assert 'overlap_param(jcol,' in call_text
+    assert 'frac(jcol,' in call_text
+    assert 'nlev' in call_text
+    assert 'RangeIndex' not in call_text
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_lower_only_slice(frontend):
+    """
+    Lower-only slices such as ``arr(2:)`` must be qualified from shape before
+    vector resolution.
+    """
+
+    fcode = """
+subroutine test_lower_only_slice(n, arr, out)
+  implicit none
+  integer, intent(in) :: n
+  real, intent(in) :: arr(n)
+  real, intent(inout) :: out(n)
+
+  out(2:) = arr(2:)
+end subroutine test_lower_only_slice
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    assert len(loops) == 1
+    assert loops[0].bounds == '2:n'
+    assert len(assigns) == 1
+    assert assigns[0].lhs == 'out(i_out_0)'
+    assert assigns[0].rhs == 'arr(i_out_0)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_indirect_rhs_index(frontend):
+    """
+    Indirect/derived-type index expressions on the RHS must be preserved while
+    other vector dimensions are resolved.
+    """
+
+    fcode = """
+module test_indirect_rhs_index_mod
+  implicit none
+  type config_type
+    integer :: band(3)
+  end type config_type
+contains
+  subroutine test_indirect_rhs_index(config, jlev, ncol, od_cloud, od_scaling, od_cloud_new)
+    implicit none
+    type(config_type), intent(in) :: config
+    integer, intent(in) :: jlev, ncol
+    real, intent(in) :: od_cloud(3, 4, ncol), od_scaling(2, 4, ncol)
+    real, intent(out) :: od_cloud_new(ncol)
+    integer :: jreg
+
+    jreg = 1
+    od_cloud_new(:) = od_cloud(config%band(1), jlev, :) * od_scaling(jreg, jlev, :)
+  end subroutine test_indirect_rhs_index
+end module test_indirect_rhs_index_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['test_indirect_rhs_index']
+    dim = Dimension(name='horizontal', index='jcol', lower='1', upper='ncol')
+    resolve_vector_dimension(routine, dimension=dim, derive_qualified_ranges=True)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    assert len(loops) == 1
+    assert loops[0].variable == 'jcol'
+    assert loops[0].bounds == '1:ncol'
+    assert len(assigns) == 2
+
+    vector_assign = next(a for a in assigns if a.lhs == 'od_cloud_new(jcol)')
+    rhs_text = str(vector_assign.rhs).replace(' ', '')
+    assert 'od_cloud(config%band(1),jlev,jcol)' in rhs_text
+    assert 'od_scaling(jreg,jlev,jcol)' in rhs_text
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_vector_valued_rhs_subscript_is_conservative(frontend):
+    """
+    Do not resolve a vector dimension when a RHS array subscript is itself
+    vector-valued, e.g. ``arr(config%band, jlev, jcol)``.
+    """
+
+    fcode = """
+module test_vector_rhs_subscript_mod
+  implicit none
+  type config_type
+    integer :: band(3)
+  end type config_type
+contains
+  subroutine test_vector_rhs_subscript(config, jlev, jcol, od_cloud, od_cloud_new)
+    implicit none
+    type(config_type), intent(in) :: config
+    integer, intent(in) :: jlev, jcol
+    real, intent(in) :: od_cloud(3, 4, 5)
+    real, intent(out) :: od_cloud_new(3, 5)
+
+    od_cloud_new(:, jcol) = od_cloud(config%band, jlev, jcol)
+  end subroutine test_vector_rhs_subscript
+end module test_vector_rhs_subscript_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['test_vector_rhs_subscript']
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    assert not loops
+    assert len(assigns) == 1
+    assert str(assigns[0].lhs) == 'od_cloud_new(:, jcol)'
+    assert str(assigns[0].rhs) == 'od_cloud(config%band, jlev, jcol)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -2133,6 +2133,37 @@ end subroutine test_upper_only_slice
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_scalar_array_element_slice_bounds(frontend):
+    """
+    Slice bounds derived from scalar array elements should remain resolvable.
+    """
+
+    fcode = """
+subroutine test_scalar_array_element_slice_bounds(n, bounds, arr1, out)
+  implicit none
+  integer, intent(in) :: n
+  integer, intent(in) :: bounds(2)
+  real, intent(in) :: arr1(n)
+  real, intent(inout) :: out(n)
+
+  out(bounds(1):bounds(2)) = arr1(bounds(1):bounds(2))
+end subroutine test_scalar_array_element_slice_bounds
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    assert len(loops) == 1
+    assert loops[0].bounds == 'bounds(1):bounds(2)'
+    assert len(assigns) == 1
+    assert assigns[0].lhs == 'out(i_out_0)'
+    assert assigns[0].rhs == 'arr1(i_out_0)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_resolve_vector_notation_indirect_rhs_index(frontend):
     """
     Indirect/derived-type index expressions on the RHS must be preserved while
@@ -2216,6 +2247,44 @@ end module test_vector_rhs_subscript_mod
     assert len(assigns) == 1
     assert str(assigns[0].lhs) == 'od_cloud_new(:, jcol)'
     assert str(assigns[0].rhs) == 'od_cloud(config%band, jlev, jcol)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_vector_valued_slice_bounds_are_conservative(frontend):
+    """
+    Do not resolve vector notation when the slice bounds are themselves
+    vector-valued, e.g. ``out(config%band:)``.
+    """
+
+    fcode = """
+module test_vector_slice_bounds_mod
+  implicit none
+  type config_type
+    integer :: band(3)
+  end type config_type
+contains
+  subroutine test_vector_slice_bounds(config, arr, out)
+    implicit none
+    type(config_type), intent(in) :: config
+    real, intent(in) :: arr(5)
+    real, intent(out) :: out(5)
+
+    out(config%band:5) = arr(config%band:5)
+  end subroutine test_vector_slice_bounds
+end module test_vector_slice_bounds_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['test_vector_slice_bounds']
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    assert not loops
+    assert len(assigns) == 1
+    assert str(assigns[0].lhs) == 'out(config%band:5)'
+    assert str(assigns[0].rhs) == 'arr(config%band:5)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -2012,7 +2012,7 @@ end module test_elemental_inline_mixed_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_vector_notation_elemental_inline_unlinked_procedure_type(frontend):
+def test_resolve_vector_notation_elemental_inline_unlinked_procedure_type(frontend, tmp_path):
     """
     Elemental inline calls should still be scalarized when the ProcedureType
     exists but its link to the contained routine has been dropped.
@@ -2041,7 +2041,7 @@ contains
 end module test_elemental_inline_unlinked_mod
     """.strip()
 
-    source = Sourcefile.from_source(fcode, frontend=frontend)
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     routine = source['test_elemental_inline_unlinked']
     dim = Dimension(name='horizontal', index='jcol', lower='kstart', upper='kend')
     resolve_vector_dimension(routine, dimension=dim, derive_qualified_ranges=True)
@@ -2133,7 +2133,7 @@ end subroutine test_upper_only_slice
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_vector_notation_scalar_array_element_slice_bounds(frontend):
+def test_resolve_vector_notation_scalar_array_element_slice_bounds(frontend, tmp_path):
     """
     Slice bounds derived from scalar array elements should remain resolvable.
     """
@@ -2150,7 +2150,7 @@ subroutine test_scalar_array_element_slice_bounds(n, bounds, arr1, out)
 end subroutine test_scalar_array_element_slice_bounds
     """.strip()
 
-    routine = Subroutine.from_source(fcode, frontend=frontend)
+    routine = Subroutine.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     resolve_vector_notation(routine)
 
     loops = FindNodes(ir.Loop).visit(routine.body)
@@ -2164,7 +2164,45 @@ end subroutine test_scalar_array_element_slice_bounds
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_vector_notation_indirect_rhs_index(frontend):
+def test_resolve_vector_notation_scalar_derived_type_slice_bounds(frontend, tmp_path):
+    """
+    Scalar derived-type members should remain valid slice bounds.
+    """
+
+    fcode = """
+module test_scalar_derived_slice_bounds_mod
+  implicit none
+  type dims_type
+    integer :: klon
+  end type dims_type
+contains
+  subroutine test_scalar_derived_slice_bounds(dims, arr, out)
+    implicit none
+    type(dims_type), intent(in) :: dims
+    real, intent(in) :: arr(5)
+    real, intent(out) :: out(5)
+
+    out(1:dims%klon) = arr(1:dims%klon)
+  end subroutine test_scalar_derived_slice_bounds
+end module test_scalar_derived_slice_bounds_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = source['test_scalar_derived_slice_bounds']
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assigns = FindNodes(ir.Assignment).visit(routine.body)
+
+    assert len(loops) == 1
+    assert loops[0].bounds == '1:dims%klon'
+    assert len(assigns) == 1
+    assert assigns[0].lhs == 'out(i_out_0)'
+    assert assigns[0].rhs == 'arr(i_out_0)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_indirect_rhs_index(frontend, tmp_path):
     """
     Indirect/derived-type index expressions on the RHS must be preserved while
     other vector dimensions are resolved.
@@ -2191,7 +2229,7 @@ contains
 end module test_indirect_rhs_index_mod
     """.strip()
 
-    source = Sourcefile.from_source(fcode, frontend=frontend)
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     routine = source['test_indirect_rhs_index']
     dim = Dimension(name='horizontal', index='jcol', lower='1', upper='ncol')
     resolve_vector_dimension(routine, dimension=dim, derive_qualified_ranges=True)
@@ -2211,7 +2249,7 @@ end module test_indirect_rhs_index_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_vector_notation_vector_valued_rhs_subscript_is_conservative(frontend):
+def test_resolve_vector_notation_vector_valued_rhs_subscript_is_conservative(frontend, tmp_path):
     """
     Do not resolve a vector dimension when a RHS array subscript is itself
     vector-valued, e.g. ``arr(config%band, jlev, jcol)``.
@@ -2236,7 +2274,7 @@ contains
 end module test_vector_rhs_subscript_mod
     """.strip()
 
-    source = Sourcefile.from_source(fcode, frontend=frontend)
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     routine = source['test_vector_rhs_subscript']
     resolve_vector_notation(routine)
 
@@ -2250,7 +2288,7 @@ end module test_vector_rhs_subscript_mod
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_vector_notation_vector_valued_slice_bounds_are_conservative(frontend):
+def test_resolve_vector_notation_vector_valued_slice_bounds_are_conservative(frontend, tmp_path):
     """
     Do not resolve vector notation when the slice bounds are themselves
     vector-valued, e.g. ``out(config%band:)``.
@@ -2274,7 +2312,7 @@ contains
 end module test_vector_slice_bounds_mod
     """.strip()
 
-    source = Sourcefile.from_source(fcode, frontend=frontend)
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
     routine = source['test_vector_slice_bounds']
     resolve_vector_notation(routine)
 
@@ -2285,6 +2323,38 @@ end module test_vector_slice_bounds_mod
     assert len(assigns) == 1
     assert str(assigns[0].lhs) == 'out(config%band:5)'
     assert str(assigns[0].rhs) == 'arr(config%band:5)'
+
+
+@pytest.mark.parametrize(
+    'frontend',
+    available_frontends(skip=[(OMNI, 'Hard to force unresolved bound members with OMNI')])
+)
+def test_resolve_vector_notation_unresolved_scalar_bound_warning(frontend, caplog):
+    """
+    Unresolved derived-type members in accepted slice bounds should emit a
+    warning because Loki cannot distinguish scalar from array-valued members.
+    """
+    from loki.logging import WARNING  # pylint: disable=import-outside-toplevel
+
+    fcode = """
+subroutine test_unresolved_scalar_bound_warning(arr, out)
+  implicit none
+  real, intent(in) :: arr(5)
+  real, intent(out) :: out(5)
+
+  out(1:dims%klon) = arr(1:dims%klon)
+end subroutine test_unresolved_scalar_bound_warning
+    """.strip()
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    caplog.set_level(WARNING)
+    resolve_vector_notation(routine)
+
+    assert any(
+        'Treating unresolved bound expression as scalar' in record.message
+        for record in caplog.records
+    )
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -1958,27 +1958,38 @@ end module test_shifted_multi_mod
             f'[{label}] Expected one frac dim to have +1 offset, got: {frac_dims}'
 
 
-@pytest.mark.parametrize('frontend', available_frontends(
-    skip=[(OMNI, 'OMNI cannot parse unresolved external function some_func')]
-))
-def test_resolve_vector_notation_non_elemental_inline_call_is_conservative(frontend):
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_non_elemental_inline_call_is_conservative(frontend, tmp_path):
     """
-    Do not scalarize array actual arguments to unknown/non-elemental inline
+    Do not scalarize array actual arguments to non-elemental inline
     calls, even if the LHS uses vector notation.
     """
 
     fcode = """
-subroutine test_non_elemental_inline(jl, n, lhs, arr)
+module test_non_elemental_inline_mod
+contains
+  function some_func(array, n) result(total)
+    implicit none
+    integer, intent(in) :: n
+    real, intent(in) :: array(n)
+    real :: total
+
+    total = array(1)
+  end function some_func
+
+  subroutine test_non_elemental_inline(jl, n, lhs, arr)
   implicit none
   integer, intent(in) :: jl, n
   real, intent(inout) :: lhs(n)
   real, intent(in)    :: arr(n)
 
   lhs(1:n) = some_func(arr(:), n)
-end subroutine test_non_elemental_inline
+  end subroutine test_non_elemental_inline
+end module test_non_elemental_inline_mod
     """.strip()
 
-    routine = Subroutine.from_source(fcode, frontend=frontend)
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = source['test_non_elemental_inline']
     resolve_vector_notation(routine)
 
     assigns = FindNodes(ir.Assignment).visit(routine.body)
@@ -1988,9 +1999,10 @@ end subroutine test_non_elemental_inline
     assert len(assigns) == 1
     assert not loops
     assert str(assigns[0].lhs) == 'lhs(1:n)'
-    assert not inline_calls
-    rhs_text = str(assigns[0].rhs).replace(' ', '')
-    assert rhs_text == 'some_func(arr(:),n)'
+    assert len(inline_calls) == 1
+    inline_call = next(iter(inline_calls))
+    assert inline_call.name == 'some_func'
+    assert inline_call.parameters[0] == 'arr(:)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -16,7 +16,7 @@ from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes, FindVariables, FindInlineCalls
 from loki.logging import WARNING
-from loki.types import ProcedureType
+from loki.types import BasicType, ProcedureType
 
 from loki.transformations.array_indexing.vector_notation import (
     resolve_vector_notation, resolve_vector_dimension,
@@ -2100,6 +2100,45 @@ end module test_elemental_inline_unlinked_mod
     assert 'RangeIndex' not in call_text
     assert any('1+' in str(dim).replace(' ', '') or '+1' in str(dim).replace(' ', '')
                for dim in resolved_inline_call.parameters[2].dimensions)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_elemental_inline_unenriched_procedure_type(frontend, tmp_path):
+    """Resolve an elemental inline call recovered from its containing scope."""
+    fcode = """
+module test_elemental_inline_unenriched_mod
+contains
+  elemental real function elemental_func(x)
+    implicit none
+    real, intent(in) :: x
+    elemental_func = x
+  end function elemental_func
+
+  subroutine test_elemental_inline_unenriched(n, lhs, arr)
+    implicit none
+    integer, intent(in) :: n
+    real, intent(inout) :: lhs(n)
+    real, intent(in) :: arr(n)
+
+    lhs(1:n) = elemental_func(arr(1:n))
+  end subroutine test_elemental_inline_unenriched
+end module test_elemental_inline_unenriched_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend, xmods=[tmp_path])
+    routine = source['test_elemental_inline_unenriched']
+    inline_call = next(iter(FindInlineCalls().visit(routine.body)))
+    inline_call.function.type = inline_call.function.type.clone(dtype=BasicType.DEFERRED)
+
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+    assert loops[0].bounds == '1:n'
+
+    assign = FindNodes(ir.Assignment).visit(loops[0].body)[0]
+    assert assign.lhs == 'lhs(i_lhs_0)'
+    assert assign.rhs == 'elemental_func(arr(i_lhs_0))'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -861,22 +861,23 @@ end subroutine test_masked_nested
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_masked_statements_fallback_unresolved_rhs(frontend):
+@pytest.mark.parametrize(('rhs', 'resolved'), (('b(:)', False), ('0.0', True)))
+def test_resolve_masked_statements_no_implicit_rhs(frontend, rhs, resolved):
     """
-    Keep unsupported masked statements unchanged when RHS bare ranges are not
-    allowed to resolve.
+    Keep masked statements with RHS bare ranges unchanged when implicit RHS
+    ranges are disabled, but still lower masked assignments with scalar RHS.
     """
 
-    fcode = """
-subroutine test_masked_fallback(start, end, n, a, b)
+    fcode = f"""
+subroutine test_masked_no_implicit_rhs(start, end, n, a, b)
   implicit none
   integer, intent(in) :: start, end, n
   real, intent(inout) :: a(n), b(n)
 
   where (a(start:end) > 0.0)
-    a(start:end) = b(:)
+    a(start:end) = {rhs}
   end where
-end subroutine test_masked_fallback
+end subroutine test_masked_no_implicit_rhs
     """.strip()
     routine = Subroutine.from_source(fcode, frontend=frontend)
 
@@ -887,10 +888,23 @@ end subroutine test_masked_fallback
     loops = FindNodes(ir.Loop).visit(routine.body)
     conds = FindNodes(ir.Conditional).visit(routine.body)
 
-    assert len(masked) == 1
-    assert not loops
-    assert not conds
-    assert masked[0].conditions[0] == 'a(start:end) > 0.0'
+    if not resolved:
+        assert len(masked) == 1
+        assert not loops
+        assert not conds
+        assert masked[0].conditions[0] == 'a(start:end) > 0.0'
+        return
+
+    assert not masked
+    assert len(loops) == 1
+    assert loops[0].variable == 'jl'
+    assert loops[0].bounds == 'start:end'
+    assert len(conds) == 1
+    assert conds[0].condition == 'a(jl) > 0.0'
+
+    loop_assign = FindNodes(ir.Assignment).visit(loops[0].body)[0]
+    assert loop_assign.lhs == 'a(jl)'
+    assert loop_assign.rhs == '0.0'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1631,45 +1645,6 @@ end subroutine test_no_implicit_rhs_pos
     assert '0.0' in rhs_texts2, f"Expected scalar literal assignment, got: {rhs_texts2}"
     assert 'scalar' in rhs_texts2, f"Expected scalar variable assignment, got: {rhs_texts2}"
     assert all(assign.lhs == 'a(1, jl)' for assign in loop_assigns2)
-
-
-@pytest.mark.parametrize('frontend', available_frontends())
-def test_resolve_masked_statements_scalar_rhs_with_no_implicit_rhs(frontend):
-    """
-    Scalar RHS masked assignments should still lower when
-    ``resolve_implicit_rhs_ranges=False``.
-    """
-
-    fcode = """
-subroutine test_masked_scalar_rhs(start, end, n, a)
-  implicit none
-  integer, intent(in) :: start, end, n
-  real, intent(inout) :: a(n)
-
-  where (a(start:end) > 0.0)
-    a(start:end) = 0.0
-  end where
-end subroutine test_masked_scalar_rhs
-    """.strip()
-    routine = Subroutine.from_source(fcode, frontend=frontend)
-
-    dim = Dimension(name='horizontal', index='jl', lower='start', upper='end')
-    resolve_vector_dimension(routine, dimension=dim, resolve_implicit_rhs_ranges=False)
-
-    masked = FindNodes(ir.MaskedStatement).visit(routine.body)
-    loops = FindNodes(ir.Loop).visit(routine.body)
-    conds = FindNodes(ir.Conditional).visit(routine.body)
-
-    assert not masked
-    assert len(loops) == 1
-    assert loops[0].variable == 'jl'
-    assert loops[0].bounds == 'start:end'
-    assert len(conds) == 1
-    assert conds[0].condition == 'a(jl) > 0.0'
-
-    loop_assign = FindNodes(ir.Assignment).visit(loops[0].body)[0]
-    assert loop_assign.lhs == 'a(jl)'
-    assert loop_assign.rhs == '0.0'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -1674,6 +1674,36 @@ end subroutine test_masked_scalar_rhs
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_masked_statements_reuse_mask_indices(frontend):
+    """Use the mask loop index for vector ranges in the WHERE body."""
+    fcode = """
+subroutine test_masked_reuse_indices(n, a, b)
+  implicit none
+  integer, intent(in) :: n
+  real, intent(in) :: a(n)
+  real, intent(inout) :: b(n)
+
+  where (a(1:n) > 0.0)
+    b(1:n) = a(1:n)
+  end where
+end subroutine test_masked_reuse_indices
+    """.strip()
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 1
+    assert loops[0].variable == 'i_mask_0'
+    assert loops[0].bounds == '1:n'
+
+    condition = FindNodes(ir.Conditional).visit(loops[0].body)[0]
+    assign = FindNodes(ir.Assignment).visit(condition.body)[0]
+    assert condition.condition == 'a(i_mask_0) > 0.0'
+    assert assign.lhs == 'b(i_mask_0)'
+    assert assign.rhs == 'a(i_mask_0)'
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 def test_resolve_vector_notation_inline_conditional(frontend):
     """
     When an inline conditional (single-line ``IF``) contains a vector

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -724,11 +724,11 @@ end subroutine test_ifs_patterns
 
     # --- Pattern 1: work(kidia:kfdia) = 1.0 -> DO jl=kidia,kfdia; work(jl)=1.0 ---
     p1_loops = [l for l in loops
-                if l.variable.name == 'jl' and str(l.bounds) == 'kidia:kfdia']
+                if l.variable.name == 'jl' and l.bounds == 'kidia:kfdia']
     assert len(p1_loops) >= 1, "Pattern 1: expected jl loop with kidia:kfdia bounds"
     p1_assigns = FindNodes(ir.Assignment).visit(p1_loops[0].body)
     assert len(p1_assigns) >= 1
-    assert str(p1_assigns[0].lhs) == 'work(jl)'
+    assert p1_assigns[0].lhs == 'work(jl)'
 
     # --- Pattern 2: element-wise pssn(jl,1:klevsn) = ptsn/pwsn ---
     # Should create inner loop for dimension 2
@@ -761,7 +761,7 @@ end subroutine test_ifs_patterns
     # --- Pattern 4: Partial range pssn(jl, 2:klevsn) = 0.0 ---
     # Should create loop starting at 2
     p4_loop_names = [l for l in loops if l.variable.name.startswith('i_pssn_')]
-    p4_loops_from2 = [l for l in p4_loop_names if '2' in str(l.bounds)]
+    p4_loops_from2 = [l for l in p4_loop_names if l.bounds.start == 2]
     assert len(p4_loops_from2) >= 1, "Pattern 4: expected loop with lower bound of 2"
 
     # --- Pattern 5: pdhtss(jl, 1:klevsn, 1) = 0.0 and pdhtss(jl, 1:klevsn, 2) = 273.15 ---
@@ -796,7 +796,7 @@ end subroutine test_ifs_patterns
     p7_loops = [l for l in loops if l.variable.name.startswith('i_zdsng_')]
     assert len(p7_loops) >= 1, "Pattern 7: expected generated loop for zdsng"
     # Loop should start at 0
-    assert '0' in str(p7_loops[0].bounds), \
+    assert p7_loops[0].bounds.start == 0, \
         f"Pattern 7: expected 0 in loop bounds, got {p7_loops[0].bounds}"
 
     # --- Pattern 8: Nested 2D full-colon zremap(jl, :, :) = 0.0 ---
@@ -856,9 +856,8 @@ end subroutine test_masked_nested
     assert second_assign.rhs == '(g(jl) + cloud(jl))/ssa_total(jl)'
 
     second_inner_cond = next(c for c in FindNodes(ir.Conditional).visit(loops[1].body))
-    second_cond = str(second_inner_cond.condition).replace(' ', '').lower()
-    assert 'ssa_total(jl)>0.0' in second_cond
-    assert 'od_total(jl)>0.0' in second_cond
+    assert 'ssa_total(jl) > 0.0' in second_inner_cond.condition
+    assert 'od_total(jl) > 0.0' in second_inner_cond.condition
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -943,14 +942,14 @@ end subroutine test_early_exits
     assigns = FindNodes(ir.Assignment).visit(routine.body)
 
     # SUM assignment should remain unchanged (total = sum(...))
-    sum_assigns = [a for a in assigns if str(a.lhs) == 'total']
+    sum_assigns = [a for a in assigns if a.lhs == 'total']
     assert len(sum_assigns) == 1, "SUM assignment should still exist"
     for l in loops:
         assert sum_assigns[0] not in FindNodes(ir.Assignment).visit(l.body), \
             "SUM assignment should not be inside a generated loop"
 
     # Scalar assignment should remain unchanged
-    scalar_assigns = [a for a in assigns if str(a.lhs) == 'scalar']
+    scalar_assigns = [a for a in assigns if a.lhs == 'scalar']
     assert len(scalar_assigns) == 1, "Scalar assignment should still exist"
     for l in loops:
         assert scalar_assigns[0] not in FindNodes(ir.Assignment).visit(l.body), \
@@ -1347,9 +1346,9 @@ end subroutine test_dt_no_subst_explicit
     loop = loops[0]
     assert loop.variable.name.lower() == 'jl', \
         f"Expected loop variable 'jl', got '{loop.variable.name}'"
-    assert str(loop.bounds.start).lower() == 'kidia', \
+    assert loop.bounds.start == 'kidia', \
         f"Expected lower bound 'kidia', got '{loop.bounds.start}'"
-    assert str(loop.bounds.stop).lower() == 'kfdia', \
+    assert loop.bounds.stop == 'kfdia', \
         f"Expected upper bound 'kfdia', got '{loop.bounds.stop}'"
 
     # The bounds must remain as plain scalars (not derived-type members)
@@ -1571,7 +1570,7 @@ end subroutine test_no_implicit_rhs
                   and any(isinstance(d, sym.RangeIndex) for d in a.lhs.dimensions)]
     assert len(unresolved) == 1, \
         "Only the assignment with bare RHS ':' should remain unresolved"
-    assert 'b(:)' in str(unresolved[0].rhs), \
+    assert unresolved[0].rhs == 'b(:)', \
         f"Unexpected unresolved assignment: {unresolved[0]}"
 
     # The resolved loops should cover explicit-range and scalar RHS assignments.
@@ -1581,7 +1580,7 @@ end subroutine test_no_implicit_rhs
         f"Expected resolved c(...) assignment, got: {rhs_texts}"
     assert '0.0' in rhs_texts, f"Expected scalar literal assignment, got: {rhs_texts}"
     assert 'scalar' in rhs_texts, f"Expected scalar variable assignment, got: {rhs_texts}"
-    assert all(str(assign.lhs) == 'a(jl)' for assign in loop_assigns)
+    assert all(assign.lhs == 'a(jl)' for assign in loop_assigns)
 
     # --- Part 2: range dimension NOT in the first position ---
     # Ensures that qualified-position tracking works when the range
@@ -1621,7 +1620,7 @@ end subroutine test_no_implicit_rhs_pos
                    and any(isinstance(d, sym.RangeIndex) for d in a.lhs.dimensions)]
     assert len(unresolved2) == 1, \
         "Only the assignment with bare RHS ':' should remain unresolved"
-    assert 'b(1, :)' in str(unresolved2[0].rhs), \
+    assert unresolved2[0].rhs == 'b(1, :)', \
         f"Unexpected unresolved assignment: {unresolved2[0]}"
 
     # The resolved loop bodies should reference explicit-range and scalar RHS cases.
@@ -1631,7 +1630,7 @@ end subroutine test_no_implicit_rhs_pos
         f"Expected resolved c(...) assignment, got: {rhs_texts2}"
     assert '0.0' in rhs_texts2, f"Expected scalar literal assignment, got: {rhs_texts2}"
     assert 'scalar' in rhs_texts2, f"Expected scalar variable assignment, got: {rhs_texts2}"
-    assert all(str(assign.lhs) == 'a(1, jl)' for assign in loop_assigns2)
+    assert all(assign.lhs == 'a(1, jl)' for assign in loop_assigns2)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -1666,7 +1665,7 @@ end subroutine test_masked_scalar_rhs
     assert loops[0].variable == 'jl'
     assert loops[0].bounds == 'start:end'
     assert len(conds) == 1
-    assert 'a(jl) > 0.0' in str(conds[0].condition)
+    assert conds[0].condition == 'a(jl) > 0.0'
 
     loop_assign = FindNodes(ir.Assignment).visit(loops[0].body)[0]
     assert loop_assign.lhs == 'a(jl)'
@@ -2032,7 +2031,7 @@ end module test_non_elemental_inline_mod
 
     assert len(assigns) == 1
     assert not loops
-    assert str(assigns[0].lhs) == 'lhs(1:n)'
+    assert assigns[0].lhs == 'lhs(1:n)'
     assert len(inline_calls) == 1
     inline_call = next(iter(inline_calls))
     assert inline_call.name == 'some_func'
@@ -2400,8 +2399,8 @@ end module test_vector_rhs_subscript_mod
 
     assert not loops
     assert len(assigns) == 1
-    assert str(assigns[0].lhs) == 'od_cloud_new(:, jcol)'
-    assert str(assigns[0].rhs) == 'od_cloud(config%band, jlev, jcol)'
+    assert assigns[0].lhs == 'od_cloud_new(:, jcol)'
+    assert assigns[0].rhs == 'od_cloud(config%band, jlev, jcol)'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
@@ -2487,7 +2486,7 @@ end subroutine test_dup_dims
     assign = resolved_assigns[0]
     dims = assign.lhs.dimensions
     # The two inner dimensions (dims[1] and dims[2]) must be distinct scalar variables
-    assert str(dims[1]).lower() != str(dims[2]).lower(), (
+    assert dims[1] != dims[2], (
         f"Both inner dimensions of zremap are identical ({dims[1]!s}), "
         f"indicating only one loop variable was used for two distinct dimensions; "
         f"expected two distinct loop variables"
@@ -2539,7 +2538,7 @@ end subroutine test_scalar_range_dup
     dims = assign.lhs.dimensions
     # dims[1] should be the original J; dims[2] must be different
     assert dims[1] == 'j'
-    assert str(dims[2]).lower() != 'j', (
+    assert dims[2] != 'j', (
         f"Third subscript of field is '{dims[2]}' which aliases the existing "
         f"scalar subscript J; expected a distinct synthesized loop variable"
     )
@@ -2577,7 +2576,7 @@ end subroutine test_nested_loop_shadowing
     outer_j_loop = next(loop for loop in loops if loop.variable == 'j' and loop.bounds == '1:ninner')
     inner_loops = FindNodes(ir.Loop).visit(outer_j_loop.body)
     assert len(inner_loops) == 1
-    assert str(inner_loops[0].variable).lower() != 'j'
+    assert inner_loops[0].variable != 'j'
 
     assign = FindNodes(ir.Assignment).visit(inner_loops[0].body)[0]
     lhs_dims = assign.lhs.dimensions

--- a/loki/transformations/array_indexing/tests/test_vector_notation.py
+++ b/loki/transformations/array_indexing/tests/test_vector_notation.py
@@ -16,6 +16,7 @@ from loki.expression import symbols as sym
 from loki.frontend import available_frontends, OMNI
 from loki.ir import nodes as ir, FindNodes, FindVariables, FindInlineCalls
 from loki.logging import WARNING
+from loki.types import ProcedureType
 
 from loki.transformations.array_indexing.vector_notation import (
     resolve_vector_notation, resolve_vector_dimension,
@@ -2008,6 +2009,65 @@ end module test_elemental_inline_mixed_mod
     assert 'frac(jcol,' in call_text
     assert 'nlev' in call_text
     assert 'RangeIndex' not in call_text
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_resolve_vector_notation_elemental_inline_unlinked_procedure_type(frontend):
+    """
+    Elemental inline calls should still be scalarized when the ProcedureType
+    exists but its link to the contained routine has been dropped.
+    """
+
+    fcode = """
+module test_elemental_inline_unlinked_mod
+contains
+  elemental real function beta2alpha(p, x, y)
+    implicit none
+    real, intent(in) :: p, x, y
+    beta2alpha = p + x + y
+  end function beta2alpha
+
+  subroutine test_elemental_inline_unlinked(jcol, kstart, kend, nlev, overlap_alpha, overlap_param, frac)
+    implicit none
+    integer, intent(in) :: kstart, kend, nlev, jcol
+    real, intent(inout) :: overlap_alpha(kend, nlev-1)
+    real, intent(in)    :: overlap_param(kend, nlev)
+    real, intent(in)    :: frac(kend, nlev)
+    do jcol = kstart, kend
+      overlap_alpha(jcol,1:nlev-1) = beta2alpha(overlap_param(jcol,:), &
+           frac(jcol,1:nlev-1), frac(jcol,2:nlev))
+    end do
+  end subroutine test_elemental_inline_unlinked
+end module test_elemental_inline_unlinked_mod
+    """.strip()
+
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source['test_elemental_inline_unlinked']
+    dim = Dimension(name='horizontal', index='jcol', lower='kstart', upper='kend')
+    resolve_vector_dimension(routine, dimension=dim, derive_qualified_ranges=True)
+
+    inline_call = next(iter(FindInlineCalls().visit(routine.body)))
+    inline_call.function.type = inline_call.function.type.clone(dtype=ProcedureType(
+        name=inline_call.name, is_function=True,
+        return_type=inline_call.function.type.dtype.return_type
+    ))
+
+    assert not inline_call.procedure_type.is_elemental
+
+    resolve_vector_notation(routine)
+
+    loops = FindNodes(ir.Loop).visit(routine.body)
+    assert len(loops) == 2
+
+    assign = FindNodes(ir.Assignment).visit(loops[1].body)[0]
+    resolved_inline_call = next(iter(FindInlineCalls().visit(assign.rhs)))
+    call_text = str(resolved_inline_call).replace(' ', '')
+
+    assert 'overlap_param(jcol,' in call_text
+    assert 'frac(jcol,' in call_text
+    assert 'RangeIndex' not in call_text
+    assert any('1+' in str(dim).replace(' ', '') or '+1' in str(dim).replace(' ', '')
+               for dim in resolved_inline_call.parameters[2].dimensions)
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -449,7 +449,18 @@ class ResolveVectorNotationTransformer(Transformer):
 
     @staticmethod
     def _is_scalarizable_bound_expr(bound):
-        return not isinstance(bound, (sym.Array, sym.DeferredTypeSymbol))
+        for var in FindVariables(unique=False).visit(bound):
+            if isinstance(var, sym.Array):
+                if not var.dimensions:
+                    return False
+                if any(isinstance(dim, sym.RangeIndex) for dim in var.dimensions):
+                    return False
+                if any(ResolveVectorNotationTransformer._expr_contains_vector_array(dim)
+                       for dim in var.dimensions):
+                    return False
+            elif isinstance(var, sym.DeferredTypeSymbol) and var.parent is not None:
+                return False
+        return True
 
     @classmethod
     def _is_resolvable_range_dim(cls, dim):

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -602,8 +602,7 @@ class ResolveVectorNotationTransformer(Transformer):
                 if routine is not None:
                     return routine.procedure_type.is_elemental
             return procedure_dtype.is_elemental
-        procedure_type = call.procedure_type
-        return procedure_type is not BasicType.DEFERRED and procedure_type.is_elemental
+        return False
 
     def _find_scalarizable_rhs_arrays(self, expr):
         """Return RHS arrays that can be safely scalarized."""

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -431,13 +431,13 @@ class ResolveVectorNotationTransformer(Transformer):
         """Return list of positions in ``dims`` that are :any:`RangeIndex`."""
         return [i for i, dim in enumerate(dims) if isinstance(dim, sym.RangeIndex)]
 
-    @staticmethod
-    def _find_qualified_range_positions(dims, range_positions):
+    @classmethod
+    def _find_qualified_range_positions(cls, dims, range_positions):
         """
         Return ordinal indices into ``range_positions`` whose corresponding
         dimension is *not* a bare ``(:)`` (i.e. ``RangeIndex((None, None))``).
         """
-        return ResolveVectorNotationTransformer._find_resolvable_range_positions(dims, range_positions)
+        return cls._find_resolvable_range_positions(dims, range_positions)
 
     @staticmethod
     def _has_explicit_range_bounds(dim):
@@ -550,9 +550,9 @@ class ResolveVectorNotationTransformer(Transformer):
             loop = ir.Loop(variable=ivar, body=as_tuple(wrapped_body), bounds=bounds)
             wrapped_body = loop
 
-        if insert_comments and loop is not None:
+        if insert_comments and loop:
             return (ir.Comment('! loki resolved vector notation'), loop)
-        if loop is not None:
+        if loop:
             return (loop,)
         return body
 
@@ -583,7 +583,7 @@ class ResolveVectorNotationTransformer(Transformer):
             return None
 
         procedure_dtype = getattr(call.function.type, 'dtype', None)
-        if procedure_dtype is None or procedure_dtype is BasicType.DEFERRED:
+        if not procedure_dtype:
             routine = resolve_routine_from_scope()
             if routine is not None:
                 return routine.procedure_type.is_elemental

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -321,10 +321,16 @@ class IterationRangeShapeMapper(LokiIdentityMapper):
             expr = expr.clone(dimensions=tuple(sym.RangeIndex((None, None)) for _ in expr.shape))
 
         # Derive fully qualified bounds for ``:``
-        new_dims = tuple(
-            self._shape_to_range(s) if isinstance(d, sym.RangeIndex) and d == ':' else d
-            for i, d, s in zip(count(), expr.dimensions, as_tuple(expr.shape))
-        )
+        new_dims = ()
+        for d, s in zip(expr.dimensions, as_tuple(expr.shape)):
+            if isinstance(d, sym.RangeIndex) and d == ':':
+                new_dims += (self._shape_to_range(s),)
+            elif isinstance(d, sym.RangeIndex) and d.upper is None:
+                new_dims += (sym.RangeIndex(
+                    (d.lower, s.upper, s.step) if isinstance(s, sym.Range) else (d.lower, s)
+                ),)
+            else:
+                new_dims += (d,)
         # make sure it is not a inline call that was misread as array access ...
         if new_dims:
             return expr.clone(dimensions=new_dims)
@@ -421,8 +427,228 @@ class ResolveVectorNotationTransformer(Transformer):
         """
         return [
             i for i, j in enumerate(range_positions)
-            if dims[j] != sym.RangeIndex((None, None))
+            if dims[j] != sym.RangeIndex((None, None)) and
+            dims[j].upper is not None and not isinstance(dims[j], sym.Array)
+            and not isinstance(dims[j], sym.DeferredTypeSymbol)
         ]
+
+    def _get_resolvable_dim_indices(
+            self, lhs_dims, rhs_dims_per_array, qualification_lhs_dims=None,
+            qualification_rhs_dims_per_array=None
+    ):
+        """
+        Return ordinal positions into the LHS range list that are safe to resolve.
+        """
+        lhs_range_positions = self._find_range_positions(lhs_dims)
+
+        if self.resolve_implicit_rhs_ranges:
+            lhs_qualified_positions = self._find_qualified_range_positions(
+                lhs_dims, lhs_range_positions
+            )
+            return lhs_range_positions, lhs_qualified_positions
+
+        qualification_lhs_dims = lhs_dims if qualification_lhs_dims is None else qualification_lhs_dims
+        qualification_lhs_positions = self._find_range_positions(qualification_lhs_dims)
+        lhs_qualified_positions = self._find_qualified_range_positions(
+            qualification_lhs_dims, qualification_lhs_positions
+        )
+
+        qualification_rhs_dims_per_array = (
+            rhs_dims_per_array if qualification_rhs_dims_per_array is None
+            else qualification_rhs_dims_per_array
+        )
+        qualification_rhs_positions_per_array = [
+            self._find_range_positions(dims) for dims in qualification_rhs_dims_per_array
+        ]
+        rhs_qualified_positions_per_array = [
+            self._find_qualified_range_positions(rhs_dims, rhs_pos)
+            for rhs_dims, rhs_pos in zip(
+                qualification_rhs_dims_per_array, qualification_rhs_positions_per_array
+            )
+        ]
+
+        resolvable_dim_indices = [
+            j for j in lhs_qualified_positions
+            if rhs_qualified_positions_per_array and all(
+                j in rhs_qualified for rhs_qualified in rhs_qualified_positions_per_array
+            )
+        ]
+        return lhs_range_positions, resolvable_dim_indices
+
+    @staticmethod
+    def _build_loop_nest(index_range_map, body, insert_comments=False):
+        """Wrap ``body`` in loops for all ranges from ``index_range_map``."""
+        loop = None
+        wrapped_body = body
+        for ivar, irange in index_range_map.items():
+            if isinstance(irange, sym.RangeIndex):
+                bounds = sym.LoopRange(irange.children)
+            else:
+                bounds = sym.LoopRange((sym.Literal(1), irange, sym.Literal(1)))
+            loop = ir.Loop(variable=ivar, body=as_tuple(wrapped_body), bounds=bounds)
+            wrapped_body = loop
+
+        if insert_comments and loop is not None:
+            return (ir.Comment('! loki resolved vector notation'), loop)
+        if loop is not None:
+            return (loop,)
+        return body
+
+    @staticmethod
+    def _collect_range_arrays(expr):
+        return [
+            var for var in FindVariables(unique=False).visit(expr)
+            if isinstance(var, sym.Array)
+            and any(isinstance(dim, sym.RangeIndex) for dim in var.dimensions)
+        ]
+
+    @staticmethod
+    def _is_scalarizable_inline_call(call):
+        """Only known elemental inline calls are safe to scalarize."""
+        if call.function.type and call.function.type.is_intrinsic:
+            return True
+        procedure_type = call.procedure_type
+        return procedure_type is not BasicType.DEFERRED and procedure_type.is_elemental
+
+    def _find_scalarizable_rhs_arrays(self, expr):
+        """Return RHS arrays that can be safely scalarized."""
+        scalarizable_arrays = []
+        unsafe_arrays = []
+
+        inline_calls = set(FindInlineCalls().visit(expr))
+        inline_call_arrays = set()
+        for call in inline_calls:
+            call_arrays = [
+                var for var in FindVariables(unique=False).visit(call)
+                if isinstance(var, sym.Array)
+                and any(isinstance(dim, sym.RangeIndex) for dim in var.dimensions)
+            ]
+            inline_call_arrays.update(call_arrays)
+            if self._is_scalarizable_inline_call(call):
+                scalarizable_arrays.extend(call_arrays)
+            else:
+                unsafe_arrays.extend(call_arrays)
+
+        plain_arrays = [
+            var for var in self._collect_range_arrays(expr)
+            if var not in inline_call_arrays
+        ]
+        scalarizable_arrays.extend(plain_arrays)
+        return scalarizable_arrays, unsafe_arrays
+
+    @staticmethod
+    def _expr_contains_vector_array(expr):
+        """Return True if ``expr`` contains an array-valued expression."""
+        for var in FindVariables(unique=False).visit(expr):
+            if not isinstance(var, sym.Array):
+                continue
+            if not var.dimensions:
+                return True
+            if any(isinstance(dim, sym.RangeIndex) for dim in var.dimensions):
+                return True
+        return False
+
+    @classmethod
+    def _has_vector_valued_rhs_subscript(cls, expr):
+        """
+        Return True if an RHS array uses a vector-valued subscript expression.
+
+        This conservatively rejects cases like ``arr(map, j)`` where ``map`` is
+        itself an array-valued expression. A more ambitious implementation could
+        scalarize that subscript elementwise with the resolved loop index.
+        """
+        for var in FindVariables(unique=False).visit(expr):
+            if not isinstance(var, sym.Array) or not var.dimensions:
+                continue
+            if var.type.dtype is BasicType.DEFERRED:
+                continue
+            for dim in var.dimensions:
+                if isinstance(dim, sym.RangeIndex):
+                    continue
+                if cls._expr_contains_vector_array(dim):
+                    return True
+        return False
+
+    def _has_unsafe_inline_call(self, expr):
+        """Return True if expr contains a non-scalarizable inline call with vector args."""
+        for call in FindInlineCalls().visit(expr):
+            if self._is_scalarizable_inline_call(call):
+                continue
+            if any(isinstance(arg, sym.Array) for arg in FindVariables(unique=False).visit(call)):
+                return True
+        for var in FindVariables(unique=False).visit(expr):
+            if not isinstance(var, sym.Array):
+                continue
+            if var.type.dtype is not BasicType.DEFERRED:
+                continue
+            if not var.dimensions:
+                continue
+            if any(isinstance(arg, sym.Array) for arg in var.dimensions):
+                return True
+        return False
+
+    @staticmethod
+    def _rhs_array_dim_map(resolved_dim_indices, rhs_range_positions):
+        """Map resolved LHS dimension ordinals to actual RHS range positions."""
+        return {
+            i: rhs_range_positions[i]
+            for i in resolved_dim_indices
+            if i < len(rhs_range_positions)
+        }
+
+    @staticmethod
+    def _has_unresolved_vector_ranges(nodes):
+        """Return True if any assignment still contains range notation."""
+        for assign in FindNodes(ir.Assignment).visit(nodes):
+            if (isinstance(assign.lhs, sym.Array)
+                    and any(isinstance(dim, sym.RangeIndex) for dim in assign.lhs.dimensions)):
+                return True
+            if ResolveVectorNotationTransformer._collect_range_arrays(assign.rhs):
+                return True
+        return False
+
+    def _resolve_mask_expr(self, expr):
+        """Resolve vector mask expressions to scalar indices when supported."""
+        if self.derive_qualified_ranges:
+            expr = IterationRangeShapeMapper()(expr)
+
+        cond_arrays = self._collect_range_arrays(expr)
+        if not cond_arrays:
+            return expr, {}, False
+
+        cond_dims_per_array = [array.dimensions for array in cond_arrays]
+        lhs_range_positions, resolvable_dim_indices = self._get_resolvable_dim_indices(
+            cond_dims_per_array[0], cond_dims_per_array
+        )
+        if not resolvable_dim_indices:
+            return expr, {}, False
+
+        resolved_ranges = [
+            cond_dims_per_array[0][lhs_range_positions[i]] for i in resolvable_dim_indices
+        ]
+        new_dims, index_range_map, _ = self._map_ranges_to_indices(
+            resolved_ranges, self.loop_map,
+            map_unknown_ranges=self.map_unknown_ranges,
+            scope=self.scope, basename='i_mask'
+        )
+
+        actually_resolved = [
+            (orig_i, new_dim) for orig_i, new_dim in zip(resolvable_dim_indices, new_dims)
+            if not isinstance(new_dim, sym.RangeIndex)
+        ]
+        if not actually_resolved:
+            return expr, {}, False
+
+        resolved_dim_indices, new_dims = zip(*actually_resolved)
+        subst_map = {}
+        for array in cond_arrays:
+            range_positions = self._find_range_positions(array.dimensions)
+            array_dims = list(array.dimensions)
+            for i, new_dim in enumerate(new_dims):
+                array_dims[range_positions[resolved_dim_indices[i]]] = new_dim
+            subst_map[array] = array.clone(dimensions=as_tuple(array_dims))
+
+        return SubstituteExpressions(subst_map).visit(expr), index_range_map, True
 
     @staticmethod
     def _compute_shifted_index(loop_var, lhs_range, rhs_range):
@@ -701,14 +927,25 @@ class ResolveVectorNotationTransformer(Transformer):
             if any(redux_op in FindExpressions().visit(stmt.rhs)
                    for redux_op in Fortran2003.Intrinsic_Name.array_reduction_names):
                 return stmt
+        if self._has_unsafe_inline_call(stmt.rhs):
+            return stmt
+        if self._has_vector_valued_rhs_subscript(stmt.rhs):
+            return stmt
 
-        # --- Step 2: Derive qualified ranges from shapes ---
+        # --- Step 2: Record original range usage before shape inference ---
+        orig_lhs_dims = stmt.lhs.dimensions
+        orig_rhs_arrays, orig_unsafe_rhs_arrays = self._find_scalarizable_rhs_arrays(stmt.rhs)
+        if orig_unsafe_rhs_arrays:
+            return stmt
+        orig_rhs_dims_per_array = [array.dimensions for array in orig_rhs_arrays]
+
+        # --- Step 3: Derive qualified ranges from shapes ---
         if self.derive_qualified_ranges:
             shape_mapper = IterationRangeShapeMapper()
             stmt._update(lhs=shape_mapper(stmt.lhs), rhs=shape_mapper(stmt.rhs))
 
         # --- Resolve literal-list RHS by unrolling ---
-        # This runs after Step 2 so the LHS range has explicit bounds.
+        # This runs after Step 3 so the LHS range has explicit bounds.
         # Falls back to the previous warn-and-bail behaviour when unrolling is
         # not possible (mixed RHS, unknown ranges).
         if FindLiteralLists().visit(stmt.rhs):
@@ -717,44 +954,27 @@ class ResolveVectorNotationTransformer(Transformer):
                 return resolved
             return stmt
 
-        # --- Step 3: Identify range-indexed dimensions ---
+        # --- Step 4: Identify range-indexed dimensions ---
 
         # RHS arrays that have at least one RangeIndex dimension
-        rhs_vars = FindVariables(unique=False).visit(stmt.rhs)
-        rhs_arrays = [
-            var for var in rhs_vars
-            if isinstance(var, sym.Array)
-            and any(isinstance(dim, sym.RangeIndex) for dim in var.dimensions)
-        ]
+        rhs_arrays, unsafe_rhs_arrays = self._find_scalarizable_rhs_arrays(stmt.rhs)
+        if unsafe_rhs_arrays:
+            return stmt
         rhs_dims_per_array = [array.dimensions for array in rhs_arrays]
-        rhs_range_positions_per_array = [
-            self._find_range_positions(dims) for dims in rhs_dims_per_array
-        ]
 
         # LHS array dimensions
         lhs_array = stmt.lhs
         lhs_dims = lhs_array.dimensions
-        lhs_range_positions = self._find_range_positions(lhs_dims)
-        lhs_qualified_positions = self._find_qualified_range_positions(
-            lhs_dims, lhs_range_positions
+        lhs_range_positions, resolvable_dim_indices = self._get_resolvable_dim_indices(
+            lhs_dims, rhs_dims_per_array,
+            qualification_lhs_dims=orig_lhs_dims,
+            qualification_rhs_dims_per_array=orig_rhs_dims_per_array,
         )
+        rhs_range_positions_per_array = [
+            self._find_range_positions(dims) for dims in rhs_dims_per_array
+        ]
 
-        # --- Step 4: Filter to resolvable dimensions ---
-        if self.resolve_implicit_rhs_ranges:
-            resolvable_dim_indices = lhs_qualified_positions
-        else:
-            rhs_qualified_positions_per_array = [
-                self._find_qualified_range_positions(rhs_dims, rhs_pos)
-                for rhs_dims, rhs_pos in zip(rhs_dims_per_array, rhs_range_positions_per_array)
-            ]
-            resolvable_dim_indices = [
-                j for j in lhs_qualified_positions
-                if all(
-                    j in rhs_qualified
-                    for rhs_qualified in rhs_qualified_positions_per_array
-                )
-            ]
-
+        # --- Step 5: Filter to resolvable dimensions ---
         # Nothing to resolve
         if not resolvable_dim_indices:
             if lhs_range_positions:
@@ -765,7 +985,7 @@ class ResolveVectorNotationTransformer(Transformer):
                 )
             return stmt
 
-        # --- Step 5: Map LHS ranges to loop index variables ---
+        # --- Step 6: Map LHS ranges to loop index variables ---
         resolved_lhs_ranges = [
             lhs_dims[lhs_range_positions[i]] for i in resolvable_dim_indices
         ]
@@ -790,17 +1010,20 @@ class ResolveVectorNotationTransformer(Transformer):
             return stmt
         resolved_dim_indices, resolved_lhs_ranges, new_lhs_dims = zip(*actually_resolved)
 
-        # --- Step 6: Compute RHS index expressions (with offset) ---
-        resolved_rhs_ranges_per_array = [
-            [array_dims[rhs_pos[i]] for i in resolved_dim_indices]
-            for array_dims, rhs_pos in zip(rhs_dims_per_array, rhs_range_positions_per_array)
-        ]
+        # --- Step 7: Compute RHS index expressions (with offset) ---
         new_rhs_dims_per_array = []
-        for array, resolved_rhs_ranges in zip(rhs_arrays, resolved_rhs_ranges_per_array):
-            new_rhs_dims = []
-            for lhs_range, new_lhs_dim, rhs_range in zip(
-                resolved_lhs_ranges, new_lhs_dims, resolved_rhs_ranges
-            ):
+        rhs_dim_maps = [
+            self._rhs_array_dim_map(resolved_dim_indices, rhs_pos)
+            for rhs_pos in rhs_range_positions_per_array
+        ]
+        for array_dims, rhs_dim_map in zip(rhs_dims_per_array, rhs_dim_maps):
+            new_rhs_dims = {}
+            for i, (lhs_range, new_lhs_dim) in enumerate(zip(resolved_lhs_ranges, new_lhs_dims)):
+                resolved_dim_index = resolved_dim_indices[i]
+                rhs_pos = rhs_dim_map.get(resolved_dim_index)
+                if rhs_pos is None:
+                    continue
+                rhs_range = array_dims[rhs_pos]
                 is_aligned_dim = (
                     lhs_range == rhs_range or rhs_range == sym.RangeIndex((None, None))
                 ) or (
@@ -808,14 +1031,14 @@ class ResolveVectorNotationTransformer(Transformer):
                     lhs_range.lower == rhs_range.lower
                 )
                 if is_aligned_dim:
-                    new_rhs_dims.append(new_lhs_dim)
+                    new_rhs_dims[resolved_dim_index] = new_lhs_dim
                 else:
-                    new_rhs_dims.append(
+                    new_rhs_dims[resolved_dim_index] = (
                         self._compute_shifted_index(new_lhs_dim, lhs_range, rhs_range)
                     )
             new_rhs_dims_per_array.append(new_rhs_dims)
 
-        # --- Step 7: Build new array expressions ---
+        # --- Step 8: Build new array expressions ---
 
         # New LHS array with loop indices replacing ranges
         new_lhs_arr_dims = list(lhs_dims)
@@ -827,8 +1050,12 @@ class ResolveVectorNotationTransformer(Transformer):
         new_rhs_array_list = []
         for i_arr, _array in enumerate(rhs_arrays):
             new_arr_dims = list(rhs_dims_per_array[i_arr])
-            for i, d in enumerate(new_rhs_dims_per_array[i_arr]):
-                new_arr_dims[rhs_range_positions_per_array[i_arr][resolved_dim_indices[i]]] = d
+            rhs_dim_map = rhs_dim_maps[i_arr]
+            for resolved_dim_index, d in new_rhs_dims_per_array[i_arr].items():
+                rhs_pos = rhs_dim_map.get(resolved_dim_index)
+                if rhs_pos is None:
+                    continue
+                new_arr_dims[rhs_pos] = d
             new_rhs_array_list.append(_array.clone(dimensions=as_tuple(new_arr_dims)))
 
         # Update the statement in-place
@@ -841,7 +1068,7 @@ class ResolveVectorNotationTransformer(Transformer):
         # Record all newly created loop index variables for declaration
         self.index_vars.update(list(index_range_map.keys()))
 
-        # --- Step 8: Substitute derived-type members in synthesized bounds ---
+        # --- Step 9: Substitute derived-type members in synthesized bounds ---
         # For bounds that were derived from array shapes (not from explicit
         # source-code ranges), replace any derived-type member references
         # (e.g., KDIM%KLEVS) with existing or new plain scalar variables
@@ -860,21 +1087,9 @@ class ResolveVectorNotationTransformer(Transformer):
             if new_vars:
                 self.index_vars.update(new_vars)
 
-        # --- Step 9: Wrap in loop nest ---
+        # --- Step 10: Wrap in loop nest ---
         if create_loops and len(index_range_map):
-            loop = None
-            body = stmt
-            for ivar, irange in index_range_map.items():
-                if isinstance(irange, sym.RangeIndex):
-                    bounds = sym.LoopRange(irange.children)
-                else:
-                    bounds = sym.LoopRange((sym.Literal(1), irange, sym.Literal(1)))
-                loop = ir.Loop(variable=ivar, body=as_tuple(body), bounds=bounds)
-                body = loop
-
-            if self.insert_comments:
-                return (ir.Comment('! loki resolved vector notation'),) + (loop,)
-            return (loop,)
+            return self._build_loop_nest(index_range_map, stmt, insert_comments=self.insert_comments)
 
         # No vector dimensions encountered, return unchanged
         return stmt
@@ -903,59 +1118,28 @@ class ResolveVectorNotationTransformer(Transformer):
         return visited
 
     def visit_MaskedStatement(self, masked, **kwargs):  # pylint: disable=unused-argument
-        # TODO: Currently limited to simple, single-clause WHERE stmts
-        assert len(masked.conditions) == 1 and len(masked.bodies) == 1
+        if len(masked.conditions) != 1 or len(masked.bodies) != 1:
+            return masked
 
-        # Replace all unbounded ranges with bounded ranges based on array shape
-        conditions = masked.conditions
-        if self.derive_qualified_ranges:
-            conditions = IterationRangeShapeMapper()(conditions)
-
-        # Find arrays with RangeIndex dims in the condition
-        cond_vars = FindVariables(unique=False).visit(conditions)
-        cond_arrays = [
-            v for v in cond_vars
-            if isinstance(v, sym.Array)
-            and any(isinstance(d, sym.RangeIndex) for d in v.dimensions)
-        ]
-
-        # Map ranges to indices using the shared static method
-        index_range_map = {}
-        subst_map = {}
-        for array in cond_arrays:
-            new_dims, arr_index_map, _ = self._map_ranges_to_indices(
-                array.dimensions, self.loop_map,
-                map_unknown_ranges=self.map_unknown_ranges,
-                scope=self.scope
-            )
-            index_range_map.update(arr_index_map)
-            subst_map[array] = array.clone(dimensions=new_dims)
-
-        conditions = SubstituteExpressions(subst_map).visit(conditions)
+        condition, index_range_map, resolved = self._resolve_mask_expr(masked.conditions[0])
+        if not resolved:
+            return masked
 
         with dict_override(kwargs, {'create_loops': False}):
-            bodies = self.visit(masked.bodies, **kwargs)
+            body = self.visit(masked.bodies[0], **kwargs)
             else_body = self.visit(masked.default, **kwargs)
 
-        # Rebuild construct as an IF conditional inside a loop over the range bounds
-        if not index_range_map:
+        body_nodes = as_tuple(body)
+        else_nodes = as_tuple(else_body)
+
+        if (FindNodes(ir.MaskedStatement).visit(body_nodes)
+                or FindNodes(ir.MaskedStatement).visit(else_nodes)
+                or self._has_unresolved_vector_ranges(body_nodes)
+                or self._has_unresolved_vector_ranges(else_nodes)):
             return masked
 
         # Record all newly created loop index variables for declaration
         self.index_vars.update(list(index_range_map.keys()))
 
-        cond = ir.Conditional(
-            condition=conditions[0], body=bodies, else_body=else_body
-        )
-
-        # Recursively build new loop nest over all implicit dims
-        loop = None
-        body = cond
-        for ivar, irange in index_range_map.items():
-            if isinstance(irange, sym.RangeIndex):
-                bounds = sym.LoopRange(irange.children)
-            else:
-                bounds = sym.LoopRange((sym.Literal(1), irange, sym.Literal(1)))
-            loop = ir.Loop(variable=ivar, body=as_tuple(body), bounds=bounds)
-            body = loop
-        return loop
+        cond = ir.Conditional(condition=condition, body=body_nodes, else_body=else_nodes)
+        return self._build_loop_nest(index_range_map, cond, insert_comments=self.insert_comments)

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -400,6 +400,7 @@ class ResolveVectorNotationTransformer(Transformer):
         self.loop_map = {} if loop_map is None else loop_map
         self.index_vars = OrderedSet()
         self.pre_body_stmts = []
+        self.active_loop_vars = set()
 
         self.map_unknown_ranges = map_unknown_ranges
         self.derive_qualified_ranges = derive_qualified_ranges
@@ -555,6 +556,13 @@ class ResolveVectorNotationTransformer(Transformer):
         if loop:
             return (loop,)
         return body
+
+    def visit_Loop(self, o, **kwargs):
+        self.active_loop_vars.add(o.variable)
+        try:
+            return self.visit_Node(o, **kwargs)
+        finally:
+            self.active_loop_vars.remove(o.variable)
 
     @staticmethod
     def _collect_range_arrays(expr):
@@ -712,8 +720,16 @@ class ResolveVectorNotationTransformer(Transformer):
         resolved_ranges = [
             cond_dims_per_array[0][lhs_range_positions[i]] for i in resolvable_dim_indices
         ]
+        cond_all_dims = cond_arrays[0].dimensions
+        reserved_ivars = {
+            d for i, d in enumerate(cond_all_dims)
+            if i not in lhs_range_positions and isinstance(d, sym.Scalar) and d in self.loop_map.values()
+        }
+        # Reusing an active outer loop variable here would create a nested loop
+        # that shadows the surrounding scalar context (e.g. an outer ``jk``).
+        reserved_ivars.update(self.active_loop_vars)
         new_dims, index_range_map, _ = self._map_ranges_to_indices(
-            resolved_ranges, self.loop_map,
+            resolved_ranges, self.loop_map, reserved_ivars=reserved_ivars,
             map_unknown_ranges=self.map_unknown_ranges,
             scope=self.scope, basename='i_mask'
         )
@@ -761,7 +777,8 @@ class ResolveVectorNotationTransformer(Transformer):
         return simplify(sym.Sum((loop_var, sym.Product((-1, lhs_range.lower)), rhs_range.lower)))
 
     @staticmethod
-    def _map_ranges_to_indices(dims, loop_map, map_unknown_ranges=True, basename='i', scope=None):
+    def _map_ranges_to_indices(dims, loop_map, map_unknown_ranges=True, basename='i',
+                              scope=None, reserved_ivars=None):
         """
         Map :any:`RangeIndex` dimensions to loop index variables.
 
@@ -783,6 +800,11 @@ class ResolveVectorNotationTransformer(Transformer):
             Base name for newly created index variables.
         scope : :any:`Subroutine` or :any:`Module`
             Scope for newly created variables.
+        reserved_ivars : set, optional
+            Set of index variables already in use as non-range scalar
+            subscripts in the same array reference.  If a loop variable
+            from ``loop_map`` collides with this set, a fresh variable
+            is synthesized to avoid aliasing.
 
         Returns
         -------
@@ -794,6 +816,8 @@ class ResolveVectorNotationTransformer(Transformer):
             that were newly created (as opposed to reused from
             ``loop_map``).
         """
+        if reserved_ivars is None:
+            reserved_ivars = set()
         index_range_map = {}
         shape_index_map = {}
         synthesized_ivars = set()
@@ -805,9 +829,13 @@ class ResolveVectorNotationTransformer(Transformer):
                     # Guard against arrays with duplicate range dimensions
                     # (e.g. arr(KLEVSN, KLEVSN)) where both positions map to
                     # the same loop variable.  If ivar is already in use for a
-                    # different position, create a fresh synthesized variable so
-                    # that each dimension gets its own distinct loop index.
-                    if ivar in index_range_map:
+                    # different position or already present as a scalar
+                    # subscript in the same array reference, or would shadow an
+                    # active outer loop variable, create a fresh synthesized
+                    # variable so that each dimension gets its own distinct
+                    # loop index and surrounding scalar references keep their
+                    # meaning.
+                    if ivar in index_range_map or ivar in reserved_ivars:
                         if not map_unknown_ranges:
                             continue
                         vtype = SymbolAttributes(BasicType.INTEGER)
@@ -1072,8 +1100,17 @@ class ResolveVectorNotationTransformer(Transformer):
         resolved_lhs_ranges = [
             lhs_dims[lhs_range_positions[i]] for i in resolvable_dim_indices
         ]
+        # Collect loop variables already present as fixed scalar subscripts so
+        # that _map_ranges_to_indices does not alias them with a resolved range.
+        reserved_ivars = {
+            d for i, d in enumerate(lhs_dims)
+            if i not in lhs_range_positions and isinstance(d, sym.Scalar) and d in self.loop_map.values()
+        }
+        # Keep existing scalar subscripts and active surrounding loop indices
+        # distinct from any new loop variable chosen for resolved ranges.
+        reserved_ivars.update(self.active_loop_vars)
         new_lhs_dims, index_range_map, synthesized_ivars = self._map_ranges_to_indices(
-            resolved_lhs_ranges, self.loop_map,
+            resolved_lhs_ranges, self.loop_map, reserved_ivars=reserved_ivars,
             map_unknown_ranges=self.map_unknown_ranges,
             scope=self.scope, basename=f'i_{stmt.lhs.basename}'
         )

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -448,19 +448,27 @@ class ResolveVectorNotationTransformer(Transformer):
         return isinstance(dim, sym.RangeIndex) and dim.lower is not None and dim.upper is not None
 
     @staticmethod
-    def _is_scalarizable_bound_expr(bound):
-        for var in FindVariables(unique=False).visit(bound):
-            if isinstance(var, sym.Array):
-                if not var.dimensions:
-                    return False
-                if any(isinstance(dim, sym.RangeIndex) for dim in var.dimensions):
-                    return False
-                if any(ResolveVectorNotationTransformer._expr_contains_vector_array(dim)
-                       for dim in var.dimensions):
-                    return False
-            elif isinstance(var, sym.DeferredTypeSymbol) and var.parent is not None:
-                return False
-        return True
+    def _warn_on_unresolved_scalarizable_bound(bound):
+        if any(isinstance(var, sym.DeferredTypeSymbol) and var.parent is not None
+               for var in FindVariables(unique=False).visit(bound)):
+            warning(
+                '[Loki::ResolveVectorNotation] Treating unresolved bound expression '
+                'as scalar: %s. This may miss vector-valued derived-type members.',
+                bound
+            )
+
+    @classmethod
+    def _is_scalarizable_bound_expr(cls, bound):
+        # This intentionally keys off vector-valuedness only. Unresolved
+        # derived-type members may still be scalar bounds (e.g. DIMS%KLON), so
+        # rejecting DeferredTypeSymbol conservatively regresses valid cases. The
+        # tradeoff is that unresolved array-valued members cannot be recognised
+        # here; warn when we accept such a bound so callers know the decision is
+        # best-effort.
+        is_scalarizable = not cls._expr_contains_vector_array(bound)
+        if is_scalarizable:
+            cls._warn_on_unresolved_scalarizable_bound(bound)
+        return is_scalarizable
 
     @classmethod
     def _is_resolvable_range_dim(cls, dim):

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -321,10 +321,6 @@ class IterationRangeShapeMapper(LokiIdentityMapper):
     def _shape_upper(s):
         return s.upper if isinstance(s, sym.Range) else s
 
-    @staticmethod
-    def _shape_step(s):
-        return s.step if isinstance(s, sym.Range) else None
-
     def map_array(self, expr, *args, **kwargs):
         """ Replace ``:`` range indices with ``1:shape`` vector indices """
 
@@ -339,7 +335,7 @@ class IterationRangeShapeMapper(LokiIdentityMapper):
                 new_dims += (self._shape_to_range(s),)
             elif isinstance(d, sym.RangeIndex) and d.upper is None:
                 new_dims += (sym.RangeIndex(
-                    (d.lower, self._shape_upper(s), self._shape_step(s))
+                    (d.lower, self._shape_upper(s), d.step)
                 ),)
             elif isinstance(d, sym.RangeIndex) and d.lower is None:
                 new_dims += (sym.RangeIndex(
@@ -447,28 +443,12 @@ class ResolveVectorNotationTransformer(Transformer):
     def _has_explicit_range_bounds(dim):
         return isinstance(dim, sym.RangeIndex) and dim.lower is not None and dim.upper is not None
 
-    @staticmethod
-    def _warn_on_unresolved_scalarizable_bound(bound):
-        if any(isinstance(var, sym.DeferredTypeSymbol) and var.parent is not None
-               for var in FindVariables(unique=False).visit(bound)):
-            warning(
-                '[Loki::ResolveVectorNotation] Treating unresolved bound expression '
-                'as scalar: %s. This may miss vector-valued derived-type members.',
-                bound
-            )
-
     @classmethod
     def _is_scalarizable_bound_expr(cls, bound):
         # This intentionally keys off vector-valuedness only. Unresolved
         # derived-type members may still be scalar bounds (e.g. DIMS%KLON), so
-        # rejecting DeferredTypeSymbol conservatively regresses valid cases. The
-        # tradeoff is that unresolved array-valued members cannot be recognised
-        # here; warn when we accept such a bound so callers know the decision is
-        # best-effort.
-        is_scalarizable = not cls._expr_contains_vector_array(bound)
-        if is_scalarizable:
-            cls._warn_on_unresolved_scalarizable_bound(bound)
-        return is_scalarizable
+        # rejecting DeferredTypeSymbol conservatively regresses valid cases.
+        return not cls._expr_contains_vector_array(bound)
 
     @classmethod
     def _is_resolvable_range_dim(cls, dim):

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -572,19 +572,28 @@ class ResolveVectorNotationTransformer(Transformer):
             return True
         if not call.function.type:
             return False
-        procedure_dtype = getattr(call.function.type, 'dtype', None)
-        if procedure_dtype is None:
+
+        def resolve_routine_from_scope():
             scope = getattr(call.function, 'scope', None)
             if scope is not None and hasattr(scope, 'subroutines'):
-                routine = next(
+                return next(
                     (routine for routine in scope.subroutines
                      if routine.name.lower() == call.name.lower()),
                     None
                 )
-                if routine is not None:
-                    return routine.procedure_type.is_elemental
+            return None
+
+        procedure_dtype = getattr(call.function.type, 'dtype', None)
+        if procedure_dtype is None or procedure_dtype is BasicType.DEFERRED:
+            routine = resolve_routine_from_scope()
+            if routine is not None:
+                return routine.procedure_type.is_elemental
             return False
         if hasattr(procedure_dtype, 'is_elemental'):
+            if getattr(procedure_dtype, 'procedure', BasicType.DEFERRED) is BasicType.DEFERRED:
+                routine = resolve_routine_from_scope()
+                if routine is not None:
+                    return routine.procedure_type.is_elemental
             return procedure_dtype.is_elemental
         procedure_type = call.procedure_type
         return procedure_type is not BasicType.DEFERRED and procedure_type.is_elemental

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -1245,9 +1245,13 @@ class ResolveVectorNotationTransformer(Transformer):
         if not resolved:
             return masked
 
-        with dict_override(kwargs, {'create_loops': False}):
-            body = self.visit(masked.bodies[0], **kwargs)
-            else_body = self.visit(masked.default, **kwargs)
+        # Reuse the mask loop indices in each body assignment so the condition
+        # and body refer to the same array element.
+        mask_loop_map = {irange: ivar for ivar, irange in index_range_map.items()}
+        with dict_override(self.loop_map, mask_loop_map):
+            with dict_override(kwargs, {'create_loops': False}):
+                body = self.visit(masked.bodies[0], **kwargs)
+                else_body = self.visit(masked.default, **kwargs)
 
         body_nodes = as_tuple(body)
         else_nodes = as_tuple(else_body)

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -177,7 +177,7 @@ def resolve_vector_notation(routine, resolve_implicit_rhs_ranges=True,
     transformer = ResolveVectorNotationTransformer(
         loop_map=loop_map, scope=routine, inplace=True,
         derive_qualified_ranges=True,
-        map_unknown_ranges=True,
+        create_new_loop_indices=True,
         resolve_implicit_rhs_ranges=resolve_implicit_rhs_ranges,
         substitute_derived_type_bounds=substitute_derived_type_bounds,
         insert_comments=insert_comments,
@@ -285,7 +285,7 @@ def resolve_vector_dimension(routine, dimension, derive_qualified_ranges=False,
     transformer = ResolveVectorNotationTransformer(
         loop_map=loop_map, scope=routine, inplace=True,
         derive_qualified_ranges=derive_qualified_ranges,
-        map_unknown_ranges=False,
+        create_new_loop_indices=False,
         resolve_implicit_rhs_ranges=resolve_implicit_rhs_ranges,
         substitute_derived_type_bounds=substitute_derived_type_bounds,
         insert_comments=insert_comments,
@@ -366,9 +366,9 @@ class ResolveVectorNotationTransformer(Transformer):
     derive_qualified_ranges : bool
         Derive explicit bounds for all unqualified index ranges
         (``:``) before resolving them with loops.
-    map_unknown_ranges : bool
-        Flag to indicate whether unknown, but fully qualified range
-        indices are to be remapped to loops.
+    create_new_loop_indices : bool
+        Flag to indicate whether fully qualified ranges without a known
+        loop index are remapped to newly created loops.
     resolve_implicit_rhs_ranges : bool
         When ``True`` (default), resolve all LHS range dimensions even
         if the corresponding RHS arrays use bare ``:`` (unqualified)
@@ -388,7 +388,7 @@ class ResolveVectorNotationTransformer(Transformer):
 
     def __init__(
             self, *args, loop_map=None, scope=None,
-            derive_qualified_ranges=True, map_unknown_ranges=True,
+            derive_qualified_ranges=True, create_new_loop_indices=True,
             resolve_implicit_rhs_ranges=True,
             substitute_derived_type_bounds=False,
             insert_comments=False,
@@ -402,7 +402,7 @@ class ResolveVectorNotationTransformer(Transformer):
         self.pre_body_stmts = []
         self.active_loop_vars = set()
 
-        self.map_unknown_ranges = map_unknown_ranges
+        self.create_new_loop_indices = create_new_loop_indices
         self.derive_qualified_ranges = derive_qualified_ranges
         self.resolve_implicit_rhs_ranges = resolve_implicit_rhs_ranges
         self.substitute_derived_type_bounds_flag = substitute_derived_type_bounds
@@ -541,21 +541,25 @@ class ResolveVectorNotationTransformer(Transformer):
     @staticmethod
     def _build_loop_nest(index_range_map, body, insert_comments=False):
         """Wrap ``body`` in loops for all ranges from ``index_range_map``."""
+        assert index_range_map, (
+            'Expected a non-empty index_range_map; add explicit no-loop handling '
+            'here if future callers need it.'
+        )
         loop = None
         wrapped_body = body
         for ivar, irange in index_range_map.items():
-            if isinstance(irange, sym.RangeIndex):
-                bounds = sym.LoopRange(irange.children)
-            else:
-                bounds = sym.LoopRange((sym.Literal(1), irange, sym.Literal(1)))
+            assert isinstance(irange, sym.RangeIndex), (
+                'Expected RangeIndex values in index_range_map; add explicit '
+                'handling here if future callers need non-range loop bounds.'
+            )
+            bounds = sym.LoopRange(irange.children)
             loop = ir.Loop(variable=ivar, body=as_tuple(wrapped_body), bounds=bounds)
             wrapped_body = loop
 
         if insert_comments and loop:
             return (ir.Comment('! loki resolved vector notation'), loop)
-        if loop:
-            return (loop,)
-        return body
+        assert loop is not None
+        return (loop,)
 
     def visit_Loop(self, o, **kwargs):
         self.active_loop_vars.add(o.variable)
@@ -729,7 +733,7 @@ class ResolveVectorNotationTransformer(Transformer):
         reserved_ivars.update(self.active_loop_vars)
         new_dims, index_range_map, _ = self._map_ranges_to_indices(
             resolved_ranges, self.loop_map, reserved_ivars=reserved_ivars,
-            map_unknown_ranges=self.map_unknown_ranges,
+            create_new_loop_indices=self.create_new_loop_indices,
             scope=self.scope, basename='i_mask'
         )
 
@@ -776,7 +780,7 @@ class ResolveVectorNotationTransformer(Transformer):
         return simplify(sym.Sum((loop_var, sym.Product((-1, lhs_range.lower)), rhs_range.lower)))
 
     @staticmethod
-    def _map_ranges_to_indices(dims, loop_map, map_unknown_ranges=True, basename='i',
+    def _map_ranges_to_indices(dims, loop_map, create_new_loop_indices=True, basename='i',
                               scope=None, reserved_ivars=None):
         """
         Map :any:`RangeIndex` dimensions to loop index variables.
@@ -793,8 +797,9 @@ class ResolveVectorNotationTransformer(Transformer):
             The dimension expressions to process.
         loop_map : dict
             Map of known ``RangeIndex`` to loop variables.
-        map_unknown_ranges : bool
-            Whether to create new indices for unknown ranges.
+        create_new_loop_indices : bool
+            Whether to create new indices for fully qualified ranges that
+            do not have a known loop index.
         basename : str
             Base name for newly created index variables.
         scope : :any:`Subroutine` or :any:`Module`
@@ -835,14 +840,14 @@ class ResolveVectorNotationTransformer(Transformer):
                     # loop index and surrounding scalar references keep their
                     # meaning.
                     if ivar in index_range_map or ivar in reserved_ivars:
-                        if not map_unknown_ranges:
+                        if not create_new_loop_indices:
                             continue
                         vtype = SymbolAttributes(BasicType.INTEGER)
                         ivar = sym.Variable(name=f'{basename}_{i}', type=vtype, scope=scope)
                         synthesized_ivars.add(ivar)
                 else:
                     # Skip if we're not supposed to create new indices
-                    if not map_unknown_ranges or dim == sym.RangeIndex((None, None)):
+                    if not create_new_loop_indices or dim == sym.RangeIndex((None, None)):
                         continue
                     vtype = SymbolAttributes(BasicType.INTEGER)
                     ivar = sym.Variable(name=f'{basename}_{i}', type=vtype, scope=scope)
@@ -1110,13 +1115,13 @@ class ResolveVectorNotationTransformer(Transformer):
         reserved_ivars.update(self.active_loop_vars)
         new_lhs_dims, index_range_map, synthesized_ivars = self._map_ranges_to_indices(
             resolved_lhs_ranges, self.loop_map, reserved_ivars=reserved_ivars,
-            map_unknown_ranges=self.map_unknown_ranges,
+            create_new_loop_indices=self.create_new_loop_indices,
             scope=self.scope, basename=f'i_{stmt.lhs.basename}'
         )
 
         # Filter out dimensions that were not actually resolved to a scalar loop
         # variable (i.e. new_lhs_dim is still a RangeIndex).  This can happen
-        # when map_unknown_ranges=False and the LHS range is not in loop_map.
+        # when create_new_loop_indices=False and the LHS range is not in loop_map.
         # Keeping such dims would corrupt RHS expressions by feeding a RangeIndex
         # into _compute_shifted_index, producing e.g. ``-1 + (1:klevsn)``.
         actually_resolved = [

--- a/loki/transformations/array_indexing/vector_notation.py
+++ b/loki/transformations/array_indexing/vector_notation.py
@@ -313,6 +313,18 @@ class IterationRangeShapeMapper(LokiIdentityMapper):
             (s.lower, s.upper, s.step) if isinstance(s, sym.Range) else (sym.IntLiteral(1), s)
         )
 
+    @staticmethod
+    def _shape_lower(s):
+        return s.lower if isinstance(s, sym.Range) else sym.IntLiteral(1)
+
+    @staticmethod
+    def _shape_upper(s):
+        return s.upper if isinstance(s, sym.Range) else s
+
+    @staticmethod
+    def _shape_step(s):
+        return s.step if isinstance(s, sym.Range) else None
+
     def map_array(self, expr, *args, **kwargs):
         """ Replace ``:`` range indices with ``1:shape`` vector indices """
 
@@ -327,7 +339,11 @@ class IterationRangeShapeMapper(LokiIdentityMapper):
                 new_dims += (self._shape_to_range(s),)
             elif isinstance(d, sym.RangeIndex) and d.upper is None:
                 new_dims += (sym.RangeIndex(
-                    (d.lower, s.upper, s.step) if isinstance(s, sym.Range) else (d.lower, s)
+                    (d.lower, self._shape_upper(s), self._shape_step(s))
+                ),)
+            elif isinstance(d, sym.RangeIndex) and d.lower is None:
+                new_dims += (sym.RangeIndex(
+                    (self._shape_lower(s), d.upper, d.step)
                 ),)
             else:
                 new_dims += (d,)
@@ -425,12 +441,56 @@ class ResolveVectorNotationTransformer(Transformer):
         Return ordinal indices into ``range_positions`` whose corresponding
         dimension is *not* a bare ``(:)`` (i.e. ``RangeIndex((None, None))``).
         """
+        return ResolveVectorNotationTransformer._find_resolvable_range_positions(dims, range_positions)
+
+    @staticmethod
+    def _has_explicit_range_bounds(dim):
+        return isinstance(dim, sym.RangeIndex) and dim.lower is not None and dim.upper is not None
+
+    @staticmethod
+    def _is_scalarizable_bound_expr(bound):
+        return not isinstance(bound, (sym.Array, sym.DeferredTypeSymbol))
+
+    @classmethod
+    def _is_resolvable_range_dim(cls, dim):
+        return (
+            cls._has_explicit_range_bounds(dim)
+            and cls._is_scalarizable_bound_expr(dim.lower)
+            and cls._is_scalarizable_bound_expr(dim.upper)
+        )
+
+    @classmethod
+    def _find_resolvable_range_positions(cls, dims, range_positions):
+        """
+        Return ordinal indices into ``range_positions`` that have explicit,
+        scalarizable bounds.
+        """
         return [
             i for i, j in enumerate(range_positions)
-            if dims[j] != sym.RangeIndex((None, None)) and
-            dims[j].upper is not None and not isinstance(dims[j], sym.Array)
-            and not isinstance(dims[j], sym.DeferredTypeSymbol)
+            if cls._is_resolvable_range_dim(dims[j])
         ]
+
+    def _get_range_resolution_info(
+            self, lhs_dims, rhs_arrays, qualification_lhs_dims=None,
+            qualification_rhs_arrays=None
+    ):
+        """
+        Collect range positions and resolvable dimension ordinals for a set of arrays.
+        """
+        rhs_dims_per_array = [array.dimensions for array in rhs_arrays]
+        qualification_rhs_dims_per_array = None
+        if qualification_rhs_arrays is not None:
+            qualification_rhs_dims_per_array = [array.dimensions for array in qualification_rhs_arrays]
+
+        lhs_range_positions, resolvable_dim_indices = self._get_resolvable_dim_indices(
+            lhs_dims, rhs_dims_per_array,
+            qualification_lhs_dims=qualification_lhs_dims,
+            qualification_rhs_dims_per_array=qualification_rhs_dims_per_array,
+        )
+        rhs_range_positions_per_array = [
+            self._find_range_positions(dims) for dims in rhs_dims_per_array
+        ]
+        return lhs_range_positions, rhs_dims_per_array, rhs_range_positions_per_array, resolvable_dim_indices
 
     def _get_resolvable_dim_indices(
             self, lhs_dims, rhs_dims_per_array, qualification_lhs_dims=None,
@@ -442,14 +502,14 @@ class ResolveVectorNotationTransformer(Transformer):
         lhs_range_positions = self._find_range_positions(lhs_dims)
 
         if self.resolve_implicit_rhs_ranges:
-            lhs_qualified_positions = self._find_qualified_range_positions(
+            lhs_qualified_positions = self._find_resolvable_range_positions(
                 lhs_dims, lhs_range_positions
             )
             return lhs_range_positions, lhs_qualified_positions
 
         qualification_lhs_dims = lhs_dims if qualification_lhs_dims is None else qualification_lhs_dims
         qualification_lhs_positions = self._find_range_positions(qualification_lhs_dims)
-        lhs_qualified_positions = self._find_qualified_range_positions(
+        lhs_qualified_positions = self._find_resolvable_range_positions(
             qualification_lhs_dims, qualification_lhs_positions
         )
 
@@ -461,15 +521,18 @@ class ResolveVectorNotationTransformer(Transformer):
             self._find_range_positions(dims) for dims in qualification_rhs_dims_per_array
         ]
         rhs_qualified_positions_per_array = [
-            self._find_qualified_range_positions(rhs_dims, rhs_pos)
+            self._find_resolvable_range_positions(rhs_dims, rhs_pos)
             for rhs_dims, rhs_pos in zip(
                 qualification_rhs_dims_per_array, qualification_rhs_positions_per_array
             )
         ]
 
+        if not rhs_qualified_positions_per_array:
+            return lhs_range_positions, lhs_qualified_positions
+
         resolvable_dim_indices = [
             j for j in lhs_qualified_positions
-            if rhs_qualified_positions_per_array and all(
+            if all(
                 j in rhs_qualified for rhs_qualified in rhs_qualified_positions_per_array
             )
         ]
@@ -507,6 +570,22 @@ class ResolveVectorNotationTransformer(Transformer):
         """Only known elemental inline calls are safe to scalarize."""
         if call.function.type and call.function.type.is_intrinsic:
             return True
+        if not call.function.type:
+            return False
+        procedure_dtype = getattr(call.function.type, 'dtype', None)
+        if procedure_dtype is None:
+            scope = getattr(call.function, 'scope', None)
+            if scope is not None and hasattr(scope, 'subroutines'):
+                routine = next(
+                    (routine for routine in scope.subroutines
+                     if routine.name.lower() == call.name.lower()),
+                    None
+                )
+                if routine is not None:
+                    return routine.procedure_type.is_elemental
+            return False
+        if hasattr(procedure_dtype, 'is_elemental'):
+            return procedure_dtype.is_elemental
         procedure_type = call.procedure_type
         return procedure_type is not BasicType.DEFERRED and procedure_type.is_elemental
 
@@ -616,9 +695,8 @@ class ResolveVectorNotationTransformer(Transformer):
         if not cond_arrays:
             return expr, {}, False
 
-        cond_dims_per_array = [array.dimensions for array in cond_arrays]
-        lhs_range_positions, resolvable_dim_indices = self._get_resolvable_dim_indices(
-            cond_dims_per_array[0], cond_dims_per_array
+        lhs_range_positions, cond_dims_per_array, _, resolvable_dim_indices = self._get_range_resolution_info(
+            cond_arrays[0].dimensions, cond_arrays
         )
         if not resolvable_dim_indices:
             return expr, {}, False
@@ -937,7 +1015,6 @@ class ResolveVectorNotationTransformer(Transformer):
         orig_rhs_arrays, orig_unsafe_rhs_arrays = self._find_scalarizable_rhs_arrays(stmt.rhs)
         if orig_unsafe_rhs_arrays:
             return stmt
-        orig_rhs_dims_per_array = [array.dimensions for array in orig_rhs_arrays]
 
         # --- Step 3: Derive qualified ranges from shapes ---
         if self.derive_qualified_ranges:
@@ -960,19 +1037,17 @@ class ResolveVectorNotationTransformer(Transformer):
         rhs_arrays, unsafe_rhs_arrays = self._find_scalarizable_rhs_arrays(stmt.rhs)
         if unsafe_rhs_arrays:
             return stmt
-        rhs_dims_per_array = [array.dimensions for array in rhs_arrays]
 
         # LHS array dimensions
         lhs_array = stmt.lhs
         lhs_dims = lhs_array.dimensions
-        lhs_range_positions, resolvable_dim_indices = self._get_resolvable_dim_indices(
-            lhs_dims, rhs_dims_per_array,
-            qualification_lhs_dims=orig_lhs_dims,
-            qualification_rhs_dims_per_array=orig_rhs_dims_per_array,
+        lhs_range_positions, rhs_dims_per_array, rhs_range_positions_per_array, resolvable_dim_indices = (
+            self._get_range_resolution_info(
+                lhs_dims, rhs_arrays,
+                qualification_lhs_dims=orig_lhs_dims,
+                qualification_rhs_arrays=orig_rhs_arrays,
+            )
         )
-        rhs_range_positions_per_array = [
-            self._find_range_positions(dims) for dims in rhs_dims_per_array
-        ]
 
         # --- Step 5: Filter to resolvable dimensions ---
         # Nothing to resolve

--- a/loki/transformations/single_column/base.py
+++ b/loki/transformations/single_column/base.py
@@ -76,13 +76,15 @@ class SCCBaseTransformation(Transformation):
 
         Notes
         -----
-        The per-routine item config key ``resolve_vector_notation`` (bool,
-        default ``True``) can be set to ``False`` to skip vector notation
-        resolution for a specific routine.  Example scheduler config::
+        The per-routine item config keys ``resolve_vector_notation`` and
+        ``resolve_implicit_rhs_ranges`` (both bool, default ``True``) can be
+        used to control vector notation resolution for a specific routine.
+        Example scheduler config::
 
             [routines.my_routine]
             role = "kernel"
             resolve_vector_notation = false
+            resolve_implicit_rhs_ranges = false
 
         Parameters
         ----------
@@ -96,23 +98,33 @@ class SCCBaseTransformation(Transformation):
         item = kwargs.get('item', None)
         rename_indices = kwargs.get('rename_index_aliases', self.rename_indices)
         do_resolve_vector_notation = True
+        do_resolve_implicit_rhs_ranges = True
         if item:
             rename_indices = item.config.get('rename_index_aliases', rename_indices)
             do_resolve_vector_notation = item.config.get(
                 'resolve_vector_notation', do_resolve_vector_notation
             )
+            do_resolve_implicit_rhs_ranges = item.config.get(
+                'resolve_implicit_rhs_ranges', do_resolve_implicit_rhs_ranges
+            )
 
         if role == 'kernel':
             self.process_kernel(
                 routine, rename_indices=rename_indices,
-                do_resolve_vector_notation=do_resolve_vector_notation
+                do_resolve_vector_notation=do_resolve_vector_notation,
+                do_resolve_implicit_rhs_ranges=do_resolve_implicit_rhs_ranges,
             )
         if role == 'driver':
             self.process_driver(
-                routine, do_resolve_vector_notation=do_resolve_vector_notation
+                routine,
+                do_resolve_vector_notation=do_resolve_vector_notation,
+                do_resolve_implicit_rhs_ranges=do_resolve_implicit_rhs_ranges,
             )
 
-    def process_kernel(self, routine, rename_indices=False, do_resolve_vector_notation=True):
+    def process_kernel(
+            self, routine, rename_indices=False, do_resolve_vector_notation=True,
+            do_resolve_implicit_rhs_ranges=True
+    ):
         """
         Applies the SCCBase utilities to a "kernel". This consists of
         resolving associates, masked statements and vector notation.
@@ -132,6 +144,10 @@ class SCCBaseTransformation(Transformation):
             regardless of this flag, so that downstream SCC
             transformations find scalar loop indices instead of range
             notation.  Default is ``True``.
+        do_resolve_implicit_rhs_ranges : bool, optional
+            Whether to resolve assignments and masked statements whose RHS
+            arrays use bare ``:`` ranges while resolving vector notation.
+            Default is ``True``.
         """
 
         # Bail if routine is marked as sequential or routine has already been processed
@@ -163,13 +179,19 @@ class SCCBaseTransformation(Transformation):
         # loop indices instead of range notation, even when full vector notation
         # resolution is disabled.
         resolve_vector_dimension(
-            routine, dimension=self.horizontal, derive_qualified_ranges=True
+            routine, dimension=self.horizontal, derive_qualified_ranges=True,
+            resolve_implicit_rhs_ranges=do_resolve_implicit_rhs_ranges,
         )
 
         if do_resolve_vector_notation:
-            resolve_vector_notation(routine)
+            resolve_vector_notation(
+                routine, resolve_implicit_rhs_ranges=do_resolve_implicit_rhs_ranges
+            )
 
-    def process_driver(self, routine, do_resolve_vector_notation=True):
+    def process_driver(
+            self, routine, do_resolve_vector_notation=True,
+            do_resolve_implicit_rhs_ranges=True
+    ):
         """
         Applies the SCCBase utilities to a "driver". This consists of
         resolving associates and, by default, vector notation.
@@ -183,6 +205,10 @@ class SCCBaseTransformation(Transformation):
             Set to ``False`` to skip this step for driver routines
             where generated loop bounds may not be available on device.
             Default is ``True``.
+        do_resolve_implicit_rhs_ranges : bool, optional
+            Whether to resolve assignments and masked statements whose RHS
+            arrays use bare ``:`` ranges while resolving vector notation.
+            Default is ``True``.
         """
 
         # Resolve associates, since the PGI compiler cannot deal with
@@ -194,5 +220,10 @@ class SCCBaseTransformation(Transformation):
             resolve_vector_dimension(
                 routine, dimension=self.horizontal, derive_qualified_ranges=True,
                 substitute_derived_type_bounds=True,
+                resolve_implicit_rhs_ranges=do_resolve_implicit_rhs_ranges,
             )
-            resolve_vector_notation(routine, substitute_derived_type_bounds=True)
+            resolve_vector_notation(
+                routine,
+                resolve_implicit_rhs_ranges=do_resolve_implicit_rhs_ranges,
+                substitute_derived_type_bounds=True,
+            )

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -262,6 +262,10 @@ def test_scc_base_resolve_implicit_rhs_ranges_config(frontend, horizontal):
     assert len(conds) == 1
     assert conds[0].condition == 'q(jl) > 0.'
 
+    assigns = FindNodes(Assignment).visit(conds[0].body)
+    assert len(assigns) == 1
+    assert assigns[0].lhs == 'q(jl)' and assigns[0].rhs == 't(1 + jl - start)'
+
 
 @pytest.mark.parametrize('frontend', available_frontends())
 def test_scc_base_resolve_implicit_rhs_ranges_scalar_rhs(frontend, horizontal):

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -264,6 +264,92 @@ def test_scc_base_resolve_implicit_rhs_ranges_config(frontend, horizontal):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
+def test_scc_base_resolve_implicit_rhs_ranges_scalar_rhs(frontend, horizontal):
+    """
+    ``resolve_implicit_rhs_ranges = False`` must not block mandatory horizontal
+    resolution when the RHS is scalar-only.
+    """
+
+    fcode_kernel = """
+  SUBROUTINE compute_scalar_rhs(start, end, nlon, q, scalar)
+    INTEGER, INTENT(IN) :: start, end, nlon
+    REAL, INTENT(INOUT) :: q(nlon)
+    REAL, INTENT(IN) :: scalar
+
+    q(start:end) = 0.
+    q(start:end) = scalar
+  END SUBROUTINE compute_scalar_rhs
+"""
+
+    kernel_source = Sourcefile.from_source(fcode_kernel, frontend=frontend)
+    kernel = kernel_source.subroutines[0]
+    kernel_item = ProcedureItem(
+        name='#compute_scalar_rhs', source=kernel_source,
+        config={
+            'resolve_vector_notation': False,
+            'resolve_implicit_rhs_ranges': False,
+        }
+    )
+
+    scc_transform = SCCBaseTransformation(horizontal=horizontal)
+    scc_transform.apply(kernel, role='kernel', item=kernel_item)
+
+    assert 'jl' in kernel.variables
+    loops = FindNodes(Loop).visit(kernel.body)
+    assert len(loops) == 2
+    assert all(loop.variable == 'jl' for loop in loops)
+    assert all(loop.bounds == 'start:end' for loop in loops)
+
+    loop_assigns = [FindNodes(Assignment).visit(loop.body)[0] for loop in loops]
+    rhs_texts = {str(assign.rhs).replace(' ', '') for assign in loop_assigns}
+    assert rhs_texts == {'0.', 'scalar'}
+    assert all(str(assign.lhs) == 'q(jl)' for assign in loop_assigns)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_scc_driver_resolve_implicit_rhs_ranges_scalar_rhs(frontend, horizontal):
+    """
+    Driver-side horizontal resolution should also preserve scalar RHS lowering
+    when ``resolve_implicit_rhs_ranges = False``.
+    """
+
+    fcode_driver = """
+  SUBROUTINE drive_scalar_rhs(start, end, nlon, q, scalar)
+    INTEGER, INTENT(IN) :: start, end, nlon
+    REAL, INTENT(INOUT) :: q(nlon)
+    REAL, INTENT(IN) :: scalar
+
+    q(start:end) = 0.
+    q(start:end) = scalar
+  END SUBROUTINE drive_scalar_rhs
+"""
+
+    driver_source = Sourcefile.from_source(fcode_driver, frontend=frontend)
+    driver = driver_source.subroutines[0]
+    driver_item = ProcedureItem(
+        name='#drive_scalar_rhs', source=driver_source,
+        config={
+            'resolve_vector_notation': True,
+            'resolve_implicit_rhs_ranges': False,
+        }
+    )
+
+    scc_transform = SCCBaseTransformation(horizontal=horizontal)
+    scc_transform.apply(driver, role='driver', item=driver_item)
+
+    assert 'jl' in driver.variables
+    loops = FindNodes(Loop).visit(driver.body)
+    assert len(loops) == 2
+    assert all(loop.variable == 'jl' for loop in loops)
+    assert all(loop.bounds == 'start:end' for loop in loops)
+
+    loop_assigns = [FindNodes(Assignment).visit(loop.body)[0] for loop in loops]
+    rhs_texts = {str(assign.rhs).replace(' ', '') for assign in loop_assigns}
+    assert rhs_texts == {'0.', 'scalar'}
+    assert all(str(assign.lhs) == 'q(jl)' for assign in loop_assigns)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
 @pytest.mark.parametrize('rel_index', ('jl', 'jcol', 'ji'))
 @pytest.mark.parametrize('indices', (('jl', 'jcol', 'jlll'), ('jcol','jcol', 'jcol'),
     ('jl', 'jl', 'jl'), ('jcol', 'jlll', 'jlll')))

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -14,7 +14,7 @@ from loki.batch import ProcedureItem, TransformationError
 from loki.expression import Scalar, Array, IntLiteral
 from loki.frontend import available_frontends, OMNI, HAVE_FP
 from loki.ir import (
-    FindNodes, Assignment, CallStatement, Conditional, Loop,
+    FindNodes, Assignment, CallStatement, Conditional, Loop, MaskedStatement,
     Pragma, PragmaRegion, pragmas_attached, is_loki_pragma,
     pragma_regions_attached, FindInlineCalls
 )
@@ -202,6 +202,65 @@ def test_scc_base_resolve_vector_notation_config(frontend, horizontal):
     assert len(z_assigns2) == 1
     assert ':' not in fgen(z_assigns2[0]).lower(), \
         f"z(:) should be resolved, got: {fgen(z_assigns2[0])}"
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_scc_base_resolve_implicit_rhs_ranges_config(frontend, horizontal):
+    """
+    Test that per-routine config key ``resolve_implicit_rhs_ranges`` controls
+    whether masked statements with bare RHS ranges are lowered.
+    """
+
+    fcode_kernel = """
+  SUBROUTINE compute_masked(start, end, nlon, q, t)
+    INTEGER, INTENT(IN) :: start, end, nlon
+    REAL, INTENT(INOUT) :: q(nlon), t(nlon)
+
+    WHERE (q(start:end) > 0.)
+      q(start:end) = t(:)
+    END WHERE
+  END SUBROUTINE compute_masked
+"""
+
+    kernel_source = Sourcefile.from_source(fcode_kernel, frontend=frontend)
+    kernel = kernel_source.subroutines[0]
+    kernel_item = ProcedureItem(
+        name='#compute_masked', source=kernel_source,
+        config={
+            'resolve_vector_notation': False,
+            'resolve_implicit_rhs_ranges': False,
+        }
+    )
+
+    scc_transform = SCCBaseTransformation(horizontal=horizontal)
+    scc_transform.apply(kernel, role='kernel', item=kernel_item)
+
+    assert len(FindNodes(MaskedStatement).visit(kernel.body)) == 1
+    assert not FindNodes(Loop).visit(kernel.body)
+
+    kernel_source2 = Sourcefile.from_source(fcode_kernel, frontend=frontend)
+    kernel2 = kernel_source2.subroutines[0]
+    kernel_item2 = ProcedureItem(
+        name='#compute_masked', source=kernel_source2,
+        config={
+            'resolve_vector_notation': False,
+            'resolve_implicit_rhs_ranges': True,
+        }
+    )
+
+    scc_transform2 = SCCBaseTransformation(horizontal=horizontal)
+    scc_transform2.apply(kernel2, role='kernel', item=kernel_item2)
+
+    assert 'jl' in kernel2.variables
+    assert not FindNodes(MaskedStatement).visit(kernel2.body)
+    loops = FindNodes(Loop).visit(kernel2.body)
+    assert len(loops) == 1
+    assert loops[0].variable == 'jl'
+    assert loops[0].bounds == 'start:end'
+
+    conds = FindNodes(Conditional).visit(kernel2.body)
+    assert len(conds) == 1
+    assert conds[0].condition == 'q(jl) > 0.'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/single_column/tests/test_scc.py
+++ b/loki/transformations/single_column/tests/test_scc.py
@@ -268,89 +268,47 @@ def test_scc_base_resolve_implicit_rhs_ranges_config(frontend, horizontal):
 
 
 @pytest.mark.parametrize('frontend', available_frontends())
-def test_scc_base_resolve_implicit_rhs_ranges_scalar_rhs(frontend, horizontal):
+@pytest.mark.parametrize('resolve_vector_notation', [True, False])
+def test_scc_resolve_implicit_rhs_ranges_scalar_rhs(frontend, horizontal, resolve_vector_notation):
     """
     ``resolve_implicit_rhs_ranges = False`` must not block mandatory horizontal
     resolution when the RHS is scalar-only.
     """
 
-    fcode_kernel = """
-  SUBROUTINE compute_scalar_rhs(start, end, nlon, q, scalar)
+    fcode = """
+  SUBROUTINE test_scalar_rhs(start, end, nlon, q, scalar)
     INTEGER, INTENT(IN) :: start, end, nlon
     REAL, INTENT(INOUT) :: q(nlon)
     REAL, INTENT(IN) :: scalar
 
     q(start:end) = 0.
     q(start:end) = scalar
-  END SUBROUTINE compute_scalar_rhs
+  END SUBROUTINE test_scalar_rhs
 """
 
-    kernel_source = Sourcefile.from_source(fcode_kernel, frontend=frontend)
-    kernel = kernel_source.subroutines[0]
-    kernel_item = ProcedureItem(
-        name='#compute_scalar_rhs', source=kernel_source,
+    source = Sourcefile.from_source(fcode, frontend=frontend)
+    routine = source.subroutines[0]
+    item = ProcedureItem(
+        name='#test_scalar_rhs', source=source,
         config={
-            'resolve_vector_notation': False,
+            'resolve_vector_notation': resolve_vector_notation,
             'resolve_implicit_rhs_ranges': False,
         }
     )
 
     scc_transform = SCCBaseTransformation(horizontal=horizontal)
-    scc_transform.apply(kernel, role='kernel', item=kernel_item)
+    role = 'driver' if resolve_vector_notation else 'kernel'
+    scc_transform.apply(routine, role=role, item=item)
 
-    assert 'jl' in kernel.variables
-    loops = FindNodes(Loop).visit(kernel.body)
+    assert 'jl' in routine.variables
+    loops = FindNodes(Loop).visit(routine.body)
     assert len(loops) == 2
     assert all(loop.variable == 'jl' for loop in loops)
     assert all(loop.bounds == 'start:end' for loop in loops)
 
-    loop_assigns = [FindNodes(Assignment).visit(loop.body)[0] for loop in loops]
-    rhs_texts = {str(assign.rhs).replace(' ', '') for assign in loop_assigns}
-    assert rhs_texts == {'0.', 'scalar'}
-    assert all(str(assign.lhs) == 'q(jl)' for assign in loop_assigns)
-
-
-@pytest.mark.parametrize('frontend', available_frontends())
-def test_scc_driver_resolve_implicit_rhs_ranges_scalar_rhs(frontend, horizontal):
-    """
-    Driver-side horizontal resolution should also preserve scalar RHS lowering
-    when ``resolve_implicit_rhs_ranges = False``.
-    """
-
-    fcode_driver = """
-  SUBROUTINE drive_scalar_rhs(start, end, nlon, q, scalar)
-    INTEGER, INTENT(IN) :: start, end, nlon
-    REAL, INTENT(INOUT) :: q(nlon)
-    REAL, INTENT(IN) :: scalar
-
-    q(start:end) = 0.
-    q(start:end) = scalar
-  END SUBROUTINE drive_scalar_rhs
-"""
-
-    driver_source = Sourcefile.from_source(fcode_driver, frontend=frontend)
-    driver = driver_source.subroutines[0]
-    driver_item = ProcedureItem(
-        name='#drive_scalar_rhs', source=driver_source,
-        config={
-            'resolve_vector_notation': True,
-            'resolve_implicit_rhs_ranges': False,
-        }
-    )
-
-    scc_transform = SCCBaseTransformation(horizontal=horizontal)
-    scc_transform.apply(driver, role='driver', item=driver_item)
-
-    assert 'jl' in driver.variables
-    loops = FindNodes(Loop).visit(driver.body)
-    assert len(loops) == 2
-    assert all(loop.variable == 'jl' for loop in loops)
-    assert all(loop.bounds == 'start:end' for loop in loops)
-
-    loop_assigns = [FindNodes(Assignment).visit(loop.body)[0] for loop in loops]
-    rhs_texts = {str(assign.rhs).replace(' ', '') for assign in loop_assigns}
-    assert rhs_texts == {'0.', 'scalar'}
-    assert all(str(assign.lhs) == 'q(jl)' for assign in loop_assigns)
+    assigns = [FindNodes(Assignment).visit(loop.body)[0] for loop in loops]
+    assert assigns[0].lhs == 'q(jl)' and assigns[0].rhs == 0.
+    assert assigns[1].lhs == 'q(jl)' and assigns[1].rhs == 'scalar'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())


### PR DESCRIPTION
### Description

#### Summary
This PR improves the robustness of vector-notation resolution by making it more conservative where transformations are ambiguous, while still preserving important scalarizable cases that appear in real physics code.

#### Key Changes

- Improves handling of inline function calls so elemental cases are recognized more reliably during vector-notation resolution.
- Refines how slice bounds are analyzed to distinguish safe scalar bounds from unsafe vector-valued expressions.
- Restores valid transformations for scalar derived-type bounds while keeping unsafe unresolved cases visible through warnings.
- Prevents incorrect resolution when array subscripts or bounds are effectively vector-valued.
- Expands regression coverage for representative IFS and ecRad-style patterns.
- Cleans up the related test setup so frontend-generated artifacts do not leak into the repository root.

#### Outcome

Overall, the diff makes resolve_vector_notation safer and more predictable: it avoids wrong-code generation in ambiguous cases, fixes missed transformations in valid cases, and adds coverage for the boundary cases that triggered the regressions.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 