### PR TITLE
Transformations: Offload nested driver region and data offload trafo bugfix

### DIFF
--- a/loki/transformations/data_offload/offload_deepcopy.py
+++ b/loki/transformations/data_offload/offload_deepcopy.py
@@ -21,8 +21,7 @@ from loki.batch import Transformation, TypeDefItem, ProcedureItem
 from loki.expression import symbols as sym
 from loki.ir import (
         nodes as ir, FindNodes, SubstituteExpressions, Transformer,
-        pragma_regions_attached, get_pragma_parameters, SubstitutePragmaStrings,
-        is_loki_pragma, pragmas_attached
+        get_pragma_parameters, SubstitutePragmaStrings
 )
 from loki.logging import warning
 from loki.tools import as_tuple, OrderedSet
@@ -33,7 +32,7 @@ from loki.transformations.field_api import (
         field_get_host_data, field_delete_device_data,
         FieldAPIAccessorType
 )
-from loki.transformations.utilities import find_driver_loops, get_integer_variable
+from loki.transformations.utilities import driver_loop_regions_attached, get_integer_variable
 from loki.transformations.data_offload.offload import do_remove_openmp_pragmas
 
 __all__ = ['DataOffloadDeepcopyAnalysis', 'DataOffloadDeepcopyTransformation']
@@ -263,57 +262,49 @@ class DataOffloadDeepcopyAnalysis(Transformation):
 
         item.trafo_data[self._key] = defaultdict(dict)
 
-        with pragmas_attached(routine, ir.Loop):
-            driver_loops = find_driver_loops(routine.body, targets)
-        loop_analyses = {}
+        symbol_map = routine.symbol_map | routine.all_imported_symbol_map
+        with driver_loop_regions_attached(routine, targets, starts_with='data') as driver_loop_regions:
+            for entry in driver_loop_regions:
+                loop = entry.loop
 
-        for loop in driver_loops:
+                # We can't simply map successor.ir: successor here because we may
+                # call a routine twice with different arguments.
+                successor_map = {}
+                for call in FindNodes(ir.CallStatement).visit(loop.body):
+                    if (successor := [s for s in successors if call.routine == s.ir]):
+                        successor_map[call] = successor[0]
 
-            # We can't simply map successor.ir: successor here because we may call a routine twice with different
-            # arguments
-            successor_map = {}
-            calls = FindNodes(ir.CallStatement).visit(loop.body)
-            for call in calls:
-                if (successor := [s for s in successors if call.routine == s.ir]):
-                    successor_map[call] = successor[0]
+                loop_analysis = {}
+                self.process_body(routine.name, item, successors, successor_map, loop, analysis=loop_analysis)
 
-            # The analysis is accumulated on item.trafo_data, so to ensure each driver loop has an independent,
-            # analysis we reset it here.
-            item.trafo_data[self._key]['analysis'] = {}
-            self.process_body(routine.name, item, successors, successor_map, loop)
+                layered_dict = {}
+                for k, v in loop_analysis.items():
+                    _temp_dict = create_nested_dict(k, v, symbol_map)
+                    layered_dict = merge_nested_dict(layered_dict, _temp_dict)
 
-            symbol_map = routine.symbol_map | routine.all_imported_symbol_map
-            layered_dict = {}
-            for k, v in item.trafo_data[self._key]['analysis'].items():
-                _temp_dict = create_nested_dict(k, v, symbol_map)
-                layered_dict = merge_nested_dict(layered_dict, _temp_dict)
+                item.trafo_data[self._key]['analysis'][entry.key] = layered_dict
 
-            loop_analyses[loop] = layered_dict
-
-            if self.output_analysis:
-                if HAVE_YAML:
-                    str_layered_dict = self.stringify_dict(layered_dict)
-                    base_dir = Path(kwargs['build_args']['output_dir'])
-                    if successor_map:
-                        target_routine_name = list(successor_map.keys())[0].name
+                if self.output_analysis:
+                    if HAVE_YAML:
+                        str_layered_dict = self.stringify_dict(layered_dict)
+                        base_dir = Path(kwargs['build_args']['output_dir'])
+                        if successor_map:
+                            target_routine_name = list(successor_map.keys())[0].name
+                        else:
+                            target_routine_name = routine.name
+                        with open(base_dir/f'driver_{target_routine_name}_dataoffload_analysis.yaml', 'w') as f:
+                            yaml.dump(str_layered_dict, f)
                     else:
-                        target_routine_name = routine.name
-                    with open(base_dir/f'driver_{target_routine_name}_dataoffload_analysis.yaml', 'w') as f:
-                        yaml.dump(str_layered_dict, f)
-                else:
-                    warning('[Loki::DataOffloadDeepcopyAnalysis] cannot output analysis because yaml is not available.')
-
-
-        # We store the collected analyses on item.trafo_data
-        for loop in driver_loops:
-            item.trafo_data[self._key]['analysis'][loop] = loop_analyses[loop]
+                        warning(
+                            '[Loki::DataOffloadDeepcopyAnalysis] cannot output analysis because yaml is not available.'
+                        )
 
     def process_kernel(self, routine, item, successors, **kwargs):
 
         item.trafo_data[self._key] = defaultdict(dict)
 
-        # We can't simply map successor.ir: successor here because we may call a routine twice with different
-        # arguments
+        # We can't simply map successor.ir: successor here because we may call
+        # a routine twice with different arguments.
         successor_map = {}
         for call in FindNodes(ir.CallStatement).visit(routine.body):
             if (successor := [s for s in successors if call.routine == s.ir]):
@@ -335,9 +326,10 @@ class DataOffloadDeepcopyAnalysis(Transformation):
             else:
                 warning('[Loki::DataOffloadDeepcopyAnalysis] cannot output analysis because yaml is not available.')
 
-    def process_body(self, routine_name, item, successors, successor_map, scope_node):
+    def process_body(self, routine_name, item, successors, successor_map, scope_node, analysis=None):
         # gather typedef configs from successors
         self.gather_typedef_configs(successors, item.trafo_data[self._key]['typedef_configs'])
+        analysis = item.trafo_data[self._key]['analysis'] if analysis is None else analysis
 
         has_spec = hasattr(scope_node, 'spec')
 
@@ -361,23 +353,23 @@ class DataOffloadDeepcopyAnalysis(Transformation):
             if has_spec:
                 for v in scope_node.spec.uses_symbols:
                     if v.name_parts[0].lower() in getattr(scope_node, '_dummies', []):
-                        item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'read'
+                        analysis[v.clone(dimensions=None)] = 'read'
 
             # Gather used and defined symbols in body
             uses_symbols = scope_node.body.uses_symbols if has_spec else scope_node.uses_symbols
 
             for v in uses_symbols:
                 if v.name_parts[0].lower() in getattr(scope_node, '_dummies', []) or not has_spec:
-                    item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'read'
+                    analysis[v.clone(dimensions=None)] = 'read'
 
             defines_symbols = scope_node.body.defines_symbols if has_spec else scope_node.defines_symbols
 
             for v in defines_symbols:
                 if v.name_parts[0].lower() in getattr(scope_node, '_dummies', []) or not has_spec:
                     if v in (spec_uses_symbols | uses_symbols):
-                        item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'readwrite'
+                        analysis[v.clone(dimensions=None)] = 'readwrite'
                     else:
-                        item.trafo_data[self._key]['analysis'][v.clone(dimensions=None)] = 'write'
+                        analysis[v.clone(dimensions=None)] = 'write'
 
     def gather_typedef_configs(self, successors, typedef_configs):
         """Gather typedef configs from children."""
@@ -468,16 +460,11 @@ class DataOffloadDeepcopyTransformation(Transformation):
 
         if role == 'driver':
             if self.remove_openmp:
-                data_regions = []
-                with pragma_regions_attached(routine):
-                    for region in FindNodes(ir.PragmaRegion).visit(routine.body):
-                        if not is_loki_pragma(region.pragma, starts_with='data'):
-                            continue
-                        with pragmas_attached(routine, ir.Loop):
-                            driver_loops = find_driver_loops(region.body, targets)
-                        if driver_loops:
-                            data_regions.append(region)
-                do_remove_openmp_pragmas(routine, data_regions)
+                data_regions = {}
+                with driver_loop_regions_attached(routine, targets, starts_with='data') as driver_loop_regions:
+                    for entry in driver_loop_regions:
+                        data_regions[entry.region_index] = entry.region
+                do_remove_openmp_pragmas(routine, tuple(data_regions.values()))
             self.process_driver(routine, item.trafo_data[self._key]['analysis'],
                                 item.trafo_data[self._key]['typedef_configs'], targets)
 
@@ -544,16 +531,15 @@ class DataOffloadDeepcopyTransformation(Transformation):
         pragma_map = {}
         imports = defaultdict(tuple)
         symbol_map = routine.symbol_map | routine.all_imported_symbol_map
-        with pragma_regions_attached(routine):
-            for region in FindNodes(ir.PragmaRegion).visit(routine.body):
+        with driver_loop_regions_attached(routine, targets, starts_with='data') as driver_loop_regions:
+            entries_by_region = defaultdict(list)
+            for entry in driver_loop_regions:
+                entries_by_region[entry.region_index].append(entry)
 
-                # Only work on active `!$loki data` regions
-                if not is_loki_pragma(region.pragma, starts_with='data'):
-                    continue
+            for entries in entries_by_region.values():
+                region = entries[0].region
 
                 parameters = get_pragma_parameters(region.pragma, starts_with='data')
-                with pragmas_attached(routine, ir.Loop):
-                    driver_loops = find_driver_loops(region.body, targets)
 
                 # skip the deepcopy for variables previously marked as present/private
                 present = self.get_pragma_vars(parameters, 'present')
@@ -567,11 +553,18 @@ class DataOffloadDeepcopyTransformation(Transformation):
 
                 copy, host, wipe = (), (), ()
                 present_vars = ()
-                for loop in driver_loops:
+                for entry in entries:
+
+                    if entry.key not in analyses:
+                        msg = (
+                            '[Loki::DataOffloadDeepcopyTransformation] item missing analysis for '
+                            f'driver loop region {entry.key} in {routine.name}.'
+                        )
+                        raise RuntimeError(msg)
 
                     # filter out root-level scalars from the analysis as these are thread-private by default
                     # and should not in any case be copied back to host
-                    analysis = {k: v for k, v in analyses[loop].items()
+                    analysis = {k: v for k, v in analyses[entry.key].items()
                                 if not (isinstance(k.type.dtype, BasicType) and isinstance(k, sym.Scalar))}
 
                     # update analysis with manual overrides

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -25,7 +25,7 @@ from loki.subroutine import Subroutine
 from loki.tools import gettempdir, flatten, as_tuple
 from loki.transformations import (
         DataOffloadDeepcopyAnalysis, DataOffloadDeepcopyTransformation, RemoveCodeTransformation,
-        find_driver_loops
+        driver_loop_regions_attached
 )
 from loki.transformations.data_offload.offload_deepcopy import DeepcopyDataflowAnalysis
 from loki.types import BasicType, DerivedType, SymbolAttributes, Scope, ProcedureType
@@ -472,13 +472,17 @@ def test_offload_deepcopy_analysis(frontend, config, deepcopy_code, expected_ana
         messages = [log.message for log in caplog.records]
         assert '[Loki::DataOffloadDeepcopyAnalysis] Pointer associations found in kernel' in messages[-1]
 
-    # The analysis is tied to driver loops
+    # The analysis is tied to driver loops inside data regions
     trafo_data_key = transformation._key
     driver_item = scheduler['driver_mod#driver']
-    driver_loop = find_driver_loops(driver_item.ir.body, targets=['kernel', 'nested_kernel_write'])[0]
+    with driver_loop_regions_attached(
+            driver_item.ir, targets=['kernel', 'nested_kernel_write'], starts_with='data'
+    ) as driver_loop_regions:
+        driver_loop_key = driver_loop_regions[0].key
 
     #stringify dict for comparison
-    stringified_dict = transformation.stringify_dict(driver_item.trafo_data[trafo_data_key]['analysis'][driver_loop])
+    analysis = driver_item.trafo_data[trafo_data_key]['analysis'][driver_loop_key]
+    stringified_dict = transformation.stringify_dict(analysis)
     sorted_expected_analysis = _nested_sort(expected_analysis)
     assert _nested_sort(stringified_dict) == sorted_expected_analysis
 
@@ -984,15 +988,16 @@ def test_offload_deepcopy_simple_driver(frontend, config, deepcopy_code, tmp_pat
     transformation = DataOffloadDeepcopyAnalysis(output_analysis=True)
     scheduler.process(transformation=transformation)
 
-    # The analysis is tied to driver loops
+    # The analysis is tied to driver loops inside data regions
     trafo_data_key = transformation._key
     driver_item = scheduler['simple_driver_mod#simple_driver']
     driver = scheduler['simple_driver_mod#simple_driver'].ir
-    with pragmas_attached(driver, ir.Loop):
-        driver_loop = find_driver_loops(driver.body, targets=[])[0]
+    with driver_loop_regions_attached(driver, targets=[], starts_with='data') as driver_loop_regions:
+        driver_loop_key = driver_loop_regions[0].key
 
     #stringify dict for comparison
-    stringified_dict = transformation.stringify_dict(driver_item.trafo_data[trafo_data_key]['analysis'][driver_loop])
+    analysis = driver_item.trafo_data[trafo_data_key]['analysis'][driver_loop_key]
+    stringified_dict = transformation.stringify_dict(analysis)
     expected_analysis = {
         'ngpblks' : 'read',
         'variable' : {

--- a/loki/transformations/data_offload/tests/test_offload_deepcopy.py
+++ b/loki/transformations/data_offload/tests/test_offload_deepcopy.py
@@ -14,8 +14,8 @@ from loki.sourcefile import Sourcefile
 from loki.batch.item import Item
 from loki.batch import Scheduler
 from loki.ir import (
-    nodes as ir, FindNodes, is_loki_pragma, pragma_regions_attached, get_pragma_parameters,
-    pragmas_attached
+    nodes as ir, FindNodes, is_loki_pragma, pragmas_attached,
+    pragma_regions_attached, get_pragma_parameters
 )
 from loki.expression import Variable, RangeIndex, IntLiteral
 from loki.expression import symbols as sym
@@ -1058,6 +1058,95 @@ def test_offload_deepcopy_transformation_remove_openmp_guard(frontend, remove_op
         pragma for pragma in FindNodes(ir.Pragma).visit(driver.body) if pragma.keyword.lower() == 'omp'
     ]
     assert bool(omp_pragmas) is not remove_openmp
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_offload_deepcopy_driver_loop_lookup_with_nested_pragma_region(frontend, config, tmp_path):
+    """
+    Test driver-loop analysis lookup with a nested pragma region inside the loop.
+    """
+
+    fcode = {
+        'kernel': """
+module kernel_mod
+contains
+subroutine kernel(a)
+  real, intent(inout) :: a(:)
+
+  a(:) = a(:) + 1.
+end subroutine kernel
+end module kernel_mod
+        """.strip(),
+        'driver': """
+module driver_mod
+contains
+subroutine driver(ngpblks, a)
+  use kernel_mod, only : kernel
+  integer, intent(in) :: ngpblks
+  real, intent(inout) :: a(:,:)
+  integer :: ibl
+
+!$loki data
+!$loki driver-loop
+  do ibl = 1, ngpblks
+    !$loki remove
+    call kernel(a(:, ibl))
+    !$loki end remove
+  enddo
+!$loki end data
+
+end subroutine driver
+end module driver_mod
+        """.strip(),
+    }
+
+    workdir = tmp_path/'test_offload_deepcopy_nested_pragma_region'
+    workdir.mkdir()
+    for name, code in fcode.items():
+        (workdir/f'{name}.F90').write_text(code)
+
+    config['routines'] = {
+        'driver': {'role': 'driver'},
+    }
+
+    scheduler = Scheduler(
+        paths=workdir, config=config, frontend=frontend, xmods=[tmp_path],
+        output_dir=tmp_path, preprocess=True
+    )
+
+    scheduler.process(transformation=DataOffloadDeepcopyAnalysis())
+    scheduler.process(transformation=DataOffloadDeepcopyTransformation(mode='offload'))
+
+    # Check pragmas have been generated correctly
+    driver = scheduler['driver_mod#driver'].ir
+    pragmas = FindNodes(ir.Pragma).visit(driver.body)
+    assert len(pragmas) == 8
+    assert is_loki_pragma(pragmas[0], starts_with='unstructured-data in(a)')
+    assert is_loki_pragma(pragmas[1], starts_with='structured-data present(a)')
+    assert is_loki_pragma(pragmas[2], starts_with='driver-loop')
+    assert is_loki_pragma(pragmas[3], starts_with='remove')
+    assert is_loki_pragma(pragmas[4], starts_with='end remove')
+    assert is_loki_pragma(pragmas[5], starts_with='end structured-data')
+    assert is_loki_pragma(pragmas[6], starts_with='update host(a)')
+    assert is_loki_pragma(pragmas[7], starts_with='exit unstructured-data delete(a) finalize')
+
+    # Ensure regions and loop-attached pragmas work
+    with pragma_regions_attached(driver):
+        with pragmas_attached(driver, node_type=ir.Loop):
+            pragmas = FindNodes(ir.Pragma).visit(driver.body)
+            assert len(pragmas) == 3
+            assert is_loki_pragma(pragmas[0], starts_with='unstructured-data in(a)')
+            assert is_loki_pragma(pragmas[1], starts_with='update host(a)')
+            assert is_loki_pragma(pragmas[2], starts_with='exit unstructured-data delete(a) finalize')
+
+            regions = FindNodes(ir.PragmaRegion).visit(driver.body)
+            assert len(regions) == 2
+            assert is_loki_pragma(regions[0].pragma, starts_with='structured-data present(a)')
+            assert is_loki_pragma(regions[1].pragma, starts_with='remove')
+
+            loops = FindNodes(ir.Loop).visit(driver.body)
+            assert len(loops) == 1
+            assert is_loki_pragma(loops[0].pragma, starts_with='driver-loop')
 
 
 def test_deepcopy_dataflow_analysis_ignore_calls_skips_unenriched_call():

--- a/loki/transformations/tests/test_utilities.py
+++ b/loki/transformations/tests/test_utilities.py
@@ -13,7 +13,7 @@ from loki.frontend import available_frontends, OMNI
 from loki.logging import WARNING
 from loki.ir import (
     nodes as ir, FindNodes, FindVariables, FindInlineCalls,
-    SubstituteExpressions, pragmas_attached
+    SubstituteExpressions, is_loki_pragma, pragma_regions_attached, pragmas_attached
 )
 from loki.types import BasicType
 
@@ -21,8 +21,9 @@ from loki.transformations.utilities import (
     single_variable_declaration, recursive_expression_map_update,
     convert_to_lower_case, replace_intrinsics, rename_variables,
     get_integer_variable, get_loop_bounds, is_driver_loop,
-    find_driver_loops, get_local_arrays, check_routine_sequential,
-    substitute_variables_for_definitions, is_pragma_driver_loop
+    find_driver_loops, find_driver_loop_regions, driver_loop_regions_attached,
+    get_local_arrays, check_routine_sequential, substitute_variables_for_definitions,
+    is_pragma_driver_loop
 )
 
 
@@ -625,6 +626,85 @@ end subroutine test_find_driver_loops
         assert len(driver_loops) == 10
         for i in [0, 3, 4, 6, 8, 9, 13, 17, 19, 20]:
             assert loops[i] in driver_loops
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_utilities_find_driver_loop_regions(frontend):
+    """Test driver-loop enumeration inside generic Loki pragma regions."""
+
+    fcode = """
+subroutine test_find_driver_loop_regions(n, arr)
+  integer, intent(in) :: n
+  real, intent(inout) :: arr(n, n)
+  integer :: i, j
+
+  !$loki parallel private(i)
+  !$loki driver-loop
+  do i=1, n
+    !$loki remove
+    call target_kernel(arr(:, i))
+    !$loki end remove
+  end do
+  !$loki end parallel
+
+  !$loki ignored-region
+  do i=1, n
+    call target_kernel(arr(:, i))
+  end do
+  !$loki end ignored-region
+
+  !$loki parallel
+  do i=1, n
+    call target_kernel(arr(:, i))
+  end do
+
+  !$loki driver-loop
+  do j=1, n
+    arr(j, j) = 0.
+  end do
+  !$loki end parallel
+end subroutine test_find_driver_loop_regions
+"""
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    with driver_loop_regions_attached(routine, targets=('target_kernel',), starts_with='parallel') as entries:
+        assert [entry.key for entry in entries] == [(0, 0), (1, 0), (1, 1)]
+        assert [entry.region_index for entry in entries] == [0, 1, 1]
+        assert [entry.loop_index for entry in entries] == [0, 0, 1]
+        assert [entry.loop.variable for entry in entries] == ['i', 'i', 'j']
+        assert all(is_loki_pragma(entry.region.pragma, starts_with='parallel') for entry in entries)
+        assert isinstance(entries[0].loop.body[0], ir.PragmaRegion)
+
+    assert not FindNodes(ir.PragmaRegion).visit(routine.body)
+
+
+@pytest.mark.parametrize('frontend', available_frontends())
+def test_transform_utilities_find_driver_loop_regions_attached_section(frontend):
+    """Test the lower-level region-loop utility on an already attached section."""
+
+    fcode = """
+subroutine test_find_driver_loop_regions_attached_section(n, arr)
+  integer, intent(in) :: n
+  real, intent(inout) :: arr(n, n)
+  integer :: i
+
+  !$loki data
+  do i=1, n
+    call target_kernel(arr(:, i))
+  end do
+  !$loki end data
+end subroutine test_find_driver_loop_regions_attached_section
+"""
+
+    routine = Subroutine.from_source(fcode, frontend=frontend)
+
+    with pragma_regions_attached(routine):
+        with pragmas_attached(routine, node_type=ir.Loop):
+            entries = find_driver_loop_regions(routine.body, targets=('target_kernel',), starts_with='data')
+            assert len(entries) == 1
+            assert entries[0].key == (0, 0)
+            assert entries[0].loop.variable == 'i'
 
 
 @pytest.mark.parametrize('frontend', available_frontends())

--- a/loki/transformations/utilities.py
+++ b/loki/transformations/utilities.py
@@ -11,6 +11,8 @@ Collection of utility routines to deal with general language conversion.
 
 import platform
 from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pymbolic.primitives import Expression
 from loki.expression import (
     symbols as sym, SubstituteExpressionsMapper, ExpressionRetriever,
@@ -20,7 +22,7 @@ from loki.ir import (
     nodes as ir, Import, TypeDef, VariableDeclaration, is_loki_pragma,
     StatementFunction, Transformer, FindNodes, FindVariables,
     FindInlineCalls, FindLiterals, SubstituteExpressions,
-    ExpressionFinder
+    ExpressionFinder, pragma_regions_attached, pragmas_attached
 )
 from loki.module import Module
 from loki.subroutine import Subroutine
@@ -35,9 +37,32 @@ __all__ = [
     'convert_to_lower_case', 'replace_intrinsics', 'rename_variables',
     'sanitise_imports', 'replace_selected_kind',
     'single_variable_declaration', 'recursive_expression_map_update',
-    'get_integer_variable', 'get_loop_bounds', 'is_pragma_driver_loop', 'find_driver_loops',
+    'get_integer_variable', 'get_loop_bounds', 'is_pragma_driver_loop',
+    'find_driver_loops', 'DriverLoopRegion', 'find_driver_loop_regions',
+    'driver_loop_regions_attached',
     'get_local_arrays', 'check_routine_sequential', 'substitute_variables_for_definitions'
 ]
+
+
+@dataclass(frozen=True, eq=False)
+class DriverLoopRegion:
+    """
+    Metadata for a driver loop inside a Loki pragma region.
+
+    The :attr:`key` property is stable across IR node mutations and is intended
+    for long-lived transformation metadata. The ``region`` and ``loop`` fields
+    are current IR handles and should not be used as persistent dictionary keys.
+    """
+
+    region_index: int
+    loop_index: int
+    region: ir.PragmaRegion
+    loop: ir.Loop
+
+    @property
+    def key(self):
+        """Stable ordinal key for this loop within the selected pragma regions."""
+        return self.region_index, self.loop_index
 
 
 def single_variable_declaration(routine, variables=None, group_by_shape=False):
@@ -767,6 +792,57 @@ def find_driver_loops(section, targets, additional_identifier=None):
     find_driver = FindDriverLoops()
     find_driver.visit(section, targets=targets)
     return find_driver.driver_loops
+
+
+def find_driver_loop_regions(section, targets, starts_with='parallel'):
+    """
+    Find driver loops inside Loki pragma regions in a given section.
+
+    This utility assumes :any:`PragmaRegion` nodes and loop pragmas have
+    already been attached in ``section``. It returns :any:`DriverLoopRegion`
+    entries with stable ordinal keys that can be used for transformation
+    metadata instead of using mutable IR nodes as dictionary keys.
+
+    Parameters
+    ----------
+    section : :any:`Section` or tuple
+        Section in which to find pragma regions and driver loops.
+    targets : list or string
+        List of subroutines that are to be considered as part of the
+        transformation call tree.
+    starts_with : str
+        Loki pragma-region marker to include, e.g. ``parallel`` or ``data``.
+    """
+
+    entries = []
+    region_index = 0
+    for region in FindNodes(ir.PragmaRegion).visit(section):
+        if not is_loki_pragma(region.pragma, starts_with=starts_with):
+            continue
+
+        driver_loops = find_driver_loops(region.body, targets)
+        for loop_index, loop in enumerate(driver_loops):
+            entries.append(DriverLoopRegion(
+                region_index=region_index, loop_index=loop_index, region=region, loop=loop
+            ))
+        region_index += 1
+
+    return entries
+
+
+@contextmanager
+def driver_loop_regions_attached(module_or_routine, targets, starts_with='parallel'):
+    """
+    Context manager yielding driver-loop metadata for Loki pragma regions.
+
+    This attaches :any:`PragmaRegion` nodes for the lifetime of the context and
+    yields :any:`DriverLoopRegion` entries collected by
+    :any:`find_driver_loop_regions`.
+    """
+
+    with pragma_regions_attached(module_or_routine):
+        with pragmas_attached(module_or_routine, ir.Loop):
+            yield find_driver_loop_regions(module_or_routine.body, targets, starts_with=starts_with)
 
 
 def get_local_arrays(routine, section, unique=True):


### PR DESCRIPTION
### Description

This PR exposes and fixes a bug in the `DataOffloadDeepCopy` analysis/transformation, where nested Loki regions can cause erroneous lookup failures. The fundamental problem is that we use loops as dict indices when passing info from analysis to transformation, but those loops will change their internal hash if `PragmaRegion` objects are inserted (the trafo uses `with_pragma_regions_attached`, and IR objects derive their hash recursively). To prevent this, a new utility `DriverLoopRegion` that enumerates loops-per-region and associated tools `driver_loop_region_attached`, which makes the traversal and lookup of the objects safe.

I've also tried to roll this out across other transformations, hoping to eventually unify the access to the "driver loop" concept across all trafos - but I only regard this as a first step. Comments on further generalisation are welcome. 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 