### PR TITLE
Only test scc pipelines in ecwam regression test

### DIFF
--- a/loki/transformations/tests/test_ecwam.py
+++ b/loki/transformations/tests/test_ecwam.py
@@ -47,7 +47,7 @@ def fixture_bundle_create(here, local_loki_bundle):
 
 @pytest.mark.usefixtures('bundle_create')
 @pytest.mark.skipif(not HAVE_FP, reason="FP needed for ECWAM parsing")
-@pytest.mark.parametrize('mode', ['idem', 'idem-stack', 'scc', 'scc-stack', 'scc-hoist'])
+@pytest.mark.parametrize('mode', ['scc', 'scc-stack', 'scc-hoist'])
 def test_ecwam(here, mode, tmp_path):
     build_dir = tmp_path/'build'
     build_cmd = [


### PR DESCRIPTION
A small fix to only test the scc pipelines in the ecwam regression test, given that the idem pipelines no longer had any really use in ecwam and have therefore been removed.
 